### PR TITLE
Fix live executable grants in Bash contexts

### DIFF
--- a/src/bash/hook.test.ts
+++ b/src/bash/hook.test.ts
@@ -199,6 +199,7 @@ describe("createBashPermissionHook", () => {
     it("allows pwd and rg for live superadmin with stale runtime capabilities", () => {
       const decision = evaluateBashPermission("pwd && rg foo", {
         agentId: "dev",
+        kind: "agent-runtime",
         capabilities: [],
       });
 
@@ -208,10 +209,31 @@ describe("createBashPermissionHook", () => {
 
       const superadminDecision = evaluateBashPermission("pwd && rg foo", {
         agentId: "dev",
+        kind: "agent-runtime",
         capabilities: [],
       });
 
       expect(superadminDecision.allowed).toBe(true);
+    });
+
+    it("allows specific executable grants added after a stale agent-runtime context was issued", () => {
+      const decision = evaluateBashPermission("git status", {
+        agentId: "dev",
+        kind: "agent-runtime",
+        capabilities: [{ permission: "use", objectType: "tool", objectId: "Bash" }],
+      });
+
+      expect(decision.allowed).toBe(false);
+
+      grant("agent", "dev", "execute", "executable", "git");
+
+      const liveGrantDecision = evaluateBashPermission("git status", {
+        agentId: "dev",
+        kind: "agent-runtime",
+        capabilities: [{ permission: "use", objectType: "tool", objectId: "Bash" }],
+      });
+
+      expect(liveGrantDecision.allowed).toBe(true);
     });
   });
 
@@ -253,6 +275,7 @@ describe("createBashPermissionHook", () => {
     it("allows session access for live superadmin with stale runtime capabilities", () => {
       const decision = evaluateBashPermission("ravi sessions send main 'hello'", {
         agentId: "dev",
+        kind: "agent-runtime",
         sessionName: "dev-own",
         capabilities: [],
       });
@@ -263,6 +286,7 @@ describe("createBashPermissionHook", () => {
 
       const superadminDecision = evaluateBashPermission("ravi sessions send main 'hello'", {
         agentId: "dev",
+        kind: "agent-runtime",
         sessionName: "dev-own",
         capabilities: [],
       });

--- a/src/bash/hook.ts
+++ b/src/bash/hook.ts
@@ -177,6 +177,7 @@ interface BashHookOptions {
 
 export interface BashPermissionContext {
   agentId?: string;
+  kind?: string | null;
   sessionKey?: string;
   sessionName?: string;
   capabilities?: ContextCapability[];

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -509,6 +509,7 @@ export class ContextCommands {
 
       const decision = evaluateBashPermission(command, {
         agentId: context.agentId,
+        kind: context.kind,
         sessionKey: context.sessionKey,
         sessionName: context.sessionName,
         capabilities: context.capabilities,

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -345,6 +345,7 @@ async function authorizeRuntimeCommandExecution(
   const eventData = request.eventData;
   const buildBashContext = () => ({
     agentId: options.agentId,
+    kind: options.context.kind,
     ...(options.context.sessionKey ? { sessionKey: options.context.sessionKey } : {}),
     sessionName: options.context.sessionName ?? options.sessionName,
     capabilities: options.context.capabilities,

--- a/src/runtime/skill-gate.test.ts
+++ b/src/runtime/skill-gate.test.ts
@@ -7,6 +7,7 @@ import { dbUpsertSkillGateRule, getOrCreateSession, getSession } from "../router
 import { evaluateSkillGate, runtimeSkillGateForCommand, runtimeSkillGateForTool } from "./skill-gate.js";
 import { createRuntimeHostServices } from "./host-services.js";
 import type { RuntimeSkillVisibilitySnapshot } from "./types.js";
+import { grantRelation } from "../permissions/relations.js";
 
 let stateDir: string | null = null;
 let previousCodexHome: string | undefined;
@@ -259,5 +260,35 @@ describe("runtime host skill-gate enforcement", () => {
 
     expect(decision.approved).toBe(true);
     expect(getSession("agent:main:main")?.runtimeSessionParams?.skillVisibility).toBeUndefined();
+  });
+
+  it("honors live executable grants after an agent-runtime context was issued", async () => {
+    getOrCreateSession("agent:main:main", "main", stateDir!, {
+      name: "permission-live-grant-test",
+      runtimeProvider: "codex",
+      providerSessionId: "thread-1",
+      runtimeSessionDisplayId: "thread-1",
+    });
+    const context = createRuntimeContext({
+      kind: "agent-runtime",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionName: "permission-live-grant-test",
+      capabilities: [{ permission: "use", objectType: "tool", objectId: "Bash", source: "test" }],
+    });
+    grantRelation("agent", "main", "execute", "executable", "git", "test");
+    const services = createRuntimeHostServices({
+      context,
+      agentId: "main",
+      sessionName: "permission-live-grant-test",
+      toolContext: {},
+    });
+
+    const decision = await services.authorizeCommandExecution({
+      command: "git status",
+      input: {},
+    });
+
+    expect(decision.approved).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #41.

Summary:
- propagate the agent-runtime context kind into Bash permission evaluation
- allow live `execute executable:<bin>` grants to augment stale runtime contexts in final Bash decisions
- add regression coverage for direct Bash hook evaluation and runtime host command authorization

Validation:
- `bun test src/bash/hook.test.ts src/permissions/engine.test.ts src/permissions/scope.test.ts src/runtime/skill-gate.test.ts src/cli/commands/context.test.ts`
- `bunx biome check src/bash/hook.ts src/runtime/host-services.ts src/cli/commands/context.ts src/bash/hook.test.ts src/runtime/skill-gate.test.ts`
- `bun run build`
- pre-push hook: SDK check, build, typecheck, full tests, SDK tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->