### PR TITLE
[codex] Codex runtime v2 control plane

### DIFF
--- a/src/approval/service.test.ts
+++ b/src/approval/service.test.ts
@@ -1,47 +1,52 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-
-afterAll(() => mock.restore());
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { dbCreateContext, dbDeleteContext, dbGetContext } from "../router/router-db.js";
+import {
+  authorizeRuntimeContext,
+  setApprovalServiceDependenciesForTest,
+  type ApprovalServiceDependencies,
+} from "./service.js";
 
 let requestReplyResult: { messageId?: string } = { messageId: "msg_1" };
 let subscribeEvents: Array<{ topic: string; data: Record<string, unknown> }> = [];
 let emitted: Array<{ topic: string; data: Record<string, unknown> }> = [];
+let stateDir: string | null = null;
 const createdContextIds = new Set<string>();
 
-mock.module("../utils/request-reply.js", () => ({
-  requestReply: async () => requestReplyResult,
-}));
-
-mock.module("../nats.js", () => ({
-  nats: {
-    emit: async (topic: string, data: Record<string, unknown>) => {
-      emitted.push({ topic, data });
-    },
-    subscribe: (...topics: string[]) =>
-      (async function* () {
-        for (const event of subscribeEvents) {
-          if (topics.includes(event.topic)) {
-            yield event;
-          }
-        }
-      })(),
-  },
-}));
-
-const { authorizeRuntimeContext } = await import("./service.js");
-const { dbCreateContext, dbDeleteContext, dbGetContext } = await import("../router/router-db.js");
-
 describe("approval service", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-approval-service-test-");
     requestReplyResult = { messageId: "msg_1" };
     subscribeEvents = [];
     emitted = [];
+    setApprovalServiceDependenciesForTest({
+      requestReply: (async <T>() => requestReplyResult as T) satisfies ApprovalServiceDependencies["requestReply"],
+      nats: {
+        emit: async (topic: string, data: Record<string, unknown>) => {
+          emitted.push({ topic, data });
+        },
+        subscribe: ((...args: unknown[]) => {
+          const topics = args.filter((arg): arg is string => typeof arg === "string");
+          return (async function* () {
+            for (const event of subscribeEvents) {
+              if (topics.includes(event.topic)) {
+                yield event;
+              }
+            }
+          })();
+        }) satisfies ApprovalServiceDependencies["nats"]["subscribe"],
+      },
+    });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    setApprovalServiceDependenciesForTest();
     for (const contextId of createdContextIds) {
       dbDeleteContext(contextId);
     }
     createdContextIds.clear();
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
   });
 
   it("returns inherited access when the context already has the capability", async () => {
@@ -100,6 +105,7 @@ describe("approval service", () => {
       permission: "execute",
       objectType: "group",
       objectId: "daemon",
+      timeoutMs: 20,
     });
 
     expect(result).toMatchObject({

--- a/src/approval/service.ts
+++ b/src/approval/service.ts
@@ -1,11 +1,30 @@
-import { nats } from "../nats.js";
+import { nats as runtimeNats } from "../nats.js";
 import { canWithCapabilityContext } from "../permissions/engine.js";
 import { dbUpdateContextCapabilities, type ContextCapability, type ContextRecord } from "../router/router-db.js";
-import { requestReply } from "../utils/request-reply.js";
+import { requestReply as runtimeRequestReply } from "../utils/request-reply.js";
 import { logger } from "../utils/logger.js";
 
 const log = logger.child("approval:service");
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface ApprovalServiceDependencies {
+  nats: Pick<typeof runtimeNats, "emit" | "subscribe">;
+  requestReply: typeof runtimeRequestReply;
+}
+
+const defaultApprovalServiceDependencies: ApprovalServiceDependencies = {
+  nats: runtimeNats,
+  requestReply: runtimeRequestReply,
+};
+
+let approvalServiceDependencies = defaultApprovalServiceDependencies;
+
+export function setApprovalServiceDependenciesForTest(overrides?: Partial<ApprovalServiceDependencies>): void {
+  approvalServiceDependencies = {
+    ...defaultApprovalServiceDependencies,
+    ...(overrides ?? {}),
+  };
+}
 
 export interface ApprovalTarget {
   channel: string;
@@ -52,7 +71,7 @@ export async function requestApproval(
 
   let sendResult: { messageId?: string };
   try {
-    sendResult = await requestReply<{ messageId?: string }>(
+    sendResult = await approvalServiceDependencies.requestReply<{ messageId?: string }>(
       "ravi.outbound.deliver",
       {
         channel: source.channel,
@@ -86,7 +105,7 @@ export async function requestPollAnswer(
 
   let sendResult: { messageId?: string };
   try {
-    sendResult = await requestReply<{ messageId?: string }>(
+    sendResult = await approvalServiceDependencies.requestReply<{ messageId?: string }>(
       "ravi.outbound.deliver",
       {
         channel: source.channel,
@@ -129,7 +148,7 @@ export async function requestCascadingApproval(
   const isDelegated = !opts.resolvedSource && !!opts.approvalSource;
   log.info(`${opts.type} approval requested`, { sessionName: opts.sessionName, isDelegated });
 
-  nats
+  approvalServiceDependencies.nats
     .emit("ravi.approval.request", {
       type: opts.type,
       sessionName: opts.sessionName,
@@ -145,7 +164,7 @@ export async function requestCascadingApproval(
   const approvalText = buildApprovalText(opts.type, opts.text, opts.agentId, isDelegated);
   const result = await requestApproval(targetSource, approvalText, { timeoutMs: opts.timeoutMs });
 
-  nats
+  approvalServiceDependencies.nats
     .emit("ravi.approval.response", {
       type: opts.type,
       sessionName: opts.sessionName,
@@ -246,7 +265,7 @@ async function waitForApprovalResponse(
   messageId: string,
   timeoutMs: number,
 ): Promise<{ approved: boolean; reason?: string }> {
-  const stream = nats.subscribe("ravi.inbound.reaction", "ravi.inbound.reply");
+  const stream = approvalServiceDependencies.nats.subscribe("ravi.inbound.reaction", "ravi.inbound.reply");
 
   return new Promise((resolve) => {
     let settled = false;
@@ -295,7 +314,7 @@ async function waitForPollAnswer(
   messageId: string,
   timeoutMs: number,
 ): Promise<{ selectedLabels: string[] } | { freeText: string }> {
-  const stream = nats.subscribe("ravi.inbound.reply", "ravi.inbound.pollVote");
+  const stream = approvalServiceDependencies.nats.subscribe("ravi.inbound.reply", "ravi.inbound.pollVote");
 
   return new Promise((resolve) => {
     let settled = false;

--- a/src/approval/service.ts
+++ b/src/approval/service.ts
@@ -32,6 +32,7 @@ export interface ContextAuthorizationOptions {
   objectType: string;
   objectId: string;
   timeoutMs?: number;
+  eventData?: Record<string, unknown>;
 }
 
 export interface ContextAuthorizationResult {
@@ -179,6 +180,7 @@ export async function authorizeRuntimeContext(opts: ContextAuthorizationOptions)
     timeoutMs: opts.timeoutMs,
     autoApproveWithoutSource: false,
     eventData: {
+      ...(opts.eventData ?? {}),
       contextId: context.contextId,
       permission,
       objectType,

--- a/src/bot.runtime-guards.test.ts
+++ b/src/bot.runtime-guards.test.ts
@@ -108,6 +108,12 @@ let canWithCapabilitiesImpl = (...args: Parameters<typeof actualPermissionsEngin
   actualPermissionsEngineModule.canWithCapabilities(...args);
 let snapshotAgentCapabilitiesImpl = () =>
   [] as Array<{ permission: string; objectType: string; objectId: string; source?: string }>;
+type TestCostResult = { inputCost: number; outputCost: number; cacheCost: number; totalCost: number } | null;
+let calculateCostImpl: (
+  model: string,
+  usage: { inputTokens: number; outputTokens: number; cacheRead: number; cacheCreation: number },
+) => TestCostResult = () => null;
+const dbInsertCostEventMock = mock((_event: Record<string, unknown>) => {});
 
 const clearProviderSession = mock((sessionKey: string) => {
   const session = sessions.get(sessionKey);
@@ -374,7 +380,7 @@ mock.module("./router/index.js", () => ({
   expandHome: (path: string) => path.replace("~", "/tmp/ravi-test-bot"),
   getAnnounceCompaction: () => false,
   getAccountForAgent: () => null,
-  dbInsertCostEvent: mock(() => {}),
+  dbInsertCostEvent: dbInsertCostEventMock,
 }));
 
 mock.module("./config-store.js", () => ({
@@ -468,7 +474,7 @@ mock.module("./hooks/sanitize-bash.js", () => ({
 }));
 
 mock.module("./constants.js", () => ({
-  calculateCost: () => null,
+  calculateCost: (model: string, usage: Parameters<typeof calculateCostImpl>[1]) => calculateCostImpl(model, usage),
 }));
 
 mock.module("./plugins/index.js", () => ({
@@ -661,6 +667,8 @@ describe("RaviBot runtime guards", () => {
     resetRuntimeDoubles();
     saveMessageImpl = () => {};
     agentCanImpl = () => true;
+    dbInsertCostEventMock.mockClear();
+    calculateCostImpl = () => null;
     snapshotAgentCapabilitiesImpl = () => [];
     canWithCapabilitiesImpl = (
       capabilities: Array<{ permission: string; objectType: string; objectId: string }>,
@@ -904,6 +912,54 @@ describe("RaviBot runtime guards", () => {
       approved: true,
       inherited: true,
       permissions: { "use:tool:Bash": true },
+    });
+  });
+
+  it("denies runtime user input when no outbound target exists", async () => {
+    activeProvider = "codex";
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-user-input-no-source", { prompt: "hello" });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const approveRuntimeRequest = runtimeStartCalls[0]?.approveRuntimeRequest;
+    expect(typeof approveRuntimeRequest).toBe("function");
+
+    await expect(
+      approveRuntimeRequest?.({
+        kind: "user_input",
+        method: "item/tool/requestUserInput",
+        input: {
+          questions: [{ id: "choice", question: "Pick one", options: [{ label: "A" }] }],
+        },
+      }),
+    ).resolves.toMatchObject({
+      approved: false,
+      reason: "Runtime user input requires a target source.",
+    });
+  });
+
+  it("denies runtime user input questions without selectable options", async () => {
+    activeProvider = "codex";
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-user-input-no-options", makePrompt("hello"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const approveRuntimeRequest = runtimeStartCalls[0]?.approveRuntimeRequest;
+    expect(typeof approveRuntimeRequest).toBe("function");
+
+    await expect(
+      approveRuntimeRequest?.({
+        kind: "user_input",
+        method: "item/tool/requestUserInput",
+        input: {
+          questions: [{ id: "freeform", question: "What should I do?" }],
+        },
+      }),
+    ).resolves.toMatchObject({
+      approved: false,
+      reason: "Runtime user input question requires selectable options: freeform",
     });
   });
 
@@ -1328,6 +1384,34 @@ describe("RaviBot runtime guards", () => {
           (entry.data.metadata as any)?.item?.id === "item-text",
       ),
     ).toBe(true);
+  });
+
+  it("does not backfill Codex cost events from the configured agent model when execution model is absent", async () => {
+    activeProvider = "codex";
+    const pricedModels: string[] = [];
+    calculateCostImpl = (model) => {
+      pricedModels.push(model);
+      return { inputCost: 1, outputCost: 2, cacheCost: 0, totalCost: 3 };
+    };
+    runtimeStartImpl = (providerId) => ({
+      provider: providerId,
+      events: (async function* () {
+        yield {
+          type: "turn.complete",
+          providerSessionId: `${providerId}-session`,
+          execution: { provider: "openai", model: null, billingType: "subscription" },
+          usage: { inputTokens: 10, outputTokens: 5 },
+        };
+      })(),
+      interrupt: async () => {},
+    });
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-cost-no-model", makePrompt("hello"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(pricedModels).toEqual([]);
+    expect(dbInsertCostEventMock).not.toHaveBeenCalled();
   });
 
   it("interrupts an active text turn for p0/immediate_interrupt prompts", async () => {

--- a/src/bot.runtime-guards.test.ts
+++ b/src/bot.runtime-guards.test.ts
@@ -1023,6 +1023,7 @@ describe("RaviBot runtime guards", () => {
         yield {
           type: "provider.raw",
           rawEvent: { type: "thread.started", thread_id: "thread-codex" },
+          metadata: { provider: "codex", nativeEvent: "thread.started", thread: { id: "thread-codex" } },
         };
         yield {
           type: "assistant.message",
@@ -1045,6 +1046,14 @@ describe("RaviBot runtime guards", () => {
     expect(
       emittedEvents.some(
         (entry) => entry.topic === `ravi.session.${sessionKey}.runtime` && entry.data?.type === "provider.raw",
+      ),
+    ).toBe(true);
+    expect(
+      emittedEvents.some(
+        (entry) =>
+          entry.topic === `ravi.session.${sessionKey}.runtime` &&
+          entry.data?.type === "provider.raw" &&
+          (entry.data.metadata as any)?.thread?.id === "thread-codex",
       ),
     ).toBe(true);
   });

--- a/src/bot.runtime-guards.test.ts
+++ b/src/bot.runtime-guards.test.ts
@@ -33,6 +33,9 @@ type RuntimeStartRequest = {
   abortController: AbortController;
   systemPromptAppend: string;
   env?: Record<string, string>;
+  approveRuntimeRequest?: (request: any) => Promise<any>;
+  dynamicTools?: Array<{ name: string; description: string; inputSchema: unknown }>;
+  handleRuntimeToolCall?: (request: any) => Promise<any>;
 };
 
 type RuntimePlugin = {
@@ -60,6 +63,7 @@ type RuntimeHandle = {
   events: AsyncIterable<Record<string, unknown>>;
   interrupt(): Promise<void>;
   setModel?(model: string): Promise<void>;
+  control?(request: Record<string, unknown>): Promise<Record<string, unknown>>;
 };
 
 const emittedEvents: Array<{ topic: string; data: any }> = [];
@@ -79,6 +83,8 @@ let agentCanImpl = (...args: Parameters<typeof actualPermissionsEngineModule.age
   actualPermissionsEngineModule.agentCan(...args);
 let canWithCapabilitiesImpl = (...args: Parameters<typeof actualPermissionsEngineModule.canWithCapabilities>) =>
   actualPermissionsEngineModule.canWithCapabilities(...args);
+let snapshotAgentCapabilitiesImpl = () =>
+  [] as Array<{ permission: string; objectType: string; objectId: string; source?: string }>;
 
 const clearProviderSession = mock((sessionKey: string) => {
   const session = sessions.get(sessionKey);
@@ -294,11 +300,44 @@ mock.module("./cli/context.js", () => ({
   runWithContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
 
+mock.module("./cli/tool-definitions.js", () => ({
+  getAllCommandClasses: () => [],
+  createSdkTools: () => [
+    {
+      name: "tools_list",
+      description: "List available tools",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    },
+  ],
+}));
+
+mock.module("./cli/tools-export.js", () => ({
+  extractTools: () => [
+    {
+      name: "tools_list",
+      description: "List available tools",
+      handler: async () => ({
+        content: [{ type: "text" as const, text: "fake tools list" }],
+        isError: false,
+      }),
+      metadata: {
+        group: "tools",
+        command: "list",
+        method: "list",
+        args: [],
+        options: [],
+        scope: "open",
+      },
+    },
+  ],
+}));
+
 mock.module("./heartbeat/index.js", () => ({
   HEARTBEAT_OK: "HEARTBEAT_OK",
 }));
 
 mock.module("./bash/index.js", () => ({
+  checkDangerousPatterns: () => ({ safe: true }),
   createBashPermissionHook: () => ({
     matcher: "Bash",
     hooks: [async () => ({})],
@@ -306,6 +345,10 @@ mock.module("./bash/index.js", () => ({
   createToolPermissionHook: () => ({
     hooks: [async () => ({})],
   }),
+  emitBashDeniedAudit: mock(() => {}),
+  evaluateBashPermission: () => ({ allowed: true }),
+  parseBashCommand: () => ({ success: true, executables: [] }),
+  UNCONDITIONAL_BLOCKS: new Set(["bash", "sh", "zsh"]),
 }));
 
 mock.module("./hooks/index.js", () => ({
@@ -376,7 +419,7 @@ mock.module("./runtime/index.js", () => ({
     metadata: input.metadata,
     createdAt: Date.now(),
   }),
-  snapshotAgentCapabilities: () => [],
+  snapshotAgentCapabilities: () => snapshotAgentCapabilitiesImpl(),
   createRuntimeProvider: (providerId: RuntimeProviderId = "claude") => {
     const capabilities =
       providerId === "codex"
@@ -499,6 +542,7 @@ describe("RaviBot runtime guards", () => {
     resetRuntimeDoubles();
     saveMessageImpl = () => {};
     agentCanImpl = () => true;
+    snapshotAgentCapabilitiesImpl = () => [];
     canWithCapabilitiesImpl = (
       capabilities: Array<{ permission: string; objectType: string; objectId: string }>,
       permission: string,
@@ -696,6 +740,95 @@ describe("RaviBot runtime guards", () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(preparePlugins).toEqual(discoveredPlugins);
+  });
+
+  it("passes a runtime approval bridge that honors inherited Codex file-change permissions", async () => {
+    activeProvider = "codex";
+    snapshotAgentCapabilitiesImpl = () => [
+      { permission: "use", objectType: "tool", objectId: "Write", source: "test" },
+      { permission: "use", objectType: "tool", objectId: "Bash", source: "test" },
+    ];
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-approval-bridge", makePrompt("hello"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const approveRuntimeRequest = runtimeStartCalls[0]?.approveRuntimeRequest;
+    expect(typeof approveRuntimeRequest).toBe("function");
+
+    const result = await approveRuntimeRequest?.({
+      kind: "file_change",
+      method: "item/fileChange/requestApproval",
+      toolName: "Write",
+      input: { changes: [{ path: "hello.txt", kind: "add" }] },
+      metadata: {
+        provider: "codex",
+        source: "codex.app-server",
+        thread: { id: "thread_test" },
+        turn: { id: "turn_test" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      approved: true,
+      inherited: true,
+      updatedInput: { changes: [{ path: "hello.txt", kind: "add" }] },
+    });
+
+    await expect(
+      approveRuntimeRequest?.({
+        kind: "permission",
+        method: "item/permissions/requestApproval",
+        input: { permissions: { "use:tool:Bash": true } },
+      }),
+    ).resolves.toMatchObject({
+      approved: true,
+      inherited: true,
+      permissions: { "use:tool:Bash": true },
+    });
+  });
+
+  it("passes a Codex dynamic tool bridge that executes inherited Ravi CLI tools", async () => {
+    activeProvider = "codex";
+    snapshotAgentCapabilitiesImpl = () => [
+      { permission: "use", objectType: "tool", objectId: "tools_list", source: "test" },
+    ];
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-dynamic-tools", makePrompt("hello"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const runtimeRequest = runtimeStartCalls[0];
+    expect(runtimeRequest?.dynamicTools?.some((tool) => tool.name === "tools_list")).toBe(true);
+    expect(typeof runtimeRequest?.handleRuntimeToolCall).toBe("function");
+
+    const result = await runtimeRequest?.handleRuntimeToolCall?.({
+      toolName: "tools_list",
+      callId: "dyn_tool_test",
+      arguments: {},
+      metadata: {
+        provider: "codex",
+        source: "codex.app-server",
+        thread: { id: "thread_test" },
+        turn: { id: "turn_test" },
+        item: { id: "dyn_tool_test", type: "dynamic_tool_call" },
+      },
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.contentItems?.[0]?.type).toBe("inputText");
+    expect(result?.contentItems?.[0]?.text).toContain("fake tools list");
+  });
+
+  it("does not advertise Codex dynamic tools outside the runtime capability snapshot", async () => {
+    activeProvider = "codex";
+    snapshotAgentCapabilitiesImpl = () => [];
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate("agent:main:codex-dynamic-tools-denied", makePrompt("hello"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(runtimeStartCalls[0]?.dynamicTools ?? []).toEqual([]);
   });
 
   it("uses the session cwd instead of the agent default when a task/session overrides the workspace", async () => {
@@ -1026,6 +1159,17 @@ describe("RaviBot runtime guards", () => {
           metadata: { provider: "codex", nativeEvent: "thread.started", thread: { id: "thread-codex" } },
         };
         yield {
+          type: "text.delta",
+          text: "hello ",
+          metadata: {
+            provider: "codex",
+            nativeEvent: "item.text_delta",
+            thread: { id: "thread-codex" },
+            turn: { id: "turn-codex" },
+            item: { id: "item-text", type: "assistant_message_delta" },
+          },
+        };
+        yield {
           type: "assistant.message",
           text: "hello from codex",
         };
@@ -1054,6 +1198,14 @@ describe("RaviBot runtime guards", () => {
           entry.topic === `ravi.session.${sessionKey}.runtime` &&
           entry.data?.type === "provider.raw" &&
           (entry.data.metadata as any)?.thread?.id === "thread-codex",
+      ),
+    ).toBe(true);
+    expect(
+      emittedEvents.some(
+        (entry) =>
+          entry.topic === `ravi.session.${sessionKey}.stream` &&
+          entry.data?.chunk === "hello " &&
+          (entry.data.metadata as any)?.item?.id === "item-text",
       ),
     ).toBe(true);
   });
@@ -1466,6 +1618,79 @@ describe("RaviBot streaming session lifecycle", () => {
     await (bot as any).handlePromptImmediate(sessionKey, prompt);
 
     expect(streamingSession.currentSource?.chatId).toBe("new-chat");
+  });
+
+  it("routes runtime control requests to the active session handle", async () => {
+    const sessionKey = "agent:main:codex-control";
+    const sessionName = "codex-control";
+    const bot = createBot();
+    let controlRequest: Record<string, unknown> | undefined;
+
+    sessions.set(sessionKey, {
+      sessionKey,
+      name: sessionName,
+      agentId: "main",
+      agentCwd: "/tmp/main",
+      runtimeProvider: "codex",
+    });
+    (bot as any).streamingSessions.set(sessionName, {
+      queryHandle: {
+        provider: "codex",
+        interrupt: async () => {},
+        control: async (request: Record<string, unknown>) => {
+          controlRequest = request;
+          return {
+            ok: true,
+            operation: request.operation,
+            state: {
+              provider: "codex",
+              threadId: "thread_control",
+              turnId: "turn_control",
+              activeTurn: true,
+            },
+            data: { interrupted: true },
+          };
+        },
+      },
+      abortController: new AbortController(),
+      pushMessage: null,
+      pendingWake: false,
+      pendingMessages: [],
+      currentSource: undefined,
+      toolRunning: false,
+      lastActivity: Date.now(),
+      done: false,
+      interrupted: false,
+      turnActive: true,
+      onTurnComplete: null,
+      compacting: false,
+      currentToolSafety: null,
+      pendingAbort: false,
+    });
+
+    await (bot as any).handleRuntimeControlRequest({
+      sessionName,
+      sessionKey,
+      replyTopic: "ravi._reply.control",
+      request: { operation: "turn.interrupt", threadId: "thread_control" },
+    });
+
+    expect(controlRequest).toEqual({ operation: "turn.interrupt", threadId: "thread_control" });
+    expect(emittedEvents.find((event) => event.topic === "ravi._reply.control")?.data).toMatchObject({
+      result: {
+        ok: true,
+        operation: "turn.interrupt",
+        data: { interrupted: true },
+        state: { provider: "codex", threadId: "thread_control", turnId: "turn_control" },
+      },
+    });
+    expect(emittedEvents.find((event) => event.topic === `ravi.session.${sessionName}.runtime`)?.data).toMatchObject({
+      type: "runtime.control",
+      provider: "codex",
+      operation: "turn.interrupt",
+      ok: true,
+      state: { provider: "codex", threadId: "thread_control", turnId: "turn_control" },
+    });
   });
 
   it("aborts and clears all streaming sessions on stop", async () => {

--- a/src/bot.runtime-guards.test.ts
+++ b/src/bot.runtime-guards.test.ts
@@ -33,9 +33,32 @@ type RuntimeStartRequest = {
   abortController: AbortController;
   systemPromptAppend: string;
   env?: Record<string, string>;
+  hooks?: Record<string, unknown>;
   approveRuntimeRequest?: (request: any) => Promise<any>;
   dynamicTools?: Array<{ name: string; description: string; inputSchema: unknown }>;
   handleRuntimeToolCall?: (request: any) => Promise<any>;
+};
+
+type RuntimeHostServices = {
+  authorizeCapability(request: {
+    permission: string;
+    objectType: string;
+    objectId: string;
+    eventData?: Record<string, unknown>;
+  }): Promise<{ allowed: boolean; inherited: boolean; reason?: string }>;
+  authorizeCommandExecution(request: {
+    command: string;
+    input?: Record<string, unknown>;
+    eventData?: Record<string, unknown>;
+  }): Promise<any>;
+  authorizeToolUse(request: {
+    toolName: string;
+    input?: Record<string, unknown>;
+    eventData?: Record<string, unknown>;
+  }): Promise<any>;
+  requestUserInput(request: { questions: any[]; eventData?: Record<string, unknown> }): Promise<any>;
+  listDynamicTools(): RuntimeStartRequest["dynamicTools"];
+  executeDynamicTool(request: any, options?: { eventData?: Record<string, unknown> }): Promise<any>;
 };
 
 type RuntimePlugin = {
@@ -72,8 +95,8 @@ let activeProvider: RuntimeProviderId = "claude";
 let runtimeStartCalls: RuntimeStartRequest[] = [];
 let runtimePrepareImpl: (
   providerId: RuntimeProviderId,
-  input: { agentId: string; cwd: string; plugins?: RuntimePlugin[] },
-) => Promise<{ env?: Record<string, string> } | undefined>;
+  input: { agentId: string; cwd: string; plugins?: RuntimePlugin[]; hostServices?: RuntimeHostServices },
+) => Promise<{ env?: Record<string, string>; startRequest?: Partial<RuntimeStartRequest> } | undefined>;
 let runtimeStartImpl: (providerId: RuntimeProviderId, request: RuntimeStartRequest) => RuntimeHandle;
 let discoveredPlugins: RuntimePlugin[] = [];
 const createdTaskIds: string[] = [];
@@ -109,6 +132,87 @@ function resetRuntimeDoubles(): void {
     })(),
     interrupt: async () => {},
   });
+}
+
+function createMockCodexStartRequest(hostServices: RuntimeHostServices): Partial<RuntimeStartRequest> {
+  return {
+    approveRuntimeRequest: async (request: any) => {
+      const eventData = {
+        runtimeApproval: {
+          provider: "codex",
+          kind: request.kind,
+          method: request.method,
+          toolName: request.toolName,
+          input: request.input,
+        },
+        runtimeMetadata: request.metadata,
+      };
+
+      if (request.kind === "command_execution") {
+        return hostServices.authorizeCommandExecution({
+          command: request.input?.command ?? "",
+          input: request.input,
+          eventData,
+        });
+      }
+      if (request.kind === "file_change") {
+        return hostServices.authorizeToolUse({
+          toolName: request.toolName ?? "Edit",
+          input: request.input,
+          eventData,
+        });
+      }
+      if (request.kind === "user_input") {
+        return hostServices.requestUserInput({
+          questions: Array.isArray(request.input?.questions) ? request.input.questions : [],
+          eventData,
+        });
+      }
+
+      const permission = request.input?.permissions;
+      const capabilities =
+        permission && typeof permission === "object"
+          ? Object.keys(permission).map((entry) => {
+              const [action = "", objectType = "", objectId = ""] = entry.split(":");
+              return { permission: action, objectType, objectId };
+            })
+          : [];
+      let inherited = true;
+      for (const capability of capabilities) {
+        const result = await hostServices.authorizeCapability({
+          ...capability,
+          eventData,
+        });
+        if (!result.allowed) {
+          return {
+            approved: false,
+            reason: result.reason,
+            permissions: {},
+          };
+        }
+        inherited = inherited && result.inherited;
+      }
+      return {
+        approved: true,
+        inherited,
+        permissions: permission ?? {},
+      };
+    },
+    dynamicTools: hostServices.listDynamicTools(),
+    handleRuntimeToolCall: (request: any) =>
+      hostServices.executeDynamicTool(request, {
+        eventData: {
+          runtimeToolCall: {
+            provider: "codex",
+            method: "item/tool/call",
+            toolName: request.toolName,
+            callId: request.callId,
+            arguments: request.arguments,
+          },
+          runtimeMetadata: request.metadata,
+        },
+      }),
+  };
 }
 
 function createDispatchedTaskForSession(
@@ -427,7 +531,8 @@ mock.module("./runtime/index.js", () => ({
             supportsSessionResume: true,
             supportsSessionFork: false,
             supportsPartialText: false,
-            supportsToolHooks: false,
+            supportsToolHooks: true,
+            supportsHostSessionHooks: false,
             supportsPlugins: false,
             supportsMcpServers: false,
             supportsRemoteSpawn: false,
@@ -437,6 +542,7 @@ mock.module("./runtime/index.js", () => ({
             supportsSessionFork: true,
             supportsPartialText: true,
             supportsToolHooks: true,
+            supportsHostSessionHooks: true,
             supportsPlugins: true,
             supportsMcpServers: true,
             supportsRemoteSpawn: true,
@@ -445,8 +551,21 @@ mock.module("./runtime/index.js", () => ({
     return {
       id: providerId,
       getCapabilities: () => capabilities,
-      prepareSession: (input: { agentId: string; cwd: string; plugins?: RuntimePlugin[] }) =>
-        runtimePrepareImpl(providerId, input),
+      prepareSession: async (input: {
+        agentId: string;
+        cwd: string;
+        plugins?: RuntimePlugin[];
+        hostServices?: RuntimeHostServices;
+      }) => {
+        const prepared = await runtimePrepareImpl(providerId, input);
+        if (providerId !== "codex" || !input.hostServices || prepared?.startRequest) {
+          return prepared;
+        }
+        return {
+          ...(prepared ?? {}),
+          startRequest: createMockCodexStartRequest(input.hostServices),
+        };
+      },
       startSession: (input: RuntimeStartRequest) => {
         runtimeStartCalls.push(input);
         return runtimeStartImpl(providerId, input);
@@ -1187,6 +1306,7 @@ describe("RaviBot runtime guards", () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(emittedEvents.some((entry) => entry.topic === `ravi.session.${sessionKey}.claude`)).toBe(false);
+    expect(runtimeStartCalls[0]?.hooks).toBeUndefined();
     expect(
       emittedEvents.some(
         (entry) => entry.topic === `ravi.session.${sessionKey}.runtime` && entry.data?.type === "provider.raw",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -2214,7 +2214,7 @@ export class RaviBot {
 
         await emitRuntimeEvent(
           event.type === "provider.raw"
-            ? { type: "provider.raw", provider: runtimeSession.provider }
+            ? { type: "provider.raw", provider: runtimeSession.provider, metadata: event.metadata }
             : { ...event, provider: runtimeSession.provider },
         );
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -27,14 +27,25 @@ import {
   getAnnounceCompaction,
   getAccountForAgent,
   dbInsertCostEvent,
-  type SessionEntry,
   type AgentConfig,
+  type ContextRecord,
+  type SessionEntry,
 } from "./router/index.js";
 import { calculateCost } from "./constants.js";
 import { configStore } from "./config-store.js";
 import { runWithContext } from "./cli/context.js";
+import { getAllCommandClasses, createSdkTools } from "./cli/tool-definitions.js";
+import { extractTools, type ExportedTool, type ToolResult } from "./cli/tools-export.js";
 import { HEARTBEAT_OK } from "./heartbeat/index.js";
-import { createBashPermissionHook, createToolPermissionHook } from "./bash/index.js";
+import {
+  checkDangerousPatterns,
+  createBashPermissionHook,
+  createToolPermissionHook,
+  emitBashDeniedAudit,
+  evaluateBashPermission,
+  parseBashCommand,
+  UNCONDITIONAL_BLOCKS,
+} from "./bash/index.js";
 import { createPreCompactHook } from "./hooks/index.js";
 import { SANITIZED_ENV_VARS, createSanitizeBashHook } from "./hooks/sanitize-bash.js";
 import { createSpecServer, isSpecModeActive, getSpecState } from "./spec/server.js";
@@ -44,8 +55,13 @@ import { SESSION_MODEL_CHANGED_TOPIC, type SessionModelChangedEvent } from "./se
 import { delimiter, dirname, join } from "node:path";
 import { createRemoteSpawn } from "./remote-spawn.js";
 import { createNatsRemoteSpawn } from "./remote-spawn-nats.js";
-import { agentCan } from "./permissions/engine.js";
-import { requestCascadingApproval, requestPollAnswer } from "./approval/service.js";
+import { agentCan, canWithCapabilityContext } from "./permissions/engine.js";
+import {
+  authorizeRuntimeContext,
+  requestCascadingApproval,
+  requestPollAnswer,
+  type ApprovalTarget,
+} from "./approval/service.js";
 import {
   DEFAULT_DELIVERY_BARRIER,
   chooseMoreUrgentBarrier,
@@ -66,6 +82,18 @@ import {
   createRuntimeContext,
   createRuntimeProvider,
   snapshotAgentCapabilities,
+  type RuntimeApprovalHandler,
+  type RuntimeApprovalQuestion,
+  type RuntimeApprovalRequest,
+  type RuntimeApprovalResult,
+  type RuntimeControlRequest,
+  type RuntimeControlResult,
+  type RuntimeDynamicToolCallContentItem,
+  type RuntimeDynamicToolCallHandler,
+  type RuntimeDynamicToolCallRequest,
+  type RuntimeDynamicToolCallResult,
+  type RuntimeDynamicToolSpec,
+  type RuntimeEventMetadata,
   type RuntimeProviderId,
   type RuntimeSessionHandle,
   type RuntimeStartRequest,
@@ -265,6 +293,594 @@ function getRuntimeToolAccessMode(providerId: RuntimeProviderId, agentId: string
   }
 
   return hasUnrestrictedToolExecution(agentId) ? "unrestricted" : "restricted";
+}
+
+const CODEX_BUILTIN_EXECUTABLES = new Set(["ravi"]);
+let cachedRuntimeDynamicTools: ExportedTool[] | null = null;
+let cachedRuntimeDynamicToolSpecs: RuntimeDynamicToolSpec[] | null = null;
+
+function getRuntimeDynamicToolDefinitions(): ExportedTool[] {
+  if (!cachedRuntimeDynamicTools) {
+    cachedRuntimeDynamicTools = extractTools(getAllCommandClasses());
+  }
+  return cachedRuntimeDynamicTools;
+}
+
+function getRuntimeDynamicToolSpecs(): RuntimeDynamicToolSpec[] {
+  if (!cachedRuntimeDynamicToolSpecs) {
+    cachedRuntimeDynamicToolSpecs = createSdkTools(getAllCommandClasses()).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+  }
+  return cachedRuntimeDynamicToolSpecs;
+}
+
+function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDynamicToolSpec[] {
+  const allowedToolNames = new Set(
+    getRuntimeDynamicToolDefinitions()
+      .filter((tool) => canAdvertiseRuntimeDynamicTool(context, tool))
+      .map((tool) => tool.name),
+  );
+
+  return getRuntimeDynamicToolSpecs().filter((tool) => allowedToolNames.has(tool.name));
+}
+
+function canAdvertiseRuntimeDynamicTool(context: ContextRecord, tool: ExportedTool): boolean {
+  if (!canWithCapabilityContext(context, "use", "tool", tool.name)) {
+    return false;
+  }
+
+  const scope = tool.metadata.scope ?? "admin";
+  switch (scope) {
+    case "open":
+    case "resource":
+      return true;
+    case "superadmin":
+      return canWithCapabilityContext(context, "admin", "system", "*");
+    case "writeContacts":
+      return canWithCapabilityContext(context, "write_contacts", "system", "*");
+    case "admin":
+      return (
+        canWithCapabilityContext(context, "execute", "group", tool.metadata.group) ||
+        canWithCapabilityContext(context, "execute", "group", `${tool.metadata.group}_${tool.metadata.command}`)
+      );
+    default:
+      return false;
+  }
+}
+
+function createRuntimeApprovalBridge(options: {
+  context: ContextRecord;
+  agentId: string;
+  sessionName: string;
+  resolvedSource?: ApprovalTarget;
+  approvalSource?: ApprovalTarget;
+}): RuntimeApprovalHandler {
+  return async (request) => {
+    switch (request.kind) {
+      case "command_execution":
+        return authorizeCodexCommandExecution(options, request);
+      case "file_change":
+        return authorizeCodexFileChange(options, request);
+      case "permission":
+        return authorizeCodexPermissionRequest(options, request);
+      case "user_input":
+        return requestCodexUserInput(options, request);
+    }
+  };
+}
+
+function createRuntimeDynamicToolBridge(options: {
+  context: ContextRecord;
+  agentId: string;
+  sessionName: string;
+  toolContext: Record<string, unknown>;
+}): RuntimeDynamicToolCallHandler {
+  return async (request) => {
+    const tool = getRuntimeDynamicToolDefinitions().find((candidate) => candidate.name === request.toolName);
+    if (!tool) {
+      return {
+        success: false,
+        contentItems: [{ type: "inputText", text: `Unknown Ravi dynamic tool: ${request.toolName}` }],
+      };
+    }
+
+    const authorization = await authorizeRuntimeDynamicToolCall(options, tool, request);
+    if (!authorization.allowed) {
+      return {
+        success: false,
+        contentItems: [{ type: "inputText", text: authorization.reason ?? `${request.toolName} permission denied.` }],
+      };
+    }
+
+    const args = normalizeDynamicToolArguments(request.arguments);
+    const result = await runWithContext(options.toolContext, () => tool.handler(args));
+    return buildRuntimeDynamicToolResult(result);
+  };
+}
+
+async function authorizeRuntimeDynamicToolCall(
+  options: { context: ContextRecord; agentId: string; sessionName: string },
+  tool: ExportedTool,
+  request: RuntimeDynamicToolCallRequest,
+): Promise<{ allowed: boolean; reason?: string }> {
+  const eventData = buildRuntimeDynamicToolEventData(request);
+  const toolAuthorization = await authorizeRuntimeContext({
+    context: options.context,
+    permission: "use",
+    objectType: "tool",
+    objectId: tool.name,
+    eventData,
+  });
+  if (!toolAuthorization.allowed) {
+    return { allowed: false, reason: toolAuthorization.reason ?? `${tool.name} tool permission denied.` };
+  }
+
+  return authorizeRuntimeDynamicToolScope(options, tool, eventData);
+}
+
+async function authorizeRuntimeDynamicToolScope(
+  options: { context: ContextRecord },
+  tool: ExportedTool,
+  eventData: Record<string, unknown>,
+): Promise<{ allowed: boolean; reason?: string }> {
+  const scope = tool.metadata.scope ?? "admin";
+  if (scope === "open" || scope === "resource") {
+    return { allowed: true };
+  }
+
+  if (scope === "superadmin") {
+    const result = await authorizeRuntimeContext({
+      context: options.context,
+      permission: "admin",
+      objectType: "system",
+      objectId: "*",
+      eventData,
+    });
+    return result.allowed
+      ? { allowed: true }
+      : { allowed: false, reason: result.reason ?? "Superadmin permission denied." };
+  }
+
+  if (scope === "writeContacts") {
+    const result = await authorizeRuntimeContext({
+      context: options.context,
+      permission: "write_contacts",
+      objectType: "system",
+      objectId: "*",
+      eventData,
+    });
+    return result.allowed
+      ? { allowed: true }
+      : { allowed: false, reason: result.reason ?? "Contact write permission denied." };
+  }
+
+  const group = tool.metadata.group;
+  const command = tool.metadata.command;
+  if (canWithCapabilityContext(options.context, "execute", "group", group)) {
+    return { allowed: true };
+  }
+
+  const result = await authorizeRuntimeContext({
+    context: options.context,
+    permission: "execute",
+    objectType: "group",
+    objectId: `${group}_${command}`,
+    eventData,
+  });
+  return result.allowed
+    ? { allowed: true }
+    : { allowed: false, reason: result.reason ?? `CLI tool permission denied: ${group}_${command}` };
+}
+
+function normalizeDynamicToolArguments(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function buildRuntimeDynamicToolResult(result: ToolResult): RuntimeDynamicToolCallResult {
+  return {
+    success: result.isError !== true,
+    contentItems: toDynamicToolContentItems(result.content),
+  };
+}
+
+function toDynamicToolContentItems(content: ToolResult["content"]): RuntimeDynamicToolCallContentItem[] {
+  const items: RuntimeDynamicToolCallContentItem[] = [];
+  for (const item of content) {
+    if (item.type === "text") {
+      items.push({ type: "inputText", text: item.text });
+    }
+  }
+
+  return items.length > 0 ? items : [{ type: "inputText", text: "(no output)" }];
+}
+
+function buildRuntimeDynamicToolEventData(request: RuntimeDynamicToolCallRequest): Record<string, unknown> {
+  return {
+    codexToolCall: {
+      method: "item/tool/call",
+      toolName: request.toolName,
+      callId: request.callId,
+      arguments: truncateOutput(request.arguments),
+    },
+    runtimeMetadata: request.metadata,
+  };
+}
+
+async function authorizeCodexCommandExecution(
+  options: {
+    context: ContextRecord;
+    agentId: string;
+    sessionName: string;
+  },
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const command = typeof request.input?.command === "string" ? request.input.command : "";
+  if (!command.trim()) {
+    return { approved: false, reason: "Codex command approval request did not include a command." };
+  }
+
+  const eventData = buildRuntimeApprovalEventData(request);
+  const buildBashContext = () => ({
+    agentId: options.agentId,
+    ...(options.context.sessionKey ? { sessionKey: options.context.sessionKey } : {}),
+    sessionName: options.context.sessionName ?? options.sessionName,
+    capabilities: options.context.capabilities,
+  });
+
+  const preliminary = evaluateBashPermission(command, buildBashContext());
+  if (!preliminary.allowed && preliminary.denialType === "env_spoofing") {
+    emitBashDeniedAudit(command, preliminary, options.agentId);
+    return { approved: false, reason: preliminary.reason ?? "Command denied by Ravi policy." };
+  }
+
+  const dangerous = checkDangerousPatterns(command);
+  if (!dangerous.safe) {
+    return { approved: false, reason: dangerous.reason ?? "Command denied by Ravi policy." };
+  }
+
+  const parsed = parseBashCommand(command);
+  if (!parsed.success) {
+    return { approved: false, reason: parsed.error ?? "Failed to parse command for approval." };
+  }
+
+  let inherited = true;
+  const toolAuthorization = await authorizeRuntimeContext({
+    context: options.context,
+    permission: "use",
+    objectType: "tool",
+    objectId: "Bash",
+    eventData,
+  });
+  if (!toolAuthorization.allowed) {
+    return {
+      approved: false,
+      reason: toolAuthorization.reason ?? "Bash tool permission denied.",
+    };
+  }
+  inherited = inherited && toolAuthorization.inherited;
+
+  if (!canWithCapabilityContext(options.context, "execute", "executable", "*")) {
+    for (const executable of parsed.executables) {
+      if (UNCONDITIONAL_BLOCKS.has(executable)) {
+        return { approved: false, reason: `${executable} is blocked by Ravi command policy.` };
+      }
+      if (CODEX_BUILTIN_EXECUTABLES.has(executable)) {
+        continue;
+      }
+
+      const executableAuthorization = await authorizeRuntimeContext({
+        context: options.context,
+        permission: "execute",
+        objectType: "executable",
+        objectId: executable,
+        eventData: {
+          ...eventData,
+          codexExecutable: executable,
+        },
+      });
+      if (!executableAuthorization.allowed) {
+        return {
+          approved: false,
+          reason: executableAuthorization.reason ?? `Executable permission denied: ${executable}`,
+        };
+      }
+      inherited = inherited && executableAuthorization.inherited;
+    }
+  }
+
+  const afterExecutableApproval = evaluateBashPermission(command, buildBashContext());
+  if (!afterExecutableApproval.allowed && afterExecutableApproval.denialType === "session_scope") {
+    const target = extractRaviSessionTarget(command);
+    if (target) {
+      const sessionAuthorization = await authorizeRuntimeContext({
+        context: options.context,
+        permission: "access",
+        objectType: "session",
+        objectId: target,
+        eventData: {
+          ...eventData,
+          codexSessionTarget: target,
+        },
+      });
+      if (!sessionAuthorization.allowed) {
+        emitBashDeniedAudit(command, afterExecutableApproval, options.agentId);
+        return {
+          approved: false,
+          reason: sessionAuthorization.reason ?? afterExecutableApproval.reason ?? `Session access denied: ${target}`,
+        };
+      }
+      inherited = inherited && sessionAuthorization.inherited;
+    }
+  }
+
+  const finalDecision = evaluateBashPermission(command, buildBashContext());
+  if (!finalDecision.allowed) {
+    emitBashDeniedAudit(command, finalDecision, options.agentId);
+    return { approved: false, reason: finalDecision.reason ?? "Command denied by Ravi policy." };
+  }
+
+  return { approved: true, inherited, updatedInput: request.input };
+}
+
+async function authorizeCodexFileChange(
+  options: { context: ContextRecord },
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const toolName = request.toolName ?? "Edit";
+  const result = await authorizeRuntimeContext({
+    context: options.context,
+    permission: "use",
+    objectType: "tool",
+    objectId: toolName,
+    eventData: buildRuntimeApprovalEventData(request),
+  });
+
+  if (!result.allowed) {
+    return { approved: false, reason: result.reason ?? `${toolName} permission denied.` };
+  }
+
+  return {
+    approved: true,
+    inherited: result.inherited,
+    updatedInput: request.input,
+  };
+}
+
+async function authorizeCodexPermissionRequest(
+  options: { context: ContextRecord },
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const capabilities = extractRuntimeApprovalCapabilities(request);
+  if (capabilities.length === 0) {
+    return {
+      approved: false,
+      reason: "Unsupported Codex permission approval request shape.",
+      permissions: {},
+    };
+  }
+
+  let inherited = true;
+  const eventData = buildRuntimeApprovalEventData(request);
+  for (const capability of capabilities) {
+    const result = await authorizeRuntimeContext({
+      context: options.context,
+      permission: capability.permission,
+      objectType: capability.objectType,
+      objectId: capability.objectId,
+      eventData,
+    });
+    if (!result.allowed) {
+      return {
+        approved: false,
+        reason: result.reason ?? `${capability.permission} ${capability.objectType}:${capability.objectId} denied.`,
+        permissions: {},
+      };
+    }
+    inherited = inherited && result.inherited;
+  }
+
+  return {
+    approved: true,
+    inherited,
+    permissions: buildGrantedPermissionsPayload(request.input?.permissions),
+  };
+}
+
+async function requestCodexUserInput(
+  options: {
+    agentId: string;
+    sessionName: string;
+    resolvedSource?: ApprovalTarget;
+    approvalSource?: ApprovalTarget;
+  },
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const questions = Array.isArray(request.input?.questions)
+    ? (request.input.questions as RuntimeApprovalQuestion[])
+    : [];
+  const targetSource = options.resolvedSource ?? options.approvalSource;
+  if (!targetSource || questions.length === 0) {
+    return { approved: true, answers: {}, inherited: true };
+  }
+
+  const eventData = buildRuntimeApprovalEventData(request);
+  const isDelegated = !options.resolvedSource && !!options.approvalSource;
+  nats
+    .emit("ravi.approval.request", {
+      type: "question",
+      sessionName: options.sessionName,
+      agentId: options.agentId,
+      delegated: isDelegated,
+      channel: targetSource.channel,
+      chatId: targetSource.chatId,
+      questionCount: questions.length,
+      timestamp: Date.now(),
+      ...eventData,
+    })
+    .catch(() => {});
+
+  const answers: Record<string, string> = {};
+
+  for (const question of questions) {
+    const optionLabels = question.options?.map((option) => option.label).filter(Boolean) ?? [];
+    if (optionLabels.length === 0) {
+      continue;
+    }
+
+    const hasDescriptions = question.options?.some((option) => option.description) ?? false;
+    let pollName = isDelegated ? `[${options.agentId}] ${question.question}` : question.question;
+    if (hasDescriptions) {
+      const descLines = (question.options ?? [])
+        .map((option) => (option.description ? `• ${option.label} — ${option.description}` : `• ${option.label}`))
+        .join("\n");
+      pollName += "\n\n" + descLines;
+    }
+    pollName += "\n(responda a mensagem para outro)";
+
+    const result = await requestPollAnswer(targetSource, pollName, optionLabels, {
+      selectableCount: question.multiSelect ? optionLabels.length : 1,
+    });
+
+    const answerKey = question.id ?? question.question;
+    answers[answerKey] = "selectedLabels" in result ? result.selectedLabels.join(", ") : result.freeText;
+  }
+
+  nats
+    .emit("ravi.approval.response", {
+      type: "question",
+      sessionName: options.sessionName,
+      agentId: options.agentId,
+      approved: true,
+      answers,
+      timestamp: Date.now(),
+      ...eventData,
+    })
+    .catch(() => {});
+
+  return { approved: true, answers };
+}
+
+function buildRuntimeApprovalEventData(request: RuntimeApprovalRequest): Record<string, unknown> {
+  return {
+    codexApproval: {
+      kind: request.kind,
+      method: request.method,
+      toolName: request.toolName,
+      input: truncateOutput(request.input),
+    },
+    runtimeMetadata: request.metadata,
+  };
+}
+
+function extractRuntimeApprovalCapabilities(
+  request: RuntimeApprovalRequest,
+): Array<{ permission: string; objectType: string; objectId: string }> {
+  const permissions = request.input?.permissions ?? request.rawRequest;
+  const candidates = collectRuntimeApprovalCapabilityCandidates(permissions);
+  return candidates.flatMap((candidate) => parseRuntimeApprovalCapability(candidate));
+}
+
+function collectRuntimeApprovalCapabilityCandidates(value: unknown): unknown[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (typeof value !== "object") {
+    return [];
+  }
+
+  const direct = parseRuntimeApprovalCapability(value);
+  if (direct.length > 0) {
+    return [value];
+  }
+
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
+    if (entry === true || entry === null || entry === undefined) {
+      return [key];
+    }
+    if (entry === false) {
+      return [];
+    }
+    return [entry, key];
+  });
+}
+
+function parseRuntimeApprovalCapability(
+  candidate: unknown,
+): Array<{ permission: string; objectType: string; objectId: string }> {
+  if (typeof candidate === "string") {
+    const match = candidate.match(/^([a-z_]+)(?:\s+|:)([a-z_]+):(.+)$/i);
+    if (!match) {
+      return [];
+    }
+    return [{ permission: match[1], objectType: match[2], objectId: match[3] }];
+  }
+
+  const record = candidate && typeof candidate === "object" ? (candidate as Record<string, unknown>) : null;
+  if (!record) {
+    return [];
+  }
+
+  const permission = firstNonEmptyString(record.permission, record.action, record.verb);
+  const objectType = firstNonEmptyString(record.objectType, record.object_type, record.resourceType, record.type);
+  const objectId = firstNonEmptyString(record.objectId, record.object_id, record.resourceId, record.id, record.name);
+  if (permission && objectType && objectId) {
+    return [{ permission, objectType, objectId }];
+  }
+
+  const toolName = firstNonEmptyString(record.toolName, record.tool_name, record.tool);
+  if (toolName) {
+    return [{ permission: "use", objectType: "tool", objectId: toolName }];
+  }
+
+  return [];
+}
+
+function buildGrantedPermissionsPayload(value: unknown): Record<string, unknown> {
+  if (!value) {
+    return {};
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  const capabilities = collectRuntimeApprovalCapabilityCandidates(value).flatMap((candidate) =>
+    parseRuntimeApprovalCapability(candidate),
+  );
+  return Object.fromEntries(
+    capabilities.map((capability) => [
+      `${capability.permission}:${capability.objectType}:${capability.objectId}`,
+      true,
+    ]),
+  );
+}
+
+function extractRaviSessionTarget(command: string): string | null {
+  const match = command.match(
+    /(?:^|\s|&&|\|\||;)\s*(?:\S+=\S+\s+)*(?:\/\S+\/)?ravi\s+[\w-]+\s+[\w-]+\s+(?:(?:-\w+\s+\S+\s+)*)["']?([^"'\s]+)/,
+  );
+  return match?.[1] ?? null;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function resolveCanonicalRaviCliPath(): string | null {
@@ -485,6 +1101,13 @@ interface StreamingSession {
   agentMode?: string;
 }
 
+interface RuntimeControlNatsRequest {
+  sessionName?: string;
+  sessionKey?: string;
+  request?: RuntimeControlRequest;
+  replyTopic?: string;
+}
+
 /** User message format for the SDK streaming input */
 interface UserMessage {
   type: "user";
@@ -585,6 +1208,7 @@ export class RaviBot {
     this.subscribeToPrompts();
     this.subscribeToSessionAborts();
     this.subscribeToSessionModelChanges();
+    this.subscribeToRuntimeControls();
     this.subscribeToTaskEvents();
     this.startSubscriberHealthCheck();
     void this.recoverActiveTasksAfterRestart();
@@ -705,6 +1329,140 @@ export class RaviBot {
       } catch (err) {
         if (!this.running) break;
         log.warn("Session abort subscription error, reconnecting in 2s", { error: err });
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    }
+  }
+
+  private resolveStreamingControlSession(
+    sessionName?: string,
+    sessionKey?: string,
+  ): { name: string; session: StreamingSession } | null {
+    if (sessionName) {
+      const direct = this.streamingSessions.get(sessionName);
+      if (direct) {
+        return { name: sessionName, session: direct };
+      }
+    }
+
+    if (sessionKey) {
+      const direct = this.streamingSessions.get(sessionKey);
+      if (direct) {
+        return { name: sessionKey, session: direct };
+      }
+
+      const stored = getSession(sessionKey);
+      if (stored?.name) {
+        const named = this.streamingSessions.get(stored.name);
+        if (named) {
+          return { name: stored.name, session: named };
+        }
+      }
+    }
+
+    if (sessionName) {
+      const stored = getSessionByName(sessionName) ?? getSession(sessionName);
+      if (stored?.sessionKey) {
+        const byKey = this.streamingSessions.get(stored.sessionKey);
+        if (byKey) {
+          return { name: stored.name ?? stored.sessionKey, session: byKey };
+        }
+      }
+    }
+
+    if (sessionKey) {
+      for (const [name, session] of this.streamingSessions) {
+        const stored = getSessionByName(name);
+        if (stored?.sessionKey === sessionKey) {
+          return { name, session };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private async replyRuntimeControlError(replyTopic: string | undefined, error: string): Promise<void> {
+    if (!replyTopic) {
+      log.warn("Runtime control request failed without reply topic", { error });
+      return;
+    }
+    await safeEmit(replyTopic, { error });
+  }
+
+  private async handleRuntimeControlRequest(data: RuntimeControlNatsRequest): Promise<void> {
+    const { replyTopic, request } = data;
+    if (!request?.operation) {
+      await this.replyRuntimeControlError(replyTopic, "Runtime control request is missing an operation.");
+      return;
+    }
+
+    const resolved = this.resolveStreamingControlSession(data.sessionName, data.sessionKey);
+    if (!resolved) {
+      await this.replyRuntimeControlError(
+        replyTopic,
+        `No active runtime session found for ${data.sessionName ?? data.sessionKey ?? "(unknown)"}.`,
+      );
+      return;
+    }
+
+    if (!resolved.session.queryHandle.control) {
+      const result: RuntimeControlResult = {
+        ok: false,
+        operation: request.operation,
+        state: {
+          provider: resolved.session.queryHandle.provider,
+          activeTurn: resolved.session.turnActive,
+          supportedOperations: [],
+        },
+        error: `Runtime provider '${resolved.session.queryHandle.provider}' does not expose control operations.`,
+      };
+      if (replyTopic) {
+        await safeEmit(replyTopic, { result });
+      }
+      return;
+    }
+
+    const result = await resolved.session.queryHandle.control(request);
+    if (replyTopic) {
+      await safeEmit(replyTopic, { result });
+    }
+
+    await safeEmit(`ravi.session.${resolved.name}.runtime`, {
+      type: "runtime.control",
+      provider: resolved.session.queryHandle.provider,
+      operation: request.operation,
+      ok: result.ok,
+      error: result.error,
+      state: result.state,
+      timestamp: Date.now(),
+    }).catch((error) => {
+      log.warn("Failed to emit runtime control event", { sessionName: resolved.name, error });
+    });
+  }
+
+  /**
+   * Internal transparent controls for native runtime thread/turn semantics.
+   * User-facing session/task/project abstractions remain the primary surface.
+   */
+  private async subscribeToRuntimeControls(): Promise<void> {
+    while (this.running) {
+      try {
+        for await (const event of nats.subscribe("ravi.session.runtime.control")) {
+          if (!this.running) break;
+          try {
+            await this.handleRuntimeControlRequest(event.data as RuntimeControlNatsRequest);
+          } catch (error) {
+            const data = event.data as RuntimeControlNatsRequest;
+            await this.replyRuntimeControlError(
+              data?.replyTopic,
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }
+      } catch (err) {
+        if (!this.running) break;
+        log.warn("Runtime control subscription error, reconnecting in 2s", { error: err });
         await new Promise((r) => setTimeout(r, 2000));
       }
     }
@@ -1852,6 +2610,34 @@ export class RaviBot {
       );
       const runtimeEnv = buildRuntimeEnv(baseRuntimeEnv, raviEnv, providerBootstrap?.env, runtimeCapabilities);
 
+      const toolContext = {
+        contextId: runtimeContext.contextId,
+        context: runtimeContext,
+        sessionKey: dbSessionKey,
+        sessionName,
+        agentId: agent.id,
+        source: resolvedSource,
+      };
+
+      const approveRuntimeRequest = createRuntimeApprovalBridge({
+        context: runtimeContext,
+        agentId: agent.id,
+        sessionName,
+        resolvedSource,
+        approvalSource,
+      });
+      const dynamicTools =
+        runtimeProviderId === "codex" ? getRuntimeDynamicToolSpecsForContext(runtimeContext) : undefined;
+      const handleRuntimeToolCall =
+        runtimeProviderId === "codex"
+          ? createRuntimeDynamicToolBridge({
+              context: runtimeContext,
+              agentId: agent.id,
+              sessionName,
+              toolContext,
+            })
+          : undefined;
+
       // canUseTool — auto-approve all tools.
       // Note: with bypassPermissions, canUseTool is NOT called. We use PreToolUse hooks instead.
       const canUseTool = async (_toolName: string, input: Record<string, unknown>) => {
@@ -1910,6 +2696,9 @@ export class RaviBot {
         abortController,
         permissionOptions,
         canUseTool,
+        approveRuntimeRequest,
+        ...(dynamicTools ? { dynamicTools } : {}),
+        ...(handleRuntimeToolCall ? { handleRuntimeToolCall } : {}),
         env: runtimeEnv,
         ...(specServer ? { mcpServers: { spec: specServer } } : {}),
         systemPromptAppend,
@@ -1953,16 +2742,6 @@ export class RaviBot {
       }
       streamingSession.queryHandle = runtimeSession;
       streamingSession.starting = false;
-
-      // Build tool context for CLI tools
-      const toolContext = {
-        contextId: runtimeContext.contextId,
-        context: runtimeContext,
-        sessionKey: dbSessionKey,
-        sessionName,
-        agentId: agent.id,
-        source: resolvedSource,
-      };
 
       // Run the event loop in the background (don't await — it stays alive)
       runWithContext(toolContext, () =>
@@ -2172,17 +2951,18 @@ export class RaviBot {
       });
     };
 
-    const emitChunk = async (text: string) => {
+    const emitChunk = async (text: string, metadata?: RuntimeEventMetadata) => {
       await safeEmit(`ravi.session.${sessionName}.stream`, {
         chunk: text,
+        ...(metadata ? { metadata } : {}),
       });
     };
 
     let chunkEmitTail: Promise<void> = Promise.resolve();
-    const queueChunkEmit = (text: string) => {
+    const queueChunkEmit = (text: string, metadata?: RuntimeEventMetadata) => {
       chunkEmitTail = chunkEmitTail
         .catch(() => {})
-        .then(() => emitChunk(text))
+        .then(() => emitChunk(text, metadata))
         .catch((error) => {
           log.warn("Failed to emit stream chunk", { sessionName, error });
         });
@@ -2202,7 +2982,7 @@ export class RaviBot {
         });
 
         if (event.type === "text.delta") {
-          queueChunkEmit(event.text);
+          queueChunkEmit(event.text, event.metadata);
           continue;
         }
 
@@ -2253,6 +3033,7 @@ export class RaviBot {
             timestamp: new Date().toISOString(),
             sessionName,
             agentId: agent.id,
+            metadata: event.metadata,
           }).catch((err) => log.warn("Failed to emit tool start", { error: err }));
           continue;
         }
@@ -2323,6 +3104,7 @@ export class RaviBot {
             timestamp: new Date().toISOString(),
             sessionName,
             agentId: agent.id,
+            metadata: event.metadata,
           }).catch((err) => log.warn("Failed to emit tool end", { error: err }));
 
           clearActiveToolState();

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -78,25 +78,29 @@ import { resolveTaskRuntimeOptions } from "./tasks/runtime-options.js";
 import { emitTaskEvent } from "./tasks/service.js";
 import type { TaskRuntimeOptions, TaskRuntimeResolution } from "./tasks/types.js";
 import {
+  DEFAULT_RUNTIME_PROVIDER_ID,
   assertRuntimeCompatibility,
   createRuntimeContext,
   createRuntimeProvider,
   snapshotAgentCapabilities,
-  type RuntimeApprovalHandler,
-  type RuntimeApprovalQuestion,
-  type RuntimeApprovalRequest,
   type RuntimeApprovalResult,
+  type RuntimeCapabilities,
+  type RuntimeCapabilityAuthorizationResult,
+  type RuntimeCommandAuthorizationRequest,
   type RuntimeControlRequest,
   type RuntimeControlResult,
   type RuntimeDynamicToolCallContentItem,
-  type RuntimeDynamicToolCallHandler,
+  type RuntimeDynamicToolExecutionOptions,
   type RuntimeDynamicToolCallRequest,
   type RuntimeDynamicToolCallResult,
   type RuntimeDynamicToolSpec,
   type RuntimeEventMetadata,
+  type RuntimeHostServices,
   type RuntimeProviderId,
   type RuntimeSessionHandle,
   type RuntimeStartRequest,
+  type RuntimeToolUseAuthorizationRequest,
+  type RuntimeUserInputRequest,
   type RuntimeToolAccessMode,
 } from "./runtime/index.js";
 
@@ -267,8 +271,8 @@ function resolveStoredRuntimeProvider(session: SessionEntry): RuntimeProviderId 
   }
 
   if (session.providerSessionId || session.sdkSessionId) {
-    // Legacy sessions predate runtime_provider and can only belong to Claude.
-    return "claude";
+    // Legacy sessions predate runtime_provider and belong to the default runtime.
+    return DEFAULT_RUNTIME_PROVIDER_ID;
   }
 
   return undefined;
@@ -285,17 +289,15 @@ function hasUnrestrictedToolSurface(agentId: string): boolean {
   return agentCan(agentId, "admin", "system", "*") || agentCan(agentId, "use", "tool", "*");
 }
 
-function getRuntimeToolAccessMode(providerId: RuntimeProviderId, agentId: string): RuntimeToolAccessMode {
-  if (providerId === "codex") {
-    // Codex is currently Bash-governed only. Require unrestricted non-Bash tool access
-    // and let executable restrictions flow through the native Bash hook.
+function getRuntimeToolAccessMode(capabilities: RuntimeCapabilities, agentId: string): RuntimeToolAccessMode {
+  if (capabilities.toolAccessRequirement === "tool_surface") {
     return hasUnrestrictedToolSurface(agentId) ? "unrestricted" : "restricted";
   }
 
   return hasUnrestrictedToolExecution(agentId) ? "unrestricted" : "restricted";
 }
 
-const CODEX_BUILTIN_EXECUTABLES = new Set(["ravi"]);
+const RUNTIME_BUILTIN_EXECUTABLES = new Set(["ravi"]);
 let cachedRuntimeDynamicTools: ExportedTool[] | null = null;
 let cachedRuntimeDynamicToolSpecs: RuntimeDynamicToolSpec[] | null = null;
 
@@ -351,62 +353,78 @@ function canAdvertiseRuntimeDynamicTool(context: ContextRecord, tool: ExportedTo
   }
 }
 
-function createRuntimeApprovalBridge(options: {
+function createRuntimeHostServices(options: {
   context: ContextRecord;
   agentId: string;
   sessionName: string;
   resolvedSource?: ApprovalTarget;
   approvalSource?: ApprovalTarget;
-}): RuntimeApprovalHandler {
-  return async (request) => {
-    switch (request.kind) {
-      case "command_execution":
-        return authorizeCodexCommandExecution(options, request);
-      case "file_change":
-        return authorizeCodexFileChange(options, request);
-      case "permission":
-        return authorizeCodexPermissionRequest(options, request);
-      case "user_input":
-        return requestCodexUserInput(options, request);
-    }
+  toolContext: Record<string, unknown>;
+}): RuntimeHostServices {
+  return {
+    authorizeCapability: (request) => authorizeRuntimeCapability(options.context, request),
+    authorizeCommandExecution: (request) => authorizeRuntimeCommandExecution(options, request),
+    authorizeToolUse: (request) => authorizeRuntimeToolUse(options, request),
+    requestUserInput: (request) => requestRuntimeUserInput(options, request),
+    listDynamicTools: () => getRuntimeDynamicToolSpecsForContext(options.context),
+    executeDynamicTool: (request, executionOptions) => executeRuntimeDynamicTool(options, request, executionOptions),
   };
 }
 
-function createRuntimeDynamicToolBridge(options: {
-  context: ContextRecord;
-  agentId: string;
-  sessionName: string;
-  toolContext: Record<string, unknown>;
-}): RuntimeDynamicToolCallHandler {
-  return async (request) => {
-    const tool = getRuntimeDynamicToolDefinitions().find((candidate) => candidate.name === request.toolName);
-    if (!tool) {
-      return {
-        success: false,
-        contentItems: [{ type: "inputText", text: `Unknown Ravi dynamic tool: ${request.toolName}` }],
-      };
-    }
+async function authorizeRuntimeCapability(
+  context: ContextRecord,
+  request: {
+    permission: string;
+    objectType: string;
+    objectId: string;
+    eventData?: Record<string, unknown>;
+  },
+): Promise<RuntimeCapabilityAuthorizationResult> {
+  return authorizeRuntimeContext({
+    context,
+    permission: request.permission,
+    objectType: request.objectType,
+    objectId: request.objectId,
+    eventData: request.eventData,
+  });
+}
 
-    const authorization = await authorizeRuntimeDynamicToolCall(options, tool, request);
-    if (!authorization.allowed) {
-      return {
-        success: false,
-        contentItems: [{ type: "inputText", text: authorization.reason ?? `${request.toolName} permission denied.` }],
-      };
-    }
+async function executeRuntimeDynamicTool(
+  options: {
+    context: ContextRecord;
+    agentId: string;
+    sessionName: string;
+    toolContext: Record<string, unknown>;
+  },
+  request: RuntimeDynamicToolCallRequest,
+  executionOptions?: RuntimeDynamicToolExecutionOptions,
+): Promise<RuntimeDynamicToolCallResult> {
+  const tool = getRuntimeDynamicToolDefinitions().find((candidate) => candidate.name === request.toolName);
+  if (!tool) {
+    return {
+      success: false,
+      contentItems: [{ type: "inputText", text: `Unknown Ravi dynamic tool: ${request.toolName}` }],
+    };
+  }
 
-    const args = normalizeDynamicToolArguments(request.arguments);
-    const result = await runWithContext(options.toolContext, () => tool.handler(args));
-    return buildRuntimeDynamicToolResult(result);
-  };
+  const authorization = await authorizeRuntimeDynamicToolCall(options, tool, executionOptions?.eventData);
+  if (!authorization.allowed) {
+    return {
+      success: false,
+      contentItems: [{ type: "inputText", text: authorization.reason ?? `${request.toolName} permission denied.` }],
+    };
+  }
+
+  const args = normalizeDynamicToolArguments(request.arguments);
+  const result = await runWithContext(options.toolContext, () => tool.handler(args));
+  return buildRuntimeDynamicToolResult(result);
 }
 
 async function authorizeRuntimeDynamicToolCall(
   options: { context: ContextRecord; agentId: string; sessionName: string },
   tool: ExportedTool,
-  request: RuntimeDynamicToolCallRequest,
+  eventData: Record<string, unknown> | undefined,
 ): Promise<{ allowed: boolean; reason?: string }> {
-  const eventData = buildRuntimeDynamicToolEventData(request);
   const toolAuthorization = await authorizeRuntimeContext({
     context: options.context,
     permission: "use",
@@ -424,7 +442,7 @@ async function authorizeRuntimeDynamicToolCall(
 async function authorizeRuntimeDynamicToolScope(
   options: { context: ContextRecord },
   tool: ExportedTool,
-  eventData: Record<string, unknown>,
+  eventData?: Record<string, unknown>,
 ): Promise<{ allowed: boolean; reason?: string }> {
   const scope = tool.metadata.scope ?? "admin";
   if (scope === "open" || scope === "resource") {
@@ -500,32 +518,20 @@ function toDynamicToolContentItems(content: ToolResult["content"]): RuntimeDynam
   return items.length > 0 ? items : [{ type: "inputText", text: "(no output)" }];
 }
 
-function buildRuntimeDynamicToolEventData(request: RuntimeDynamicToolCallRequest): Record<string, unknown> {
-  return {
-    codexToolCall: {
-      method: "item/tool/call",
-      toolName: request.toolName,
-      callId: request.callId,
-      arguments: truncateOutput(request.arguments),
-    },
-    runtimeMetadata: request.metadata,
-  };
-}
-
-async function authorizeCodexCommandExecution(
+async function authorizeRuntimeCommandExecution(
   options: {
     context: ContextRecord;
     agentId: string;
     sessionName: string;
   },
-  request: RuntimeApprovalRequest,
+  request: RuntimeCommandAuthorizationRequest,
 ): Promise<RuntimeApprovalResult> {
-  const command = typeof request.input?.command === "string" ? request.input.command : "";
+  const command = request.command;
   if (!command.trim()) {
-    return { approved: false, reason: "Codex command approval request did not include a command." };
+    return { approved: false, reason: "Runtime command approval request did not include a command." };
   }
 
-  const eventData = buildRuntimeApprovalEventData(request);
+  const eventData = request.eventData;
   const buildBashContext = () => ({
     agentId: options.agentId,
     ...(options.context.sessionKey ? { sessionKey: options.context.sessionKey } : {}),
@@ -570,7 +576,7 @@ async function authorizeCodexCommandExecution(
       if (UNCONDITIONAL_BLOCKS.has(executable)) {
         return { approved: false, reason: `${executable} is blocked by Ravi command policy.` };
       }
-      if (CODEX_BUILTIN_EXECUTABLES.has(executable)) {
+      if (RUNTIME_BUILTIN_EXECUTABLES.has(executable)) {
         continue;
       }
 
@@ -581,7 +587,7 @@ async function authorizeCodexCommandExecution(
         objectId: executable,
         eventData: {
           ...eventData,
-          codexExecutable: executable,
+          runtimeExecutable: executable,
         },
       });
       if (!executableAuthorization.allowed) {
@@ -605,7 +611,7 @@ async function authorizeCodexCommandExecution(
         objectId: target,
         eventData: {
           ...eventData,
-          codexSessionTarget: target,
+          runtimeSessionTarget: target,
         },
       });
       if (!sessionAuthorization.allowed) {
@@ -628,21 +634,20 @@ async function authorizeCodexCommandExecution(
   return { approved: true, inherited, updatedInput: request.input };
 }
 
-async function authorizeCodexFileChange(
+async function authorizeRuntimeToolUse(
   options: { context: ContextRecord },
-  request: RuntimeApprovalRequest,
+  request: RuntimeToolUseAuthorizationRequest,
 ): Promise<RuntimeApprovalResult> {
-  const toolName = request.toolName ?? "Edit";
   const result = await authorizeRuntimeContext({
     context: options.context,
     permission: "use",
     objectType: "tool",
-    objectId: toolName,
-    eventData: buildRuntimeApprovalEventData(request),
+    objectId: request.toolName,
+    eventData: request.eventData,
   });
 
   if (!result.allowed) {
-    return { approved: false, reason: result.reason ?? `${toolName} permission denied.` };
+    return { approved: false, reason: result.reason ?? `${request.toolName} permission denied.` };
   }
 
   return {
@@ -652,64 +657,22 @@ async function authorizeCodexFileChange(
   };
 }
 
-async function authorizeCodexPermissionRequest(
-  options: { context: ContextRecord },
-  request: RuntimeApprovalRequest,
-): Promise<RuntimeApprovalResult> {
-  const capabilities = extractRuntimeApprovalCapabilities(request);
-  if (capabilities.length === 0) {
-    return {
-      approved: false,
-      reason: "Unsupported Codex permission approval request shape.",
-      permissions: {},
-    };
-  }
-
-  let inherited = true;
-  const eventData = buildRuntimeApprovalEventData(request);
-  for (const capability of capabilities) {
-    const result = await authorizeRuntimeContext({
-      context: options.context,
-      permission: capability.permission,
-      objectType: capability.objectType,
-      objectId: capability.objectId,
-      eventData,
-    });
-    if (!result.allowed) {
-      return {
-        approved: false,
-        reason: result.reason ?? `${capability.permission} ${capability.objectType}:${capability.objectId} denied.`,
-        permissions: {},
-      };
-    }
-    inherited = inherited && result.inherited;
-  }
-
-  return {
-    approved: true,
-    inherited,
-    permissions: buildGrantedPermissionsPayload(request.input?.permissions),
-  };
-}
-
-async function requestCodexUserInput(
+async function requestRuntimeUserInput(
   options: {
     agentId: string;
     sessionName: string;
     resolvedSource?: ApprovalTarget;
     approvalSource?: ApprovalTarget;
   },
-  request: RuntimeApprovalRequest,
+  request: RuntimeUserInputRequest,
 ): Promise<RuntimeApprovalResult> {
-  const questions = Array.isArray(request.input?.questions)
-    ? (request.input.questions as RuntimeApprovalQuestion[])
-    : [];
+  const questions = request.questions;
   const targetSource = options.resolvedSource ?? options.approvalSource;
   if (!targetSource || questions.length === 0) {
     return { approved: true, answers: {}, inherited: true };
   }
 
-  const eventData = buildRuntimeApprovalEventData(request);
+  const eventData = request.eventData;
   const isDelegated = !options.resolvedSource && !!options.approvalSource;
   nats
     .emit("ravi.approval.request", {
@@ -766,121 +729,11 @@ async function requestCodexUserInput(
   return { approved: true, answers };
 }
 
-function buildRuntimeApprovalEventData(request: RuntimeApprovalRequest): Record<string, unknown> {
-  return {
-    codexApproval: {
-      kind: request.kind,
-      method: request.method,
-      toolName: request.toolName,
-      input: truncateOutput(request.input),
-    },
-    runtimeMetadata: request.metadata,
-  };
-}
-
-function extractRuntimeApprovalCapabilities(
-  request: RuntimeApprovalRequest,
-): Array<{ permission: string; objectType: string; objectId: string }> {
-  const permissions = request.input?.permissions ?? request.rawRequest;
-  const candidates = collectRuntimeApprovalCapabilityCandidates(permissions);
-  return candidates.flatMap((candidate) => parseRuntimeApprovalCapability(candidate));
-}
-
-function collectRuntimeApprovalCapabilityCandidates(value: unknown): unknown[] {
-  if (!value) {
-    return [];
-  }
-  if (Array.isArray(value)) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return [value];
-  }
-  if (typeof value !== "object") {
-    return [];
-  }
-
-  const direct = parseRuntimeApprovalCapability(value);
-  if (direct.length > 0) {
-    return [value];
-  }
-
-  return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
-    if (entry === true || entry === null || entry === undefined) {
-      return [key];
-    }
-    if (entry === false) {
-      return [];
-    }
-    return [entry, key];
-  });
-}
-
-function parseRuntimeApprovalCapability(
-  candidate: unknown,
-): Array<{ permission: string; objectType: string; objectId: string }> {
-  if (typeof candidate === "string") {
-    const match = candidate.match(/^([a-z_]+)(?:\s+|:)([a-z_]+):(.+)$/i);
-    if (!match) {
-      return [];
-    }
-    return [{ permission: match[1], objectType: match[2], objectId: match[3] }];
-  }
-
-  const record = candidate && typeof candidate === "object" ? (candidate as Record<string, unknown>) : null;
-  if (!record) {
-    return [];
-  }
-
-  const permission = firstNonEmptyString(record.permission, record.action, record.verb);
-  const objectType = firstNonEmptyString(record.objectType, record.object_type, record.resourceType, record.type);
-  const objectId = firstNonEmptyString(record.objectId, record.object_id, record.resourceId, record.id, record.name);
-  if (permission && objectType && objectId) {
-    return [{ permission, objectType, objectId }];
-  }
-
-  const toolName = firstNonEmptyString(record.toolName, record.tool_name, record.tool);
-  if (toolName) {
-    return [{ permission: "use", objectType: "tool", objectId: toolName }];
-  }
-
-  return [];
-}
-
-function buildGrantedPermissionsPayload(value: unknown): Record<string, unknown> {
-  if (!value) {
-    return {};
-  }
-
-  if (typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-
-  const capabilities = collectRuntimeApprovalCapabilityCandidates(value).flatMap((candidate) =>
-    parseRuntimeApprovalCapability(candidate),
-  );
-  return Object.fromEntries(
-    capabilities.map((capability) => [
-      `${capability.permission}:${capability.objectType}:${capability.objectId}`,
-      true,
-    ]),
-  );
-}
-
 function extractRaviSessionTarget(command: string): string | null {
   const match = command.match(
     /(?:^|\s|&&|\|\||;)\s*(?:\S+=\S+\s+)*(?:\/\S+\/)?ravi\s+[\w-]+\s+[\w-]+\s+(?:(?:-\w+\s+\S+\s+)*)["']?([^"'\s]+)/,
   );
   return match?.[1] ?? null;
-}
-
-function firstNonEmptyString(...values: unknown[]): string | undefined {
-  for (const value of values) {
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
-  }
-  return undefined;
 }
 
 function resolveCanonicalRaviCliPath(): string | null {
@@ -1965,7 +1818,7 @@ export class RaviBot {
     const sessionEntry = getSessionByName(sessionName);
     const agentId = (prompt as any)._agentId ?? sessionEntry?.agentId ?? routerConfig.defaultAgent;
     const agent = routerConfig.agents[agentId] ?? routerConfig.agents[routerConfig.defaultAgent];
-    const requestedProvider: RuntimeProviderId = agent?.provider ?? "claude";
+    const requestedProvider: RuntimeProviderId = agent?.provider ?? DEFAULT_RUNTIME_PROVIDER_ID;
     const existing = this.streamingSessions.get(sessionName);
 
     if (existing && !existing.done) {
@@ -2137,7 +1990,7 @@ export class RaviBot {
     }
 
     const agentCwd = expandHome(agent.cwd);
-    const runtimeProviderId: RuntimeProviderId = agent.provider ?? "claude";
+    const runtimeProviderId: RuntimeProviderId = agent.provider ?? DEFAULT_RUNTIME_PROVIDER_ID;
     const runtimeProvider = createRuntimeProvider(runtimeProviderId);
     const runtimeCapabilities = runtimeProvider.getCapabilities();
 
@@ -2220,9 +2073,9 @@ export class RaviBot {
       agentMode: agent.mode,
     });
 
-    // Build hooks (SDK expects HookCallbackMatcher[] per event)
+    // Build provider-specific host hooks only for runtimes that consume this hook protocol.
     const hooks: Record<string, Array<{ matcher?: string; hooks: Array<(...args: any[]) => any> }>> = {};
-    if (runtimeCapabilities.supportsToolHooks) {
+    if (runtimeCapabilities.supportsHostSessionHooks) {
       const hookOpts = { getAgentId: () => agent.id };
       hooks.PreToolUse = [
         createToolPermissionHook(hookOpts), // SDK tools (dynamic REBAC)
@@ -2520,7 +2373,7 @@ export class RaviBot {
       assertRuntimeCompatibility(runtimeProvider, {
         requiresMcpServers: !!agent.specMode,
         requiresRemoteSpawn: !!agent.remote,
-        toolAccessMode: getRuntimeToolAccessMode(runtimeProviderId, agent.id),
+        toolAccessMode: getRuntimeToolAccessMode(runtimeCapabilities, agent.id),
       });
 
       // Create spec mode MCP server for this session (only if agent has specMode enabled)
@@ -2600,16 +2453,6 @@ export class RaviBot {
       }
       Object.assign(raviEnv, buildTaskRuntimeEnv(sessionName, sessionCwd, prompt.taskBarrierTaskId));
 
-      const providerBootstrap = await runtimeProvider.prepareSession?.({
-        agentId: agent.id,
-        cwd: sessionCwd,
-        ...(discoveredPlugins.length > 0 ? { plugins: discoveredPlugins } : {}),
-      });
-      const baseRuntimeEnv = Object.fromEntries(
-        Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
-      );
-      const runtimeEnv = buildRuntimeEnv(baseRuntimeEnv, raviEnv, providerBootstrap?.env, runtimeCapabilities);
-
       const toolContext = {
         contextId: runtimeContext.contextId,
         context: runtimeContext,
@@ -2618,25 +2461,24 @@ export class RaviBot {
         agentId: agent.id,
         source: resolvedSource,
       };
-
-      const approveRuntimeRequest = createRuntimeApprovalBridge({
+      const hostServices = createRuntimeHostServices({
         context: runtimeContext,
         agentId: agent.id,
         sessionName,
         resolvedSource,
         approvalSource,
+        toolContext,
       });
-      const dynamicTools =
-        runtimeProviderId === "codex" ? getRuntimeDynamicToolSpecsForContext(runtimeContext) : undefined;
-      const handleRuntimeToolCall =
-        runtimeProviderId === "codex"
-          ? createRuntimeDynamicToolBridge({
-              context: runtimeContext,
-              agentId: agent.id,
-              sessionName,
-              toolContext,
-            })
-          : undefined;
+      const providerBootstrap = await runtimeProvider.prepareSession?.({
+        agentId: agent.id,
+        cwd: sessionCwd,
+        ...(discoveredPlugins.length > 0 ? { plugins: discoveredPlugins } : {}),
+        hostServices,
+      });
+      const baseRuntimeEnv = Object.fromEntries(
+        Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+      );
+      const runtimeEnv = buildRuntimeEnv(baseRuntimeEnv, raviEnv, providerBootstrap?.env, runtimeCapabilities);
 
       // canUseTool — auto-approve all tools.
       // Note: with bypassPermissions, canUseTool is NOT called. We use PreToolUse hooks instead.
@@ -2696,9 +2538,7 @@ export class RaviBot {
         abortController,
         permissionOptions,
         canUseTool,
-        approveRuntimeRequest,
-        ...(dynamicTools ? { dynamicTools } : {}),
-        ...(handleRuntimeToolCall ? { handleRuntimeToolCall } : {}),
+        ...(providerBootstrap?.startRequest ?? {}),
         env: runtimeEnv,
         ...(specServer ? { mcpServers: { spec: specServer } } : {}),
         systemPromptAppend,
@@ -2745,7 +2585,16 @@ export class RaviBot {
 
       // Run the event loop in the background (don't await — it stays alive)
       runWithContext(toolContext, () =>
-        this.runEventLoop(runId, sessionName, session, agent, streamingSession, runtimeSession),
+        this.runEventLoop(
+          runId,
+          sessionName,
+          session,
+          agent,
+          streamingSession,
+          runtimeSession,
+          runtimeCapabilities,
+          model,
+        ),
       ).catch((err) => {
         const isAbort = err instanceof Error && /abort/i.test(err.message);
         if (isAbort) {
@@ -2877,6 +2726,8 @@ export class RaviBot {
     agent: AgentConfig,
     streaming: StreamingSession,
     runtimeSession: RuntimeSessionHandle,
+    runtimeCapabilities: RuntimeCapabilities,
+    model: string,
   ): Promise<void> {
     // Timeout watchdog
     const SESSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes (longer for streaming)
@@ -2895,7 +2746,7 @@ export class RaviBot {
       }
     }, 30000);
 
-    let sdkEventCount = 0;
+    let providerRawEventCount = 0;
     let responseText = "";
     const clearActiveToolState = () => {
       streaming.toolRunning = false;
@@ -2911,8 +2762,9 @@ export class RaviBot {
       }
     };
 
-    const emitSdkEvent = async (event: Record<string, unknown>) => {
-      if (runtimeSession.provider !== "claude") {
+    const emitLegacyProviderEvent = async (event: Record<string, unknown>) => {
+      const legacyEventTopicSuffix = runtimeCapabilities.legacyEventTopicSuffix;
+      if (!legacyEventTopicSuffix) {
         return;
       }
 
@@ -2923,7 +2775,7 @@ export class RaviBot {
         (event.type === "result" || event.type === "silent") && streaming.currentSource
           ? { ...event, _source: streaming.currentSource }
           : event;
-      await safeEmit(`ravi.session.${sessionName}.claude`, augmented);
+      await safeEmit(`ravi.session.${sessionName}.${legacyEventTopicSuffix}`, augmented);
     };
 
     const emitRuntimeEvent = async (event: Record<string, unknown>) => {
@@ -2970,13 +2822,13 @@ export class RaviBot {
 
     try {
       for await (const event of runtimeSession.events) {
-        sdkEventCount++;
+        providerRawEventCount++;
         streaming.lastActivity = Date.now();
 
         const logLevel = event.type === "text.delta" ? "debug" : "info";
         log[logLevel]("Runtime event", {
           runId,
-          seq: sdkEventCount,
+          seq: providerRawEventCount,
           type: event.type,
           sessionName,
         });
@@ -2989,7 +2841,7 @@ export class RaviBot {
         await chunkEmitTail;
 
         if (event.type === "provider.raw" && event.rawEvent) {
-          await emitSdkEvent(event.rawEvent);
+          await emitLegacyProviderEvent(event.rawEvent);
         }
 
         await emitRuntimeEvent(
@@ -3058,7 +2910,7 @@ export class RaviBot {
             } else if (!messageText) {
               // After stripping SILENT_TOKEN, nothing left
               log.info("Silent response (stripped)", { sessionName });
-              await emitSdkEvent({ type: "silent" });
+              await emitLegacyProviderEvent({ type: "silent" });
               await emitRuntimeEvent({ type: "silent", provider: runtimeSession.provider });
             } else {
               responseText += messageText;
@@ -3067,11 +2919,11 @@ export class RaviBot {
               if (trimmed === "prompt is too long") {
                 log.warn("Prompt too long — will auto-reset session", { sessionName });
                 streaming._promptTooLong = true;
-                await emitSdkEvent({ type: "silent" });
+                await emitLegacyProviderEvent({ type: "silent" });
                 await emitRuntimeEvent({ type: "silent", provider: runtimeSession.provider });
               } else if (messageText.trim().endsWith(HEARTBEAT_OK)) {
                 log.info("Heartbeat OK", { sessionName });
-                await emitSdkEvent({ type: "silent" });
+                await emitLegacyProviderEvent({ type: "silent" });
                 await emitRuntimeEvent({ type: "silent", provider: runtimeSession.provider });
               } else if (
                 trimmed === "no response requested." ||
@@ -3080,7 +2932,7 @@ export class RaviBot {
                 trimmed === "no response needed"
               ) {
                 log.info("Silent response (no response requested)", { sessionName });
-                await emitSdkEvent({ type: "silent" });
+                await emitLegacyProviderEvent({ type: "silent" });
                 await emitRuntimeEvent({ type: "silent", provider: runtimeSession.provider });
               } else {
                 await emitResponse(messageText);
@@ -3167,15 +3019,8 @@ export class RaviBot {
           updateTokens(session.sessionKey, inputTokens, outputTokens);
 
           // Track cost event
-          const executionProvider =
-            event.execution?.provider ??
-            (runtimeSession.provider === "claude"
-              ? "anthropic"
-              : runtimeSession.provider === "codex"
-                ? "openai"
-                : null);
           const executionModel =
-            executionProvider === "anthropic" ? (event.execution?.model ?? streaming.currentModel) : null;
+            event.execution?.model ?? (runtimeSession.provider === DEFAULT_RUNTIME_PROVIDER_ID ? streaming.currentModel : null);
           const cost = executionModel
             ? calculateCost(executionModel, {
                 inputTokens,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -297,6 +297,19 @@ function getRuntimeToolAccessMode(capabilities: RuntimeCapabilities, agentId: st
   return hasUnrestrictedToolExecution(agentId) ? "unrestricted" : "restricted";
 }
 
+function resolveCostTrackingModel(
+  runtimeProvider: RuntimeProviderId,
+  executionModel: string | null | undefined,
+  configuredModel: string,
+): string | null {
+  const explicitModel = executionModel?.trim();
+  if (explicitModel) {
+    return explicitModel;
+  }
+
+  return runtimeProvider === DEFAULT_RUNTIME_PROVIDER_ID ? configuredModel : null;
+}
+
 const RUNTIME_BUILTIN_EXECUTABLES = new Set(["ravi"]);
 let cachedRuntimeDynamicTools: ExportedTool[] | null = null;
 let cachedRuntimeDynamicToolSpecs: RuntimeDynamicToolSpec[] | null = null;
@@ -668,8 +681,20 @@ async function requestRuntimeUserInput(
 ): Promise<RuntimeApprovalResult> {
   const questions = request.questions;
   const targetSource = options.resolvedSource ?? options.approvalSource;
-  if (!targetSource || questions.length === 0) {
-    return { approved: true, answers: {}, inherited: true };
+  if (!targetSource) {
+    return { approved: false, reason: "Runtime user input requires a target source." };
+  }
+  if (questions.length === 0) {
+    return { approved: false, reason: "Runtime user input request did not include questions." };
+  }
+  const unsupportedQuestion = questions.find(
+    (question) => (question.options?.map((option) => option.label).filter(Boolean) ?? []).length === 0,
+  );
+  if (unsupportedQuestion) {
+    return {
+      approved: false,
+      reason: `Runtime user input question requires selectable options: ${unsupportedQuestion.id ?? unsupportedQuestion.question}`,
+    };
   }
 
   const eventData = request.eventData;
@@ -692,9 +717,6 @@ async function requestRuntimeUserInput(
 
   for (const question of questions) {
     const optionLabels = question.options?.map((option) => option.label).filter(Boolean) ?? [];
-    if (optionLabels.length === 0) {
-      continue;
-    }
 
     const hasDescriptions = question.options?.some((option) => option.description) ?? false;
     let pollName = isDelegated ? `[${options.agentId}] ${question.question}` : question.question;
@@ -3019,8 +3041,7 @@ export class RaviBot {
           updateTokens(session.sessionKey, inputTokens, outputTokens);
 
           // Track cost event
-          const executionModel =
-            event.execution?.model ?? (runtimeSession.provider === DEFAULT_RUNTIME_PROVIDER_ID ? streaming.currentModel : null);
+          const executionModel = resolveCostTrackingModel(runtimeSession.provider, event.execution?.model, model);
           const cost = executionModel
             ? calculateCost(executionModel, {
                 inputTokens,

--- a/src/cli/commands/agents.test.ts
+++ b/src/cli/commands/agents.test.ts
@@ -103,6 +103,7 @@ mock.module("../../runtime/agent-instructions.js", () => ({
     agents: null,
     claude: null,
   }),
+  loadAgentWorkspaceInstructions: () => null,
 }));
 
 mock.module("../../router/router-db.js", () => ({

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -22,6 +22,7 @@ import {
 } from "../../router/config.js";
 import { DmScopeSchema } from "../../router/router-db.js";
 import { deleteSession, getSessionsByAgent, getMainSession, resolveSession } from "../../router/sessions.js";
+import { DEFAULT_RUNTIME_PROVIDER_ID } from "../../runtime/index.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
 import {
   ensureAgentInstructionFiles,
@@ -223,7 +224,7 @@ export class AgentsCommands {
     console.log(`  Name:          ${agent.name || "-"}`);
     console.log(`  CWD:           ${agent.cwd}`);
     console.log(`  Model:         ${agent.model || "-"}`);
-    console.log(`  Provider:      ${agent.provider || "claude"}`);
+    console.log(`  Provider:      ${agent.provider || DEFAULT_RUNTIME_PROVIDER_ID}`);
     console.log(`  DM Scope:      ${agent.dmScope || "-"}`);
     console.log(`  Mode:          ${agent.mode ?? "active"}`);
     console.log(`  Debounce:      ${agent.debounceMs ? `${agent.debounceMs}ms` : "disabled"}`);
@@ -250,17 +251,14 @@ export class AgentsCommands {
   create(
     @Arg("id", { description: "Agent ID" }) id: string,
     @Arg("cwd", { description: "Working directory" }) cwd: string,
-    @Option({ flags: "--provider <provider>", description: "Runtime provider: claude or codex" }) provider?: string,
+    @Option({ flags: "--provider <provider>", description: "Runtime provider id" }) provider?: string,
     @Option({
       flags: "--allow-runtime-mismatch",
       description: "Allow mutation even when the CLI bundle differs from the live daemon runtime",
     })
     allowRuntimeMismatch?: boolean,
   ) {
-    if (provider && provider !== "claude" && provider !== "codex") {
-      fail(`Invalid provider: ${provider}. Valid providers: claude, codex`);
-    }
-    const normalizedProvider = provider === "claude" || provider === "codex" ? provider : undefined;
+    const normalizedProvider = provider?.trim() || undefined;
     assertAgentMutationRuntime(allowRuntimeMismatch);
 
     try {
@@ -441,12 +439,7 @@ export class AgentsCommands {
       }
     }
 
-    // Validate provider values
-    if (key === "provider") {
-      if (value !== "claude" && value !== "codex") {
-        fail(`Invalid provider: ${value}. Valid providers: claude, codex`);
-      }
-    }
+    // Provider ids are intentionally open; runtime registration decides whether an id can execute.
 
     // Validate matrixAccount (will be validated in updateAgent, but give better error)
     if (key === "matrixAccount" && value !== "null" && value !== "") {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { inspectAgentInstructionFiles, type AgentInstructionState } from "../../runtime/agent-instructions.js";
-import { getRuntimeCompatibilityIssues } from "../../runtime/index.js";
+import { getRuntimeCompatibilityIssues, listRegisteredRuntimeProviderIds } from "../../runtime/index.js";
 import type { RuntimeCompatibilityIssue, RuntimeProviderId } from "../../runtime/types.js";
 import { dbListAgents, dbListInstances, getRaviDbPath } from "../../router/router-db.js";
 import { listTaskAutomations } from "../../tasks/index.js";
@@ -48,6 +48,7 @@ type DoctorDeps = {
       requiresRemoteSpawn?: boolean;
     },
   ) => RuntimeCompatibilityIssue[];
+  listRegisteredRuntimeProviderIds: typeof listRegisteredRuntimeProviderIds;
   exists: (path: string) => boolean;
   readFile: (path: string) => string;
   homeDir: () => string;
@@ -62,6 +63,7 @@ const DEFAULT_DEPS: DoctorDeps = {
   inspectAgentInstructionFiles,
   listTaskAutomations,
   getRuntimeCompatibilityIssues,
+  listRegisteredRuntimeProviderIds,
   exists: existsSync,
   readFile: (path: string) => readFileSync(path, "utf8"),
   homeDir: homedir,
@@ -620,7 +622,7 @@ function buildUnexpectedFailureCheck(id: string, title: string, error: unknown):
 }
 
 function buildProviderCompatibilityCheck(deps: DoctorDeps): DoctorCheck {
-  const providers: RuntimeProviderId[] = ["claude", "codex"];
+  const providers = deps.listRegisteredRuntimeProviderIds();
   const results = providers.map((provider) => ({
     provider,
     issues: deps.getRuntimeCompatibilityIssues(provider, { toolAccessMode: "restricted" }),

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -27,6 +27,7 @@ export * from "./permissions.js";
 export * from "./projects.js";
 export * from "./react.js";
 export * from "./service.js";
+export * from "./sessions-runtime.js";
 export * from "./sessions.js";
 export * from "./settings.js";
 export * from "./setup.js";

--- a/src/cli/commands/sessions-runtime.test.ts
+++ b/src/cli/commands/sessions-runtime.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+afterAll(() => mock.restore());
+
+type RequestReplyCall = {
+  topic: string;
+  data: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+let requestReplyCalls: RequestReplyCall[] = [];
+let requestReplyResult: Record<string, unknown> = {};
+let resolvedSession: Record<string, unknown> | null = null;
+let scopeEnforced = false;
+let canAccess = true;
+let canModify = true;
+
+mock.module("../decorators.js", () => ({
+  Group: () => () => {},
+  Command: () => () => {},
+  Arg: () => () => {},
+  Option: () => () => {},
+}));
+
+mock.module("../context.js", () => ({
+  fail: (message: string) => {
+    throw new Error(message);
+  },
+}));
+
+mock.module("../../utils/request-reply.js", () => ({
+  requestReply: mock(async (topic: string, data: Record<string, unknown>, timeoutMs?: number) => {
+    requestReplyCalls.push({ topic, data, timeoutMs });
+    return requestReplyResult;
+  }),
+}));
+
+mock.module("../../router/sessions.js", () => ({
+  resolveSession: () => resolvedSession,
+}));
+
+mock.module("../../permissions/scope.js", () => ({
+  getScopeContext: () => ({ agentId: "dev" }),
+  isScopeEnforced: () => scopeEnforced,
+  canAccessSession: () => canAccess,
+  canModifySession: () => canModify,
+}));
+
+const { SessionRuntimeCommands } = await import("./sessions-runtime.js");
+
+async function captureLogs<T>(run: () => Promise<T>): Promise<{ result: T; output: string }> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((arg) => String(arg)).join(" "));
+  };
+
+  try {
+    const result = await run();
+    return { result, output: lines.join("\n") };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+describe("SessionRuntimeCommands", () => {
+  beforeEach(() => {
+    requestReplyCalls = [];
+    requestReplyResult = {
+      result: {
+        ok: true,
+        operation: "turn.steer",
+        data: { accepted: true },
+        state: { provider: "codex", threadId: "thread_1", turnId: "turn_1", activeTurn: true },
+      },
+    };
+    resolvedSession = {
+      sessionKey: "agent:dev:main",
+      name: "dev-main",
+      agentId: "dev",
+      agentCwd: "/tmp/dev",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    scopeEnforced = false;
+    canAccess = true;
+    canModify = true;
+  });
+
+  it("maps steer to a runtime control request through NATS", async () => {
+    const commands = new SessionRuntimeCommands();
+
+    const { result, output } = await captureLogs(() =>
+      commands.steer("dev-main", "use this detail", "thread_1", "turn_1", "turn_1", true),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(output).toContain('"operation": "turn.steer"');
+    expect(requestReplyCalls).toHaveLength(1);
+    expect(requestReplyCalls[0]?.topic).toBe("ravi.session.runtime.control");
+    expect(requestReplyCalls[0]?.timeoutMs).toBe(15000);
+    expect(requestReplyCalls[0]?.data).toMatchObject({
+      sessionName: "dev-main",
+      sessionKey: "agent:dev:main",
+      request: {
+        operation: "turn.steer",
+        text: "use this detail",
+        threadId: "thread_1",
+        turnId: "turn_1",
+        expectedTurnId: "turn_1",
+      },
+    });
+  });
+
+  it("maps list filters to thread.list without requiring modify access", async () => {
+    scopeEnforced = true;
+    canAccess = true;
+    canModify = false;
+    requestReplyResult = {
+      result: {
+        ok: true,
+        operation: "thread.list",
+        data: { threads: [] },
+        state: { provider: "codex", supportedOperations: ["thread.list"] },
+      },
+    };
+    const commands = new SessionRuntimeCommands();
+
+    const { result } = await captureLogs(() =>
+      commands.list("dev-main", "5", "cursor_1", "/tmp/dev", "term", true, true),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(requestReplyCalls[0]?.data).toMatchObject({
+      request: {
+        operation: "thread.list",
+        limit: 5,
+        cursor: "cursor_1",
+        cwd: "/tmp/dev",
+        searchTerm: "term",
+        archived: true,
+      },
+    });
+  });
+
+  it("requires modify access for rollback", async () => {
+    scopeEnforced = true;
+    canAccess = true;
+    canModify = false;
+    const commands = new SessionRuntimeCommands();
+
+    await expect(commands.rollback("dev-main", "1")).rejects.toThrow("Session not found: dev-main");
+    expect(requestReplyCalls).toHaveLength(0);
+  });
+});

--- a/src/cli/commands/sessions-runtime.ts
+++ b/src/cli/commands/sessions-runtime.ts
@@ -1,0 +1,225 @@
+/**
+ * Transparent runtime controls for active sessions.
+ *
+ * This is intentionally nested under sessions: Ravi sessions remain the user-facing
+ * abstraction, while native runtime thread/turn ids are operational metadata.
+ */
+
+import "reflect-metadata";
+import { Group, Command, Arg, Option } from "../decorators.js";
+import { fail } from "../context.js";
+import { requestReply } from "../../utils/request-reply.js";
+import { resolveSession } from "../../router/sessions.js";
+import type { SessionEntry } from "../../router/types.js";
+import type { RuntimeControlRequest, RuntimeControlResult } from "../../runtime/types.js";
+import { getScopeContext, isScopeEnforced, canAccessSession, canModifySession } from "../../permissions/scope.js";
+
+const RUNTIME_CONTROL_TOPIC = "ravi.session.runtime.control";
+const RUNTIME_CONTROL_TIMEOUT_MS = 15_000;
+
+interface RuntimeControlReply {
+  result?: RuntimeControlResult;
+}
+
+function parsePositiveInt(value: string | number | undefined, fallback: number): number {
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    fail(`Expected a positive integer, got: ${value}`);
+  }
+  return parsed;
+}
+
+function ensureSessionAccess(session: SessionEntry, access: "read" | "modify", original: string): void {
+  const scopeCtx = getScopeContext();
+  if (!isScopeEnforced(scopeCtx)) {
+    return;
+  }
+
+  const sessionName = session.name ?? session.sessionKey;
+  const allowed =
+    access === "modify" ? canModifySession(scopeCtx, sessionName) : canAccessSession(scopeCtx, sessionName);
+
+  if (!allowed) {
+    fail(`Session not found: ${original}`);
+  }
+}
+
+function resolveControlSession(nameOrKey: string, access: "read" | "modify"): SessionEntry {
+  const session = resolveSession(nameOrKey);
+  if (!session) {
+    fail(`Session not found: ${nameOrKey}`);
+  }
+  ensureSessionAccess(session, access, nameOrKey);
+  return session;
+}
+
+function printRuntimeControlResult(
+  result: RuntimeControlResult,
+  asJson: boolean | undefined,
+  successMessage?: string,
+): RuntimeControlResult {
+  if (asJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+
+  if (!result.ok) {
+    fail(result.error ?? `Runtime control failed: ${result.operation}`);
+  }
+
+  if (successMessage) {
+    console.log(successMessage);
+  } else {
+    console.log(JSON.stringify(result.data ?? {}, null, 2));
+  }
+
+  return result;
+}
+
+async function requestRuntimeControl(
+  session: SessionEntry,
+  request: RuntimeControlRequest,
+): Promise<RuntimeControlResult> {
+  const reply = await requestReply<RuntimeControlReply>(
+    RUNTIME_CONTROL_TOPIC,
+    {
+      sessionName: session.name,
+      sessionKey: session.sessionKey,
+      request,
+    },
+    RUNTIME_CONTROL_TIMEOUT_MS,
+  );
+
+  if (!reply.result) {
+    fail("Runtime control reply did not include a result.");
+  }
+
+  return reply.result;
+}
+
+@Group({
+  name: "sessions.runtime",
+  description: "Transparent controls for active session runtimes",
+  scope: "admin",
+})
+export class SessionRuntimeCommands {
+  @Command({ name: "list", description: "List runtime threads through an active session" })
+  async list(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Option({ flags: "--limit <count>", description: "Maximum number of threads to return" }) limit?: string,
+    @Option({ flags: "--cursor <cursor>", description: "Pagination cursor" }) cursor?: string,
+    @Option({ flags: "--cwd <path>", description: "Filter by Codex working directory" }) cwd?: string,
+    @Option({ flags: "--search <term>", description: "Search runtime thread text" }) searchTerm?: string,
+    @Option({ flags: "--archived", description: "Only include archived threads" }) archived?: boolean,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "read");
+    const result = await requestRuntimeControl(session, {
+      operation: "thread.list",
+      limit: limit ? parsePositiveInt(limit, 20) : null,
+      cursor: cursor ?? null,
+      cwd: cwd ?? null,
+      searchTerm: searchTerm ?? null,
+      archived: archived ?? null,
+    });
+
+    return printRuntimeControlResult(result, asJson);
+  }
+
+  @Command({ name: "read", description: "Read a runtime thread through an active session" })
+  async read(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Arg("threadId", { description: "Runtime thread id; defaults to current thread", required: false })
+    threadId?: string,
+    @Option({ flags: "--summary-only", description: "Do not include runtime turns" }) summaryOnly?: boolean,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "read");
+    const result = await requestRuntimeControl(session, {
+      operation: "thread.read",
+      threadId,
+      includeTurns: !summaryOnly,
+    });
+
+    return printRuntimeControlResult(result, asJson);
+  }
+
+  @Command({ name: "steer", description: "Steer the active runtime turn" })
+  async steer(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Arg("text", { description: "Steering text to append to the active turn" }) text: string,
+    @Option({ flags: "--thread <id>", description: "Expected runtime thread id" }) threadId?: string,
+    @Option({ flags: "--turn <id>", description: "Runtime turn id" }) turnId?: string,
+    @Option({ flags: "--expected-turn <id>", description: "Expected active runtime turn id" }) expectedTurnId?: string,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "modify");
+    const result = await requestRuntimeControl(session, {
+      operation: "turn.steer",
+      text,
+      threadId,
+      turnId,
+      expectedTurnId,
+    });
+
+    return printRuntimeControlResult(result, asJson, "Steered active runtime turn.");
+  }
+
+  @Command({ name: "interrupt", description: "Interrupt the active runtime turn" })
+  async interrupt(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Option({ flags: "--thread <id>", description: "Expected runtime thread id" }) threadId?: string,
+    @Option({ flags: "--turn <id>", description: "Runtime turn id" }) turnId?: string,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "modify");
+    const result = await requestRuntimeControl(session, {
+      operation: "turn.interrupt",
+      threadId,
+      turnId,
+    });
+
+    return printRuntimeControlResult(result, asJson, "Interrupt requested for active runtime turn.");
+  }
+
+  @Command({ name: "rollback", description: "Rollback completed runtime turns" })
+  async rollback(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Arg("turns", { description: "Number of completed turns to rollback", required: false }) turns?: string,
+    @Option({ flags: "--thread <id>", description: "Runtime thread id; defaults to current thread" }) threadId?: string,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "modify");
+    const result = await requestRuntimeControl(session, {
+      operation: "thread.rollback",
+      threadId,
+      numTurns: parsePositiveInt(turns, 1),
+    });
+
+    return printRuntimeControlResult(result, asJson, "Rolled back runtime thread.");
+  }
+
+  @Command({ name: "fork", description: "Fork a runtime thread if the provider supports it" })
+  async fork(
+    @Arg("session", { description: "Ravi session name or key" }) nameOrKey: string,
+    @Arg("threadId", { description: "Runtime thread id; defaults to current thread", required: false })
+    threadId?: string,
+    @Option({ flags: "--path <path>", description: "Runtime fork path" }) path?: string,
+    @Option({ flags: "--cwd <path>", description: "Working directory for the fork" }) cwd?: string,
+    @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+  ) {
+    const session = resolveControlSession(nameOrKey, "modify");
+    const result = await requestRuntimeControl(session, {
+      operation: "thread.fork",
+      threadId,
+      path: path ?? null,
+      cwd: cwd ?? null,
+    });
+
+    return printRuntimeControlResult(result, asJson);
+  }
+}

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -36,6 +36,7 @@ import { loadConfig } from "../../utils/config.js";
 import type { ResponseMessage, ChannelContext } from "../../bot.js";
 import { dbListContexts, type ContextRecord } from "../../router/router-db.js";
 import type { SessionEntry } from "../../router/types.js";
+import type { RuntimeProviderId } from "../../runtime/types.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
 import {
   getScopeContext,
@@ -1460,7 +1461,7 @@ export interface NormalizedTranscriptMessage {
 
 export function extractNormalizedTranscriptMessages(
   raw: string,
-  runtimeProvider?: "claude" | "codex",
+  runtimeProvider?: RuntimeProviderId,
 ): NormalizedTranscriptMessage[] {
   if (runtimeProvider === "codex") {
     const messages = extractCodexTranscriptMessages(raw);

--- a/src/projects/project-db.ts
+++ b/src/projects/project-db.ts
@@ -210,6 +210,15 @@ function listProjectLinkRowsByAsset(assetType: ProjectLink["assetType"], assetId
     .all(assetType, assetId) as ProjectLinkRow[];
 }
 
+function nextProjectLinkTimestamp(projectId: string): number {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT MAX(updated_at) AS max_updated_at FROM project_links WHERE project_id = ?")
+    .get(projectId) as { max_updated_at?: number | null } | undefined;
+  const latest = typeof row?.max_updated_at === "number" ? row.max_updated_at : 0;
+  return Math.max(Date.now(), latest + 1);
+}
+
 function hasOwn<T extends object, K extends keyof T>(value: T, key: K): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
 }
@@ -395,7 +404,7 @@ export function dbUpsertProjectLink(input: UpsertProjectLinkInput): ProjectLink 
       throw new Error(`Workflow ${input.assetId} already linked to project ${conflicting.project_id}.`);
     }
   }
-  const now = Date.now();
+  const now = nextProjectLinkTimestamp(project.id);
 
   if (input.assetType === "workflow" && input.role === "primary") {
     db.prepare(`

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -34,7 +34,7 @@ const LEGACY_DB_PATH = join(RAVI_DIR, "ravi.db");
 export const DmScopeSchema = z.enum(["main", "per-peer", "per-channel-peer", "per-account-channel-peer"]);
 
 export const AgentModeSchema = z.enum(["active", "sentinel"]);
-export const RuntimeProviderSchema = z.enum(["claude", "codex"]);
+export const RuntimeProviderSchema = z.string().min(1);
 
 export const AgentInputSchema = z.object({
   id: z.string().min(1),
@@ -340,7 +340,7 @@ function getDb(): Database {
       name TEXT,
       cwd TEXT NOT NULL,
       model TEXT,
-      provider TEXT CHECK(provider IS NULL OR provider IN ('claude','codex')),
+      provider TEXT,
       remote TEXT,
       remote_user TEXT,
       dm_scope TEXT CHECK(dm_scope IS NULL OR dm_scope IN ('main','per-peer','per-channel-peer','per-account-channel-peer')),
@@ -372,7 +372,7 @@ function getDb(): Database {
       session_key TEXT PRIMARY KEY,
       name TEXT,
       sdk_session_id TEXT,
-      runtime_provider TEXT CHECK(runtime_provider IS NULL OR runtime_provider IN ('claude','codex')),
+      runtime_provider TEXT,
       runtime_session_json TEXT,
       runtime_session_display_id TEXT,
       agent_id TEXT NOT NULL,
@@ -1306,7 +1306,7 @@ function rowToAgent(row: AgentRow): AgentConfig {
 
   if (row.name !== null) result.name = row.name;
   if (row.model !== null) result.model = row.model;
-  if (row.provider === "claude" || row.provider === "codex") result.provider = row.provider;
+  if (row.provider !== null) result.provider = row.provider;
   if (row.remote !== null) result.remote = row.remote;
   if (row.remote_user !== null) result.remoteUser = row.remote_user;
   if (row.dm_scope !== null) {

--- a/src/router/sessions.ts
+++ b/src/router/sessions.ts
@@ -64,8 +64,7 @@ function rowToEntry(row: SessionRow): SessionEntry {
   return {
     sessionKey: row.session_key,
     name: row.name ?? undefined,
-    runtimeProvider:
-      row.runtime_provider === "claude" || row.runtime_provider === "codex" ? row.runtime_provider : undefined,
+    runtimeProvider: row.runtime_provider ?? undefined,
     runtimeSessionParams,
     runtimeSessionDisplayId: row.runtime_session_display_id ?? undefined,
     providerSessionId,

--- a/src/runtime/claude-provider.ts
+++ b/src/runtime/claude-provider.ts
@@ -38,9 +38,11 @@ export function createClaudeRuntimeProvider(): ClaudeRuntimeProvider {
         supportsSessionFork: true,
         supportsPartialText: true,
         supportsToolHooks: true,
+        supportsHostSessionHooks: true,
         supportsPlugins: true,
         supportsMcpServers: true,
         supportsRemoteSpawn: true,
+        legacyEventTopicSuffix: "claude",
       };
     },
     prepareSession(input: RuntimePrepareSessionRequest): RuntimePrepareSessionResult {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildGeneratedAgentsBridge } from "./agent-instructions.js";
@@ -472,6 +472,246 @@ describe("createCodexRuntimeProvider", () => {
     expect(toolCompleted[1]?.toolUseId).toBe("fc_1");
     expect(toolCompleted[1]?.toolName).toBe("file_change");
     expect(toolCompleted[1]?.content).toEqual([{ path: "/tmp/ravi-codex/hi.txt", kind: "add" }]);
+  });
+
+  it("emits native thread, turn, and item graph events with compatibility events", async () => {
+    const { transport } = createMockTransport([
+      () => ({
+        events: (async function* () {
+          yield { type: "thread.started", thread_id: "thread_graph", thread: { id: "thread_graph", title: "Graph" } };
+          yield {
+            type: "turn.started",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            turn: { id: "turn_graph", status: "in_progress" },
+          };
+          yield {
+            type: "item.started",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            item: {
+              id: "cmd_graph",
+              type: "command_execution",
+              command: "pwd",
+              status: "in_progress",
+              parent_id: "turn_graph",
+            },
+          };
+          yield {
+            type: "item.completed",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            item: {
+              id: "cmd_graph",
+              type: "command_execution",
+              command: "pwd",
+              aggregated_output: "/tmp/ravi-codex\n",
+              status: "completed",
+              parent_id: "turn_graph",
+            },
+          };
+          yield {
+            type: "agent_message.delta",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            item_id: "msg_graph",
+            delta: "done",
+          };
+          yield {
+            type: "item.completed",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            item: {
+              id: "msg_graph",
+              type: "agent_message",
+              text: "done",
+              status: "completed",
+              parent_id: "turn_graph",
+            },
+          };
+          yield {
+            type: "turn.completed",
+            thread_id: "thread_graph",
+            turn_id: "turn_graph",
+            usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+          };
+        })(),
+      }),
+    ]);
+
+    const provider = createCodexRuntimeProvider({ transport: transport as any, defaultModel: "gpt-5" });
+    const session = provider.startSession(makeStartRequest(["graph"]));
+
+    const events = await collectEvents(session.events);
+    const threadStarted = findEventsByType(events, "thread.started");
+    const turnStarted = findEventsByType(events, "turn.started");
+    const itemStarted = findEventsByType(events, "item.started");
+    const itemCompleted = findEventsByType(events, "item.completed");
+    const deltas = findEventsByType(events, "text.delta");
+    const toolStarts = findEventsByType(events, "tool.started");
+    const toolCompleted = findEventsByType(events, "tool.completed");
+    const assistantMessages = findEventsByType(events, "assistant.message");
+    const completions = findEventsByType(events, "turn.complete");
+
+    expect(threadStarted[0]?.thread).toEqual({ id: "thread_graph", title: "Graph" });
+    expect(threadStarted[0]?.metadata?.thread?.id).toBe("thread_graph");
+    expect(turnStarted[0]?.turn).toEqual({ id: "turn_graph", status: "in_progress" });
+    expect(turnStarted[0]?.metadata?.thread?.id).toBe("thread_graph");
+    expect(itemStarted[0]?.item).toEqual({
+      id: "cmd_graph",
+      type: "command_execution",
+      status: "in_progress",
+      parentId: "turn_graph",
+    });
+    expect(itemCompleted.map((event) => event.item.id)).toEqual(["cmd_graph", "msg_graph"]);
+    expect(deltas[0]?.text).toBe("done");
+    expect(deltas[0]?.metadata?.item?.id).toBe("msg_graph");
+    expect(toolStarts).toHaveLength(1);
+    expect(toolCompleted).toHaveLength(1);
+    expect(assistantMessages[0]?.text).toBe("done");
+    expect(completions[0]?.providerSessionId).toBe("thread_graph");
+    expect(completions[0]?.metadata?.turn?.id).toBe("turn_graph");
+  });
+
+  it("maps app-server notifications into the runtime event graph", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-app-server-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+    send({
+      id: message.id,
+      result: {
+        thread: { id: "thread_app", title: "App thread" },
+        model: "gpt-5.4",
+        modelProvider: "openai",
+      },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({ jsonrpc: "2.0", method: "thread/started", params: { thread: { id: "thread_app", title: "App thread" } } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_app", turn: { id: "turn_app", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        item: {
+          id: "cmd_app",
+          type: "commandExecution",
+          command: "pwd",
+          status: "inProgress",
+          parentItemId: "turn_app",
+          processId: 123,
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          id: "cmd_app",
+          type: "commandExecution",
+          command: "pwd",
+          status: "completed",
+          aggregatedOutput: "/tmp/ravi-codex\\n",
+          exitCode: 0,
+          parentItemId: "turn_app",
+          processId: 123,
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { delta: "done", itemId: "msg_app" },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          id: "msg_app",
+          type: "agentMessage",
+          text: "done",
+          status: "completed",
+          parentItemId: "turn_app",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "thread/tokenUsage/updated",
+      params: { tokenUsage: { last: { inputTokens: 2, cachedInputTokens: 1, outputTokens: 3 } } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_app", turn: { id: "turn_app", status: "completed" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(makeStartRequest(["app-server"], { cwd }));
+
+    const events = await collectEvents(session.events);
+    const threadStarted = findEventsByType(events, "thread.started");
+    const turnStarted = findEventsByType(events, "turn.started");
+    const itemStarted = findEventsByType(events, "item.started");
+    const toolStarted = findEventsByType(events, "tool.started");
+    const assistantMessages = findEventsByType(events, "assistant.message");
+    const completions = findEventsByType(events, "turn.complete");
+
+    expect(threadStarted[0]?.thread).toEqual({ id: "thread_app", title: "App thread" });
+    expect(turnStarted[0]?.turn).toEqual({ id: "turn_app", status: "in_progress" });
+    expect(itemStarted[0]?.item).toEqual({
+      id: "cmd_app",
+      type: "command_execution",
+      status: "in_progress",
+      parentId: "turn_app",
+    });
+    expect(itemStarted[0]?.metadata?.source).toBe("codex.app-server");
+    expect(toolStarted[0]?.toolUse).toEqual({
+      id: "cmd_app",
+      name: "shell",
+      input: { command: "pwd" },
+    });
+    expect(assistantMessages[0]?.text).toBe("done");
+    expect(completions[0]?.usage).toEqual({
+      inputTokens: 2,
+      outputTokens: 3,
+      cacheReadTokens: 1,
+      cacheCreationTokens: 0,
+    });
+    expect(completions[0]?.metadata?.thread?.id).toBe("thread_app");
+    expect(completions[0]?.metadata?.turn?.id).toBe("turn_app");
   });
 
   it("emits turn.interrupted and continues with the next turn", async () => {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildGeneratedAgentsBridge } from "./agent-instructions.js";
 import { createCodexRuntimeProvider } from "./codex-provider.js";
-import type { RuntimeEvent, RuntimeStartRequest } from "./types.js";
+import type { RuntimeEvent, RuntimeHostServices, RuntimeStartRequest } from "./types.js";
 
 type TransportRequest = {
   cwd: string;
@@ -147,6 +147,154 @@ describe("createCodexRuntimeProvider", () => {
         process.env.HOME = originalHome;
       }
     }
+  });
+
+  it("builds Codex-local start handlers from generic runtime host services", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-provider-"));
+    const toolSpec = {
+      name: "tools_list",
+      description: "List tools",
+      inputSchema: { type: "object" },
+    };
+    const capabilityRequests: Array<Parameters<RuntimeHostServices["authorizeCapability"]>[0]> = [];
+    const hostServices: RuntimeHostServices = {
+      authorizeCapability: async (request) => {
+        capabilityRequests.push(request);
+        return { allowed: true, inherited: false };
+      },
+      authorizeCommandExecution: async (request) => ({
+        approved: true,
+        inherited: true,
+        updatedInput: request.input,
+      }),
+      authorizeToolUse: async (request) => ({
+        approved: true,
+        inherited: true,
+        updatedInput: request.input,
+      }),
+      requestUserInput: async () => ({ approved: true, answers: { choice: "A" } }),
+      listDynamicTools: () => [toolSpec],
+      executeDynamicTool: async (request) => ({
+        success: true,
+        contentItems: [{ type: "inputText", text: `ran ${request.toolName}` }],
+      }),
+    };
+
+    const provider = createCodexRuntimeProvider({ defaultModel: "gpt-5", syncSkills: () => [] });
+    const prepared = await provider.prepareSession?.({
+      agentId: "main",
+      cwd,
+      plugins: [],
+      hostServices,
+    });
+
+    expect(prepared?.startRequest?.dynamicTools).toEqual([toolSpec]);
+    await expect(
+      prepared?.startRequest?.approveRuntimeRequest?.({
+        kind: "permission",
+        method: "item/permissions/requestApproval",
+        input: { permissions: { "use:tool:Bash": true } },
+      }),
+    ).resolves.toMatchObject({
+      approved: true,
+      inherited: false,
+      permissions: { "use:tool:Bash": true },
+    });
+    expect(capabilityRequests[0]).toMatchObject({
+      permission: "use",
+      objectType: "tool",
+      objectId: "Bash",
+    });
+
+    await expect(
+      prepared?.startRequest?.handleRuntimeToolCall?.({
+        toolName: "tools_list",
+        callId: "call_1",
+        arguments: {},
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      contentItems: [{ type: "inputText", text: "ran tools_list" }],
+    });
+  });
+
+  it("passes dynamic tools when bootstrapping a resumed app-server thread", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-resume-tools-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    const requestsPath = join(cwd, "thread-requests.jsonl");
+    const toolSpec = {
+      name: "tools_list",
+      description: "List tools",
+      inputSchema: { type: "object" },
+    };
+
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const requestsPath = ${JSON.stringify(requestsPath)};
+const rl = createInterface({ input: process.stdin });
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    send({
+      id: message.id,
+      result: { thread: { id: message.params.threadId ?? "thread_new" }, model: "gpt-5.4", modelProvider: "openai" },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_prev", turn: { id: "turn_resume", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_prev", turn: { id: "turn_resume", status: "completed" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest(["resume"], {
+        cwd,
+        resume: "thread_prev",
+        dynamicTools: [toolSpec],
+      }),
+    );
+
+    const events = await collectEvents(session.events);
+    const threadRequests = readFileSync(requestsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(findEventsByType(events, "turn.complete")).toHaveLength(1);
+    expect(threadRequests).toHaveLength(1);
+    expect(threadRequests[0]?.method).toBe("thread/resume");
+    expect(threadRequests[0]?.params.threadId).toBe("thread_prev");
+    expect(threadRequests[0]?.params.dynamicTools).toEqual([toolSpec]);
   });
 
   it("maps CLI completion events and composes prompts with system instructions", async () => {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -714,6 +714,694 @@ rl.on("line", (line) => {
     expect(completions[0]?.metadata?.turn?.id).toBe("turn_app");
   });
 
+  it("executes app-server thread control requests through runtime control", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-thread-control-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    const logPath = join(cwd, "requests.jsonl");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const logPath = process.env.RAVI_CODEX_TEST_LOG;
+const log = (message) => {
+  if (logPath) appendFileSync(logPath, JSON.stringify({ method: message.method, params: message.params ?? {} }) + "\\n");
+};
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method) log(message);
+
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && message.method === "thread/start") {
+    send({
+      id: message.id,
+      result: { thread: { id: "thread_control", title: "Control thread" }, model: "gpt-5.4", modelProvider: "openai" },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({ jsonrpc: "2.0", method: "thread/started", params: { thread: { id: "thread_control", title: "Control thread" } } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_control", turn: { id: "turn_control", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_control", turn: { id: "turn_control", status: "completed" } },
+    });
+    return;
+  }
+  if (message.id && message.method === "thread/list") {
+    send({ id: message.id, result: { threads: [{ id: "thread_control", title: "Control thread" }], nextCursor: null } });
+    return;
+  }
+  if (message.id && message.method === "thread/read") {
+    send({
+      id: message.id,
+      result: {
+        thread: { id: message.params.threadId, title: "Control thread" },
+        turns: message.params.includeTurns ? [{ id: "turn_control", status: "completed" }] : [],
+      },
+    });
+    return;
+  }
+  if (message.id && message.method === "thread/rollback") {
+    send({ id: message.id, result: { thread: { id: message.params.threadId }, rolledBackTurns: message.params.numTurns } });
+    return;
+  }
+  if (message.id && message.method === "thread/fork") {
+    send({ id: message.id, result: { thread: { id: "thread_forked", cwd: message.params.cwd ?? null } } });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    let releasePrompt!: () => void;
+    const promptDone = new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+    const abortController = new AbortController();
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest([], {
+        cwd,
+        abortController,
+        env: { PATH: process.env.PATH ?? "", RAVI_CODEX_TEST_LOG: logPath },
+        prompt: (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "control" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+          await promptDone;
+        })(),
+      }),
+    );
+
+    const iterator = session.events[Symbol.asyncIterator]();
+    try {
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) {
+          throw new Error("Codex session ended before turn completion");
+        }
+        if (next.value.type === "turn.complete") {
+          break;
+        }
+      }
+
+      const list = await session.control?.({ operation: "thread.list", limit: 3, searchTerm: "Control" });
+      const read = await session.control?.({ operation: "thread.read", includeTurns: false });
+      const rollback = await session.control?.({ operation: "thread.rollback", numTurns: 2 });
+      const fork = await session.control?.({ operation: "thread.fork", cwd: cwd, path: "forked" });
+
+      expect(list?.ok).toBe(true);
+      expect(read?.ok).toBe(true);
+      expect(rollback?.ok).toBe(true);
+      expect(fork?.ok).toBe(true);
+      expect(read?.state?.threadId).toBe("thread_control");
+      expect(rollback?.data?.rolledBackTurns).toBe(2);
+      expect((fork?.data?.thread as Record<string, unknown> | undefined)?.id).toBe("thread_forked");
+
+      const requests = readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(requests.map((request) => request.method)).toEqual([
+        "initialize",
+        "thread/start",
+        "turn/start",
+        "thread/list",
+        "thread/read",
+        "thread/rollback",
+        "thread/fork",
+      ]);
+      expect(requests.find((request) => request.method === "thread/read")?.params).toMatchObject({
+        threadId: "thread_control",
+        includeTurns: false,
+      });
+      expect(requests.find((request) => request.method === "thread/fork")?.params).toMatchObject({
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        persistExtendedHistory: true,
+      });
+    } finally {
+      abortController.abort();
+      releasePrompt();
+      await iterator.return?.();
+    }
+  });
+
+  it("steers and interrupts an active app-server turn through runtime control", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-turn-control-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    const logPath = join(cwd, "requests.jsonl");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const logPath = process.env.RAVI_CODEX_TEST_LOG;
+const log = (message) => {
+  if (logPath) appendFileSync(logPath, JSON.stringify({ method: message.method, params: message.params ?? {} }) + "\\n");
+};
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method) log(message);
+
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && message.method === "thread/start") {
+    send({
+      id: message.id,
+      result: { thread: { id: "thread_turn_control", title: "Turn control" }, model: "gpt-5.4", modelProvider: "openai" },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({ jsonrpc: "2.0", method: "thread/started", params: { thread: { id: "thread_turn_control", title: "Turn control" } } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_turn_control", turn: { id: "turn_live", status: "inProgress" } },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/steer") {
+    send({ id: message.id, result: { accepted: true, expectedTurnId: message.params.expectedTurnId } });
+    return;
+  }
+  if (message.id && message.method === "turn/interrupt") {
+    send({ id: message.id, result: { accepted: true } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_turn_control", turn: { id: "turn_live", status: "interrupted" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    let releasePrompt!: () => void;
+    const promptDone = new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+    const abortController = new AbortController();
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest([], {
+        cwd,
+        abortController,
+        env: { PATH: process.env.PATH ?? "", RAVI_CODEX_TEST_LOG: logPath },
+        prompt: (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "control" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+          await promptDone;
+        })(),
+      }),
+    );
+
+    const iterator = session.events[Symbol.asyncIterator]();
+    try {
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) {
+          throw new Error("Codex session ended before turn start");
+        }
+        if (next.value.type === "turn.started") {
+          break;
+        }
+      }
+
+      const steer = await session.control?.({ operation: "turn.steer", text: "use this detail" });
+      const interrupt = await session.control?.({ operation: "turn.interrupt" });
+
+      expect(steer?.ok).toBe(true);
+      expect(steer?.data?.accepted).toBe(true);
+      expect(interrupt?.ok).toBe(true);
+      expect(interrupt?.data).toMatchObject({
+        interrupted: true,
+        pending: false,
+        threadId: "thread_turn_control",
+        turnId: "turn_live",
+      });
+
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) {
+          throw new Error("Codex session ended before turn interrupt event");
+        }
+        if (next.value.type === "turn.interrupted") {
+          break;
+        }
+      }
+
+      const requests = readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const steerRequest = requests.find((request) => request.method === "turn/steer");
+      expect(steerRequest?.params).toMatchObject({
+        threadId: "thread_turn_control",
+        expectedTurnId: "turn_live",
+        input: [{ type: "text", text: "use this detail", text_elements: [] }],
+      });
+      expect(requests.find((request) => request.method === "turn/interrupt")?.params).toEqual({
+        threadId: "thread_turn_control",
+        turnId: "turn_live",
+      });
+    } finally {
+      abortController.abort();
+      releasePrompt();
+      await iterator.return?.();
+    }
+  });
+
+  it("routes app-server approval requests through the runtime approval handler", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-approval-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const responses = {};
+const expected = ["cmd_req", "file_req", "perm_req", "input_req"];
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+const finishIfReady = () => {
+  if (!expected.every((id) => responses[id])) return;
+  send({
+    jsonrpc: "2.0",
+    method: "item/completed",
+    params: {
+      item: {
+        id: "msg_approval",
+        type: "agentMessage",
+        text: JSON.stringify(responses),
+        status: "completed",
+        parentItemId: "turn_approval",
+      },
+    },
+  });
+  send({
+    jsonrpc: "2.0",
+    method: "thread/tokenUsage/updated",
+    params: { tokenUsage: { last: { inputTokens: 1, cachedInputTokens: 0, outputTokens: 1 } } },
+  });
+  send({
+    jsonrpc: "2.0",
+    method: "turn/completed",
+    params: { threadId: "thread_approval", turn: { id: "turn_approval", status: "completed" } },
+  });
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && !message.method) {
+    responses[message.id] = message.result;
+    finishIfReady();
+    return;
+  }
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+    send({
+      id: message.id,
+      result: {
+        thread: { id: "thread_approval", title: "Approval thread" },
+        model: "gpt-5.4",
+        modelProvider: "openai",
+      },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({
+      jsonrpc: "2.0",
+      method: "thread/started",
+      params: { thread: { id: "thread_approval", title: "Approval thread" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_approval", turn: { id: "turn_approval", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "cmd_req",
+      method: "item/commandExecution/requestApproval",
+      params: {
+        command: "pwd",
+        item: {
+          id: "cmd_approval",
+          type: "commandExecution",
+          command: "pwd",
+          status: "inProgress",
+          parentItemId: "turn_approval",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "file_req",
+      method: "item/fileChange/requestApproval",
+      params: {
+        item: {
+          id: "file_approval",
+          type: "fileChange",
+          changes: [{ path: "hello.txt", kind: "add" }],
+          status: "inProgress",
+          parentItemId: "turn_approval",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "perm_req",
+      method: "item/permissions/requestApproval",
+      params: {
+        permissions: [{ permission: "use", objectType: "tool", objectId: "Bash" }],
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "input_req",
+      method: "item/tool/requestUserInput",
+      params: {
+        questions: [
+          {
+            id: "choice",
+            question: "Pick one",
+            options: [{ label: "A", description: "alpha" }, { label: "B" }],
+          },
+        ],
+      },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const approvalRequests: Array<Parameters<NonNullable<RuntimeStartRequest["approveRuntimeRequest"]>>[0]> = [];
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest(["approval"], {
+        cwd,
+        approveRuntimeRequest: async (request) => {
+          approvalRequests.push(request);
+          if (request.kind === "file_change") {
+            return { approved: false, reason: "file changes require review" };
+          }
+          if (request.kind === "permission") {
+            return { approved: true, inherited: false, permissions: { Bash: true } };
+          }
+          if (request.kind === "user_input") {
+            return { approved: true, answers: { choice: "A" } };
+          }
+          return { approved: true, inherited: true };
+        },
+      }),
+    );
+
+    const events = await collectEvents(session.events);
+    const assistantText = findEventsByType(events, "assistant.message")[0]?.text ?? "{}";
+    const approvalResponses = JSON.parse(assistantText);
+    const requested = findEventsByType(events, "approval.requested");
+    const resolved = findEventsByType(events, "approval.resolved");
+
+    expect(approvalRequests.map((request) => request.kind)).toEqual([
+      "command_execution",
+      "file_change",
+      "permission",
+      "user_input",
+    ]);
+    expect(approvalRequests[0]?.metadata?.source).toBe("codex.app-server");
+    expect(approvalRequests[0]?.metadata?.thread?.id).toBe("thread_approval");
+    expect(approvalRequests[0]?.metadata?.turn?.id).toBe("turn_approval");
+    expect(approvalRequests[0]?.metadata?.item?.id).toBe("cmd_approval");
+    expect(requested).toHaveLength(4);
+    expect(resolved).toHaveLength(4);
+    expect(resolved.find((event) => event.approval.kind === "file_change")?.approval).toMatchObject({
+      approved: false,
+      reason: "file changes require review",
+    });
+    expect(approvalResponses.cmd_req.decision).toBe("acceptForSession");
+    expect(approvalResponses.file_req.decision).toBe("deny");
+    expect(approvalResponses.file_req.reason).toBe("file changes require review");
+    expect(approvalResponses.perm_req.permissions).toEqual({ Bash: true });
+    expect(approvalResponses.input_req.answers).toEqual({ choice: "A" });
+  });
+
+  it("routes app-server dynamic tool calls through the runtime tool handler", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-tool-call-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+let toolResponse;
+const finishIfReady = () => {
+  if (!toolResponse) return;
+  send({
+    jsonrpc: "2.0",
+    method: "item/completed",
+    params: {
+      item: {
+        id: "msg_tool",
+        type: "agentMessage",
+        text: JSON.stringify(toolResponse),
+        status: "completed",
+        parentItemId: "turn_tool",
+      },
+    },
+  });
+  send({
+    jsonrpc: "2.0",
+    method: "turn/completed",
+    params: { threadId: "thread_tool", turn: { id: "turn_tool", status: "completed" } },
+  });
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && !message.method) {
+    toolResponse = message.result;
+    finishIfReady();
+    return;
+  }
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+    send({
+      id: message.id,
+      result: { thread: { id: "thread_tool", title: "Tool thread" }, model: "gpt-5.4", modelProvider: "openai" },
+    });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({ jsonrpc: "2.0", method: "thread/started", params: { thread: { id: "thread_tool", title: "Tool thread" } } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_tool", turn: { id: "turn_tool", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "tool_req",
+      method: "item/tool/call",
+      params: {
+        callId: "dyn_tool_1",
+        threadId: "thread_tool",
+        turnId: "turn_tool",
+        tool: "tools_list",
+        arguments: { verbose: true },
+      },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const toolRequests: Array<Parameters<NonNullable<RuntimeStartRequest["handleRuntimeToolCall"]>>[0]> = [];
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest(["tool"], {
+        cwd,
+        handleRuntimeToolCall: async (request) => {
+          toolRequests.push(request);
+          return {
+            success: true,
+            contentItems: [{ type: "inputText", text: "tool output" }],
+          };
+        },
+      }),
+    );
+
+    const events = await collectEvents(session.events);
+    const response = JSON.parse(findEventsByType(events, "assistant.message")[0]?.text ?? "{}");
+    const toolStarted = findEventsByType(events, "tool.started");
+    const toolCompleted = findEventsByType(events, "tool.completed");
+
+    expect(toolRequests).toHaveLength(1);
+    expect(toolRequests[0]?.toolName).toBe("tools_list");
+    expect(toolRequests[0]?.callId).toBe("dyn_tool_1");
+    expect(toolRequests[0]?.arguments).toEqual({ verbose: true });
+    expect(toolRequests[0]?.metadata?.source).toBe("codex.app-server");
+    expect(toolRequests[0]?.metadata?.thread?.id).toBe("thread_tool");
+    expect(toolRequests[0]?.metadata?.turn?.id).toBe("turn_tool");
+    expect(toolRequests[0]?.metadata?.item?.id).toBe("dyn_tool_1");
+    expect(toolStarted[0]?.toolUse).toEqual({
+      id: "dyn_tool_1",
+      name: "tools_list",
+      input: { verbose: true },
+    });
+    expect(toolStarted[0]?.metadata?.item?.type).toBe("dynamic_tool_call");
+    expect(toolCompleted[0]?.toolUseId).toBe("dyn_tool_1");
+    expect(toolCompleted[0]?.toolName).toBe("tools_list");
+    expect(toolCompleted[0]?.content).toEqual([{ type: "inputText", text: "tool output" }]);
+    expect(toolCompleted[0]?.isError).toBe(false);
+    expect(response).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "tool output" }],
+    });
+  });
+
+  it("denies app-server command approvals when no runtime approval handler is available", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-approval-deny-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin });
+const send = (message) => {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+};
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && !message.method) {
+    send({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          id: "msg_deny",
+          type: "agentMessage",
+          text: JSON.stringify(message.result),
+          status: "completed",
+          parentItemId: "turn_deny",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_deny", turn: { id: "turn_deny", status: "completed" } },
+    });
+    return;
+  }
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") {
+    return;
+  }
+  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+    send({ id: message.id, result: { thread: { id: "thread_deny" }, model: "gpt-5", modelProvider: "openai" } });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    send({ id: message.id, result: {} });
+    send({ jsonrpc: "2.0", method: "thread/started", params: { thread: { id: "thread_deny" } } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_deny", turn: { id: "turn_deny", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      id: "cmd_deny_req",
+      method: "item/commandExecution/requestApproval",
+      params: { command: "pwd", item: { id: "cmd_deny", type: "commandExecution", command: "pwd" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(makeStartRequest(["deny"], { cwd }));
+
+    const events = await collectEvents(session.events);
+    const response = JSON.parse(findEventsByType(events, "assistant.message")[0]?.text ?? "{}");
+
+    expect(response.decision).toBe("deny");
+    expect(response.reason).toContain("No Ravi approval handler");
+    expect(findEventsByType(events, "approval.resolved")[0]?.approval.approved).toBe(false);
+  });
+
   it("emits turn.interrupted and continues with the next turn", async () => {
     let rejectInterruptedTurn: ((error: Error) => void) | undefined;
     const { calls, transport } = createMockTransport([

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -25,6 +25,7 @@ import type {
   RuntimeExecutionMetadata,
   RuntimeEvent,
   RuntimeEventMetadata,
+  RuntimeHostServices,
   RuntimeItemMetadata,
   RuntimePlugin,
   RuntimePrepareSessionRequest,
@@ -162,9 +163,11 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
         supportsSessionFork: false,
         supportsPartialText: true,
         supportsToolHooks: true,
+        supportsHostSessionHooks: false,
         supportsPlugins: false,
         supportsMcpServers: false,
         supportsRemoteSpawn: false,
+        toolAccessRequirement: "tool_surface",
       };
     },
     prepareSession(input: RuntimePrepareSessionRequest): RuntimePrepareSessionResult {
@@ -172,7 +175,11 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
       ensureGlobalCodexBashHookConfig();
       const syncedSkills = syncSkills(input.plugins ?? []);
       syncedSkillsByCwd.set(input.cwd, Array.isArray(syncedSkills) ? syncedSkills : []);
-      return {};
+      return input.hostServices
+        ? {
+            startRequest: createCodexRuntimeStartRequest(input.hostServices),
+          }
+        : {};
     },
     startSession(input) {
       const transport = options.transport ?? createCodexAppServerTransport({ command: options.command });
@@ -212,6 +219,246 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
       };
     },
   };
+}
+
+function createCodexRuntimeStartRequest(
+  hostServices: RuntimeHostServices,
+): NonNullable<RuntimePrepareSessionResult["startRequest"]> {
+  return {
+    approveRuntimeRequest: createCodexApprovalHandler(hostServices),
+    dynamicTools: hostServices.listDynamicTools(),
+    handleRuntimeToolCall: createCodexDynamicToolHandler(hostServices),
+  };
+}
+
+function createCodexApprovalHandler(hostServices: RuntimeHostServices): RuntimeApprovalHandler {
+  return async (request) => {
+    switch (request.kind) {
+      case "command_execution":
+        return authorizeCodexCommandExecution(hostServices, request);
+      case "file_change":
+        return authorizeCodexFileChange(hostServices, request);
+      case "permission":
+        return authorizeCodexPermissionRequest(hostServices, request);
+      case "user_input":
+        return requestCodexUserInput(hostServices, request);
+    }
+  };
+}
+
+function createCodexDynamicToolHandler(hostServices: RuntimeHostServices): RuntimeDynamicToolCallHandler {
+  return (request) =>
+    hostServices.executeDynamicTool(request, {
+      eventData: buildCodexDynamicToolEventData(request),
+    });
+}
+
+async function authorizeCodexCommandExecution(
+  hostServices: RuntimeHostServices,
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const command = typeof request.input?.command === "string" ? request.input.command : "";
+  if (!command.trim()) {
+    return { approved: false, reason: "Codex command approval request did not include a command." };
+  }
+
+  return hostServices.authorizeCommandExecution({
+    command,
+    input: request.input,
+    eventData: buildCodexApprovalEventData(request),
+  });
+}
+
+async function authorizeCodexFileChange(
+  hostServices: RuntimeHostServices,
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  return hostServices.authorizeToolUse({
+    toolName: request.toolName ?? "Edit",
+    input: request.input,
+    eventData: buildCodexApprovalEventData(request),
+  });
+}
+
+async function authorizeCodexPermissionRequest(
+  hostServices: RuntimeHostServices,
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const capabilities = extractRuntimeApprovalCapabilities(request);
+  if (capabilities.length === 0) {
+    return {
+      approved: false,
+      reason: "Unsupported Codex permission approval request shape.",
+      permissions: {},
+    };
+  }
+
+  let inherited = true;
+  const eventData = buildCodexApprovalEventData(request);
+  for (const capability of capabilities) {
+    const result = await hostServices.authorizeCapability({
+      ...capability,
+      eventData,
+    });
+    if (!result.allowed) {
+      return {
+        approved: false,
+        reason: result.reason ?? `${capability.permission} ${capability.objectType}:${capability.objectId} denied.`,
+        permissions: {},
+      };
+    }
+    inherited = inherited && result.inherited;
+  }
+
+  return {
+    approved: true,
+    inherited,
+    permissions: buildGrantedPermissionsPayload(request.input?.permissions),
+  };
+}
+
+function requestCodexUserInput(
+  hostServices: RuntimeHostServices,
+  request: RuntimeApprovalRequest,
+): Promise<RuntimeApprovalResult> {
+  const questions = Array.isArray(request.input?.questions)
+    ? (request.input.questions as RuntimeApprovalQuestion[])
+    : [];
+  return hostServices.requestUserInput({
+    questions,
+    eventData: buildCodexApprovalEventData(request),
+  });
+}
+
+function buildCodexApprovalEventData(request: RuntimeApprovalRequest): Record<string, unknown> {
+  return {
+    runtimeApproval: {
+      provider: "codex",
+      kind: request.kind,
+      method: request.method,
+      toolName: request.toolName,
+      input: truncateRuntimeEventData(request.input),
+    },
+    runtimeMetadata: request.metadata,
+  };
+}
+
+function buildCodexDynamicToolEventData(request: RuntimeDynamicToolCallRequest): Record<string, unknown> {
+  return {
+    runtimeToolCall: {
+      provider: "codex",
+      method: "item/tool/call",
+      toolName: request.toolName,
+      callId: request.callId,
+      arguments: truncateRuntimeEventData(request.arguments),
+    },
+    runtimeMetadata: request.metadata,
+  };
+}
+
+function extractRuntimeApprovalCapabilities(
+  request: RuntimeApprovalRequest,
+): Array<{ permission: string; objectType: string; objectId: string }> {
+  const permissions = request.input?.permissions ?? request.rawRequest;
+  const candidates = collectRuntimeApprovalCapabilityCandidates(permissions);
+  return candidates.flatMap((candidate) => parseRuntimeApprovalCapability(candidate));
+}
+
+function collectRuntimeApprovalCapabilityCandidates(value: unknown): unknown[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (typeof value !== "object") {
+    return [];
+  }
+
+  const direct = parseRuntimeApprovalCapability(value);
+  if (direct.length > 0) {
+    return [value];
+  }
+
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) => {
+    if (entry === true || entry === null || entry === undefined) {
+      return [key];
+    }
+    if (entry === false) {
+      return [];
+    }
+    return [entry, key];
+  });
+}
+
+function parseRuntimeApprovalCapability(
+  candidate: unknown,
+): Array<{ permission: string; objectType: string; objectId: string }> {
+  if (typeof candidate === "string") {
+    const match = candidate.match(/^([a-z_]+)(?:\s+|:)([a-z_]+):(.+)$/i);
+    if (!match) {
+      return [];
+    }
+    return [{ permission: match[1], objectType: match[2], objectId: match[3] }];
+  }
+
+  const record = asRecord(candidate);
+  if (!record) {
+    return [];
+  }
+
+  const permission = firstString(record.permission, record.action, record.verb);
+  const objectType = firstString(record.objectType, record.object_type, record.resourceType, record.type);
+  const objectId = firstString(record.objectId, record.object_id, record.resourceId, record.id, record.name);
+  if (permission && objectType && objectId) {
+    return [{ permission, objectType, objectId }];
+  }
+
+  const toolName = firstString(record.toolName, record.tool_name, record.tool);
+  if (toolName) {
+    return [{ permission: "use", objectType: "tool", objectId: toolName }];
+  }
+
+  return [];
+}
+
+function buildGrantedPermissionsPayload(value: unknown): Record<string, unknown> {
+  if (!value) {
+    return {};
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  const capabilities = collectRuntimeApprovalCapabilityCandidates(value).flatMap((candidate) =>
+    parseRuntimeApprovalCapability(candidate),
+  );
+  return Object.fromEntries(
+    capabilities.map((capability) => [
+      `${capability.permission}:${capability.objectType}:${capability.objectId}`,
+      true,
+    ]),
+  );
+}
+
+function truncateRuntimeEventData(value: unknown): unknown {
+  if (typeof value === "string" && value.length > 1000) {
+    return value.slice(0, 1000) + "... [truncated]";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => truncateRuntimeEventData(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, truncateRuntimeEventData(entry)]),
+  );
 }
 
 async function* normalizeCodexEvents(
@@ -1191,6 +1438,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
               config: input.effort ? { model_reasoning_effort: input.effort } : null,
               baseInstructions: null,
               developerInstructions: input.systemPromptAppend || null,
+              dynamicTools: input.dynamicTools ?? null,
               personality: null,
               persistExtendedHistory: false,
             })

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -9,6 +9,8 @@ import type {
   RuntimeBillingType,
   RuntimeExecutionMetadata,
   RuntimeEvent,
+  RuntimeEventMetadata,
+  RuntimeItemMetadata,
   RuntimePlugin,
   RuntimePrepareSessionRequest,
   RuntimePrepareSessionResult,
@@ -17,6 +19,8 @@ import type {
   RuntimeSessionHandle,
   RuntimeStartRequest,
   RuntimeStatus,
+  RuntimeThreadMetadata,
+  RuntimeTurnMetadata,
   RuntimeToolUse,
   RuntimeUsage,
   SessionRuntimeProvider,
@@ -200,18 +204,24 @@ async function* normalizeCodexEvents(
 
       let turnEnded = false;
       let turnSessionId = previousSessionId;
+      let activeTurnId: string | undefined;
       let lastErrorMessage: string | undefined;
+      const startedToolUseIds = new Set<string>();
 
       try {
         for await (const event of turn.events) {
           const rawEvent = event as Record<string, unknown>;
+          const metadata = buildCodexEventMetadata(rawEvent, {
+            threadId: turnSessionId,
+            turnId: activeTurnId,
+          });
           if (event.type !== "agent_message.delta") {
-            yield { type: "provider.raw", rawEvent };
+            yield { type: "provider.raw", rawEvent, metadata };
           }
 
           const status = mapStatusFromCliEvent(event.type);
           if (status) {
-            yield { type: "status", status, rawEvent };
+            yield { type: "status", status, rawEvent, metadata };
           }
 
           if (event.type === "agent_message.delta") {
@@ -220,47 +230,98 @@ async function* normalizeCodexEvents(
               yield {
                 type: "text.delta",
                 text: delta,
+                metadata,
               };
             }
             continue;
           }
 
           if (event.type === "thread.started") {
-            const threadId = firstString(event.thread_id);
+            const thread = metadata.thread ?? extractRuntimeThreadMetadata(rawEvent);
+            const threadId = thread?.id;
             if (threadId) {
               turnSessionId = threadId;
+            }
+            if (thread) {
+              yield {
+                type: "thread.started",
+                thread,
+                rawEvent,
+                metadata,
+              };
+            }
+            continue;
+          }
+
+          if (event.type === "turn.started") {
+            const turnMetadata = metadata.turn ?? extractRuntimeTurnMetadata(rawEvent);
+            if (turnMetadata?.id) {
+              activeTurnId = turnMetadata.id;
+            }
+            if (turnMetadata) {
+              yield {
+                type: "turn.started",
+                turn: turnMetadata,
+                rawEvent,
+                metadata,
+              };
             }
             continue;
           }
 
           if (event.type === "item.started") {
+            const itemMetadata = metadata.item ?? extractRuntimeItemMetadata(event.item);
+            if (itemMetadata) {
+              yield {
+                type: "item.started",
+                item: itemMetadata,
+                rawEvent,
+                metadata,
+              };
+            }
+
             const toolStart = extractCliToolStarted(event.item);
             if (toolStart) {
+              startedToolUseIds.add(toolStart.id);
               yield {
                 type: "tool.started",
                 toolUse: toolStart,
                 rawEvent,
+                metadata,
               };
             }
             continue;
           }
 
           if (event.type === "item.completed") {
+            const itemMetadata = metadata.item ?? extractRuntimeItemMetadata(event.item);
+            if (itemMetadata) {
+              yield {
+                type: "item.completed",
+                item: itemMetadata,
+                rawEvent,
+                metadata,
+              };
+            }
+
             const assistantText = extractAssistantText(event.item);
             if (assistantText) {
               yield {
                 type: "assistant.message",
                 text: assistantText,
                 rawEvent,
+                metadata,
               };
             }
 
             const toolCompleted = extractCliToolCompleted(event.item);
-            if (toolCompleted?.syntheticStart) {
+            const toolUseId = toolCompleted?.toolUseId ?? toolCompleted?.syntheticStart?.id;
+            if (toolCompleted?.syntheticStart && !(toolUseId && startedToolUseIds.has(toolUseId))) {
               yield {
                 type: "tool.started",
                 toolUse: toolCompleted.syntheticStart,
                 rawEvent,
+                metadata,
               };
             }
             if (toolCompleted) {
@@ -271,6 +332,7 @@ async function* normalizeCodexEvents(
                 content: toolCompleted.content,
                 isError: toolCompleted.isError,
                 rawEvent,
+                metadata,
               };
             }
             continue;
@@ -282,7 +344,7 @@ async function* normalizeCodexEvents(
           }
 
           if (event.type === "turn.interrupted") {
-            yield { type: "turn.interrupted", rawEvent };
+            yield { type: "turn.interrupted", rawEvent, metadata };
             turnEnded = true;
             break;
           }
@@ -293,17 +355,18 @@ async function* normalizeCodexEvents(
               error: extractCliFailureMessage(event) ?? lastErrorMessage ?? "Codex turn failed",
               recoverable: true,
               rawEvent,
+              metadata,
             };
             turnEnded = true;
             break;
           }
 
           if (event.type === "turn.completed") {
-            previousSessionId = turnSessionId;
+            previousSessionId = metadata.thread?.id ?? turnSessionId;
             yield {
               type: "turn.complete",
-              providerSessionId: turnSessionId,
-              session: buildCodexSessionState(turnSessionId, input.cwd),
+              providerSessionId: previousSessionId,
+              session: buildCodexSessionState(previousSessionId, input.cwd),
               execution: buildCodexExecutionMetadata(
                 input,
                 defaultModel,
@@ -312,6 +375,7 @@ async function* normalizeCodexEvents(
               ),
               usage: mapCliUsage(event.usage),
               rawEvent,
+              metadata,
             };
             turnEnded = true;
             break;
@@ -330,18 +394,27 @@ async function* normalizeCodexEvents(
 
         if (state.interrupted || result.signal === "SIGINT" || result.signal === "SIGTERM") {
           state.interrupted = false;
-          yield { type: "status", status: "idle" };
-          yield { type: "turn.interrupted" };
+          const metadata = buildCodexEventMetadata(
+            { type: "turn.interrupted", thread_id: turnSessionId, turn_id: activeTurnId },
+            { threadId: turnSessionId, turnId: activeTurnId },
+          );
+          yield { type: "status", status: "idle", metadata };
+          yield { type: "turn.interrupted", metadata };
           continue;
         }
 
         const stderrMessage = result.stderr.trim();
+        const metadata = buildCodexEventMetadata(
+          { type: "turn.failed", thread_id: turnSessionId, turn_id: activeTurnId },
+          { threadId: turnSessionId, turnId: activeTurnId },
+        );
         yield {
           type: "turn.failed",
           error:
             lastErrorMessage ??
             (stderrMessage || `Codex CLI exited without a terminal event (code ${result.exitCode ?? "unknown"})`),
           recoverable: true,
+          metadata,
         };
       } catch (error) {
         if (outerAbortSignal.aborted && !state.interrupted) {
@@ -350,8 +423,12 @@ async function* normalizeCodexEvents(
 
         if (state.interrupted || isAbortLikeError(error)) {
           state.interrupted = false;
-          yield { type: "status", status: "idle" };
-          yield { type: "turn.interrupted" };
+          const metadata = buildCodexEventMetadata(
+            { type: "turn.interrupted", thread_id: turnSessionId, turn_id: activeTurnId },
+            { threadId: turnSessionId, turnId: activeTurnId },
+          );
+          yield { type: "status", status: "idle", metadata };
+          yield { type: "turn.interrupted", metadata };
           continue;
         }
 
@@ -656,12 +733,18 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "thread/started": {
-        const threadId = firstString(asRecord(params.thread)?.id);
+        const thread = normalizeAppServerThread(params.thread);
+        const threadId = thread?.id;
         if (threadId) {
           currentThreadId = threadId;
           if (turn) {
             turn.threadId = threadId;
-            turn.queue.push({ type: "thread.started", thread_id: threadId });
+            turn.queue.push({
+              type: "thread.started",
+              source: "codex.app-server",
+              thread_id: threadId,
+              thread,
+            });
             if (turn.interruptRequested && turn.turnId) {
               void requestTurnInterrupt(turn);
             }
@@ -671,10 +754,16 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
       }
       case "turn/started": {
         if (turn) {
-          const startedTurn = asRecord(params.turn);
+          const startedTurn = normalizeAppServerTurn(params.turn);
           turn.threadId = firstString(params.threadId, turn.threadId, currentThreadId);
           turn.turnId = firstString(startedTurn?.id, turn.turnId);
-          turn.queue.push({ type: "turn.started" });
+          turn.queue.push({
+            type: "turn.started",
+            source: "codex.app-server",
+            thread_id: turn.threadId,
+            turn_id: turn.turnId,
+            turn: startedTurn,
+          });
           if (turn.interruptRequested) {
             void requestTurnInterrupt(turn);
           }
@@ -685,7 +774,13 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         if (turn) {
           const item = normalizeAppServerItem(params.item);
           if (item) {
-            turn.queue.push({ type: "item.started", item });
+            turn.queue.push({
+              type: "item.started",
+              source: "codex.app-server",
+              thread_id: turn.threadId ?? currentThreadId,
+              turn_id: turn.turnId,
+              item,
+            });
           }
         }
         break;
@@ -694,7 +789,13 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         if (turn) {
           const item = normalizeAppServerItem(params.item);
           if (item) {
-            turn.queue.push({ type: "item.completed", item });
+            turn.queue.push({
+              type: "item.completed",
+              source: "codex.app-server",
+              thread_id: turn.threadId ?? currentThreadId,
+              turn_id: turn.turnId,
+              item,
+            });
           }
         }
         break;
@@ -705,6 +806,9 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
           if (delta) {
             turn.queue.push({
               type: "agent_message.delta",
+              source: "codex.app-server",
+              thread_id: turn.threadId ?? currentThreadId,
+              turn_id: turn.turnId,
               delta,
               item_id: firstString(params.itemId),
             });
@@ -728,15 +832,29 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         if (status === "completed") {
           turn.queue.push({
             type: "turn.completed",
+            source: "codex.app-server",
+            thread_id: turn.threadId ?? currentThreadId,
+            turn_id: turn.turnId,
+            turn: normalizeAppServerTurn(completedTurn),
             usage: turn.lastUsage ?? {},
             model: resolvedModel,
             model_provider: resolvedModelProvider,
           });
         } else if (status === "interrupted") {
-          turn.queue.push({ type: "turn.interrupted" });
+          turn.queue.push({
+            type: "turn.interrupted",
+            source: "codex.app-server",
+            thread_id: turn.threadId ?? currentThreadId,
+            turn_id: turn.turnId,
+            turn: normalizeAppServerTurn(completedTurn),
+          });
         } else {
           turn.queue.push({
             type: "turn.failed",
+            source: "codex.app-server",
+            thread_id: turn.threadId ?? currentThreadId,
+            turn_id: turn.turnId,
+            turn: normalizeAppServerTurn(completedTurn),
             error: extractAppServerTurnError(completedTurn) ?? `Codex turn ${status}`,
           });
         }
@@ -1274,6 +1392,104 @@ function mapStatusFromCliEvent(type: string): RuntimeStatus | null {
   return null;
 }
 
+function buildCodexEventMetadata(
+  event: Record<string, unknown>,
+  fallback: { threadId?: string; turnId?: string } = {},
+): RuntimeEventMetadata {
+  const thread =
+    extractRuntimeThreadMetadata(event) ??
+    (fallback.threadId
+      ? {
+          id: fallback.threadId,
+        }
+      : undefined);
+  const turn =
+    extractRuntimeTurnMetadata(event) ??
+    (fallback.turnId
+      ? {
+          id: fallback.turnId,
+        }
+      : undefined);
+  const item = extractRuntimeItemMetadata(event.item) ?? extractRuntimeItemMetadata(event);
+
+  return {
+    provider: "codex",
+    source: firstString(event.source) ?? "codex",
+    nativeEvent: typeof event.type === "string" ? event.type : undefined,
+    ...(thread ? { thread } : {}),
+    ...(turn ? { turn } : {}),
+    ...(item ? { item } : {}),
+  };
+}
+
+function extractRuntimeThreadMetadata(event: Record<string, unknown> | null): RuntimeThreadMetadata | undefined {
+  if (!event) {
+    return undefined;
+  }
+
+  const thread = asRecord(event.thread);
+  const id = firstString(event.thread_id, event.threadId, thread?.id);
+  const title = firstString(thread?.title, event.thread_title, event.threadTitle);
+  if (!id && !title) {
+    return undefined;
+  }
+
+  return {
+    ...(id ? { id } : {}),
+    ...(title ? { title } : {}),
+  };
+}
+
+function extractRuntimeTurnMetadata(event: Record<string, unknown> | null): RuntimeTurnMetadata | undefined {
+  if (!event) {
+    return undefined;
+  }
+
+  const turn = asRecord(event.turn);
+  const id = firstString(event.turn_id, event.turnId, turn?.id);
+  const status = firstString(event.turn_status, event.turnStatus, turn?.status);
+  if (!id && !status) {
+    return undefined;
+  }
+
+  return {
+    ...(id ? { id } : {}),
+    ...(status ? { status } : {}),
+  };
+}
+
+function extractRuntimeItemMetadata(item: unknown): RuntimeItemMetadata | undefined {
+  const record = asRecord(item);
+  if (!record) {
+    return undefined;
+  }
+
+  const nested = asRecord(record.item);
+  const source = nested ?? record;
+  const id = firstString(record.item_id, record.itemId, source.id);
+  const type = nested || (!record.item_id && !record.itemId) ? firstString(source.type) : undefined;
+  const status = firstString(source.status);
+  const parentId = firstString(
+    source.parent_id,
+    source.parentId,
+    source.parent_item_id,
+    source.parentItemId,
+    record.parent_item_id,
+    record.parentItemId,
+  );
+
+  if (!id && !type && !status && !parentId) {
+    return undefined;
+  }
+
+  return {
+    ...(id ? { id } : {}),
+    ...(type ? { type } : {}),
+    ...(status ? { status } : {}),
+    ...(parentId ? { parentId } : {}),
+  };
+}
+
 function extractAssistantText(item: unknown): string {
   const record = asRecord(item);
   if (!record || record.type !== "agent_message") {
@@ -1386,46 +1602,98 @@ function extractCliErrorMessage(event: Record<string, unknown>): string | undefi
   return undefined;
 }
 
+function normalizeAppServerThread(value: unknown): RuntimeThreadMetadata | undefined {
+  const thread = asRecord(value);
+  if (!thread) {
+    return undefined;
+  }
+
+  const id = firstString(thread.id);
+  const title = firstString(thread.title);
+  if (!id && !title) {
+    return undefined;
+  }
+
+  return {
+    ...(id ? { id } : {}),
+    ...(title ? { title } : {}),
+  };
+}
+
+function normalizeAppServerTurn(value: unknown): RuntimeTurnMetadata | undefined {
+  const turn = asRecord(value);
+  if (!turn) {
+    return undefined;
+  }
+
+  const id = firstString(turn.id);
+  const status = normalizeAppServerStatus(turn.status);
+  if (!id && !status) {
+    return undefined;
+  }
+
+  return {
+    ...(id ? { id } : {}),
+    ...(status ? { status } : {}),
+  };
+}
+
 function normalizeAppServerItem(value: unknown): Record<string, unknown> | null {
   const item = asRecord(value);
   if (!item || typeof item.type !== "string") {
     return null;
   }
 
+  const base = {
+    id: item.id,
+    status: normalizeAppServerStatus(item.status),
+    parent_id: firstString(item.parentItemId, item.parentId, item.parent_item_id),
+    title: item.title,
+    phase: item.phase,
+  };
+
   switch (item.type) {
     case "agentMessage":
       return {
+        ...base,
         type: "agent_message",
-        id: item.id,
         text: item.text,
-        status: normalizeAppServerStatus(item.status),
-        phase: item.phase,
       };
     case "commandExecution":
       return {
+        ...base,
         type: "command_execution",
-        id: item.id,
         command: item.command,
         aggregated_output: item.aggregatedOutput,
         exit_code: item.exitCode,
-        status: normalizeAppServerStatus(item.status),
         process_id: item.processId,
+        cwd: item.cwd,
+      };
+    case "fileChange":
+      return {
+        ...base,
+        type: "file_change",
+        changes: item.changes,
+        diff: item.diff,
+        path: item.path,
       };
     case "reasoning":
       return {
+        ...base,
         type: "reasoning",
-        id: item.id,
-        status: normalizeAppServerStatus(item.status),
+        text: item.text,
+        summary: item.summary,
       };
     case "userMessage":
       return {
+        ...base,
         type: "user_message",
-        id: item.id,
         content: item.content,
       };
     default:
       return {
         ...item,
+        ...base,
         type: item.type,
         status: normalizeAppServerStatus(item.status),
       };

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -6,7 +6,22 @@ import { createInterface } from "node:readline";
 import { syncCodexSkills } from "../plugins/codex-skills.js";
 import { ensureAgentInstructionFiles, loadAgentWorkspaceInstructions } from "./agent-instructions.js";
 import type {
+  RuntimeApprovalEvent,
+  RuntimeApprovalHandler,
+  RuntimeApprovalKind,
+  RuntimeApprovalQuestion,
+  RuntimeApprovalRequest,
+  RuntimeApprovalResult,
   RuntimeBillingType,
+  RuntimeControlOperation,
+  RuntimeControlRequest,
+  RuntimeControlResult,
+  RuntimeControlState,
+  RuntimeDynamicToolCallContentItem,
+  RuntimeDynamicToolCallHandler,
+  RuntimeDynamicToolCallRequest,
+  RuntimeDynamicToolCallResult,
+  RuntimeDynamicToolSpec,
   RuntimeExecutionMetadata,
   RuntimeEvent,
   RuntimeEventMetadata,
@@ -31,6 +46,14 @@ const INTERRUPT_GRACE_MS = 1_500;
 const CODEX_APP_SERVER_SANDBOX = "danger-full-access";
 const RAVI_CODEX_BASH_HOOK_STATUS = "ravi codex bash permission gate";
 const RAVI_CODEX_BASH_HOOK_MATCHER = "^Bash$";
+const CODEX_RUNTIME_CONTROL_OPERATIONS: RuntimeControlOperation[] = [
+  "thread.list",
+  "thread.read",
+  "thread.rollback",
+  "thread.fork",
+  "turn.steer",
+  "turn.interrupt",
+];
 const CODEX_SKILL_DISCOVERY_NOTE = [
   "Ravi may install native Codex skills under ~/.codex/skills (or $CODEX_HOME/skills).",
   "If the task clearly matches a skill, inspect that directory and follow the relevant SKILL.md files.",
@@ -62,6 +85,9 @@ interface CodexCliTurnRequest {
   prompt: string;
   resume?: string;
   systemPromptAppend: string;
+  approveRuntimeRequest?: RuntimeApprovalHandler;
+  dynamicTools?: RuntimeDynamicToolSpec[];
+  handleRuntimeToolCall?: RuntimeDynamicToolCallHandler;
 }
 
 interface CodexCliTurnResult {
@@ -74,10 +100,12 @@ interface CodexCliTurnHandle {
   events: AsyncIterable<CodexCliEvent>;
   result: Promise<CodexCliTurnResult>;
   interrupt(): Promise<void> | void;
+  control?(request: RuntimeControlRequest): Promise<RuntimeControlResult>;
 }
 
 interface CodexCliTransport {
   startTurn(input: CodexCliTurnRequest): CodexCliTurnHandle;
+  control?(request: RuntimeControlRequest): Promise<RuntimeControlResult>;
   close?(): Promise<void>;
 }
 
@@ -104,6 +132,11 @@ type PendingRequest = {
   resolve(value: Record<string, unknown>): void;
   reject(error: unknown): void;
 };
+
+interface AppServerApprovalTurn {
+  threadId?: string;
+  turnId?: string;
+}
 
 export interface CreateCodexRuntimeProviderOptions {
   transport?: CodexCliTransport;
@@ -158,6 +191,24 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
           state.interrupted = true;
           await state.activeTurn.interrupt();
         },
+        control: async (request) => {
+          if (transport.control) {
+            return transport.control(request);
+          }
+          if (state.activeTurn?.control) {
+            return state.activeTurn.control(request);
+          }
+          return {
+            ok: false,
+            operation: request.operation,
+            state: {
+              provider: "codex",
+              activeTurn: Boolean(state.activeTurn),
+              supportedOperations: [],
+            },
+            error: "Codex runtime control is unavailable for this transport.",
+          };
+        },
       };
     },
   };
@@ -193,6 +244,9 @@ async function* normalizeCodexEvents(
         prompt: promptText,
         resume: previousSessionId,
         systemPromptAppend,
+        approveRuntimeRequest: input.approveRuntimeRequest,
+        dynamicTools: input.dynamicTools,
+        handleRuntimeToolCall: input.handleRuntimeToolCall,
       });
 
       state.activeTurn = turn;
@@ -338,6 +392,19 @@ async function* normalizeCodexEvents(
             continue;
           }
 
+          if (event.type === "approval.requested" || event.type === "approval.resolved") {
+            const approval = extractRuntimeApprovalEvent(rawEvent);
+            if (approval) {
+              yield {
+                type: event.type,
+                approval,
+                rawEvent,
+                metadata,
+              };
+            }
+            continue;
+          }
+
           if (event.type === "error") {
             lastErrorMessage = extractCliErrorMessage(event) ?? lastErrorMessage;
             continue;
@@ -456,6 +523,8 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     lastUsage?: CodexCliUsage;
     turnId?: string;
     threadId?: string;
+    approveRuntimeRequest?: RuntimeApprovalHandler;
+    handleRuntimeToolCall?: RuntimeDynamicToolCallHandler;
     settled: boolean;
     interruptRequested: boolean;
   };
@@ -625,30 +694,36 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     });
   }
 
-  async function handleServerRequest(id: string, method: string, _params: Record<string, unknown>): Promise<void> {
+  async function handleServerRequest(id: string, method: string, params: Record<string, unknown>): Promise<void> {
+    if (isCodexApprovalRequestMethod(method)) {
+      const request = buildRuntimeApprovalRequest(method, params, activeTurn, currentThreadId);
+      activeTurn?.queue.push(buildApprovalTraceEvent("approval.requested", request));
+
+      let approvalResult: RuntimeApprovalResult;
+      if (!activeTurn?.approveRuntimeRequest) {
+        approvalResult = {
+          approved: false,
+          reason: "No Ravi approval handler is available for this Codex request.",
+        };
+      } else {
+        try {
+          approvalResult = await activeTurn.approveRuntimeRequest(request);
+        } catch (error) {
+          approvalResult = {
+            approved: false,
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
+
+      activeTurn?.queue.push(buildApprovalTraceEvent("approval.resolved", request, approvalResult));
+      await writeJsonRpc({ id, result: buildCodexApprovalResponse(method, params, approvalResult) });
+      return;
+    }
+
     switch (method) {
-      case "item/commandExecution/requestApproval":
-      case "execCommandApproval":
-        await writeJsonRpc({ id, result: { decision: "acceptForSession" } });
-        return;
-      case "item/fileChange/requestApproval":
-      case "applyPatchApproval":
-        await writeJsonRpc({ id, result: { decision: "acceptForSession" } });
-        return;
-      case "item/permissions/requestApproval":
-        await writeJsonRpc({ id, result: { permissions: {} } });
-        return;
-      case "item/tool/requestUserInput":
-        await writeJsonRpc({ id, result: { answers: {} } });
-        return;
       case "item/tool/call":
-        await writeJsonRpc({
-          id,
-          result: {
-            success: false,
-            contentItems: [{ type: "inputText", text: "Dynamic tools are unsupported in the Ravi Codex adapter." }],
-          },
-        });
+        await handleDynamicToolCall(id, params);
         return;
       default:
         await writeJsonRpc({
@@ -659,6 +734,34 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
           },
         });
     }
+  }
+
+  async function handleDynamicToolCall(id: string, params: Record<string, unknown>): Promise<void> {
+    const request = buildRuntimeDynamicToolCallRequest(params, activeTurn, currentThreadId);
+    activeTurn?.queue.push(buildDynamicToolTraceEvent("item.started", request));
+
+    let result: RuntimeDynamicToolCallResult;
+    if (!activeTurn?.handleRuntimeToolCall) {
+      result = {
+        success: false,
+        contentItems: [
+          { type: "inputText", text: "No Ravi dynamic tool handler is available for this Codex request." },
+        ],
+      };
+    } else {
+      try {
+        result = await activeTurn.handleRuntimeToolCall(request);
+      } catch (error) {
+        result = {
+          success: false,
+          contentItems: [{ type: "inputText", text: error instanceof Error ? error.message : String(error) }],
+        };
+      }
+    }
+
+    const response = buildCodexDynamicToolCallResponse(result);
+    activeTurn?.queue.push(buildDynamicToolTraceEvent("item.completed", request, response));
+    await writeJsonRpc({ id, result: response });
   }
 
   const requestTurnInterrupt = async (turn: AppServerTurnState) => {
@@ -687,6 +790,184 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         }
       }, INTERRUPT_GRACE_MS);
       forcedKillTimer.unref?.();
+    }
+  };
+
+  const buildRuntimeControlState = (): RuntimeControlState => ({
+    provider: "codex",
+    threadId: activeTurn?.threadId ?? currentThreadId,
+    turnId: activeTurn?.turnId,
+    activeTurn: Boolean(activeTurn && !activeTurn.settled),
+    supportedOperations: CODEX_RUNTIME_CONTROL_OPERATIONS,
+  });
+
+  const buildRuntimeControlSuccess = (
+    request: RuntimeControlRequest,
+    data: Record<string, unknown> = {},
+  ): RuntimeControlResult => ({
+    ok: true,
+    operation: request.operation,
+    data,
+    state: buildRuntimeControlState(),
+  });
+
+  const buildRuntimeControlError = (request: RuntimeControlRequest, error: unknown): RuntimeControlResult => ({
+    ok: false,
+    operation: request.operation,
+    error: error instanceof Error ? error.message : String(error),
+    state: buildRuntimeControlState(),
+  });
+
+  const resolveControlThreadId = (request: RuntimeControlRequest): string => {
+    const threadId = request.threadId ?? activeTurn?.threadId ?? currentThreadId;
+    if (!threadId) {
+      throw new Error(`${request.operation} requires a Codex thread id.`);
+    }
+    return threadId;
+  };
+
+  const resolveActiveTurnForControl = (request: RuntimeControlRequest): AppServerTurnState => {
+    if (!activeTurn || activeTurn.settled) {
+      throw new Error(`${request.operation} requires an active Codex turn.`);
+    }
+    return activeTurn;
+  };
+
+  const normalizeRuntimeControlUserInput = (request: RuntimeControlRequest): unknown[] => {
+    if (Array.isArray(request.input) && request.input.length > 0) {
+      return request.input;
+    }
+
+    const text = typeof request.text === "string" ? request.text : "";
+    if (!text.trim()) {
+      throw new Error("turn.steer requires text or input.");
+    }
+
+    return [
+      {
+        type: "text",
+        text,
+        text_elements: [],
+      },
+    ];
+  };
+
+  const assertNoActiveTurnForThreadMutation = (request: RuntimeControlRequest) => {
+    if (activeTurn && !activeTurn.settled) {
+      throw new Error(`${request.operation} cannot run while a Codex turn is active.`);
+    }
+  };
+
+  const handleRuntimeControl = async (request: RuntimeControlRequest): Promise<RuntimeControlResult> => {
+    try {
+      switch (request.operation) {
+        case "thread.list": {
+          const data = await sendRequest("thread/list", {
+            cursor: request.cursor ?? null,
+            limit: request.limit ?? null,
+            sortKey: request.sortKey ?? null,
+            modelProviders: request.modelProviders ?? null,
+            sourceKinds: request.sourceKinds ?? null,
+            archived: request.archived ?? null,
+            cwd: request.cwd ?? null,
+            searchTerm: request.searchTerm ?? null,
+          });
+          return buildRuntimeControlSuccess(request, data);
+        }
+
+        case "thread.read": {
+          const threadId = resolveControlThreadId(request);
+          const data = await sendRequest("thread/read", {
+            threadId,
+            includeTurns: request.includeTurns ?? true,
+          });
+          return buildRuntimeControlSuccess(request, data);
+        }
+
+        case "thread.rollback": {
+          assertNoActiveTurnForThreadMutation(request);
+          const threadId = resolveControlThreadId(request);
+          const numTurns = request.numTurns ?? 1;
+          if (!Number.isInteger(numTurns) || numTurns < 1) {
+            throw new Error("thread.rollback requires numTurns >= 1.");
+          }
+
+          const data = await sendRequest("thread/rollback", {
+            threadId,
+            numTurns,
+          });
+          return buildRuntimeControlSuccess(request, data);
+        }
+
+        case "thread.fork": {
+          assertNoActiveTurnForThreadMutation(request);
+          const threadId = resolveControlThreadId(request);
+          const data = await sendRequest("thread/fork", {
+            threadId,
+            path: request.path ?? null,
+            model: null,
+            modelProvider: null,
+            serviceTier: null,
+            cwd: request.cwd ?? null,
+            approvalPolicy: "never",
+            approvalsReviewer: null,
+            sandbox: CODEX_APP_SERVER_SANDBOX,
+            config: null,
+            baseInstructions: null,
+            developerInstructions: null,
+            ephemeral: false,
+            persistExtendedHistory: true,
+          });
+          return buildRuntimeControlSuccess(request, data);
+        }
+
+        case "turn.steer": {
+          const turn = resolveActiveTurnForControl(request);
+          const threadId = request.threadId ?? turn.threadId ?? currentThreadId;
+          const turnId = request.expectedTurnId ?? request.turnId ?? turn.turnId;
+          if (!threadId || !turnId) {
+            throw new Error("turn.steer requires an active Codex thread and turn id.");
+          }
+
+          const data = await sendRequest("turn/steer", {
+            threadId,
+            input: normalizeRuntimeControlUserInput(request),
+            responsesapiClientMetadata: null,
+            expectedTurnId: turnId,
+          });
+          return buildRuntimeControlSuccess(request, data);
+        }
+
+        case "turn.interrupt": {
+          const turn = resolveActiveTurnForControl(request);
+          turn.interruptRequested = true;
+          const threadId = request.threadId ?? turn.threadId ?? currentThreadId;
+          const turnId = request.turnId ?? turn.turnId;
+          if (!threadId) {
+            throw new Error("turn.interrupt requires an active Codex thread id.");
+          }
+
+          if (turnId) {
+            if (turnId === turn.turnId) {
+              await requestTurnInterrupt(turn);
+            } else {
+              await sendRequest("turn/interrupt", { threadId, turnId });
+            }
+          }
+
+          return buildRuntimeControlSuccess(request, {
+            interrupted: Boolean(turnId),
+            pending: !turnId,
+            threadId,
+            turnId: turnId ?? null,
+          });
+        }
+
+        default:
+          return buildRuntimeControlError(request, `Unsupported Codex runtime control operation: ${request.operation}`);
+      }
+    } catch (error) {
+      return buildRuntimeControlError(request, error);
     }
   };
 
@@ -923,6 +1204,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
               serviceName: null,
               baseInstructions: null,
               developerInstructions: input.systemPromptAppend || null,
+              dynamicTools: input.dynamicTools ?? null,
               personality: null,
               ephemeral: false,
               experimentalRawEvents: false,
@@ -964,6 +1246,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
   };
 
   return {
+    control: handleRuntimeControl,
     startTurn(input) {
       if (activeTurn && !activeTurn.settled) {
         throw new Error("Codex app-server transport does not support overlapping turns");
@@ -978,6 +1261,8 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         }),
         resolveResult,
         stderrOffset: stderr.length,
+        approveRuntimeRequest: input.approveRuntimeRequest,
+        handleRuntimeToolCall: input.handleRuntimeToolCall,
         settled: false,
         interruptRequested: false,
       };
@@ -1029,6 +1314,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
             await requestTurnInterrupt(turn);
           }
         },
+        control: handleRuntimeControl,
       };
     },
     close,
@@ -1510,7 +1796,8 @@ function extractCliToolStarted(item: unknown): RuntimeToolUse | null {
     return null;
   }
 
-  const toolName = normalizeCliToolName(record.type);
+  const toolName =
+    record.type === "dynamic_tool_call" ? (firstString(record.tool) ?? record.type) : normalizeCliToolName(record.type);
   const toolUseId = firstString(record.id);
   if (!toolUseId) {
     return null;
@@ -1530,7 +1817,8 @@ function extractCliToolCompleted(item: unknown): ToolCompletedEvent | null {
   }
 
   const toolUseId = firstString(record.id);
-  const toolName = normalizeCliToolName(record.type);
+  const toolName =
+    record.type === "dynamic_tool_call" ? (firstString(record.tool) ?? record.type) : normalizeCliToolName(record.type);
   const status = typeof record.status === "string" ? record.status : "completed";
 
   const result: ToolCompletedEvent = {
@@ -1568,6 +1856,9 @@ function normalizeCliToolName(type: string): string {
 }
 
 function extractCliToolInput(item: Record<string, unknown>): unknown {
+  if (item.type === "dynamic_tool_call") {
+    return item.arguments;
+  }
   if (typeof item.command === "string") {
     return { command: item.command };
   }
@@ -1578,6 +1869,9 @@ function extractCliToolInput(item: Record<string, unknown>): unknown {
 }
 
 function extractCliToolOutput(item: Record<string, unknown>): unknown {
+  if (item.type === "dynamic_tool_call") {
+    return item.content_items;
+  }
   if (typeof item.aggregated_output === "string") {
     return item.aggregated_output;
   }
@@ -1677,6 +1971,17 @@ function normalizeAppServerItem(value: unknown): Record<string, unknown> | null 
         diff: item.diff,
         path: item.path,
       };
+    case "dynamicToolCall":
+    case "dynamic_tool_call":
+      return {
+        ...base,
+        type: "dynamic_tool_call",
+        tool: item.tool,
+        arguments: item.arguments,
+        success: item.success,
+        content_items: item.contentItems ?? item.content_items,
+        duration_ms: item.durationMs ?? item.duration_ms,
+      };
     case "reasoning":
       return {
         ...base,
@@ -1710,6 +2015,402 @@ function normalizeAppServerStatus(value: unknown): string | undefined {
   }
 
   return value.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`);
+}
+
+function isCodexApprovalRequestMethod(method: string): boolean {
+  return (
+    method === "item/commandExecution/requestApproval" ||
+    method === "execCommandApproval" ||
+    method === "item/fileChange/requestApproval" ||
+    method === "applyPatchApproval" ||
+    method === "item/permissions/requestApproval" ||
+    method === "item/tool/requestUserInput"
+  );
+}
+
+function buildRuntimeDynamicToolCallRequest(
+  params: Record<string, unknown>,
+  turn: AppServerApprovalTurn | null,
+  currentThreadId: string | undefined,
+): RuntimeDynamicToolCallRequest {
+  const toolName = firstString(params.tool, params.toolName, params.name) ?? "unknown";
+  const callId = firstString(params.callId, params.call_id, params.id);
+  const threadId = firstString(params.threadId, params.thread_id, turn?.threadId, currentThreadId);
+  const turnId = firstString(params.turnId, params.turn_id, turn?.turnId);
+  const args = params.arguments ?? params.input ?? params.args ?? {};
+  const item = buildDynamicToolCallItem({
+    callId,
+    toolName,
+    args,
+    status: "in_progress",
+    parentId: turnId,
+  });
+  const metadata = buildCodexEventMetadata(
+    {
+      type: "item/tool/call",
+      source: "codex.app-server",
+      thread_id: threadId,
+      turn_id: turnId,
+      item,
+    },
+    { threadId, turnId },
+  );
+
+  return {
+    toolName,
+    ...(callId ? { callId } : {}),
+    arguments: args,
+    rawRequest: params,
+    metadata,
+  };
+}
+
+function buildDynamicToolTraceEvent(
+  type: "item.started" | "item.completed",
+  request: RuntimeDynamicToolCallRequest,
+  result?: { success: boolean; contentItems: RuntimeDynamicToolCallContentItem[] },
+): CodexCliEvent {
+  const status = type === "item.started" ? "in_progress" : result?.success ? "completed" : "failed";
+  return {
+    type,
+    source: "codex.app-server",
+    ...(request.metadata?.thread?.id ? { thread_id: request.metadata.thread.id } : {}),
+    ...(request.metadata?.turn?.id ? { turn_id: request.metadata.turn.id } : {}),
+    item: buildDynamicToolCallItem({
+      callId: request.callId,
+      toolName: request.toolName,
+      args: request.arguments,
+      status,
+      parentId: request.metadata?.turn?.id,
+      result,
+    }),
+  };
+}
+
+function buildDynamicToolCallItem(input: {
+  callId?: string;
+  toolName: string;
+  args: unknown;
+  status: string;
+  parentId?: string;
+  result?: { success: boolean; contentItems: RuntimeDynamicToolCallContentItem[] };
+}): Record<string, unknown> {
+  return {
+    id: input.callId ?? `${input.toolName}-unknown`,
+    type: "dynamic_tool_call",
+    status: input.status,
+    parent_id: input.parentId,
+    tool: input.toolName,
+    arguments: input.args,
+    ...(input.result
+      ? {
+          success: input.result.success,
+          content_items: input.result.contentItems,
+        }
+      : {}),
+  };
+}
+
+function buildCodexDynamicToolCallResponse(result: RuntimeDynamicToolCallResult): {
+  success: boolean;
+  contentItems: RuntimeDynamicToolCallContentItem[];
+} {
+  const success = result.success === true;
+  const contentItems = normalizeDynamicToolCallContentItems(result.contentItems, result.reason);
+  return { success, contentItems };
+}
+
+function normalizeDynamicToolCallContentItems(
+  contentItems: RuntimeDynamicToolCallContentItem[] | undefined,
+  fallbackText?: string,
+): RuntimeDynamicToolCallContentItem[] {
+  const normalized =
+    contentItems?.filter((item): item is RuntimeDynamicToolCallContentItem => {
+      if (item?.type === "inputText") {
+        return typeof item.text === "string";
+      }
+      if (item?.type === "inputImage") {
+        return typeof item.imageUrl === "string";
+      }
+      return false;
+    }) ?? [];
+
+  if (normalized.length > 0) {
+    return normalized;
+  }
+
+  return [{ type: "inputText", text: fallbackText ?? "(no output)" }];
+}
+
+function buildRuntimeApprovalRequest(
+  method: string,
+  params: Record<string, unknown>,
+  turn: AppServerApprovalTurn | null,
+  currentThreadId: string | undefined,
+): RuntimeApprovalRequest {
+  const item = normalizeAppServerItem(params.item) ?? asRecord(params.item) ?? undefined;
+  const metadataEvent = {
+    type: method,
+    source: "codex.app-server",
+    thread_id: turn?.threadId ?? currentThreadId,
+    turn_id: turn?.turnId,
+    ...(item ? { item } : {}),
+  };
+  const metadata = buildCodexEventMetadata(metadataEvent, {
+    threadId: turn?.threadId ?? currentThreadId,
+    turnId: turn?.turnId,
+  });
+
+  if (method === "item/commandExecution/requestApproval" || method === "execCommandApproval") {
+    const command = extractApprovalCommand(params);
+    return {
+      kind: "command_execution",
+      method,
+      toolName: "Bash",
+      input: {
+        ...(command ? { command } : {}),
+        ...(item ? { item } : {}),
+      },
+      rawRequest: params,
+      metadata,
+    };
+  }
+
+  if (method === "item/fileChange/requestApproval" || method === "applyPatchApproval") {
+    const input = extractFileChangeApprovalInput(params, item);
+    return {
+      kind: "file_change",
+      method,
+      toolName: inferFileChangeToolName(input),
+      input,
+      rawRequest: params,
+      metadata,
+    };
+  }
+
+  if (method === "item/tool/requestUserInput") {
+    return {
+      kind: "user_input",
+      method,
+      toolName: "AskUserQuestion",
+      input: {
+        questions: extractApprovalQuestions(params),
+        ...(item ? { item } : {}),
+      },
+      rawRequest: params,
+      metadata,
+    };
+  }
+
+  return {
+    kind: "permission",
+    method,
+    input: {
+      permissions: extractRequestedPermissions(params),
+      ...(item ? { item } : {}),
+    },
+    rawRequest: params,
+    metadata,
+  };
+}
+
+function buildApprovalTraceEvent(
+  type: "approval.requested" | "approval.resolved",
+  request: RuntimeApprovalRequest,
+  result?: RuntimeApprovalResult,
+): CodexCliEvent {
+  const approval: RuntimeApprovalEvent = {
+    kind: request.kind,
+    ...(request.method ? { method: request.method } : {}),
+    ...(request.toolName ? { toolName: request.toolName } : {}),
+    ...(result ? { approved: result.approved } : {}),
+    ...(typeof result?.inherited === "boolean" ? { inherited: result.inherited } : {}),
+    ...(result?.reason ? { reason: result.reason } : {}),
+  };
+
+  return {
+    type,
+    source: "codex.app-server",
+    ...(request.metadata?.thread?.id ? { thread_id: request.metadata.thread.id } : {}),
+    ...(request.metadata?.turn?.id ? { turn_id: request.metadata.turn.id } : {}),
+    ...(request.input?.item ? { item: request.input.item } : {}),
+    approval,
+  };
+}
+
+function extractRuntimeApprovalEvent(event: Record<string, unknown>): RuntimeApprovalEvent | null {
+  const approval = asRecord(event.approval);
+  const kind = firstString(approval?.kind);
+  if (!approval || !isRuntimeApprovalKind(kind)) {
+    return null;
+  }
+
+  return {
+    kind,
+    ...(firstString(approval.method) ? { method: firstString(approval.method) } : {}),
+    ...(firstString(approval.toolName) ? { toolName: firstString(approval.toolName) } : {}),
+    ...(typeof approval.approved === "boolean" ? { approved: approval.approved } : {}),
+    ...(typeof approval.inherited === "boolean" ? { inherited: approval.inherited } : {}),
+    ...(firstString(approval.reason) ? { reason: firstString(approval.reason) } : {}),
+  };
+}
+
+function isRuntimeApprovalKind(value: unknown): value is RuntimeApprovalKind {
+  return value === "command_execution" || value === "file_change" || value === "permission" || value === "user_input";
+}
+
+function buildCodexApprovalResponse(
+  method: string,
+  params: Record<string, unknown>,
+  result: RuntimeApprovalResult,
+): Record<string, unknown> {
+  if (method === "item/tool/requestUserInput") {
+    return {
+      answers: result.answers ?? {},
+      ...(result.approved ? {} : { denied: true, reason: result.reason ?? "Denied by Ravi approval policy." }),
+    };
+  }
+
+  if (method === "item/permissions/requestApproval") {
+    if (result.approved) {
+      return {
+        permissions: result.permissions ?? extractRequestedPermissions(params) ?? {},
+      };
+    }
+    return {
+      permissions: {},
+      denied: true,
+      reason: result.reason ?? "Denied by Ravi approval policy.",
+    };
+  }
+
+  if (result.approved) {
+    return { decision: "acceptForSession" };
+  }
+
+  return {
+    decision: "deny",
+    reason: result.reason ?? "Denied by Ravi approval policy.",
+  };
+}
+
+function extractApprovalCommand(params: Record<string, unknown>): string | undefined {
+  const item = asRecord(params.item);
+  const commandExecution = asRecord(params.commandExecution) ?? asRecord(params.command_execution);
+  const toolInput = asRecord(params.toolInput) ?? asRecord(params.tool_input);
+  return firstCommand(
+    params.command,
+    params.commandLine,
+    params.command_line,
+    commandExecution?.command,
+    toolInput?.command,
+    item?.command,
+  );
+}
+
+function firstCommand(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+    if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+      const joined = value.join(" ").trim();
+      if (joined.length > 0) {
+        return joined;
+      }
+    }
+  }
+  return undefined;
+}
+
+function extractFileChangeApprovalInput(
+  params: Record<string, unknown>,
+  item: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const fileChange = asRecord(params.fileChange) ?? asRecord(params.file_change);
+  const changes = firstArray(params.changes, fileChange?.changes, item?.changes);
+  const path = firstString(params.path, fileChange?.path, item?.path);
+  const diff = firstString(params.diff, fileChange?.diff, item?.diff);
+  return {
+    ...(changes ? { changes } : {}),
+    ...(path ? { path } : {}),
+    ...(diff ? { diff } : {}),
+    ...(item ? { item } : {}),
+  };
+}
+
+function inferFileChangeToolName(input: Record<string, unknown>): string {
+  const changes = Array.isArray(input.changes) ? input.changes : [];
+  const hasAdditiveChange = changes.some((change) => {
+    const record = asRecord(change);
+    const kind = firstString(record?.kind, record?.type, record?.operation);
+    return kind === "add" || kind === "create" || kind === "write";
+  });
+  return hasAdditiveChange ? "Write" : "Edit";
+}
+
+function extractRequestedPermissions(params: Record<string, unknown>): unknown {
+  return params.permissions ?? params.permission ?? params.requestedPermissions ?? params.requested_permissions;
+}
+
+function extractApprovalQuestions(params: Record<string, unknown>): RuntimeApprovalQuestion[] {
+  const toolInput = asRecord(params.toolInput) ?? asRecord(params.tool_input);
+  const questions = firstArray(params.questions, toolInput?.questions);
+  if (!questions) {
+    return [];
+  }
+
+  return questions.flatMap((question) => {
+    const record = asRecord(question);
+    if (!record) {
+      return [];
+    }
+
+    const text = firstString(record.question, record.text, record.prompt, record.label, record.header);
+    if (!text) {
+      return [];
+    }
+
+    const options = firstArray(record.options, record.choices, record.values)
+      ?.map((option) => {
+        if (typeof option === "string") {
+          return { label: option };
+        }
+        const optionRecord = asRecord(option);
+        const label = firstString(optionRecord?.label, optionRecord?.value, optionRecord?.text, optionRecord?.name);
+        if (!label) {
+          return null;
+        }
+        return {
+          label,
+          ...(firstString(optionRecord?.description) ? { description: firstString(optionRecord?.description) } : {}),
+        };
+      })
+      .filter((option): option is { label: string; description?: string } => !!option);
+
+    return [
+      {
+        ...(firstString(record.id, record.name) ? { id: firstString(record.id, record.name) } : {}),
+        ...(firstString(record.header) ? { header: firstString(record.header) } : {}),
+        question: text,
+        ...(options && options.length > 0 ? { options } : {}),
+        ...(typeof record.multiSelect === "boolean"
+          ? { multiSelect: record.multiSelect }
+          : typeof record.selectableCount === "number"
+            ? { multiSelect: record.selectableCount > 1 }
+            : {}),
+      },
+    ];
+  });
+}
+
+function firstArray(...values: unknown[]): unknown[] | undefined {
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function extractAppServerUsage(tokenUsage: unknown): CodexCliUsage | undefined {

--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { assertRuntimeCompatibility, createRuntimeProvider, getRuntimeCompatibilityIssues } from "./index.js";
+import {
+  assertRuntimeCompatibility,
+  createRuntimeProvider,
+  getRuntimeCompatibilityIssues,
+  listRegisteredRuntimeProviderIds,
+  registerRuntimeProvider,
+  unregisterRuntimeProvider,
+} from "./index.js";
 import type { RuntimeProvider } from "./types.js";
 
 describe("runtime compatibility preflight", () => {
@@ -15,7 +22,7 @@ describe("runtime compatibility preflight", () => {
     ).not.toThrow();
   });
 
-  it("reports Codex restrictions through the shared runtime abstraction", () => {
+  it("reports provider capability restrictions through the shared runtime abstraction", () => {
     const issues = getRuntimeCompatibilityIssues(createRuntimeProvider("codex"), {
       requiresMcpServers: true,
       requiresRemoteSpawn: true,
@@ -54,5 +61,32 @@ describe("runtime compatibility preflight", () => {
         toolAccessMode: "unrestricted",
       }),
     ).not.toThrow();
+  });
+
+  it("supports registering additional runtime providers without changing the factory switch", () => {
+    try {
+      registerRuntimeProvider("test-provider", () => ({
+        id: "test-provider",
+        getCapabilities: () => ({
+          supportsSessionResume: false,
+          supportsSessionFork: false,
+          supportsPartialText: false,
+          supportsToolHooks: true,
+          supportsPlugins: false,
+          supportsMcpServers: false,
+          supportsRemoteSpawn: false,
+        }),
+        startSession: () => ({
+          provider: "test-provider",
+          events: (async function* () {})(),
+          interrupt: async () => {},
+        }),
+      }));
+
+      expect(listRegisteredRuntimeProviderIds()).toContain("test-provider");
+      expect(createRuntimeProvider("test-provider").id).toBe("test-provider");
+    } finally {
+      unregisterRuntimeProvider("test-provider");
+    }
   });
 });

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -13,15 +13,40 @@ import type {
   SessionRuntimeProvider,
 } from "./types.js";
 
-export function createRuntimeProvider(providerId: RuntimeProviderId = "claude"): SessionRuntimeProvider {
-  switch (providerId) {
-    case "claude":
-      return createClaudeRuntimeProvider();
-    case "codex":
-      return createCodexRuntimeProvider();
-    default:
-      throw new Error(`Unknown runtime provider '${providerId}'`);
+type RuntimeProviderFactory = () => SessionRuntimeProvider;
+
+export const DEFAULT_RUNTIME_PROVIDER_ID: RuntimeProviderId = "claude";
+
+const runtimeProviderFactories = new Map<RuntimeProviderId, RuntimeProviderFactory>([
+  [DEFAULT_RUNTIME_PROVIDER_ID, createClaudeRuntimeProvider],
+  ["codex", createCodexRuntimeProvider],
+]);
+
+const builtInRuntimeProviderIds = new Set<RuntimeProviderId>([DEFAULT_RUNTIME_PROVIDER_ID, "codex"]);
+
+export function registerRuntimeProvider(providerId: RuntimeProviderId, factory: RuntimeProviderFactory): void {
+  runtimeProviderFactories.set(providerId, factory);
+}
+
+export function unregisterRuntimeProvider(providerId: RuntimeProviderId): void {
+  if (builtInRuntimeProviderIds.has(providerId)) {
+    throw new Error(`Cannot unregister built-in runtime provider '${providerId}'`);
   }
+  runtimeProviderFactories.delete(providerId);
+}
+
+export function listRegisteredRuntimeProviderIds(): RuntimeProviderId[] {
+  return [...runtimeProviderFactories.keys()];
+}
+
+export function createRuntimeProvider(
+  providerId: RuntimeProviderId = DEFAULT_RUNTIME_PROVIDER_ID,
+): SessionRuntimeProvider {
+  const factory = runtimeProviderFactories.get(providerId);
+  if (!factory) {
+    throw new Error(`Unknown runtime provider '${providerId}'`);
+  }
+  return factory();
 }
 
 export function getRuntimeCompatibilityIssues(

--- a/src/runtime/model-catalog.test.ts
+++ b/src/runtime/model-catalog.test.ts
@@ -62,4 +62,10 @@ describe("model catalog", () => {
 
     expect(resolvePreferredRuntimeModel("codex", "sonnet", { codexCachePath: cachePath })).toBe("gpt-5.2-codex");
   });
+
+  test("passes through models for providers without a registered catalog", () => {
+    expect(listRuntimeModels("custom-provider")).toEqual([]);
+    expect(getDefaultModelForProvider("custom-provider")).toBe("default");
+    expect(resolvePreferredRuntimeModel("custom-provider", "custom-model")).toBe("custom-model");
+  });
 });

--- a/src/runtime/model-catalog.ts
+++ b/src/runtime/model-catalog.ts
@@ -99,15 +99,19 @@ export function listRuntimeModels(
     return CLAUDE_MODEL_OPTIONS;
   }
 
-  const models = readCodexModelOptions(options.codexCachePath);
-  return models.length > 0 ? models : FALLBACK_CODEX_MODEL_OPTIONS;
+  if (provider === "codex") {
+    const models = readCodexModelOptions(options.codexCachePath);
+    return models.length > 0 ? models : FALLBACK_CODEX_MODEL_OPTIONS;
+  }
+
+  return [];
 }
 
 export function getDefaultModelForProvider(
   provider: RuntimeProviderId,
   options: RuntimeModelCatalogOptions = {},
 ): string {
-  return listRuntimeModels(provider, options)[0]?.id ?? (provider === "claude" ? "sonnet" : "gpt-5.4");
+  return listRuntimeModels(provider, options)[0]?.id ?? (provider === "claude" ? "sonnet" : "default");
 }
 
 export function resolvePreferredRuntimeModel(
@@ -117,6 +121,9 @@ export function resolvePreferredRuntimeModel(
 ): string {
   const normalized = normalizeRuntimeModel(provider, model);
   const models = listRuntimeModels(provider, options);
+  if (normalized && models.length === 0) {
+    return normalized;
+  }
   if (normalized && models.some((entry) => entry.id.toLowerCase() === normalized.toLowerCase())) {
     return normalized;
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,10 +7,11 @@ export interface RuntimeUsage {
 
 export type RuntimeBillingType = "api" | "subscription" | "unknown";
 
-export type RuntimeProviderId = "claude" | "codex";
+export type RuntimeProviderId = string;
 export type RuntimeToolAccessMode = "restricted" | "unrestricted";
 export type RuntimeEffort = "low" | "medium" | "high" | "xhigh" | "max";
 export type RuntimeThinking = "off" | "normal" | "verbose";
+export type RuntimeToolAccessRequirement = "tool_and_executable" | "tool_surface";
 
 export type RuntimeStatus = "queued" | "thinking" | "compacting" | "idle";
 
@@ -96,6 +97,36 @@ export interface RuntimeApprovalEvent {
 
 export type RuntimeApprovalHandler = (request: RuntimeApprovalRequest) => Promise<RuntimeApprovalResult>;
 
+export interface RuntimeCapabilityAuthorizationRequest {
+  permission: string;
+  objectType: string;
+  objectId: string;
+  eventData?: Record<string, unknown>;
+}
+
+export interface RuntimeCapabilityAuthorizationResult {
+  allowed: boolean;
+  inherited: boolean;
+  reason?: string;
+}
+
+export interface RuntimeCommandAuthorizationRequest {
+  command: string;
+  input?: Record<string, unknown>;
+  eventData?: Record<string, unknown>;
+}
+
+export interface RuntimeToolUseAuthorizationRequest {
+  toolName: string;
+  input?: Record<string, unknown>;
+  eventData?: Record<string, unknown>;
+}
+
+export interface RuntimeUserInputRequest {
+  questions: RuntimeApprovalQuestion[];
+  eventData?: Record<string, unknown>;
+}
+
 export interface RuntimeDynamicToolSpec {
   name: string;
   description: string;
@@ -130,6 +161,22 @@ export interface RuntimeDynamicToolCallResult {
 export type RuntimeDynamicToolCallHandler = (
   request: RuntimeDynamicToolCallRequest,
 ) => Promise<RuntimeDynamicToolCallResult>;
+
+export interface RuntimeDynamicToolExecutionOptions {
+  eventData?: Record<string, unknown>;
+}
+
+export interface RuntimeHostServices {
+  authorizeCapability(request: RuntimeCapabilityAuthorizationRequest): Promise<RuntimeCapabilityAuthorizationResult>;
+  authorizeCommandExecution(request: RuntimeCommandAuthorizationRequest): Promise<RuntimeApprovalResult>;
+  authorizeToolUse(request: RuntimeToolUseAuthorizationRequest): Promise<RuntimeApprovalResult>;
+  requestUserInput(request: RuntimeUserInputRequest): Promise<RuntimeApprovalResult>;
+  listDynamicTools(): RuntimeDynamicToolSpec[];
+  executeDynamicTool(
+    request: RuntimeDynamicToolCallRequest,
+    options?: RuntimeDynamicToolExecutionOptions,
+  ): Promise<RuntimeDynamicToolCallResult>;
+}
 
 export type RuntimeControlOperation =
   | "thread.list"
@@ -190,10 +237,12 @@ export interface RuntimePrepareSessionRequest {
   agentId: string;
   cwd: string;
   plugins?: RuntimePlugin[];
+  hostServices?: RuntimeHostServices;
 }
 
 export interface RuntimePrepareSessionResult {
   env?: Record<string, string>;
+  startRequest?: Partial<Pick<RuntimeStartRequest, "approveRuntimeRequest" | "dynamicTools" | "handleRuntimeToolCall">>;
 }
 
 export interface RuntimeSessionState {
@@ -355,9 +404,12 @@ export interface RuntimeCapabilities {
   supportsSessionFork: boolean;
   supportsPartialText: boolean;
   supportsToolHooks: boolean;
+  supportsHostSessionHooks?: boolean;
   supportsPlugins: boolean;
   supportsMcpServers: boolean;
   supportsRemoteSpawn: boolean;
+  legacyEventTopicSuffix?: string;
+  toolAccessRequirement?: RuntimeToolAccessRequirement;
 }
 
 export interface RuntimeProvider {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -83,6 +83,36 @@ export interface RuntimeExecutionMetadata {
   billingType?: RuntimeBillingType | null;
 }
 
+export interface RuntimeThreadMetadata {
+  id?: string;
+  title?: string;
+}
+
+export interface RuntimeTurnMetadata {
+  id?: string;
+  status?: string;
+}
+
+export interface RuntimeItemMetadata {
+  id?: string;
+  type?: string;
+  status?: string;
+  parentId?: string;
+}
+
+export interface RuntimeEventMetadata {
+  provider?: RuntimeProviderId;
+  source?: string;
+  nativeEvent?: string;
+  thread?: RuntimeThreadMetadata;
+  turn?: RuntimeTurnMetadata;
+  item?: RuntimeItemMetadata;
+}
+
+interface RuntimeEventBase {
+  metadata?: RuntimeEventMetadata;
+}
+
 export interface RuntimeStartRequest {
   prompt: AsyncGenerator<RuntimePromptMessage>;
   model: string;
@@ -105,55 +135,75 @@ export interface RuntimeStartRequest {
 }
 
 export type RuntimeEvent =
-  | {
+  | ({
       type: "provider.raw";
       rawEvent: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
+      type: "thread.started";
+      thread: RuntimeThreadMetadata;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
+      type: "turn.started";
+      turn: RuntimeTurnMetadata;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
+      type: "item.started";
+      item: RuntimeItemMetadata;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
+      type: "item.completed";
+      item: RuntimeItemMetadata;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
       type: "text.delta";
       text: string;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "status";
       status: RuntimeStatus;
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "assistant.message";
       text: string;
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "tool.started";
       toolUse: RuntimeToolUse;
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "tool.completed";
       toolUseId?: string;
       toolName?: string;
       content?: unknown;
       isError?: boolean;
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "turn.interrupted";
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "turn.failed";
       error: string;
       recoverable?: boolean;
       rawEvent?: Record<string, unknown>;
-    }
-  | {
+    } & RuntimeEventBase)
+  | ({
       type: "turn.complete";
       providerSessionId?: string;
       session?: RuntimeSessionState;
       execution?: RuntimeExecutionMetadata;
       usage: RuntimeUsage;
       rawEvent?: Record<string, unknown>;
-    };
+    } & RuntimeEventBase);
 
 export interface RuntimeSessionHandle {
   provider: RuntimeProviderId;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -52,6 +52,130 @@ export type RuntimeToolPermissionHandler = (
   input: Record<string, unknown>,
 ) => Promise<RuntimeToolPermissionResult>;
 
+export type RuntimeApprovalKind = "command_execution" | "file_change" | "permission" | "user_input";
+
+export interface RuntimeApprovalQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface RuntimeApprovalQuestion {
+  id?: string;
+  header?: string;
+  question: string;
+  options?: RuntimeApprovalQuestionOption[];
+  multiSelect?: boolean;
+}
+
+export interface RuntimeApprovalRequest {
+  kind: RuntimeApprovalKind;
+  method?: string;
+  toolName?: string;
+  input?: Record<string, unknown>;
+  rawRequest?: Record<string, unknown>;
+  metadata?: RuntimeEventMetadata;
+}
+
+export interface RuntimeApprovalResult {
+  approved: boolean;
+  reason?: string;
+  updatedInput?: Record<string, unknown>;
+  answers?: Record<string, string>;
+  permissions?: unknown;
+  inherited?: boolean;
+}
+
+export interface RuntimeApprovalEvent {
+  kind: RuntimeApprovalKind;
+  method?: string;
+  toolName?: string;
+  approved?: boolean;
+  reason?: string;
+  inherited?: boolean;
+}
+
+export type RuntimeApprovalHandler = (request: RuntimeApprovalRequest) => Promise<RuntimeApprovalResult>;
+
+export interface RuntimeDynamicToolSpec {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  deferLoading?: boolean;
+}
+
+export type RuntimeDynamicToolCallContentItem =
+  | {
+      type: "inputText";
+      text: string;
+    }
+  | {
+      type: "inputImage";
+      imageUrl: string;
+    };
+
+export interface RuntimeDynamicToolCallRequest {
+  toolName: string;
+  callId?: string;
+  arguments?: unknown;
+  rawRequest?: Record<string, unknown>;
+  metadata?: RuntimeEventMetadata;
+}
+
+export interface RuntimeDynamicToolCallResult {
+  success: boolean;
+  contentItems: RuntimeDynamicToolCallContentItem[];
+  reason?: string;
+}
+
+export type RuntimeDynamicToolCallHandler = (
+  request: RuntimeDynamicToolCallRequest,
+) => Promise<RuntimeDynamicToolCallResult>;
+
+export type RuntimeControlOperation =
+  | "thread.list"
+  | "thread.read"
+  | "thread.rollback"
+  | "thread.fork"
+  | "turn.steer"
+  | "turn.interrupt";
+
+export interface RuntimeControlState {
+  provider: RuntimeProviderId;
+  threadId?: string;
+  turnId?: string;
+  activeTurn?: boolean;
+  supportedOperations?: RuntimeControlOperation[];
+}
+
+export interface RuntimeControlRequest {
+  operation: RuntimeControlOperation;
+  threadId?: string;
+  turnId?: string;
+  expectedTurnId?: string;
+  text?: string;
+  input?: unknown[];
+  includeTurns?: boolean;
+  cursor?: string | null;
+  limit?: number | null;
+  sortKey?: string | null;
+  modelProviders?: string[] | null;
+  sourceKinds?: string[] | null;
+  archived?: boolean | null;
+  cwd?: string | null;
+  searchTerm?: string | null;
+  numTurns?: number;
+  path?: string | null;
+  params?: Record<string, unknown>;
+}
+
+export interface RuntimeControlResult {
+  ok: boolean;
+  operation: RuntimeControlOperation;
+  data?: Record<string, unknown>;
+  state?: RuntimeControlState;
+  error?: string;
+}
+
 export interface RuntimeHookMatcher {
   matcher?: string;
   hooks: Array<(...args: any[]) => any>;
@@ -128,6 +252,9 @@ export interface RuntimeStartRequest {
   settingSources?: ("user" | "project")[];
   permissionOptions?: Record<string, unknown>;
   canUseTool?: RuntimeToolPermissionHandler;
+  approveRuntimeRequest?: RuntimeApprovalHandler;
+  dynamicTools?: RuntimeDynamicToolSpec[];
+  handleRuntimeToolCall?: RuntimeDynamicToolCallHandler;
   mcpServers?: Record<string, unknown>;
   hooks?: Record<string, RuntimeHookMatcher[]>;
   plugins?: RuntimePlugin[];
@@ -187,6 +314,16 @@ export type RuntimeEvent =
       rawEvent?: Record<string, unknown>;
     } & RuntimeEventBase)
   | ({
+      type: "approval.requested";
+      approval: RuntimeApprovalEvent;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
+      type: "approval.resolved";
+      approval: RuntimeApprovalEvent;
+      rawEvent?: Record<string, unknown>;
+    } & RuntimeEventBase)
+  | ({
       type: "turn.interrupted";
       rawEvent?: Record<string, unknown>;
     } & RuntimeEventBase)
@@ -210,6 +347,7 @@ export interface RuntimeSessionHandle {
   events: AsyncIterable<RuntimeEvent>;
   interrupt(): Promise<void>;
   setModel?(model: string): Promise<void>;
+  control?(request: RuntimeControlRequest): Promise<RuntimeControlResult>;
 }
 
 export interface RuntimeCapabilities {

--- a/src/whatsapp-overlay/bridge.ts
+++ b/src/whatsapp-overlay/bridge.ts
@@ -2910,7 +2910,7 @@ async function trackSessionRuntime(): Promise<void> {
       if (type === "approval.requested") {
         pushLiveEvent(sessionName, {
           kind: "approval",
-          label: "codex approval",
+          label: "runtime approval",
           detail: formatRuntimeApprovalDetail(data, "pending"),
           timestamp: eventTimestamp,
           ...(metadata ? { metadata } : {}),
@@ -2919,7 +2919,7 @@ async function trackSessionRuntime(): Promise<void> {
       } else if (type === "approval.resolved") {
         pushLiveEvent(sessionName, {
           kind: "approval",
-          label: "codex approval",
+          label: "runtime approval",
           detail: formatRuntimeApprovalDetail(data, "answered"),
           timestamp: eventTimestamp,
           ...(metadata ? { metadata } : {}),
@@ -2928,7 +2928,7 @@ async function trackSessionRuntime(): Promise<void> {
       } else if (isRuntimeGraphEvent(type)) {
         pushLiveEvent(sessionName, {
           kind: "runtime",
-          label: "codex runtime",
+          label: "runtime graph",
           detail: formatRuntimeGraphDetail(type, data, metadata),
           timestamp: eventTimestamp,
           ...(metadata ? { metadata } : {}),

--- a/src/whatsapp-overlay/bridge.ts
+++ b/src/whatsapp-overlay/bridge.ts
@@ -42,6 +42,7 @@ import {
   type OverlayChatArtifactAnchor,
   type OverlayLiveState,
   type OverlayQuery,
+  type OverlayRuntimeMetadata,
   type OverlaySessionSnapshot,
   type OverlaySessionEvent,
   type OverlaySessionWorkspaceMessage,
@@ -2843,7 +2844,8 @@ async function trackSessionRuntime(): Promise<void> {
 
     if (topic.endsWith(".stream")) {
       const chunk = typeof data.chunk === "string" ? data.chunk : "";
-      updateStreamEvent(sessionName, chunk);
+      const metadata = extractRuntimeMetadata(data);
+      updateStreamEvent(sessionName, chunk, metadata);
       upsertLive(sessionName, "streaming", "streaming reply");
       continue;
     }
@@ -2879,11 +2881,13 @@ async function trackSessionRuntime(): Promise<void> {
       const toolId = cleanNullable(typeof data.toolId === "string" ? data.toolId : null) ?? `tool-${eventTimestamp}`;
       const toolName = typeof data.toolName === "string" ? data.toolName : "tool";
       const toolDetail = summarizeToolArtifactPreview(data, summarizeToolInput(data.input) || null) || undefined;
+      const metadata = extractRuntimeMetadata(data);
       pushLiveEvent(sessionName, {
         kind: "tool",
         label: toolName,
         detail: toolDetail,
         timestamp: eventTimestamp,
+        ...(metadata ? { metadata } : {}),
       });
       if (eventName === "start" || eventName === "end") {
         pushLiveArtifact(sessionName, buildToolArtifact(sessionName, toolId, toolName, data, eventTimestamp));
@@ -2901,13 +2905,50 @@ async function trackSessionRuntime(): Promise<void> {
       const subtype = typeof data.subtype === "string" ? data.subtype : undefined;
       const status = typeof data.status === "string" ? data.status : undefined;
       const eventTimestamp = Date.now();
+      const metadata = extractRuntimeMetadata(data);
 
-      if (status === "compacting" || (type === "system" && subtype === "status" && status === "compacting")) {
+      if (type === "approval.requested") {
+        pushLiveEvent(sessionName, {
+          kind: "approval",
+          label: "codex approval",
+          detail: formatRuntimeApprovalDetail(data, "pending"),
+          timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
+        });
+        upsertLive(sessionName, "awaiting_approval", "approval pending", true);
+      } else if (type === "approval.resolved") {
+        pushLiveEvent(sessionName, {
+          kind: "approval",
+          label: "codex approval",
+          detail: formatRuntimeApprovalDetail(data, "answered"),
+          timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
+        });
+        upsertLive(sessionName, "thinking", "approval answered", false);
+      } else if (isRuntimeGraphEvent(type)) {
+        pushLiveEvent(sessionName, {
+          kind: "runtime",
+          label: "codex runtime",
+          detail: formatRuntimeGraphDetail(type, data, metadata),
+          timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
+        });
+        upsertLive(sessionName, "thinking", formatRuntimeGraphSummary(type));
+      } else if (type === "runtime.control") {
+        pushLiveEvent(sessionName, {
+          kind: "runtime",
+          label: "runtime control",
+          detail: formatRuntimeControlDetail(data),
+          timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
+        });
+      } else if (status === "compacting" || (type === "system" && subtype === "status" && status === "compacting")) {
         pushLiveEvent(sessionName, {
           kind: "runtime",
           label: "runtime",
           detail: "compacting",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "compacting", "compacting");
       } else if (status === "thinking" || status === "queued") {
@@ -2920,6 +2961,7 @@ async function trackSessionRuntime(): Promise<void> {
           label: "tool",
           detail: "running",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "thinking", "tool running");
       } else if (type === "tool.completed") {
@@ -2928,6 +2970,7 @@ async function trackSessionRuntime(): Promise<void> {
           label: "tool",
           detail: "finished",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "thinking", "tool finished");
       } else if (type === "provider.raw" || type === "system" || type === "user") {
@@ -2944,6 +2987,7 @@ async function trackSessionRuntime(): Promise<void> {
           label: "runtime",
           detail: "turn.interrupted",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         pushLiveArtifact(sessionName, artifact);
         const pendingEmitId = getLatestResponseEmitId(sessionName);
@@ -2958,6 +3002,7 @@ async function trackSessionRuntime(): Promise<void> {
           label: "runtime",
           detail: type ?? status ?? "idle",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "idle", "idle");
         resetActiveArtifactTurnState(sessionName);
@@ -2967,6 +3012,7 @@ async function trackSessionRuntime(): Promise<void> {
           label: "runtime",
           detail: type ?? status ?? "idle",
           timestamp: eventTimestamp,
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "idle", "idle");
       }
@@ -2981,11 +3027,13 @@ async function trackApprovalRuntime(): Promise<void> {
     if (topic === "ravi.approval.request") {
       const sessionName = typeof data.sessionName === "string" ? data.sessionName : null;
       if (sessionName) {
+        const metadata = extractRuntimeMetadata(data);
         pushLiveEvent(sessionName, {
           kind: "approval",
           label: "approval",
           detail: "pending",
           timestamp: Date.now(),
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "awaiting_approval", "approval pending", true);
       }
@@ -2995,16 +3043,108 @@ async function trackApprovalRuntime(): Promise<void> {
     if (topic === "ravi.approval.response") {
       const sessionName = typeof data.sessionName === "string" ? data.sessionName : null;
       if (sessionName) {
+        const metadata = extractRuntimeMetadata(data);
         pushLiveEvent(sessionName, {
           kind: "approval",
           label: "approval",
           detail: "answered",
           timestamp: Date.now(),
+          ...(metadata ? { metadata } : {}),
         });
         upsertLive(sessionName, "idle", "approval answered", false);
       }
     }
   }
+}
+
+const RUNTIME_GRAPH_EVENT_TYPES = ["thread.started", "turn.started", "item.started", "item.completed"] as const;
+type RuntimeGraphEventType = (typeof RUNTIME_GRAPH_EVENT_TYPES)[number];
+const RUNTIME_GRAPH_EVENT_TYPE_SET = new Set<string>(RUNTIME_GRAPH_EVENT_TYPES);
+
+function isRuntimeGraphEvent(type?: string): type is RuntimeGraphEventType {
+  return Boolean(type && RUNTIME_GRAPH_EVENT_TYPE_SET.has(type));
+}
+
+function extractRuntimeMetadata(data: Record<string, unknown>): OverlayRuntimeMetadata | undefined {
+  const metadata = data.metadata ?? data.runtimeMetadata;
+  return asPlainRecord(metadata) ?? undefined;
+}
+
+function formatRuntimeGraphDetail(
+  type: string,
+  data: Record<string, unknown>,
+  metadata: OverlayRuntimeMetadata | undefined,
+): string {
+  const thread = asPlainRecord(data.thread) ?? asPlainRecord(metadata?.thread);
+  const turn = asPlainRecord(data.turn) ?? asPlainRecord(metadata?.turn);
+  const item = asPlainRecord(data.item) ?? asPlainRecord(metadata?.item);
+
+  const parts = [
+    type,
+    formatRuntimeGraphPart("thread", cleanUnknownString(thread?.id)),
+    formatRuntimeGraphPart("turn", cleanUnknownString(turn?.id)),
+    formatRuntimeGraphPart("item", cleanUnknownString(item?.id)),
+    formatRuntimeGraphPart("kind", cleanUnknownString(item?.type)),
+    formatRuntimeGraphPart("status", cleanUnknownString(item?.status)),
+  ].filter(Boolean);
+
+  return parts.join(" ");
+}
+
+function formatRuntimeGraphSummary(type: string): string {
+  switch (type) {
+    case "thread.started":
+      return "runtime thread active";
+    case "turn.started":
+      return "runtime turn active";
+    case "item.started":
+      return "runtime item active";
+    case "item.completed":
+      return "runtime item completed";
+    default:
+      return "working";
+  }
+}
+
+function formatRuntimeApprovalDetail(data: Record<string, unknown>, fallbackState: string): string {
+  const approval = asPlainRecord(data.approval);
+  const kind = cleanUnknownString(approval?.kind) ?? "approval";
+  const approved = approval && typeof approval.approved === "boolean" ? approval.approved : undefined;
+  const state =
+    typeof approved === "boolean"
+      ? approved
+        ? "approved"
+        : "denied"
+      : (cleanUnknownString(approval?.status) ?? fallbackState);
+  const inherited = approval?.inherited === true ? "inherited" : null;
+  const toolName = formatRuntimeGraphPart("tool", cleanUnknownString(approval?.toolName));
+  const method = formatRuntimeGraphPart("method", cleanUnknownString(approval?.method));
+  const reason = cleanUnknownString(approval?.reason);
+
+  return [kind, state, inherited, toolName, method, reason].filter(Boolean).join(" · ");
+}
+
+function formatRuntimeControlDetail(data: Record<string, unknown>): string {
+  const operation = cleanUnknownString(data.operation) ?? "control";
+  const status = typeof data.ok === "boolean" ? (data.ok ? "ok" : "failed") : "requested";
+  const error = cleanUnknownString(data.error);
+  return [operation, status, error].filter(Boolean).join(" · ");
+}
+
+function formatRuntimeGraphPart(label: string, value: string | null): string | null {
+  if (!value) return null;
+  return `${label}=${formatLiveText(value, 96)}`;
+}
+
+function cleanUnknownString(value: unknown): string | null {
+  return typeof value === "string" ? cleanNullable(value) : null;
+}
+
+function asPlainRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
 }
 
 function isTerminalRuntimeEvent(type?: string): boolean {
@@ -3249,7 +3389,7 @@ function liveWorkspaceTextsOverlap(left: string, right: string): boolean {
   return left === right || left.includes(right) || right.includes(left);
 }
 
-function updateStreamEvent(sessionName: string, detail: string): void {
+function updateStreamEvent(sessionName: string, detail: string, metadata?: OverlayRuntimeMetadata): void {
   const current = liveBySessionName.get(sessionName);
   const previous = Array.isArray(current?.events) ? [...current.events] : [];
   const timestamp = Date.now();
@@ -3261,6 +3401,7 @@ function updateStreamEvent(sessionName: string, detail: string): void {
       ...previous[existingIndex]!,
       detail: nextDetail,
       timestamp,
+      ...(metadata ? { metadata } : {}),
     };
   } else {
     previous.unshift({
@@ -3268,6 +3409,7 @@ function updateStreamEvent(sessionName: string, detail: string): void {
       label: "stream",
       detail: nextDetail,
       timestamp,
+      ...(metadata ? { metadata } : {}),
     });
   }
 
@@ -3286,6 +3428,7 @@ function updateStreamEvent(sessionName: string, detail: string): void {
     createdAt: timestamp,
     source: "live",
     pending: true,
+    ...(metadata ? { metadata } : {}),
   });
 }
 
@@ -3317,6 +3460,7 @@ function buildInterruptionArtifact(
   anchor: OverlayChatArtifactAnchor,
 ): OverlayChatArtifact {
   const detail = extractRuntimeText(data) || "execução interrompida";
+  const metadata = extractRuntimeMetadata(data);
   return {
     id: `${sessionName}:turn.interrupted:${timestamp}`,
     kind: "interruption",
@@ -3325,6 +3469,7 @@ function buildInterruptionArtifact(
     createdAt: timestamp,
     updatedAt: timestamp,
     anchor,
+    ...(metadata ? { metadata } : {}),
   };
 }
 
@@ -3342,6 +3487,7 @@ function buildToolArtifact(
   const fullDetail = buildToolArtifactFullDetail(data, existing?.fullDetail ?? null);
   const status = resolveToolArtifactStatus(data, existing?.status ?? null);
   const duration = resolveToolArtifactDuration(data, existing?.duration ?? null);
+  const metadata = extractRuntimeMetadata(data) ?? existing?.metadata ?? undefined;
   return {
     id: artifactId,
     kind: "tool",
@@ -3356,6 +3502,7 @@ function buildToolArtifact(
     updatedAt: timestamp,
     anchor: existing?.anchor ?? resolveActiveArtifactAnchor(sessionName),
     dedupeKey: artifactId,
+    ...(metadata ? { metadata } : {}),
   };
 }
 

--- a/src/whatsapp-overlay/model.test.ts
+++ b/src/whatsapp-overlay/model.test.ts
@@ -529,14 +529,14 @@ describe("whatsapp overlay model", () => {
         events: [
           {
             kind: "runtime",
-            label: "codex runtime",
+            label: "runtime graph",
             detail: "thread.started thread=thread_1",
             timestamp: Date.parse("2026-04-12T03:00:00Z"),
             metadata: runtimeMetadata,
           },
           {
             kind: "approval",
-            label: "codex approval",
+            label: "runtime approval",
             detail: "command_execution · pending",
             timestamp: Date.parse("2026-04-12T03:00:01Z"),
             metadata: approvalMetadata,
@@ -562,7 +562,7 @@ describe("whatsapp overlay model", () => {
       },
     });
 
-    const runtimeEvent = timeline.find((item) => item.type === "event" && item.label === "codex runtime");
+    const runtimeEvent = timeline.find((item) => item.type === "event" && item.label === "runtime graph");
     expect(runtimeEvent).toMatchObject({
       type: "event",
       kind: "runtime",
@@ -573,7 +573,7 @@ describe("whatsapp overlay model", () => {
     const approvalEvent = timeline.find((item) => item.type === "event" && item.kind === "approval");
     expect(approvalEvent).toMatchObject({
       type: "event",
-      label: "codex approval",
+      label: "runtime approval",
       metadata: approvalMetadata,
     });
 

--- a/src/whatsapp-overlay/model.test.ts
+++ b/src/whatsapp-overlay/model.test.ts
@@ -497,6 +497,102 @@ describe("whatsapp overlay model", () => {
     });
   });
 
+  it("preserves runtime graph metadata on operational timeline items", () => {
+    const runtimeMetadata = {
+      provider: "codex",
+      thread: { id: "thread_1" },
+      turn: { id: "turn_1" },
+    };
+    const approvalMetadata = {
+      provider: "codex",
+      thread: { id: "thread_1" },
+      turn: { id: "turn_1" },
+      item: { id: "approval_1", type: "approval_request" },
+    };
+    const streamMetadata = {
+      provider: "codex",
+      thread: { id: "thread_1" },
+      turn: { id: "turn_1" },
+      item: { id: "message_1", type: "assistant_message_delta" },
+    };
+    const toolMetadata = {
+      provider: "codex",
+      thread: { id: "thread_1" },
+      turn: { id: "turn_1" },
+      item: { id: "tool_1", type: "tool_call", status: "completed" },
+    };
+
+    const timeline = buildOverlaySessionWorkspaceTimeline({
+      messages: [],
+      live: {
+        activity: "thinking",
+        events: [
+          {
+            kind: "runtime",
+            label: "codex runtime",
+            detail: "thread.started thread=thread_1",
+            timestamp: Date.parse("2026-04-12T03:00:00Z"),
+            metadata: runtimeMetadata,
+          },
+          {
+            kind: "approval",
+            label: "codex approval",
+            detail: "command_execution · pending",
+            timestamp: Date.parse("2026-04-12T03:00:01Z"),
+            metadata: approvalMetadata,
+          },
+          {
+            kind: "stream",
+            label: "stream",
+            detail: "resposta parcial",
+            timestamp: Date.parse("2026-04-12T03:00:03Z"),
+            metadata: streamMetadata,
+          },
+        ],
+        artifacts: [
+          {
+            id: "tool-1",
+            kind: "tool",
+            label: "bash",
+            detail: "ok",
+            createdAt: Date.parse("2026-04-12T03:00:02Z"),
+            metadata: toolMetadata,
+          },
+        ],
+      },
+    });
+
+    const runtimeEvent = timeline.find((item) => item.type === "event" && item.label === "codex runtime");
+    expect(runtimeEvent).toMatchObject({
+      type: "event",
+      kind: "runtime",
+      detail: "thread.started thread=thread_1",
+      metadata: runtimeMetadata,
+    });
+
+    const approvalEvent = timeline.find((item) => item.type === "event" && item.kind === "approval");
+    expect(approvalEvent).toMatchObject({
+      type: "event",
+      label: "codex approval",
+      metadata: approvalMetadata,
+    });
+
+    const streamMessage = timeline.find((item) => item.type === "message" && item.eventKind === "stream");
+    expect(streamMessage).toMatchObject({
+      type: "message",
+      role: "assistant",
+      content: "resposta parcial",
+      metadata: streamMetadata,
+    });
+
+    const toolArtifact = timeline.find((item) => item.type === "artifact" && item.kind === "tool");
+    expect(toolArtifact).toMatchObject({
+      type: "artifact",
+      label: "bash",
+      metadata: toolMetadata,
+    });
+  });
+
   it("suppresses kind:tool events when tool artifacts exist", () => {
     const timeline = buildOverlaySessionWorkspaceTimeline({
       messages: [],

--- a/src/whatsapp-overlay/model.ts
+++ b/src/whatsapp-overlay/model.ts
@@ -15,11 +15,14 @@ export interface OverlayQuery {
   session?: string | null;
 }
 
+export type OverlayRuntimeMetadata = Record<string, unknown>;
+
 export interface OverlaySessionEvent {
   kind: "prompt" | "stream" | "tool" | "response" | "approval" | "runtime";
   label: string;
   detail?: string;
   timestamp: number;
+  metadata?: OverlayRuntimeMetadata | null;
 }
 
 export type OverlayToolCallStatus = "running" | "ok" | "error";
@@ -47,6 +50,7 @@ export interface OverlayChatArtifact {
   updatedAt?: number;
   anchor?: OverlayChatArtifactAnchor;
   dedupeKey?: string | null;
+  metadata?: OverlayRuntimeMetadata | null;
 }
 
 export interface OverlayLiveState {
@@ -67,6 +71,7 @@ export interface OverlaySessionWorkspaceMessage {
   createdAt: number;
   source?: "history" | "live";
   pending?: boolean;
+  metadata?: OverlayRuntimeMetadata | null;
 }
 
 export type OverlaySessionWorkspaceTimelineItem =
@@ -79,6 +84,7 @@ export type OverlaySessionWorkspaceTimelineItem =
       source: "history" | "live";
       pending?: boolean;
       eventKind?: OverlaySessionEvent["kind"];
+      metadata?: OverlayRuntimeMetadata | null;
     }
   | {
       id: string;
@@ -88,6 +94,7 @@ export type OverlaySessionWorkspaceTimelineItem =
       detail: string;
       timestamp: number;
       source: "live";
+      metadata?: OverlayRuntimeMetadata | null;
     }
   | {
       id: string;
@@ -102,6 +109,7 @@ export type OverlaySessionWorkspaceTimelineItem =
       timestamp: number;
       source: "live";
       anchor?: OverlayChatArtifactAnchor;
+      metadata?: OverlayRuntimeMetadata | null;
     };
 
 export interface OverlayPermissionDecision {
@@ -345,6 +353,7 @@ export function buildOverlaySessionWorkspaceTimeline(args: {
     timestamp: message.createdAt,
     source: message.source ?? "history",
     pending: message.pending ?? false,
+    ...(message.metadata ? { metadata: message.metadata } : {}),
   }));
 
   const liveMessageItems: Extract<OverlaySessionWorkspaceTimelineItem, { type: "message" }>[] = [];
@@ -360,6 +369,7 @@ export function buildOverlaySessionWorkspaceTimeline(args: {
       timestamp: message.createdAt,
       source: message.source ?? "live",
       pending: message.pending ?? false,
+      ...(message.metadata ? { metadata: message.metadata } : {}),
     };
 
     if (hasMatchingWorkspaceMessage(historyMessages, item)) {
@@ -406,6 +416,7 @@ export function buildOverlaySessionWorkspaceTimeline(args: {
       timestamp,
       source: "live",
       anchor: artifact.anchor,
+      ...(artifact.metadata ? { metadata: artifact.metadata } : {}),
     });
   }
 
@@ -563,6 +574,7 @@ function toWorkspaceTimelineItemFromEvent(event: OverlaySessionEvent): OverlaySe
   const kind = normalizeLookupToken(event.kind);
   const detail = normalizeWorkspaceText(event.detail);
   const timestamp = parseOverlayTimestamp(event.timestamp);
+  const metadata = event.metadata ?? undefined;
 
   if (!kind || !timestamp) {
     return null;
@@ -579,6 +591,7 @@ function toWorkspaceTimelineItemFromEvent(event: OverlaySessionEvent): OverlaySe
       source: "live",
       pending: true,
       eventKind: event.kind,
+      ...(metadata ? { metadata } : {}),
     };
   }
 
@@ -593,6 +606,7 @@ function toWorkspaceTimelineItemFromEvent(event: OverlaySessionEvent): OverlaySe
       source: "live",
       pending: true,
       eventKind: event.kind,
+      ...(metadata ? { metadata } : {}),
     };
   }
 
@@ -607,6 +621,7 @@ function toWorkspaceTimelineItemFromEvent(event: OverlaySessionEvent): OverlaySe
       source: "live",
       pending: true,
       eventKind: event.kind,
+      ...(metadata ? { metadata } : {}),
     };
   }
 
@@ -632,6 +647,7 @@ function toWorkspaceTimelineItemFromEvent(event: OverlaySessionEvent): OverlaySe
     detail: body,
     timestamp,
     source: "live",
+    ...(metadata ? { metadata } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds the Codex runtime v2 control plane: native thread/turn/item event graph, approval bridge, dynamic tools bridge, runtime control, and overlay/stream metadata surfaces.
- Hardens the provider boundary so `bot.ts` is a provider-agnostic host: generic runtime host services, provider registry, open provider IDs through CLI/DB/session/model catalog, and provider-specific bridges contained in their provider package.
- Splits runtime permission capabilities so providers that support restricted access do not automatically receive host-managed session hooks unless they explicitly declare that protocol.
- Keeps compatibility surfaces for existing sessions while preserving the new runtime graph metadata.

## Rebase / conflict resolution
- Rebases the branch onto current `dev` (`cd9bb4f`).
- Preserves the live session model-change flow alongside runtime control requests.
- Preserves task/profile runtime override semantics while adding runtime graph/control behavior.
- Keeps runtime cost tracking conservative: no configured-model backfill for non-default runtime events without an explicit execution model.

## Quality Gate follow-ups
- Updates the agents CLI test mock for the wider runtime provider registry import graph.
- Makes `project_links.updated_at` monotonic per project so focused workflow selection is deterministic even when links are created in the same millisecond.

## Validation
- `bun run typecheck`
- `bun test src/bot.runtime-guards.test.ts --timeout 20000`
- `bun test src/runtime/codex-provider.test.ts src/runtime/index.test.ts src/runtime/model-catalog.test.ts src/cli/commands/sessions-runtime.test.ts src/whatsapp-overlay/model.test.ts --timeout 20000`
- `bun run test:cli-commands`
- `bun test src/projects/service.test.ts --timeout 20000`
- `bun run build`

## Runtime note
- Daemon was not restarted in this cut.
