### PR TITLE
fix(omni): lazy session commit to prevent orphan sessions

### DIFF
--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeAbortProvenance } from "../runtime/session-dispatcher.js";
 import type { MessageMetadata } from "../router/router-db.js";
 
 const actualRouterDbModule = await import("../router/router-db.js");
+const actualRouterIndexModule = await import("../router/index.js");
 const actualRouterSessionsModule = await import("../router/sessions.js");
 const actualChatDbModule = await import("../db.js");
 const actualDbSaveMessageMeta = actualRouterDbModule.dbSaveMessageMeta;
@@ -71,9 +72,16 @@ mock.module("../slash/index.js", () => ({
   handleSlashCommand: mock(async () => false),
 }));
 
+// Note: we intentionally do NOT override `matchRoute` here. Overriding a
+// re-exported symbol in `../router/index.js` leaks into direct imports
+// from `../router/resolver.js` (a bun quirk where the live binding is
+// mutated in place), which would break `resolver.test.ts`. Instead we
+// fix the config so the real `matchRoute` returns a valid match, and
+// only override `commitMatchedRoute` to inject the test's routeResult.
 mock.module("../router/index.js", () => ({
+  ...actualRouterIndexModule,
   expandHome: (cwd: string) => cwd,
-  resolveRoute: () => routeResult,
+  commitMatchedRoute: () => routeResult,
 }));
 
 mock.module("../config-store.js", () => ({
@@ -91,10 +99,23 @@ mock.module("../config-store.js", () => ({
         },
       },
       routes: [],
-      agents: {},
+      agents: {
+        main: {
+          id: "main",
+          cwd: agentCwd,
+          dmScope: "main",
+          mode: "active",
+        },
+      },
       defaultAgent: "main",
       defaultDmScope: "main",
-      accountAgents: {},
+      // When routeResult is null, the test wants to exercise the "no route"
+      // fallback in the consumer. We mirror that by leaving accountAgents
+      // empty so the real matchRoute hits its "no route for account, skip"
+      // branch. When routeResult is set, accountAgents maps main→main so
+      // matchRoute returns a valid match; commitMatchedRoute is then mocked
+      // to inject the test's routeResult for downstream assertions.
+      accountAgents: routeResult ? { main: "main" } : {},
       ignoredOmniInstanceIds: [],
     }),
   },
@@ -184,6 +205,7 @@ mock.module("../router/router-db.js", () => ({
 
 mock.module("../session-trace/channel-trace.js", () => ({
   recordChannelMessageReceivedTrace: mock(() => ({})),
+  recordRouteRejectedTrace: mock(() => ({})),
   recordRouteResolvedTrace: mock(() => ({})),
 }));
 

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -48,6 +48,7 @@ import {
   recordRouteRejectedTrace,
   recordRouteResolvedTrace,
   type NormalizedSessionTraceSource,
+  type RouteRejectionReason,
 } from "../session-trace/channel-trace.js";
 import { recordRuntimeTraceEvent } from "../session-trace/runtime-trace.js";
 import { logger } from "../utils/logger.js";
@@ -901,12 +902,42 @@ export class OmniConsumer {
       identityProvenance: effectiveActorMetadata.identityProvenance ?? null,
     };
 
+    // Fail-soft trace recorder shared by every trace on this path. Trace
+    // writes must never crash the inbound handler, so each call is guarded
+    // with a single warn-on-failure pattern instead of repeating try/catch
+    // at every site.
+    const safeTrace = <T>(description: string, fn: () => T): T | null => {
+      try {
+        return fn();
+      } catch (error) {
+        log.warn(description, { sessionKey: matched.sessionKey, messageId: payload.externalId, error });
+        return null;
+      }
+    };
+
+    // `route.rejected` emitter for the policy / scope rejection sites
+    // below. `sessionName` is null because the session row hasn't been
+    // committed yet — that's the orphan-prevention contract.
+    const rejectRoute = (reason: RouteRejectionReason, payloadJson: Record<string, unknown>) => {
+      safeTrace("Failed to record route.rejected trace", () =>
+        recordRouteRejectedTrace({
+          sessionKey: matched.sessionKey,
+          sessionName: null,
+          agentId: matched.agent.id,
+          timestamp: msgTs,
+          source: traceSource,
+          reason,
+          payloadJson,
+        }),
+      );
+    };
+
     // Factual "we received this message" trace fires before any rejection
     // gate. `sessionName` may be unknown until `commitMatchedRoute` runs,
     // so the trace is keyed by the matched `sessionKey` only — that's
     // enough for `sessions trace` lookups and for follow-up traces
     // (`route.resolved` / `route.rejected`) to be correlated.
-    try {
+    safeTrace("Failed to record channel.message.received trace", () =>
       recordChannelMessageReceivedTrace({
         sessionKey: matched.sessionKey,
         sessionName: null,
@@ -932,14 +963,8 @@ export class OmniConsumer {
           routePhone,
         },
         preview: payload.content?.text ?? null,
-      });
-    } catch (error) {
-      log.warn("Failed to record channel.message.received trace", {
-        sessionKey: matched.sessionKey,
-        messageId: payload.externalId,
-        error,
-      });
-    }
+      }),
+    );
 
     // -- Policy resolution helper --
     // Lookup order: route.policy → instance config → default
@@ -967,23 +992,7 @@ export class OmniConsumer {
       const groupPolicy = resolvePolicy("groupPolicy", matched.route?.policy, "open");
       if (groupPolicy === "closed") {
         log.info("Group rejected by policy (closed)", { chatJid, accountId: effectiveAccountId });
-        try {
-          recordRouteRejectedTrace({
-            sessionKey: matched.sessionKey,
-            sessionName: null,
-            agentId: matched.agent.id,
-            timestamp: msgTs,
-            source: traceSource,
-            reason: "group_closed",
-            payloadJson: { groupPolicy, chatJid, accountId: effectiveAccountId },
-          });
-        } catch (error) {
-          log.warn("Failed to record route.rejected trace", {
-            sessionKey: matched.sessionKey,
-            reason: "group_closed",
-            error,
-          });
-        }
+        rejectRoute("group_closed", { groupPolicy, chatJid, accountId: effectiveAccountId });
         return;
       }
       if (groupPolicy === "allowlist") {
@@ -1010,28 +1019,12 @@ export class OmniConsumer {
               isGroup: true,
             });
           }
-          try {
-            recordRouteRejectedTrace({
-              sessionKey: matched.sessionKey,
-              sessionName: null,
-              agentId: matched.agent.id,
-              timestamp: msgTs,
-              source: traceSource,
-              reason: "group_allowlist_pending",
-              payloadJson: {
-                groupPolicy,
-                chatJid,
-                accountId: effectiveAccountId,
-                contactStatus: contact?.status ?? null,
-              },
-            });
-          } catch (error) {
-            log.warn("Failed to record route.rejected trace", {
-              sessionKey: matched.sessionKey,
-              reason: "group_allowlist_pending",
-              error,
-            });
-          }
+          rejectRoute("group_allowlist_pending", {
+            groupPolicy,
+            chatJid,
+            accountId: effectiveAccountId,
+            contactStatus: contact?.status ?? null,
+          });
           return;
         }
       }
@@ -1043,23 +1036,7 @@ export class OmniConsumer {
       const dmPolicy = resolvePolicy("dmPolicy", matched.route?.policy, "open");
       if (dmPolicy === "closed") {
         log.info("DM rejected by policy (closed)", { senderPhone, accountId: effectiveAccountId });
-        try {
-          recordRouteRejectedTrace({
-            sessionKey: matched.sessionKey,
-            sessionName: null,
-            agentId: matched.agent.id,
-            timestamp: msgTs,
-            source: traceSource,
-            reason: "dm_closed",
-            payloadJson: { dmPolicy, senderPhone, accountId: effectiveAccountId },
-          });
-        } catch (error) {
-          log.warn("Failed to record route.rejected trace", {
-            sessionKey: matched.sessionKey,
-            reason: "dm_closed",
-            error,
-          });
-        }
+        rejectRoute("dm_closed", { dmPolicy, senderPhone, accountId: effectiveAccountId });
         return;
       }
       if (dmPolicy === "pairing") {
@@ -1085,28 +1062,12 @@ export class OmniConsumer {
               isGroup: false,
             });
           }
-          try {
-            recordRouteRejectedTrace({
-              sessionKey: matched.sessionKey,
-              sessionName: null,
-              agentId: matched.agent.id,
-              timestamp: msgTs,
-              source: traceSource,
-              reason: "dm_pairing_pending",
-              payloadJson: {
-                dmPolicy,
-                senderPhone,
-                accountId: effectiveAccountId,
-                contactStatus: contact?.status ?? null,
-              },
-            });
-          } catch (error) {
-            log.warn("Failed to record route.rejected trace", {
-              sessionKey: matched.sessionKey,
-              reason: "dm_pairing_pending",
-              error,
-            });
-          }
+          rejectRoute("dm_pairing_pending", {
+            dmPolicy,
+            senderPhone,
+            accountId: effectiveAccountId,
+            contactStatus: contact?.status ?? null,
+          });
           return;
         }
       }
@@ -1114,37 +1075,19 @@ export class OmniConsumer {
     }
 
     // -- Per-agent contact scoping --
-    const matchedAgentMode = matched.agent.mode ?? "active";
-    if (matchedAgentMode !== "sentinel") {
+    const agentMode = matched.agent.mode ?? "active";
+    if (agentMode !== "sentinel") {
       const checkId = isGroup ? chatJid : senderPhone;
       if (!isContactAllowedForAgent(checkId, matched.agent.id)) {
         log.info("Contact not allowed for agent", { checkId, agentId: matched.agent.id });
-        try {
-          recordRouteRejectedTrace({
-            sessionKey: matched.sessionKey,
-            sessionName: null,
-            agentId: matched.agent.id,
-            timestamp: msgTs,
-            source: traceSource,
-            reason: "agent_contact_scope_denied",
-            payloadJson: { checkId, agentId: matched.agent.id, isGroup },
-          });
-        } catch (error) {
-          log.warn("Failed to record route.rejected trace", {
-            sessionKey: matched.sessionKey,
-            reason: "agent_contact_scope_denied",
-            error,
-          });
-        }
+        rejectRoute("agent_contact_scope_denied", { checkId, agentId: matched.agent.id, isGroup });
         return;
       }
     }
 
-    // All policy / scope gates passed — commit the matched route so the
-    // session row exists, bind it to the canonical chat, register the
-    // participant, and emit the `route.resolved` trace. Up to this point
-    // no rows have been written for this inbound — that's how we avoid
-    // orphan sessions when policy rejects.
+    // All policy / scope gates passed — commit the route, bind the
+    // session to the canonical chat, register the participant, and emit
+    // `route.resolved`.
     const resolved = commitMatchedRoute(matched, {
       phone: routePhone,
       isGroup,
@@ -1178,7 +1121,7 @@ export class OmniConsumer {
       seenAt: msgTs,
     });
 
-    try {
+    safeTrace("Failed to record route.resolved trace", () =>
       recordRouteResolvedTrace({
         sessionKey: resolved.sessionKey,
         sessionName: resolved.sessionName,
@@ -1203,17 +1146,10 @@ export class OmniConsumer {
           groupId: sessionGroupId ?? null,
           threadId: threadId ?? null,
         },
-      });
-    } catch (error) {
-      log.warn("Failed to record route.resolved trace", {
-        sessionName: resolved.sessionName,
-        messageId: payload.externalId,
-        error,
-      });
-    }
+      }),
+    );
 
     const { sessionName, agent } = resolved;
-    const agentMode = agent.mode ?? "active";
     this.recordInboundContactInteraction(effectiveActorMetadata);
 
     // Resolve sender display name: pushName (from rawPayload) → contacts DB → phone

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -20,7 +20,7 @@ const CONSUMER_READY_TIMEOUT = 60_000; // Wait up to 60s for streams to appear
 const CONSUMER_RETRY_DELAY_MS = 2_000;
 const UNREGISTERED_COOLDOWN_MS = 5 * 60_000; // 5 min cooldown per instanceId
 const unregisteredCooldowns = new Map<string, number>();
-import { expandHome, resolveRoute } from "../router/index.js";
+import { commitMatchedRoute, expandHome, matchRoute } from "../router/index.js";
 import { configStore } from "../config-store.js";
 import {
   getContact,
@@ -45,6 +45,7 @@ import {
 import { resetSession } from "../router/sessions.js";
 import {
   recordChannelMessageReceivedTrace,
+  recordRouteRejectedTrace,
   recordRouteResolvedTrace,
   type NormalizedSessionTraceSource,
 } from "../session-trace/channel-trace.js";
@@ -842,8 +843,11 @@ export class OmniConsumer {
       return;
     }
 
-    // Resolve route to get session key
-    const resolved = resolveRoute(routerConfig, {
+    // Match route (pure) — no DB writes yet. The session row is only
+    // committed after every policy/scope gate passes so rejected inbounds
+    // don't leave orphan sessions behind (spec contacts/identity-graph/
+    // unified-model: identity → policy → route resolution → persist).
+    const matched = matchRoute(routerConfig, {
       phone: routePhone,
       channel: sessionChannel,
       accountId: effectiveAccountId,
@@ -853,7 +857,7 @@ export class OmniConsumer {
       peerKind,
     });
 
-    if (!resolved) {
+    if (!matched) {
       const isNew = saveAccountPending(effectiveAccountId, routePhone, {
         chatId: chatJid,
         isGroup,
@@ -896,6 +900,258 @@ export class OmniConsumer {
       identityConfidence: effectiveActorMetadata.identityConfidence ?? null,
       identityProvenance: effectiveActorMetadata.identityProvenance ?? null,
     };
+
+    // Factual "we received this message" trace fires before any rejection
+    // gate. `sessionName` may be unknown until `commitMatchedRoute` runs,
+    // so the trace is keyed by the matched `sessionKey` only — that's
+    // enough for `sessions trace` lookups and for follow-up traces
+    // (`route.resolved` / `route.rejected`) to be correlated.
+    try {
+      recordChannelMessageReceivedTrace({
+        sessionKey: matched.sessionKey,
+        sessionName: null,
+        agentId: matched.agent.id,
+        timestamp: msgTs,
+        source: traceSource,
+        payloadJson: {
+          eventId: event.id,
+          subject,
+          omniType: event.type,
+          instanceId,
+          channelType,
+          contentType: payload.content?.type ?? null,
+          isGroup,
+          senderId: senderPhone,
+          resolvedSenderPhone,
+          canonicalChatId: canonicalChat.id,
+          actorType: effectiveActorType,
+          contactId: effectiveActorType === "contact" ? (effectiveContactId ?? null) : null,
+          actorAgentId: effectiveActorAgentId ?? null,
+          platformIdentityId: effectivePlatformIdentityId ?? null,
+          chatName: rawPayloadString(rawPayload, "chatName") ?? null,
+          routePhone,
+        },
+        preview: payload.content?.text ?? null,
+      });
+    } catch (error) {
+      log.warn("Failed to record channel.message.received trace", {
+        sessionKey: matched.sessionKey,
+        messageId: payload.externalId,
+        error,
+      });
+    }
+
+    // -- Policy resolution helper --
+    // Lookup order: route.policy → instance config → default
+    const resolvePolicy = (
+      policyName: "groupPolicy" | "dmPolicy",
+      routePolicy: string | undefined,
+      defaultValue: string,
+    ): string => {
+      // 1. Explicit override on the matched route
+      if (routePolicy) return routePolicy;
+      // 2. Instance config (from instances table via RouterConfig)
+      const instance = routerConfig.instances?.[effectiveAccountId];
+      if (instance) {
+        const val = policyName === "groupPolicy" ? instance.groupPolicy : instance.dmPolicy;
+        if (val) return val;
+      }
+      return defaultValue;
+    };
+
+    // -- Group policy enforcement --
+    // Skip policy check if the group has an explicit route (not wildcard) —
+    // having a specific route is an implicit approval.
+    const hasExplicitRoute = matched.route && matched.route.pattern !== "*";
+    if (isGroup && !hasExplicitRoute) {
+      const groupPolicy = resolvePolicy("groupPolicy", matched.route?.policy, "open");
+      if (groupPolicy === "closed") {
+        log.info("Group rejected by policy (closed)", { chatJid, accountId: effectiveAccountId });
+        try {
+          recordRouteRejectedTrace({
+            sessionKey: matched.sessionKey,
+            sessionName: null,
+            agentId: matched.agent.id,
+            timestamp: msgTs,
+            source: traceSource,
+            reason: "group_closed",
+            payloadJson: { groupPolicy, chatJid, accountId: effectiveAccountId },
+          });
+        } catch (error) {
+          log.warn("Failed to record route.rejected trace", {
+            sessionKey: matched.sessionKey,
+            reason: "group_closed",
+            error,
+          });
+        }
+        return;
+      }
+      if (groupPolicy === "allowlist") {
+        const contact = getContact(chatJid);
+        if (!contact || contact.status !== "allowed") {
+          const isNew = saveAccountPending(effectiveAccountId, chatJid, {
+            chatId: chatJid,
+            isGroup: true,
+            name: getContactName(chatJid) ?? undefined,
+          });
+          log.info("Group not in allowlist, saved as pending", {
+            chatJid,
+            accountId: effectiveAccountId,
+            canonicalChatId: canonicalChat.id,
+            reviewKind: "chat",
+            isNew,
+          });
+          if (isNew) {
+            emitPendingReviewEvent({
+              channel: channelType,
+              accountId: effectiveAccountId,
+              senderId: senderPhone,
+              chatId: chatJid,
+              isGroup: true,
+            });
+          }
+          try {
+            recordRouteRejectedTrace({
+              sessionKey: matched.sessionKey,
+              sessionName: null,
+              agentId: matched.agent.id,
+              timestamp: msgTs,
+              source: traceSource,
+              reason: "group_allowlist_pending",
+              payloadJson: {
+                groupPolicy,
+                chatJid,
+                accountId: effectiveAccountId,
+                contactStatus: contact?.status ?? null,
+              },
+            });
+          } catch (error) {
+            log.warn("Failed to record route.rejected trace", {
+              sessionKey: matched.sessionKey,
+              reason: "group_allowlist_pending",
+              error,
+            });
+          }
+          return;
+        }
+      }
+      // "open" → falls through normally
+    }
+
+    // -- DM policy enforcement --
+    if (!isGroup) {
+      const dmPolicy = resolvePolicy("dmPolicy", matched.route?.policy, "open");
+      if (dmPolicy === "closed") {
+        log.info("DM rejected by policy (closed)", { senderPhone, accountId: effectiveAccountId });
+        try {
+          recordRouteRejectedTrace({
+            sessionKey: matched.sessionKey,
+            sessionName: null,
+            agentId: matched.agent.id,
+            timestamp: msgTs,
+            source: traceSource,
+            reason: "dm_closed",
+            payloadJson: { dmPolicy, senderPhone, accountId: effectiveAccountId },
+          });
+        } catch (error) {
+          log.warn("Failed to record route.rejected trace", {
+            sessionKey: matched.sessionKey,
+            reason: "dm_closed",
+            error,
+          });
+        }
+        return;
+      }
+      if (dmPolicy === "pairing") {
+        const contact = getContact(senderPhone);
+        if (!contact || contact.status !== "allowed") {
+          const isNew = saveAccountPending(effectiveAccountId, senderPhone, {
+            chatId: chatJid,
+            isGroup: false,
+          });
+          log.info("DM contact not approved (pairing policy), saved as pending", {
+            senderPhone,
+            accountId: effectiveAccountId,
+            canonicalChatId: canonicalChat.id,
+            reviewKind: "contact",
+            isNew,
+          });
+          if (isNew) {
+            emitPendingReviewEvent({
+              channel: channelType,
+              accountId: effectiveAccountId,
+              senderId: senderPhone,
+              chatId: chatJid,
+              isGroup: false,
+            });
+          }
+          try {
+            recordRouteRejectedTrace({
+              sessionKey: matched.sessionKey,
+              sessionName: null,
+              agentId: matched.agent.id,
+              timestamp: msgTs,
+              source: traceSource,
+              reason: "dm_pairing_pending",
+              payloadJson: {
+                dmPolicy,
+                senderPhone,
+                accountId: effectiveAccountId,
+                contactStatus: contact?.status ?? null,
+              },
+            });
+          } catch (error) {
+            log.warn("Failed to record route.rejected trace", {
+              sessionKey: matched.sessionKey,
+              reason: "dm_pairing_pending",
+              error,
+            });
+          }
+          return;
+        }
+      }
+      // "open" → falls through normally
+    }
+
+    // -- Per-agent contact scoping --
+    const matchedAgentMode = matched.agent.mode ?? "active";
+    if (matchedAgentMode !== "sentinel") {
+      const checkId = isGroup ? chatJid : senderPhone;
+      if (!isContactAllowedForAgent(checkId, matched.agent.id)) {
+        log.info("Contact not allowed for agent", { checkId, agentId: matched.agent.id });
+        try {
+          recordRouteRejectedTrace({
+            sessionKey: matched.sessionKey,
+            sessionName: null,
+            agentId: matched.agent.id,
+            timestamp: msgTs,
+            source: traceSource,
+            reason: "agent_contact_scope_denied",
+            payloadJson: { checkId, agentId: matched.agent.id, isGroup },
+          });
+        } catch (error) {
+          log.warn("Failed to record route.rejected trace", {
+            sessionKey: matched.sessionKey,
+            reason: "agent_contact_scope_denied",
+            error,
+          });
+        }
+        return;
+      }
+    }
+
+    // All policy / scope gates passed — commit the matched route so the
+    // session row exists, bind it to the canonical chat, register the
+    // participant, and emit the `route.resolved` trace. Up to this point
+    // no rows have been written for this inbound — that's how we avoid
+    // orphan sessions when policy rejects.
+    const resolved = commitMatchedRoute(matched, {
+      phone: routePhone,
+      isGroup,
+      groupId: sessionGroupId,
+      threadId,
+      peerKind,
+    });
     const routeId = (resolved.route as { id?: number } | undefined)?.id ?? null;
     dbBindSessionToChat({
       sessionKey: resolved.sessionKey,
@@ -923,32 +1179,6 @@ export class OmniConsumer {
     });
 
     try {
-      recordChannelMessageReceivedTrace({
-        sessionKey: resolved.sessionKey,
-        sessionName: resolved.sessionName,
-        agentId: resolved.agent.id,
-        timestamp: msgTs,
-        source: traceSource,
-        payloadJson: {
-          eventId: event.id,
-          subject,
-          omniType: event.type,
-          instanceId,
-          channelType,
-          contentType: payload.content?.type ?? null,
-          isGroup,
-          senderId: senderPhone,
-          resolvedSenderPhone,
-          canonicalChatId: canonicalChat.id,
-          actorType: effectiveActorType,
-          contactId: effectiveActorType === "contact" ? (effectiveContactId ?? null) : null,
-          actorAgentId: effectiveActorAgentId ?? null,
-          platformIdentityId: effectivePlatformIdentityId ?? null,
-          chatName: rawPayloadString(rawPayload, "chatName") ?? null,
-          routePhone,
-        },
-        preview: payload.content?.text ?? null,
-      });
       recordRouteResolvedTrace({
         sessionKey: resolved.sessionKey,
         sessionName: resolved.sessionName,
@@ -975,118 +1205,15 @@ export class OmniConsumer {
         },
       });
     } catch (error) {
-      log.warn("Failed to record inbound session trace", {
+      log.warn("Failed to record route.resolved trace", {
         sessionName: resolved.sessionName,
         messageId: payload.externalId,
         error,
       });
     }
 
-    // -- Policy resolution helper --
-    // Lookup order: route.policy → instance config → default
-    const resolvePolicy = (
-      policyName: "groupPolicy" | "dmPolicy",
-      routePolicy: string | undefined,
-      defaultValue: string,
-    ): string => {
-      // 1. Explicit override on the matched route
-      if (routePolicy) return routePolicy;
-      // 2. Instance config (from instances table via RouterConfig)
-      const instance = routerConfig.instances?.[effectiveAccountId];
-      if (instance) {
-        const val = policyName === "groupPolicy" ? instance.groupPolicy : instance.dmPolicy;
-        if (val) return val;
-      }
-      return defaultValue;
-    };
-
-    // -- Group policy enforcement --
-    // Skip policy check if the group has an explicit route (not wildcard) —
-    // having a specific route is an implicit approval.
-    const hasExplicitRoute = resolved.route && resolved.route.pattern !== "*";
-    if (isGroup && !hasExplicitRoute) {
-      const groupPolicy = resolvePolicy("groupPolicy", resolved.route?.policy, "open");
-      if (groupPolicy === "closed") {
-        log.info("Group rejected by policy (closed)", { chatJid, accountId: effectiveAccountId });
-        return;
-      }
-      if (groupPolicy === "allowlist") {
-        const contact = getContact(chatJid);
-        if (!contact || contact.status !== "allowed") {
-          const isNew = saveAccountPending(effectiveAccountId, chatJid, {
-            chatId: chatJid,
-            isGroup: true,
-            name: getContactName(chatJid) ?? undefined,
-          });
-          log.info("Group not in allowlist, saved as pending", {
-            chatJid,
-            accountId: effectiveAccountId,
-            canonicalChatId: canonicalChat.id,
-            reviewKind: "chat",
-            isNew,
-          });
-          if (isNew) {
-            emitPendingReviewEvent({
-              channel: channelType,
-              accountId: effectiveAccountId,
-              senderId: senderPhone,
-              chatId: chatJid,
-              isGroup: true,
-            });
-          }
-          return;
-        }
-      }
-      // "open" → falls through normally
-    }
-
-    // -- DM policy enforcement --
-    if (!isGroup) {
-      const dmPolicy = resolvePolicy("dmPolicy", resolved.route?.policy, "open");
-      if (dmPolicy === "closed") {
-        log.info("DM rejected by policy (closed)", { senderPhone, accountId: effectiveAccountId });
-        return;
-      }
-      if (dmPolicy === "pairing") {
-        const contact = getContact(senderPhone);
-        if (!contact || contact.status !== "allowed") {
-          const isNew = saveAccountPending(effectiveAccountId, senderPhone, {
-            chatId: chatJid,
-            isGroup: false,
-          });
-          log.info("DM contact not approved (pairing policy), saved as pending", {
-            senderPhone,
-            accountId: effectiveAccountId,
-            canonicalChatId: canonicalChat.id,
-            reviewKind: "contact",
-            isNew,
-          });
-          if (isNew) {
-            emitPendingReviewEvent({
-              channel: channelType,
-              accountId: effectiveAccountId,
-              senderId: senderPhone,
-              chatId: chatJid,
-              isGroup: false,
-            });
-          }
-          return;
-        }
-      }
-      // "open" → falls through normally
-    }
-
     const { sessionName, agent } = resolved;
     const agentMode = agent.mode ?? "active";
-
-    // Per-agent contact scoping
-    if (agentMode !== "sentinel") {
-      const checkId = isGroup ? chatJid : senderPhone;
-      if (!isContactAllowedForAgent(checkId, agent.id)) {
-        log.info("Contact not allowed for agent", { checkId, agentId: agent.id });
-        return;
-      }
-    }
     this.recordInboundContactInteraction(effectiveActorMetadata);
 
     // Resolve sender display name: pushName (from rawPayload) → contacts DB → phone

--- a/src/router/commit-matched-route.test.ts
+++ b/src/router/commit-matched-route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the lazy session-commit refactor.
+ *
+ * The orphan-session bug fix splits route resolution into two phases:
+ *  - `matchRoute` — pure, returns a candidate `MatchedRoute` with no DB
+ *    side effects, safe to call before policy enforcement.
+ *  - `commitMatchedRoute` — writes the session row (idempotent via
+ *    `getOrCreateSession`) and assigns a canonical sessionName.
+ *
+ * These tests pin the contract that lets the omni consumer reject inbound
+ * messages on policy without leaving orphan session rows behind: when the
+ * caller never invokes `commitMatchedRoute`, no session row may exist.
+ *
+ * Note: we deliberately only assert the purity side of the contract here.
+ * Asserting on `commitMatchedRoute` directly is unreliable inside the
+ * full-suite run because `src/omni/consumer-context.test.ts` installs a
+ * `mock.module("../router/index.js", ...)` whose `commitMatchedRoute`
+ * override bun propagates into direct imports of `./resolver.js` — a
+ * known limitation of bun's module-mock implementation. The commit-side
+ * behaviour is exercised indirectly by every existing `resolveRoute`
+ * call site, since `resolveRoute = matchRoute + commitMatchedRoute`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { matchRoute } from "./resolver.js";
+import { getSession, listSessions } from "./sessions.js";
+import type { AgentConfig, RouterConfig } from "./types.js";
+
+let stateDir: string | null = null;
+
+const agentMain: AgentConfig = {
+  id: "main",
+  cwd: "/tmp/main",
+  dmScope: "per-peer",
+};
+
+function makeConfig(): RouterConfig {
+  return {
+    agents: { main: agentMain },
+    routes: [],
+    defaultAgent: "main",
+    defaultDmScope: "per-peer",
+    accountAgents: { acc: "main" },
+    instanceToAccount: {},
+    instances: {},
+  };
+}
+
+describe("matchRoute purity (orphan-session prevention)", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-match-route-purity-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("matchRoute returns a candidate without writing a session row", () => {
+    const config = makeConfig();
+    const matched = matchRoute(config, {
+      phone: "5511999999999",
+      accountId: "acc",
+      isGroup: false,
+    });
+
+    expect(matched).not.toBeNull();
+    expect(matched?.sessionKey).toContain("agent:main");
+    expect(listSessions()).toHaveLength(0);
+    expect(getSession(matched!.sessionKey)).toBeNull();
+  });
+
+  it("matchRoute followed by no commit leaves zero session rows", () => {
+    // Mirrors the consumer policy-rejection path: route is matched, but the
+    // caller (consumer) decides not to commit because a policy gate fails
+    // (e.g. group_closed, dm_pairing_pending). No session row may exist.
+    const config = makeConfig();
+    const matched = matchRoute(config, {
+      phone: "5511999999999",
+      accountId: "acc",
+      isGroup: false,
+    });
+    expect(matched).not.toBeNull();
+
+    // Intentionally do NOT call commitMatchedRoute — the caller rejected
+    // the inbound message after matching but before committing.
+    expect(listSessions()).toHaveLength(0);
+  });
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,7 @@ export {
   findRoute,
   matchRoute,
   resolveRoute,
+  commitMatchedRoute,
   expandHome,
   getAgentCwd,
 } from "./resolver.js";

--- a/src/router/resolver.ts
+++ b/src/router/resolver.ts
@@ -163,7 +163,12 @@ export function matchRoute(
 
 /**
  * Resolve a phone number to an agent, session key, and session name.
- * Calls matchRoute() for pure routing, then creates/resolves the session (DB side effect).
+ *
+ * Convenience wrapper that pairs `matchRoute` (pure) with
+ * `commitMatchedRoute` (DB writes). Callers that need to gate session
+ * creation — e.g. inbound policy enforcement — should call the two
+ * primitives directly so policy checks run before the session row exists.
+ * See `src/omni/consumer.ts` for that pattern.
  */
 export function resolveRoute(
   config: RouterConfig,
@@ -179,8 +184,33 @@ export function resolveRoute(
 ): ResolvedRoute | null {
   const match = matchRoute(config, params);
   if (!match) return null;
+  return commitMatchedRoute(match, params);
+}
 
-  const { agentId, agent, dmScope, sessionKey, route } = match;
+/**
+ * Commit a previously matched route to the DB: ensures the session row
+ * exists (idempotent) and assigns or reuses a canonical sessionName.
+ *
+ * Separated from `matchRoute` so callers can run policy / contact-scope
+ * checks against the routing decision before any DB write happens. This
+ * is what prevents orphan session rows when policy rejects an inbound
+ * message — the unified-model spec requires policy enforcement to run
+ * before route/session resolution.
+ *
+ * The `params` shape is a subset of `resolveRoute`'s; only the fields
+ * needed for naming (peerKind, peerId, threadId) are read.
+ */
+export function commitMatchedRoute(
+  matched: MatchedRoute,
+  params: {
+    phone: string;
+    isGroup?: boolean;
+    groupId?: string;
+    threadId?: string;
+    peerKind?: string;
+  },
+): ResolvedRoute {
+  const { agentId, agent, dmScope, sessionKey, route } = matched;
   const { isGroup, groupId, phone } = params;
 
   // If route forces a session name that already exists, route directly to it
@@ -227,7 +257,7 @@ export function resolveRoute(
     updateSessionName(sessionKey, sessionName);
   }
 
-  log.debug("Resolved route", {
+  log.debug("Committed matched route", {
     phone,
     agentId,
     dmScope,

--- a/src/session-trace/channel-trace.ts
+++ b/src/session-trace/channel-trace.ts
@@ -43,6 +43,28 @@ export interface RecordRouteResolvedTraceInput {
   payloadJson?: unknown;
 }
 
+/**
+ * Reason for a `route.rejected` trace. Lets dashboards/`sessions trace`
+ * tell apart the different gates that drop an inbound message before
+ * dispatch.
+ */
+export type RouteRejectionReason =
+  | "group_closed"
+  | "group_allowlist_pending"
+  | "dm_closed"
+  | "dm_pairing_pending"
+  | "agent_contact_scope_denied";
+
+export interface RecordRouteRejectedTraceInput {
+  sessionKey: string;
+  sessionName?: string | null;
+  agentId?: string | null;
+  timestamp?: number;
+  source: NormalizedSessionTraceSource;
+  reason: RouteRejectionReason;
+  payloadJson?: unknown;
+}
+
 export interface RecordPromptPublishedTraceInput {
   sessionName: string;
   payload: Record<string, unknown>;
@@ -381,6 +403,34 @@ export function recordRouteResolvedTrace(input: RecordRouteResolvedTraceInput): 
     timestamp: input.timestamp,
     source: input.source,
     payloadJson: input.payloadJson,
+  });
+}
+
+/**
+ * Emit a `route.rejected` event when an inbound message matched a route
+ * but was dropped before dispatch by a policy / contact-scope check.
+ *
+ * The session row may not exist when this fires (lazy session commit on
+ * the inbound path) — `session_events` has no FK to `sessions`, so the
+ * trace is keyed only by the candidate `sessionKey`. `sessions trace
+ * <sessionKey>` still surfaces these rows when an operator investigates
+ * a chat that "never replied".
+ */
+export function recordRouteRejectedTrace(input: RecordRouteRejectedTraceInput): SessionEventRecord {
+  const payload =
+    input.payloadJson && typeof input.payloadJson === "object" && !Array.isArray(input.payloadJson)
+      ? { ...(input.payloadJson as Record<string, unknown>), reason: input.reason }
+      : { reason: input.reason };
+  return recordSourceEvent({
+    sessionKey: input.sessionKey,
+    sessionName: input.sessionName,
+    agentId: input.agentId,
+    eventType: "route.rejected",
+    eventGroup: "routing",
+    status: "rejected",
+    timestamp: input.timestamp,
+    source: input.source,
+    payloadJson: payload,
   });
 }
 


### PR DESCRIPTION
## Summary

The omni consumer was creating session rows **before** running policy / contact-scope checks, leaving orphan sessions whenever inbound messages were rejected by `closed` / `allowlist` / `pairing` policies (28 orphans in 2h on instance `luis`).

This PR follows the canonical order from spec `contacts/identity-graph/unified-model`: **identity → policy → route resolution → persist**. It splits route resolution into two phases:

- **`matchRoute(config, params)`** — pure, returns a `MatchedRoute` with no DB writes. Safe to call before policy enforcement.
- **`commitMatchedRoute(matched, params)`** — writes the session row (idempotent via `getOrCreateSession`) and assigns the canonical `sessionName`. Only called once every gate has passed.

`resolveRoute` is kept as a thin convenience wrapper combining both phases, so non-policy-gating callers are unaffected.

The omni consumer (`handleMessageEvent`) now:
1. Calls `matchRoute` and emits `channel.message.received` (factual).
2. Runs group / DM policy + per-agent contact scoping against the matched candidate.
3. Emits `route.rejected` with a specific reason at each rejection site (`group_closed`, `group_allowlist_pending`, `dm_closed`, `dm_pairing_pending`, `agent_contact_scope_denied`) so `sessions trace` can explain why a chat never received a reply.
4. Only calls `commitMatchedRoute` + `dbBindSessionToChat` + `dbUpsertSessionParticipant` + `recordRouteResolvedTrace` after all gates pass.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] New `src/router/commit-matched-route.test.ts` pins the orphan-prevention invariant.
- [x] `bun test src/omni/ src/router/ src/session-trace/` — 141 pass, 0 fail.
- [x] Full sweep (`bun test`) — 1551 pass (+2 over baseline). The 71 pre-existing failures are unrelated and unchanged.
- [ ] After merge: validate on instance `luis` that `closed`-policy inbound messages no longer create session rows, and that `sessions trace <key>` shows `route.rejected` with the correct reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->