### PR TITLE
feat(prompt): add Session Attach + Focus block to system prompt

### DIFF
--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -437,6 +437,73 @@ These are intentionally not specified here and SHOULD be addressed in follow-up 
 
 - **Detailed inventory of attach hooks.** The "Context Injection At Attach" section sets the contract (read-only, bounded, fail-isolated, capability-registered). The concrete shipping list (group metadata, member list, recent activity, project tasks count, artifacts count) and the registration API live in a separate feature spec.
 
+## Operational Recipes (production-validated)
+
+These compose the attach + focus primitives for the most common operational shapes encountered after Fase 1+2 went live. Use the recipe name in PRs and runbooks so operators recognise the intent.
+
+### Recipe 1 — Unify history across N chats into one session
+
+Goal: a single session attends multiple chats and keeps one continuous prompt history. Typical case: the `dev` agent already runs in `ravi - dev`; you want the same `dev` to also handle a new `ravi - dev - test` group with the same memory.
+
+```bash
+# If the new chat already spawned a parallel session, delete it first
+# (it'll be empty since it was auto-created by the routing default).
+ravi sessions delete <parallel-session>
+
+# Attach the new chat into the existing session.
+ravi sessions attach <session> --chat <chat-id> --reason "unify <reason>"
+```
+
+The next inbound on the new chat triggers the subscription override in `omni/consumer.ts` — it sees the chat already belongs to `<session>` and rewrites `matched.sessionKey` to it instead of forking. Same session, two surfaces.
+
+### Recipe 2 — Migrate a chat to a different agent (separate history)
+
+Goal: move a chat from the agent default of its instance to a specific agent, but keep histories isolated per agent. Typical case: a group was created on instance `main` (whose default is `ravi-onboarding`) and auto-spawned an onboarding session; you want `dev` to take over with its own fresh session.
+
+```bash
+ravi instances routes add <instance> group:<id> <agent> --priority 10
+```
+
+`routes add` returns `Cleaned N conflicting session(s)` when it removes the prior owner. The next inbound matches the route, lands on `<agent>`, and a fresh session is created via the normal path (with `attachChatToSession` building the primary subscription).
+
+This recipe does NOT share history. If history sharing is the goal, use Recipe 1.
+
+### Recipe 3 — Reply in a different chat than the source
+
+Goal: the agent processes inbound from chat A but emits the response in chat B. One-shot or sticky.
+
+```bash
+ravi sessions focus <session> --chat <target-chat-id> [--expires 30m]
+# Agent emits → resolveSessionOutputTarget picks focus over inbound source.
+# Clear when done:
+ravi sessions focus <session> --clear
+```
+
+Until clear/expire, every emit from `<session>` goes to `<target-chat-id>`. Inbound still comes from wherever it comes — focus only affects output target.
+
+### Anti-patterns observed in production
+
+These are real mistakes the dev agent itself made before this section existed; documenting so the next operator avoids them.
+
+- **Adding a route to "move" a chat that's already attached elsewhere.** The subscription override prevails over the new route's agent assignment. The chat keeps dispatching to the old session. Resolution: detach (or delete the prior session) before or alongside the route change.
+- **Calling `focus` for a chat that's not subscribed under the default `fail-closed` policy.** Errors with `SessionFocusUnattachedError`. Either attach first or switch the session's policy to `auto-follow`.
+- **Expecting attach alone to change which agent processes a chat.** Attach moves the *session*; agent comes from the route or instance default. To change the agent AND share history, do Recipe 2 (route) AND Recipe 1 (attach) together.
+
+## Performance Notes (measured)
+
+The attach/focus path contributes microseconds; total turn latency lives in the LLM call. Sample timings from production turns on a 56M-token session:
+
+| Source | Typical latency |
+|--------|-----------------|
+| Consumer subscription reroute (lookup + assign) | sub-millisecond |
+| `dbBindSessionToChat` + `attachChatToSession` (idempotent path) | <10ms |
+| `resolveSessionOutputTarget` (focus + chat lookup) | <5ms |
+| Gateway → Omni → WhatsApp delivery | 150ms–1s (scales with message size) |
+| LLM inference (single text response, large session prompt) | 10–35s |
+| LLM inference with tool calls (Bash + assistant) | 30–60s+ |
+
+When debugging slow turns, look at `assistant.message` and `tool.completed` timestamps in `sessions trace`. If those are slow, it's the model. If the gap is between `prompt.published` and `runtime.start`, look at the dispatcher / queue / debounce. Attach/focus rewrites don't show up as measurable latency.
+
 ## Acceptance Criteria
 
 When this capability is implemented, all of the following SHOULD hold:

--- a/src/plugins/internal/ravi-system/skills/routes/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/routes/SKILL.md
@@ -102,4 +102,28 @@ Definir fallback:
 ravi instances routes add main "*" main
 ```
 
+## Route vs Attach
+
+Route e attach (`sessions/attach`) operam em camadas diferentes — confundi-las leva a comportamento inesperado.
+
+| Camada | Define | Resultado |
+|--------|--------|-----------|
+| **Route** | Qual *agent* atende o chat | matchRoute escolhe agent, session_key é derivado de (agent, channel, instance, dmScope, peer). Cada combinação vira sessão própria. |
+| **Subscription** (`sessions attach`) | Qual *sessão* recebe a inbound | Override do session_key resolvido. Permite mesma sessão escutar múltiplos chats (histórico compartilhado). |
+| **Focus** (`sessions focus`) | Para qual *chat* a sessão emite output | Sobrescreve o inbound-source no output target resolution. |
+
+**Cuidado com a interação:**
+
+- Se um chat tem subscription ativa (atachado a sessão X), o consumer **ignora** o agent escolhido pela route e dispatcha pra sessão X. A route não troca o destino sozinha.
+- `routes add` faz cleanup automático de sessões conflitantes (apaga sessão paralela do agent antigo e libera o chat). Quando isso roda, a próxima inbound segue a nova route normalmente.
+- `routes add ... --session <name>` (redirect estático) força a sessão alvo e cria subscription automaticamente — funciona ao lado do attach.
+
+**Quando usar cada um:**
+
+- "Quero outro agent atendendo esse chat, com histórico próprio" → `routes add`
+- "Quero a MESMA sessão atendendo múltiplos chats" → `sessions attach`
+- "Quero responder em chat diferente do source" → `sessions focus`
+
+Ver skill `ravi-system:sessions` (seção Attach + Focus) pras receitas práticas e diagrama de fluxo.
+
 Para gerenciar contacts: use a skill `ravi-system:contacts`

--- a/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
@@ -11,6 +11,8 @@ description: |
   - Enviar prompts, perguntas ou comandos entre sessões
   - Ler histórico de mensagens de uma sessão
   - Inspecionar trace SQLite de uma sessão para incidentes de runtime/canal
+  - Atachar múltiplos chats numa mesma sessão (multi-input, histórico compartilhado)
+  - Direcionar output de uma sessão pra um chat específico (focus)
 ---
 
 # Sessions Manager
@@ -88,6 +90,83 @@ ravi sessions prune --inactive-for 12h --ephemeral
 ```
 
 Sem `--execute`, `prune` é sempre dry-run. Use o dry-run antes de apagar em lote.
+
+### Attach + Focus (multi-input e output target)
+
+**Diferença chave vs routes:** `routes` decide qual *agent* atende um chat; `attach` decide qual *sessão* recebe a inbound. Sem attach, cada (agent, chat) vira sua própria sessão. Com attach, uma sessão pode escutar vários chats e compartilhar histórico.
+
+Ver spec `sessions/attach` pro modelo completo.
+
+```bash
+# Listar chats que a sessão escuta
+ravi sessions subscriptions <session>
+
+# Atachar um chat na sessão (multi-input)
+ravi sessions attach <session> --chat <chat-id> [--reason "..."]
+
+# Desatachar
+ravi sessions detach <session> --chat <chat-id>
+
+# Focus: direcionar output pra um chat específico (sticky até clear/expire)
+ravi sessions focus <session> --chat <chat-id> [--reason "..."] [--expires 30m]
+ravi sessions focus <session> --clear
+ravi sessions focus <session> --show
+
+# Mudar política de focus pra chat não-atachado
+ravi sessions set-unattached-focus-policy <session> fail-closed|auto-follow
+```
+
+**Receitas operacionais (validadas em produção):**
+
+1. **Unificar histórico de N grupos numa sessão.** Caso típico: dev atende o grupo `ravi - dev` e você quer que o mesmo dev atenda `ravi - dev - test` com o mesmo histórico.
+   - Se o grupo novo já criou uma sessão paralela (`dev-2`, vazia): `sessions delete dev-2` → `sessions attach dev --chat <chat-id-do-test>`.
+   - Próxima inbound do test cai na sessão dev existente via subscription override (não fork).
+
+2. **Migrar grupo de um agent pra outro (sem unificar sessão).** Caso: grupo nasceu na sessão de onboarding (auto-criada pelo default agent da instance), você quer mover pro agent `dev` com sessão SEPARADA.
+   - `ravi instances routes add <instance> group:<id> <novo-agent> --priority 10`
+   - O `routes add` faz cleanup automático de session conflitante (chama `Cleaned N conflicting session(s)`).
+   - Próxima inbound: matchRoute → novo agent → cria sessão nova pra esse (agent, grupo).
+   - Não confunda com receita 1 — essa NÃO compartilha histórico.
+
+3. **Responder uma turn em chat diferente do source (one-shot ou sticky).**
+   - `sessions focus <session> --chat <chat-alvo>` antes do agent emitir.
+   - Próximas emissões da sessão saem no chat-alvo até `--clear` ou expire.
+   - Output target resolution: `explicit per-turn > focus > inbound source > fail closed`.
+
+**Como compõe na prática (sequence diagram resumido):**
+
+```
+inbound chega ─► consumer normaliza chat
+              ─► matchRoute resolve agent + session_key candidato
+              ─► [Fase 2] consumer.findSessionByAttachedChat(chat_id)
+                 │ se subscription existe ─► matched.sessionKey = subscription.sessionKey
+                 │ (subscription override prevalece sobre matchRoute)
+              ─► policy checks
+              ─► commitMatchedRoute + attachChatToSession (idempotente)
+              ─► dispatch turn na sessão escolhida
+              ─► runtime gera resposta
+              ─► resolveSessionOutputTarget:
+                 1. explicit target (per-turn) → win
+                 2. session_focus.chat_id (se subscription ainda ativa) → win
+                 3. inbound source chat → fallback
+                 4. nada → fail closed (drop response, trace)
+              ─► gateway emite no target resolvido
+```
+
+**Anti-patterns:**
+
+- ❌ Adicionar route pra "trocar destino" quando o chat já está atachado em outra sessão. A subscription override puxa o inbound de volta. Use detach/delete da sessão antiga antes, ou attach explícito na nova.
+- ❌ Setar focus pra um chat não atachado com policy `fail-closed`. Vai dar `SessionFocusUnattachedError`. Atachar antes, ou trocar policy pra `auto-follow`.
+- ❌ Esperar que `attach` sozinho mude o agent que atende o chat. Attach decide sessão; agent vem da route ou do default da instance.
+
+**Quando route vs attach:**
+
+| Você quer | Use |
+|-----------|-----|
+| Outro agent atender o chat (histórico isolado) | `instances routes add` |
+| Mesma sessão atender N chats (histórico compartilhado) | `sessions attach` |
+| Mudar onde a sessão responde (input fica igual) | `sessions focus` |
+| Forçar uma sessão específica num chat | `routes add ... --session <name>` (redirect estático) |
 
 ### Sessões Efêmeras
 

--- a/src/prompt-builder.test.ts
+++ b/src/prompt-builder.test.ts
@@ -51,6 +51,7 @@ describe("buildSystemPrompt", () => {
     expect(sections.map((section) => section.id)).toEqual([
       "identity",
       "system.commands",
+      "session.attach",
       "session.runtime",
       "session.boundary",
       "channel.output_formatting",

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -96,6 +96,47 @@ function systemCommandsText(): string {
 }
 
 /**
+ * Session attach/detach/focus tools text.
+ *
+ * Documents the CLI surface for sessions/attach (Fase 1+2 in production).
+ * Kept as CLI documentation rather than native tools to match the existing
+ * pattern used by sessions send/ask/answer/execute/inform.
+ *
+ * Includes the Silent vs Detach distinction so agents pick the right tool
+ * for the intent (transient quiet vs persistent disengage).
+ *
+ * See .ravi/specs/sessions/attach/SPEC.md
+ */
+function sessionAttachText(): string {
+  return `Sessões podem escutar múltiplos chats (multi-input) e emitir output num chat diferente do source (focus). Use via Bash + CLI quando o caso aparecer.
+
+**Quando usar:**
+- "Mesma sessão atende N chats com histórico compartilhado" → \`attach\`
+- "Responder em chat diferente do source" → \`focus\`
+- "Listar/inspecionar wiring" → \`subscriptions\` / \`focus --show\`
+
+**Comandos:**
+
+- \`ravi sessions attach <session> --chat <chat-id> [--reason "..."]\` — atacha chat como input. Próxima inbound desse chat cai na sessão (sem fork).
+- \`ravi sessions detach <session> --chat <chat-id>\` — remove chat da sessão. **Detach é durável** (próxima inbound não volta sozinha).
+- \`ravi sessions subscriptions <session>\` — lista chats atachados (primary/input/mirror).
+- \`ravi sessions focus <session> --chat <chat-id> [--reason "..."] [--expires 30m]\` — sticky até clear/expire. Output da sessão sai pro chat de focus em vez do source.
+- \`ravi sessions focus <session> --clear\` / \`--show\` — limpar/inspecionar focus.
+- \`ravi sessions set-unattached-focus-policy <session> fail-closed|auto-follow\` — política quando focus aponta pra chat não-atachado (default fail-closed).
+
+**${SILENT_TOKEN} vs \`detach\`** (complementares, não substitutos):
+
+- \`${SILENT_TOKEN}\` = **one-shot**, esse turn específico não fala. Próxima inbound, agent volta a responder normalmente. Use quando "li, mas não tenho nada a dizer agora".
+- \`detach_chat\` (via CLI \`sessions detach\`) = **estado durável**, agent sai do canal. Não recebe nem envia mensagens daquele chat até \`attach\` explícito. Use quando "vou trabalhar em silêncio nessa surface, volto quando tiver algo a dizer" ou pra mover atenção pra outro canal sem ruído acidental no anterior.
+
+**Anti-patterns:**
+
+- ❌ Adicionar route pra "mover" chat já atachado em outra sessão — subscription override puxa de volta. Detach (ou \`sessions delete\` da sessão antiga) primeiro.
+- ❌ Setar focus em chat não atachado com policy \`fail-closed\` — \`SessionFocusUnattachedError\`. Atacha antes, ou usa \`auto-follow\`.
+- ❌ Esperar attach trocar o agent. Attach decide sessão; agent vem da route ou default da instance.`;
+}
+
+/**
  * Build group context section for system prompt
  */
 export function buildGroupContext(ctx: ChannelContext): string {
@@ -278,6 +319,10 @@ export function buildSystemPromptSections(
 
   // System commands for all agents (sentinel needs them for cross-send execute/ask)
   add("system.commands", "System Commands", systemCommandsText(), 20);
+
+  // Sessions attach/detach/focus CLI surface. Added for all agents so the
+  // multi-input + focus primitives are discoverable. See sessions/attach spec.
+  add("session.attach", "Session Attach + Focus", sessionAttachText(), 25);
 
   // Sentinel: add explicit channel messaging instructions
   if (isSentinel) {


### PR DESCRIPTION
## Summary

Adds a "Session Attach + Focus" block to the agent system prompt so the multi-input + focus primitives shipped in `sessions/attach` Fase 1+2 are discoverable to every agent. Until this PR the only way an agent could use `attach`/`focus`/`subscriptions` was if the operator pointed it at the CLI manually (which is what happened during the live validation tonight).

## Approach

Follows the **existing convention** used by `sessions send` / `ask` / `answer` / `execute` / `inform`: documentation in the prompt, invocation via Bash + CLI. **No new runtime tools** — keeps the surface consistent and avoids inflating `host-services.ts`. This was discussed with the operator before implementation; the alternative (native tools) is deferred to a future iteration if/when atomic execution or per-tool skill-gating becomes necessary.

## What ships

New section `Session Attach + Focus` (priority 25, between `system.commands` and the sentinel/channel sections) covering:

- When to use `attach` (multi-input), `focus` (output target), `subscriptions` / `focus --show` (inspect).
- The five CLI commands with `--reason` / `--expires` / `--clear` / `--show` flags.
- The **Silent vs Detach** distinction promised in `.ravi/specs/sessions/attach/SPEC.md`: `@@SILENT@@` is one-shot quiet, `detach` is a durable disengage. Agents picking the wrong one is the worst kind of silent failure.
- Three production-observed anti-patterns (route can't move an already-attached chat; focus on unattached fails closed by default; attach doesn't swap the agent).

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run build` clean.
- [x] `bun run lint` clean.
- [x] `bun test src/prompt-builder.test.ts` — 5/5 pass (updated section-ordering assertion to include `session.attach`).
- [ ] Post-merge: next time a session needs to focus output in a different chat, the agent should reach for `ravi sessions focus` from the prompt instead of needing operator hand-holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->