### PR TITLE
ci(sdk): add manual SDK release workflow

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,0 +1,144 @@
+name: SDK Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to release the SDK from"
+        required: true
+        type: choice
+        options: [main, dev]
+        default: main
+      prefix:
+        description: "Version major prefix (defaults to current package.json major)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sdk-release-${{ github.event.inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Version And Publish SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      SDK_PACKAGE_PATH: packages/ravi-os-sdk/package.json
+      SDK_DIR: packages/ravi-os-sdk
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve prefix
+        id: prefix
+        run: |
+          PREFIX="${{ github.event.inputs.prefix }}"
+          if [ -z "$PREFIX" ]; then
+            PREFIX=$(jq -r '.version | split(".") | .[0]' "$SDK_PACKAGE_PATH")
+          fi
+          if ! echo "$PREFIX" | grep -Eq '^[0-9]+$'; then
+            echo "Resolved prefix '$PREFIX' is not numeric" >&2
+            exit 1
+          fi
+          echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"
+          echo "Resolved prefix: ${PREFIX}"
+
+      - name: Derive version
+        id: version
+        env:
+          PREFIX: ${{ steps.prefix.outputs.prefix }}
+        run: |
+          set -euo pipefail
+          PACKAGE=$(jq -r '.name' "$SDK_PACKAGE_PATH")
+          TODAY=$(date -u +%y%m%d)
+          PATTERN="${PREFIX}.${TODAY}."
+
+          VERSIONS_JSON=$(npm view "$PACKAGE" versions --json 2>/dev/null || echo '[]')
+          if [ -z "$VERSIONS_JSON" ]; then
+            VERSIONS_JSON='[]'
+          fi
+          EXISTING=$(echo "$VERSIONS_JSON" | jq --arg p "$PATTERN" '
+            if type == "string"
+            then (if startswith($p) then 1 else 0 end)
+            else [.[] | select(startswith($p))] | length
+            end
+          ')
+          BUILD_NUMBER=$((EXISTING + 1))
+          VERSION="${PREFIX}.${TODAY}.${BUILD_NUMBER}"
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Derived SDK version: ${VERSION} (existing today: ${EXISTING})"
+
+      - name: Sync SDK version
+        env:
+          RAVI_PACKAGE_PATH: ${{ env.SDK_PACKAGE_PATH }}
+          RAVI_VERSION_PREFIX: ${{ steps.prefix.outputs.prefix }}
+          RAVI_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+          RAVI_VERSION: ${{ steps.version.outputs.version }}
+        run: bun run version
+
+      - name: Regenerate SDK client (live registry → typed client)
+        run: bun run sdk:generate
+
+      - name: Commit SDK version bump
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="${{ github.event.inputs.branch }}"
+
+          git add "$SDK_PACKAGE_PATH" packages/ravi-os-sdk/src
+          if git diff --cached --quiet; then
+            echo "No version changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(sdk-version): bump to ${VERSION} [skip ci]"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+
+      - name: Build SDK
+        working-directory: ${{ env.SDK_DIR }}
+        run: bun run build
+
+      - name: Publish to npm
+        working-directory: ${{ env.SDK_DIR }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN not set; cannot publish SDK" >&2
+            exit 1
+          fi
+
+          PACKAGE=$(jq -r '.name' package.json)
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${VERSION} already exists; moving dist-tag latest"
+            npm dist-tag add "${PACKAGE}@${VERSION}" latest
+          else
+            bun publish --access public --tag latest
+          fi

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -22,6 +22,12 @@ function repoRoot(): string {
   return join(dirname(import.meta.path), "..");
 }
 
+function resolvePackagePath(root: string): string {
+  const override = process.env.RAVI_PACKAGE_PATH?.trim();
+  if (!override) return join(root, "package.json");
+  return override.startsWith("/") ? override : join(root, override);
+}
+
 function todayUtc(): string {
   const now = new Date();
   const yy = String(now.getUTCFullYear()).slice(-2);
@@ -31,8 +37,7 @@ function todayUtc(): string {
 }
 
 function readCurrentPackage(root: string): PackageJson {
-  const packagePath = join(root, "package.json");
-  return JSON.parse(readFileSync(packagePath, "utf8")) as PackageJson;
+  return JSON.parse(readFileSync(resolvePackagePath(root), "utf8")) as PackageJson;
 }
 
 function resolvePrefix(pkg: PackageJson): string {
@@ -67,8 +72,7 @@ function resolveBuildNumber(prefix: string, datePrefix: string): number {
   return countTagsForToday(prefix, datePrefix) + 1;
 }
 
-async function updatePackageVersion(root: string, version: string): Promise<void> {
-  const packagePath = join(root, "package.json");
+async function updatePackageVersion(packagePath: string, version: string): Promise<void> {
   if (!existsSync(packagePath)) throw new Error(`package.json not found: ${packagePath}`);
 
   const pkg = JSON.parse(await readFile(packagePath, "utf8")) as PackageJson;
@@ -78,15 +82,16 @@ async function updatePackageVersion(root: string, version: string): Promise<void
 
 async function main(): Promise<void> {
   const root = repoRoot();
+  const packagePath = resolvePackagePath(root);
   const pkg = readCurrentPackage(root);
   const prefix = resolvePrefix(pkg);
   const datePrefix = todayUtc();
   const buildNumber = resolveBuildNumber(prefix, datePrefix);
   const version = process.env.RAVI_VERSION?.trim() || `${prefix}.${datePrefix}.${buildNumber}`;
 
-  await updatePackageVersion(root, version);
+  await updatePackageVersion(packagePath, version);
   console.log(`Ravi version: ${version}`);
-  console.log("Updated package.json");
+  console.log(`Updated ${packagePath}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Carrega o backlog atual de \`dev\` pra \`main\` — highlight: workflow manual pra release do SDK \`@ravi-os/sdk\` via GHA.

## Por que precisa ir pra main

\`workflow_dispatch\` exige que o arquivo do workflow esteja registrado na branch default do repo. Tentei \`gh workflow run sdk-release.yml --ref dev\` e o GitHub retornou 404 confirmando isso. Sem este merge, não há jeito de disparar o workflow.

## Mudanças

- \`.github/workflows/sdk-release.yml\` (NEW): release manual do SDK
  - \`workflow_dispatch\` only — sem auto-trigger em CI
  - Inputs: \`branch\` (main/dev, default main), \`prefix\` (default = major do package.json atual, hoje \`0\`)
  - Versão derivada de \`npm view @ravi-os/sdk versions\` filtrando por \`<prefix>.YYMMDD.*\` (sem tags git)
  - Regenera client SDK via \`bun run sdk:generate\`, commit \`chore(sdk-version): bump to X [skip ci]\`, push branch, build, \`bun publish --tag latest\`
  - Único dist-tag: \`latest\` (sem next/latest split — Luís pediu)
  - Se versão já existe no registry, só move \`latest\`

- \`scripts/version.ts\`: extensão mínima — honra \`RAVI_PACKAGE_PATH\` (default = repo root). Default behavior unchanged.

## Validação

- YAML parse OK (\`js-yaml\` / \`pyyaml\`)
- \`bun run version\` com \`RAVI_PACKAGE_PATH=packages/ravi-os-sdk/package.json\` atualiza o SDK certo, deixa root intacto
- Dry-run da derivação de versão: \`@ravi-os/sdk\` tem \`[0.1.0, 0.2.0, 0.2.1]\` → próxima hoje seria \`0.260519.1\`
- Pre-push hook (sdk:check + build + typecheck + tests) passou OK

## Watchouts

- \`bun publish\` precisa \`NPM_TOKEN\` (já existe nos secrets do repo, mesmo usado por \`version.yml\`)
- Workflow assume \`packages/ravi-os-sdk\` existe e tem \`tsconfig.json\` configurado pra \`tsc\` (já tá)
- Commit do bump usa \`github-actions[bot]\` — sem GPG signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->