### PR TITLE
Fix CRM task JSON field aliases

### DIFF
--- a/src/cli/commands/crm.test.ts
+++ b/src/cli/commands/crm.test.ts
@@ -9,6 +9,7 @@ let crmContactProfile: Record<string, unknown> | null = null;
 let crmAccount: Record<string, unknown> | null = null;
 let crmOpportunity: Record<string, unknown> | null = null;
 let crmTask: Record<string, unknown> | null = null;
+let taskRecords: Array<Record<string, unknown>> = [];
 let nextActionRecords: Array<Record<string, unknown>> = [];
 let contactCardRecords: Array<Record<string, unknown>> = [];
 let opportunityBoardRecords: Array<Record<string, unknown>> = [];
@@ -277,6 +278,7 @@ mock.module("../../contacts.js", () => ({
           ...crmTask,
         }
       : null,
+  listCrmTasks: (options: { limit?: string; offset?: string }) => pageRecords(taskRecords, options),
   createCrmTask: (input: Record<string, unknown>) => {
     lastTaskCreateInput = input;
     return { id: "crm_task_1", title: input.title, contactId: input.contactRef ?? null };
@@ -345,6 +347,37 @@ describe("CRM commands", () => {
     crmAccount = { lifecycle: "lead" };
     crmOpportunity = { valueCents: 500_000 };
     crmTask = { dueAt: "2026-05-09T10:00:00Z" };
+    taskRecords = [
+      {
+        id: "crm_task_1",
+        contactId: "contact-1",
+        accountId: "crm_acc_1",
+        opportunityId: "crm_opp_1",
+        chatId: "chat-1",
+        sessionKey: "dev",
+        title: "Follow up",
+        body: null,
+        taskType: "commitment",
+        status: "open",
+        priority: "urgent",
+        dueAt: "2026-05-09T10:00:00Z",
+        snoozedUntil: null,
+        completedAt: null,
+        canceledAt: null,
+        ownerType: "agent",
+        ownerId: "dev",
+        createdByType: "user",
+        createdById: "luis",
+        source: "test",
+        idempotencyKey: "idem-task",
+        confidence: 0.9,
+        evidence: [],
+        metadata: {},
+        raviTaskId: "task-1",
+        createdAt: "2026-05-09T09:00:00Z",
+        updatedAt: "2026-05-09T09:30:00Z",
+      },
+    ];
     nextActionRecords = [
       {
         taskId: "crm_task_1",
@@ -440,6 +473,49 @@ describe("CRM commands", () => {
     expect(payload.total).toBe(1);
     expect((payload.pagination as Record<string, unknown>).returned).toBe(1);
     expect((payload.items as Array<Record<string, unknown>>)[0]?.taskId).toBe("crm_task_1");
+  });
+
+  it("adds snake_case aliases to CRM task JSON surfaces", () => {
+    const listPayload = captureJson(() => {
+      new CrmTaskCommands().list(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "10",
+        "0",
+        true,
+      );
+    });
+    const showPayload = captureJson(() => {
+      new CrmTaskCommands().show("crm_task_1", true);
+    });
+
+    const task = (listPayload.tasks as Array<Record<string, unknown>>)[0];
+    expect(task).toMatchObject({
+      taskType: "commitment",
+      task_type: "commitment",
+      dueAt: "2026-05-09T10:00:00Z",
+      due_at: "2026-05-09T10:00:00Z",
+      due_date: "2026-05-09T10:00:00Z",
+      ownerType: "agent",
+      owner_type: "agent",
+      idempotencyKey: "idem-task",
+      idempotency_key: "idem-task",
+      createdAt: "2026-05-09T09:00:00Z",
+      created_at: "2026-05-09T09:00:00Z",
+    });
+    expect((listPayload.items as Array<Record<string, unknown>>)[0]).toEqual(task);
+    expect(showPayload.task).toMatchObject({
+      dueAt: "2026-05-09T10:00:00Z",
+      due_at: "2026-05-09T10:00:00Z",
+      due_date: "2026-05-09T10:00:00Z",
+    });
   });
 
   it("supports direct ravi crm contact/account/opportunity read commands", () => {

--- a/src/cli/commands/crm.ts
+++ b/src/cli/commands/crm.ts
@@ -40,11 +40,37 @@ import {
   updateCrmPipelineStage,
   updateCrmPipelineStageTopic,
   updateCrmContactProfile,
+  type CrmTask,
   type CrmOwnerType,
 } from "../../contacts.js";
 
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
+}
+
+function formatCrmTaskForJson<T extends Partial<CrmTask>>(task: T): T & Record<string, unknown> {
+  return {
+    ...task,
+    contact_id: task.contactId,
+    account_id: task.accountId,
+    opportunity_id: task.opportunityId,
+    chat_id: task.chatId,
+    session_key: task.sessionKey,
+    task_type: task.taskType,
+    due_at: task.dueAt,
+    due_date: task.dueAt,
+    snoozed_until: task.snoozedUntil,
+    completed_at: task.completedAt,
+    canceled_at: task.canceledAt,
+    owner_type: task.ownerType,
+    owner_id: task.ownerId,
+    created_by_type: task.createdByType,
+    created_by_id: task.createdById,
+    idempotency_key: task.idempotencyKey,
+    ravi_task_id: task.raviTaskId,
+    created_at: task.createdAt,
+    updated_at: task.updatedAt,
+  };
 }
 
 function parseOwner(owner?: string): { ownerType?: CrmOwnerType; ownerId?: string } {
@@ -1478,7 +1504,7 @@ export class CrmTaskCommands {
   ) {
     const task = getCrmTask(taskId);
     if (!task) fail(`CRM task not found: ${taskId}`);
-    const payload = { target: taskId, task };
+    const payload = { target: taskId, task: formatCrmTaskForJson(task) };
     if (asJson) {
       printJson(payload);
       return payload;
@@ -1532,7 +1558,7 @@ export class CrmTaskCommands {
       evidence,
       metadata,
     });
-    const payload = { status: "created" as const, task, changedCount: 1 };
+    const payload = { status: "created" as const, task: formatCrmTaskForJson(task), changedCount: 1 };
     if (asJson) {
       printJson(payload);
     } else {
@@ -1548,7 +1574,7 @@ export class CrmTaskCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     const task = completeCrmTask({ taskId, source: "cli", actorType: "user" });
-    const payload = { status: "done" as const, task, changedCount: 1 };
+    const payload = { status: "done" as const, task: formatCrmTaskForJson(task), changedCount: 1 };
     if (asJson) {
       printJson(payload);
     } else {
@@ -1566,7 +1592,7 @@ export class CrmTaskCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     const task = cancelCrmTask({ taskId, reason, source: "cli", actorType: "user" });
-    const payload = { status: "canceled" as const, task, changedCount: 1 };
+    const payload = { status: "canceled" as const, task: formatCrmTaskForJson(task), changedCount: 1 };
     if (asJson) {
       printJson(payload);
     } else {
@@ -1591,7 +1617,7 @@ export class CrmTaskCommands {
       actorType: "user",
       evidence: reason ? { reason } : undefined,
     });
-    const payload = { status: "snoozed" as const, task, changedCount: 1 };
+    const payload = { status: "snoozed" as const, task: formatCrmTaskForJson(task), changedCount: 1 };
     if (asJson) {
       printJson(payload);
     } else {
@@ -1657,7 +1683,8 @@ export class CrmTaskCommands {
         dueAfter,
       ],
     });
-    const payload = { total: page.total, pagination, items: page.items, tasks: page.items };
+    const items = page.items.map(formatCrmTaskForJson);
+    const payload = { total: page.total, pagination, items, tasks: items };
     if (asJson) {
       printJson(payload);
       return payload;


### PR DESCRIPTION
Fixes #38.
Fixes #39.

Summary:
- add snake_case aliases to CRM task JSON output while preserving camelCase fields
- cover task list/show and task mutation JSON payloads
- keep the internal CRM model unchanged and normalize only at the CLI boundary

Root cause:
- `crm task list --help` documents `due_at`/`task_type`, but JSON output exposed the internal camelCase `CrmTask` shape directly.

Validation:
- `bun test src/cli/commands/crm.test.ts`
- `bunx biome check src/cli/commands/crm.ts src/cli/commands/crm.test.ts`
- `bun run build`
- `bun test src/tasks/ src/projects/ src/workflow-substrate/ src/whatsapp-overlay/`
- pre-push hook: SDK check, build, typecheck, full tests, SDK tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->