### PR TITLE
fix(chats): canonicalize WhatsApp DM aliases

### DIFF
--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -13,6 +13,7 @@ import {
 import { detachTagFromSelector, searchTagBindingsForSelector } from "./tags/service.js";
 import { buildSqlWhereClause, countRows, normalizeLimitOffsetPage, type ListPage } from "./utils/pagination.js";
 import { nats } from "./nats.js";
+import { dbCanonicalizeDmChatForContact } from "./router/router-db.js";
 
 // Re-export shared phone helpers.
 export {
@@ -8448,12 +8449,31 @@ export function backfillInboundContacts(input: BackfillInboundContactsInput = {}
         const participantsUpdated = chatDatabase
           ? upsertBackfilledChatParticipant(chatDatabase, candidate, intake.contact.id, platformIdentityId)
           : 0;
+        const canonicalChat =
+          chatDatabase && candidate.chatId && candidate.chatType === "dm"
+            ? dbCanonicalizeDmChatForContact({
+                chatId: candidate.chatId,
+                contactId: intake.contact.id,
+                platformChatId: candidate.platformSenderId,
+                title: candidate.displayName ?? null,
+                avatarUrl: candidate.avatarUrl ?? null,
+                rawProvenance: {
+                  source: "inbound_contact_backfill",
+                  candidateKey: candidate.key,
+                  sources: candidate.sources,
+                  platformChatId: candidate.provenance.platformChatId ?? null,
+                },
+                seenAt: candidate.lastSeenAt ?? Date.now(),
+              })
+            : null;
+        const canonicalChatId = canonicalChat?.id ?? candidate.chatId;
         const readingListMemberAdded = chatDatabase
-          ? addBackfilledChatToReadingList(chatDatabase, readingList?.id ?? null, candidate.chatId)
+          ? addBackfilledChatToReadingList(chatDatabase, readingList?.id ?? null, canonicalChatId)
           : false;
 
         item = {
           ...item,
+          chatId: canonicalChatId,
           contactId: intake.contact.id,
           platformIdentityId,
           createdContact: intake.createdContact,

--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -13,6 +13,8 @@ const actualChatDbModule = await import("../db.js");
 const actualDbSaveMessageMeta = actualRouterDbModule.dbSaveMessageMeta;
 const actualDbGetMessageMeta = actualRouterDbModule.dbGetMessageMeta;
 const actualDbUpsertChat = actualRouterDbModule.dbUpsertChat;
+const actualDbCanonicalizeDmChatForContact = actualRouterDbModule.dbCanonicalizeDmChatForContact;
+const actualDbContactDmNormalizedChatId = actualRouterDbModule.dbContactDmNormalizedChatId;
 const actualDbUpsertChatMessage = actualRouterDbModule.dbUpsertChatMessage;
 const actualDbUpsertChatParticipant = actualRouterDbModule.dbUpsertChatParticipant;
 const actualDbBindSessionToChat = actualRouterDbModule.dbBindSessionToChat;
@@ -200,6 +202,10 @@ mock.module("../router/router-db.js", () => ({
   }),
   dbGetMessageMeta: mock((messageId: string) => messageMetaById.get(messageId) ?? actualDbGetMessageMeta(messageId)),
   dbUpsertChat: mock((input: Parameters<typeof actualDbUpsertChat>[0]) => actualDbUpsertChat(input)),
+  dbCanonicalizeDmChatForContact: mock((input: Parameters<typeof actualDbCanonicalizeDmChatForContact>[0]) =>
+    actualDbCanonicalizeDmChatForContact(input),
+  ),
+  dbContactDmNormalizedChatId: actualDbContactDmNormalizedChatId,
   dbUpsertChatMessage: mock((input: Parameters<typeof actualDbUpsertChatMessage>[0]) => {
     chatMessageCalls.push(input);
     return actualDbUpsertChatMessage(input);

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -45,6 +45,8 @@ import {
 } from "../contacts.js";
 import {
   dbBindSessionToChat,
+  dbCanonicalizeDmChatForContact,
+  dbContactDmNormalizedChatId,
   dbGetMessageMeta,
   dbSaveMessageMeta,
   dbUpsertChat,
@@ -677,10 +679,27 @@ export class OmniConsumer {
     // - Strip JID domain suffixes (@g.us, @s.whatsapp.net)
     const sessionChannel = channelType.replace(/-baileys$/, "");
     const sessionGroupId = isGroup ? chatJid.replace(/@.*$/, "") : undefined;
-    const canonicalChat = dbUpsertChat({
+    const normalizedSenderId = resolvedSenderPhone || senderPhone;
+    let senderPlatformIdentity = resolveSenderPlatformIdentity({
+      channel: sessionChannel,
+      instanceId,
+      normalizedSenderId,
+      rawSenderId: senderPhone,
+      rawProviderSenderId: payload.from,
+    });
+    let senderContact =
+      senderPlatformIdentity?.ownerType === "contact" && senderPlatformIdentity.ownerId
+        ? getContact(senderPlatformIdentity.ownerId)
+        : (getContact(resolvedSenderPhone) ?? getContact(senderPhone));
+    const senderContactChatKey =
+      !isGroup && !threadId && !isNonDmChannel && senderPlatformIdentity?.ownerType !== "agent" && senderContact?.id
+        ? dbContactDmNormalizedChatId(senderContact.id)
+        : undefined;
+    let canonicalChat = dbUpsertChat({
       channel: sessionChannel,
       instanceId,
       platformChatId: threadId ? `${chatJid}#${threadId}` : chatJid,
+      normalizedChatId: senderContactChatKey,
       chatType: threadId ? "thread" : isGroup ? "group" : isNonDmChannel ? "channel" : "dm",
       title: rawPayloadString(rawPayload, "chatName") ?? null,
       rawProvenance: {
@@ -694,18 +713,23 @@ export class OmniConsumer {
       },
       seenAt: msgTs,
     });
-    const normalizedSenderId = resolvedSenderPhone || senderPhone;
-    let senderPlatformIdentity = resolveSenderPlatformIdentity({
-      channel: sessionChannel,
-      instanceId,
-      normalizedSenderId,
-      rawSenderId: senderPhone,
-      rawProviderSenderId: payload.from,
-    });
-    let senderContact =
-      senderPlatformIdentity?.ownerType === "contact" && senderPlatformIdentity.ownerId
-        ? getContact(senderPlatformIdentity.ownerId)
-        : (getContact(resolvedSenderPhone) ?? getContact(senderPhone));
+    if (senderContactChatKey && senderContact?.id) {
+      canonicalChat = dbCanonicalizeDmChatForContact({
+        chatId: canonicalChat.id,
+        contactId: senderContact.id,
+        platformChatId: chatJid,
+        title: rawPayloadString(rawPayload, "chatName") ?? rawPayloadString(rawPayload, "pushName") ?? null,
+        rawProvenance: {
+          source: "omni.message.received",
+          eventId: event.id,
+          accountId: effectiveAccountId,
+          instanceId,
+          chatId: chatJid,
+          senderId: payload.from,
+        },
+        seenAt: msgTs,
+      });
+    }
 
     if (
       !isGroup &&
@@ -748,6 +772,23 @@ export class OmniConsumer {
         });
         if (intake.platformIdentity) senderPlatformIdentity = intake.platformIdentity;
         if (intake.contact) senderContact = intake.contact;
+        if (!threadId && !isNonDmChannel && intake.contact?.id) {
+          canonicalChat = dbCanonicalizeDmChatForContact({
+            chatId: canonicalChat.id,
+            contactId: intake.contact.id,
+            platformChatId: chatJid,
+            title: rawPayloadString(rawPayload, "chatName") ?? rawPayloadString(rawPayload, "pushName") ?? null,
+            rawProvenance: {
+              source: "omni.message.received",
+              eventId: event.id,
+              accountId: effectiveAccountId,
+              instanceId,
+              chatId: chatJid,
+              senderId: payload.from,
+            },
+            seenAt: msgTs,
+          });
+        }
       } catch (error) {
         log.warn("Failed to ensure inbound contact", {
           instanceId,

--- a/src/router/chat-schema.test.ts
+++ b/src/router/chat-schema.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   dbBindSessionToChat,
   dbAddChatToReadingList,
+  dbCanonicalizeDmChatForContact,
   dbCreateChatReadingList,
   dbFindChat,
   dbFindChatByRef,
   dbFindChatReadingList,
+  dbContactDmNormalizedChatId,
   dbGetSessionChatBinding,
   dbGetChatReadingDelta,
   dbListChats,
@@ -257,6 +259,146 @@ describe("identity chat schema", () => {
     expect(messages.total).toBe(2);
     expect(messages.items.map((message) => message.content?.text)).toEqual(["primeira", "segunda"]);
     expect(messages.items[0]?.sortKey).toMatch(/cm_/);
+  });
+
+  it("canonicalizes WhatsApp DM LID and phone chats for the same contact", () => {
+    const normalizedChatId = dbContactDmNormalizedChatId("contact_1");
+    const list = dbCreateChatReadingList({ name: "crm-analysis", ownerType: "agent", ownerId: "crm" });
+    const lidChat = dbUpsertChat({
+      channel: "whatsapp",
+      instanceId: "instance-1",
+      platformChatId: "238289734901889@lid",
+      chatType: "dm",
+      title: "Raquel",
+    });
+    dbUpsertChatMessage({
+      chatId: lidChat.id,
+      channel: "whatsapp",
+      instanceId: "instance-1",
+      providerMessageId: "wamid-lid",
+      rawChatId: "238289734901889@lid",
+      rawSenderId: "238289734901889@lid",
+      normalizedSenderId: "lid:238289734901889",
+      actorType: "contact",
+      contactId: "contact_1",
+      platformIdentityId: "pi_lid",
+      content: { type: "text", text: "via lid" },
+      providerTimestamp: 1_700_000_000_000,
+      ingestedAt: 1_700_000_000_100,
+    });
+    dbUpsertChatParticipant({
+      chatId: lidChat.id,
+      contactId: "contact_1",
+      platformIdentityId: "pi_lid",
+      rawPlatformUserId: "238289734901889@lid",
+      normalizedPlatformUserId: "lid:238289734901889",
+      source: "inbound_message",
+    });
+    dbAddChatToReadingList({ listId: list.id, chatId: lidChat.id, source: "crm" });
+
+    expect(
+      dbUpsertChat({
+        channel: "whatsapp",
+        instanceId: "instance-1",
+        platformChatId: "238289734901889@lid",
+        normalizedChatId,
+        chatType: "dm",
+      }).id,
+    ).toBe(lidChat.id);
+
+    const canonicalLid = dbCanonicalizeDmChatForContact({
+      chatId: lidChat.id,
+      contactId: "contact_1",
+      platformChatId: "238289734901889@lid",
+      title: "Raquel",
+      rawProvenance: { source: "test", alias: "lid" },
+      seenAt: 1_700_000_000_100,
+    });
+    expect(canonicalLid.id).toBe(lidChat.id);
+    expect(canonicalLid.normalizedChatId).toBe(normalizedChatId);
+
+    const phoneChat = dbUpsertChat({
+      channel: "whatsapp",
+      instanceId: "instance-1",
+      platformChatId: "5511999999999@s.whatsapp.net",
+      chatType: "dm",
+      title: "Raquel",
+    });
+    dbUpsertChatMessage({
+      chatId: phoneChat.id,
+      channel: "whatsapp",
+      instanceId: "instance-1",
+      providerMessageId: "wamid-phone",
+      rawChatId: "5511999999999@s.whatsapp.net",
+      rawSenderId: "5511999999999@s.whatsapp.net",
+      normalizedSenderId: "5511999999999",
+      actorType: "contact",
+      contactId: "contact_1",
+      platformIdentityId: "pi_phone",
+      content: { type: "text", text: "via phone" },
+      providerTimestamp: 1_700_000_001_000,
+      ingestedAt: 1_700_000_001_100,
+    });
+    dbUpsertChatParticipant({
+      chatId: phoneChat.id,
+      contactId: "contact_1",
+      platformIdentityId: "pi_phone",
+      rawPlatformUserId: "5511999999999@s.whatsapp.net",
+      normalizedPlatformUserId: "5511999999999",
+      source: "inbound_message",
+    });
+    dbAddChatToReadingList({ listId: list.id, chatId: phoneChat.id, source: "crm" });
+
+    const canonicalPhone = dbCanonicalizeDmChatForContact({
+      chatId: phoneChat.id,
+      contactId: "contact_1",
+      platformChatId: "5511999999999@s.whatsapp.net",
+      title: "Raquel",
+      rawProvenance: { source: "test", alias: "phone" },
+      seenAt: 1_700_000_001_100,
+    });
+
+    expect(canonicalPhone.id).toBe(canonicalLid.id);
+    expect(canonicalPhone.normalizedChatId).toBe(normalizedChatId);
+    expect(
+      dbFindChat({ channel: "whatsapp", instanceId: "instance-1", platformChatId: "238289734901889@lid" })?.id,
+    ).toBe(canonicalLid.id);
+    expect(
+      dbFindChat({ channel: "whatsapp", instanceId: "instance-1", platformChatId: "5511999999999@s.whatsapp.net" })?.id,
+    ).toBe(canonicalLid.id);
+    expect(
+      dbUpsertChat({
+        channel: "whatsapp",
+        instanceId: "instance-1",
+        platformChatId: "238289734901889@lid",
+        normalizedChatId,
+        chatType: "dm",
+      }).id,
+    ).toBe(canonicalLid.id);
+    expect(
+      dbUpsertChat({
+        channel: "whatsapp",
+        instanceId: "instance-1",
+        platformChatId: "5511999999999@s.whatsapp.net",
+        chatType: "dm",
+      }).id,
+    ).toBe(canonicalLid.id);
+    expect(
+      dbFindChat({ channel: "whatsapp", instanceId: "instance-1", platformChatId: "238289734901889@lid" })?.id,
+    ).toBe(canonicalLid.id);
+
+    const chats = dbListChats({ instanceId: "instance-1", contactId: "contact_1" });
+    expect(chats.total).toBe(1);
+    expect(chats.items[0]?.chat.id).toBe(canonicalLid.id);
+    expect(
+      dbListChatMessages(canonicalLid.id)
+        .map((message) => message.providerMessageId)
+        .sort(),
+    ).toEqual(["wamid-lid", "wamid-phone"]);
+    expect(dbListChatParticipants(canonicalLid.id)).toHaveLength(1);
+    const members = dbListChatReadingListMembers({ listId: list.id });
+    expect(members.total).toBe(1);
+    expect(members.items[0]?.chat.id).toBe(canonicalLid.id);
   });
 
   it("keeps reading-list cursors independent per list and reader", () => {

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -513,6 +513,16 @@ export interface UpsertChatInput {
   seenAt?: number;
 }
 
+export interface CanonicalizeDmChatForContactInput {
+  chatId: string;
+  contactId: string;
+  platformChatId?: string | null;
+  title?: string | null;
+  avatarUrl?: string | null;
+  rawProvenance?: Record<string, unknown> | null;
+  seenAt?: number;
+}
+
 export interface ChatParticipantRecord {
   id: string;
   chatId: string;
@@ -2548,6 +2558,12 @@ function normalizeChatIdentity(channel: string, platformChatId: string, chatType
   return trimmed.toLowerCase();
 }
 
+export function dbContactDmNormalizedChatId(contactId: string): string {
+  const trimmed = contactId.trim();
+  if (!trimmed) throw new Error("contactId is required to canonicalize a DM chat");
+  return `contact:${trimmed}`;
+}
+
 function inferChatType(platformChatId: string, explicit?: ChatType | null): ChatType {
   if (explicit && explicit !== "unknown") return explicit;
   if (platformChatId.includes("#")) return "thread";
@@ -2739,8 +2755,11 @@ function upsertChat(database: Database, input: UpsertChatInput): ChatRecord {
   const channel = normalizeChannelId(input.channel);
   const instanceId = input.instanceId?.trim() ?? "";
   const chatType = inferChatType(input.platformChatId, input.chatType);
+  const existingByPlatform = findChatByPlatformOrAlias(database, channel, instanceId, input.platformChatId);
   const normalizedChatId =
-    input.normalizedChatId?.trim() || normalizeChatIdentity(channel, input.platformChatId, chatType);
+    existingByPlatform?.normalized_chat_id ||
+    input.normalizedChatId?.trim() ||
+    normalizeChatIdentity(channel, input.platformChatId, chatType);
   const id = semanticId("chat", [channel, instanceId, normalizedChatId]);
 
   database
@@ -2783,6 +2802,402 @@ function upsertChat(database: Database, input: UpsertChatInput): ChatRecord {
   const row = database
     .prepare("SELECT * FROM chats WHERE channel = ? AND instance_id = ? AND normalized_chat_id = ?")
     .get(channel, instanceId, normalizedChatId) as ChatRow;
+  return rowToChat(row);
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function chatPlatformAliases(row: ChatRow): string[] {
+  const provenance = parseJsonRecord(row.raw_provenance_json);
+  const canonicalization =
+    provenance?.canonicalization && typeof provenance.canonicalization === "object"
+      ? (provenance.canonicalization as Record<string, unknown>)
+      : {};
+  const platformChatIds = Array.isArray(canonicalization.platformChatIds)
+    ? canonicalization.platformChatIds.filter((value): value is string => typeof value === "string")
+    : [];
+  return uniqueStrings([row.platform_chat_id, ...platformChatIds]);
+}
+
+function findChatByPlatformOrAlias(
+  database: Database,
+  channel: string,
+  instanceId: string,
+  platformChatId: string,
+): ChatRow | undefined {
+  const exact = database
+    .prepare("SELECT * FROM chats WHERE channel = ? AND instance_id = ? AND platform_chat_id = ?")
+    .get(channel, instanceId, platformChatId) as ChatRow | undefined;
+  if (exact) return exact;
+
+  const rows = database
+    .prepare("SELECT * FROM chats WHERE channel = ? AND instance_id = ? AND raw_provenance_json IS NOT NULL")
+    .all(channel, instanceId) as ChatRow[];
+  return rows.find((row) => chatPlatformAliases(row).includes(platformChatId));
+}
+
+function mergeChatCanonicalizationProvenance(
+  target: ChatRow,
+  source: ChatRow | null,
+  input: CanonicalizeDmChatForContactInput,
+): Record<string, unknown> {
+  const existingTarget = parseJsonRecord(target.raw_provenance_json) ?? {};
+  const existingSource = source ? (parseJsonRecord(source.raw_provenance_json) ?? {}) : {};
+  const existingCanonicalization =
+    existingTarget.canonicalization && typeof existingTarget.canonicalization === "object"
+      ? (existingTarget.canonicalization as Record<string, unknown>)
+      : {};
+  const previousPlatformChatIds = Array.isArray(existingCanonicalization.platformChatIds)
+    ? existingCanonicalization.platformChatIds.filter((value): value is string => typeof value === "string")
+    : [];
+  const previousMergedChatIds = Array.isArray(existingCanonicalization.mergedChatIds)
+    ? existingCanonicalization.mergedChatIds.filter((value): value is string => typeof value === "string")
+    : [];
+  return mergeJsonRecords(existingSource, existingTarget, input.rawProvenance ?? undefined, {
+    canonicalization: {
+      ...existingCanonicalization,
+      source: "contact_dm",
+      contactId: input.contactId,
+      platformChatIds: uniqueStrings([
+        ...previousPlatformChatIds,
+        target.platform_chat_id,
+        source?.platform_chat_id,
+        input.platformChatId,
+      ]),
+      mergedChatIds: uniqueStrings([
+        ...previousMergedChatIds,
+        source?.id && source.id !== target.id ? source.id : null,
+      ]),
+    },
+  })!;
+}
+
+function mergeChatMessagesIntoTarget(
+  database: Database,
+  sourceChatId: string,
+  targetChatId: string,
+  now: number,
+): void {
+  const rows = database.prepare("SELECT * FROM chat_messages WHERE chat_id = ?").all(sourceChatId) as ChatMessageRow[];
+  for (const row of rows) {
+    const existing = database
+      .prepare(
+        `
+        SELECT *
+        FROM chat_messages
+        WHERE channel = ? AND instance_id = ? AND chat_id = ? AND provider_message_id = ?
+      `,
+      )
+      .get(row.channel, row.instance_id, targetChatId, row.provider_message_id) as ChatMessageRow | undefined;
+    if (!existing) {
+      database
+        .prepare("UPDATE chat_messages SET chat_id = ?, updated_at = ? WHERE id = ?")
+        .run(targetChatId, now, row.id);
+      continue;
+    }
+    const mergedProvenance = mergeJsonRecords(
+      parseJsonRecord(existing.raw_provenance_json),
+      parseJsonRecord(row.raw_provenance_json),
+      { mergedFromChatId: sourceChatId },
+    );
+    database
+      .prepare(
+        `
+        UPDATE chat_messages
+        SET raw_sender_id = COALESCE(raw_sender_id, ?),
+            normalized_sender_id = COALESCE(normalized_sender_id, ?),
+            actor_type = CASE WHEN actor_type = 'unknown' AND ? != 'unknown' THEN ? ELSE actor_type END,
+            contact_id = COALESCE(contact_id, ?),
+            agent_id = COALESCE(agent_id, ?),
+            platform_identity_id = COALESCE(platform_identity_id, ?),
+            message_type = COALESCE(message_type, ?),
+            content_json = COALESCE(content_json, ?),
+            raw_provenance_json = COALESCE(?, raw_provenance_json),
+            provider_timestamp = COALESCE(provider_timestamp, ?),
+            updated_at = ?
+        WHERE id = ?
+      `,
+      )
+      .run(
+        row.raw_sender_id,
+        row.normalized_sender_id,
+        row.actor_type,
+        row.actor_type,
+        row.contact_id,
+        row.agent_id,
+        row.platform_identity_id,
+        row.message_type,
+        row.content_json,
+        cleanJsonRecord(mergedProvenance),
+        row.provider_timestamp,
+        now,
+        existing.id,
+      );
+    database.prepare("DELETE FROM chat_messages WHERE id = ?").run(row.id);
+  }
+}
+
+function mergeChatParticipantsIntoTarget(
+  database: Database,
+  sourceChatId: string,
+  targetChatId: string,
+  now: number,
+): void {
+  const rows = database
+    .prepare("SELECT * FROM chat_participants WHERE chat_id = ?")
+    .all(sourceChatId) as ChatParticipantRow[];
+  for (const row of rows) {
+    upsertChatParticipant(database, {
+      chatId: targetChatId,
+      platformIdentityId: row.platform_identity_id,
+      contactId: row.contact_id,
+      agentId: row.agent_id,
+      rawPlatformUserId: row.raw_platform_user_id,
+      normalizedPlatformUserId: row.normalized_platform_user_id ?? undefined,
+      role: row.role,
+      status: row.status,
+      source: row.source,
+      metadata: mergeJsonRecords(parseJsonRecord(row.metadata_json), { canonicalizedFromChatId: sourceChatId }),
+      seenAt: Math.max(row.last_seen_at, now),
+    });
+    database.prepare("DELETE FROM chat_participants WHERE id = ?").run(row.id);
+  }
+}
+
+function mergeSessionChatBindingsIntoTarget(database: Database, sourceChatId: string, targetChatId: string): void {
+  const rows = database
+    .prepare("SELECT session_key FROM session_chat_bindings WHERE chat_id = ?")
+    .all(sourceChatId) as Array<{ session_key: string }>;
+  for (const row of rows) {
+    const existing = database
+      .prepare("SELECT 1 FROM session_chat_bindings WHERE session_key = ? AND chat_id = ?")
+      .get(row.session_key, targetChatId);
+    if (existing) {
+      database
+        .prepare("DELETE FROM session_chat_bindings WHERE session_key = ? AND chat_id = ?")
+        .run(row.session_key, sourceChatId);
+    } else {
+      database
+        .prepare("UPDATE session_chat_bindings SET chat_id = ? WHERE session_key = ? AND chat_id = ?")
+        .run(targetChatId, row.session_key, sourceChatId);
+    }
+  }
+}
+
+function mergeSessionChatSubscriptionsIntoTarget(
+  database: Database,
+  sourceChatId: string,
+  targetChatId: string,
+  now: number,
+): void {
+  const rows = database
+    .prepare("SELECT id, session_key, detached_at FROM session_chat_subscriptions WHERE chat_id = ?")
+    .all(sourceChatId) as Array<{ id: number; session_key: string; detached_at: number | null }>;
+  for (const row of rows) {
+    const activeTarget = database
+      .prepare("SELECT 1 FROM session_chat_subscriptions WHERE chat_id = ? AND detached_at IS NULL")
+      .get(targetChatId);
+    const activePair = database
+      .prepare("SELECT 1 FROM session_chat_subscriptions WHERE session_key = ? AND chat_id = ? AND detached_at IS NULL")
+      .get(row.session_key, targetChatId);
+    if (row.detached_at === null && (activeTarget || activePair)) {
+      database
+        .prepare("UPDATE session_chat_subscriptions SET detached_at = ?, updated_at = ? WHERE id = ?")
+        .run(now, now, row.id);
+      continue;
+    }
+    database
+      .prepare("UPDATE session_chat_subscriptions SET chat_id = ?, updated_at = ? WHERE id = ?")
+      .run(targetChatId, now, row.id);
+  }
+}
+
+function mergeReadingListMembersIntoTarget(
+  database: Database,
+  sourceChatId: string,
+  targetChatId: string,
+  now: number,
+): void {
+  const rows = database
+    .prepare("SELECT id, list_id, removed_at FROM chat_reading_list_members WHERE chat_id = ?")
+    .all(sourceChatId) as Array<{ id: string; list_id: string; removed_at: number | null }>;
+  for (const row of rows) {
+    const activeTarget = database
+      .prepare("SELECT 1 FROM chat_reading_list_members WHERE list_id = ? AND chat_id = ? AND removed_at IS NULL")
+      .get(row.list_id, targetChatId);
+    if (row.removed_at === null && activeTarget) {
+      database.prepare("UPDATE chat_reading_list_members SET removed_at = ? WHERE id = ?").run(now, row.id);
+    } else {
+      database.prepare("UPDATE chat_reading_list_members SET chat_id = ? WHERE id = ?").run(targetChatId, row.id);
+    }
+  }
+}
+
+function mergeReadingCursorsIntoTarget(
+  database: Database,
+  sourceChatId: string,
+  targetChatId: string,
+  now: number,
+): void {
+  const rows = database.prepare("SELECT * FROM chat_reading_cursors WHERE chat_id = ?").all(sourceChatId) as Array<{
+    id: string;
+    list_id: string;
+    reader_type: string;
+    reader_id: string;
+    last_read_message_id: string | null;
+    last_read_message_sort_key: string | null;
+    last_read_event_id: string | null;
+    last_read_event_sort_key: string | null;
+    last_read_at: number | null;
+    read_reason: string | null;
+    metadata_json: string | null;
+    updated_at: number;
+  }>;
+  for (const row of rows) {
+    const existing = database
+      .prepare(
+        `
+        SELECT id, updated_at
+        FROM chat_reading_cursors
+        WHERE list_id = ? AND chat_id = ? AND reader_type = ? AND reader_id = ?
+      `,
+      )
+      .get(row.list_id, targetChatId, row.reader_type, row.reader_id) as { id: string; updated_at: number } | undefined;
+    if (!existing) {
+      database
+        .prepare("UPDATE chat_reading_cursors SET chat_id = ?, updated_at = ? WHERE id = ?")
+        .run(targetChatId, now, row.id);
+      continue;
+    }
+    if (row.updated_at > existing.updated_at) {
+      database
+        .prepare(
+          `
+          UPDATE chat_reading_cursors
+          SET last_read_message_id = ?,
+              last_read_message_sort_key = ?,
+              last_read_event_id = ?,
+              last_read_event_sort_key = ?,
+              last_read_at = ?,
+              read_reason = ?,
+              metadata_json = ?,
+              updated_at = ?
+          WHERE id = ?
+        `,
+        )
+        .run(
+          row.last_read_message_id,
+          row.last_read_message_sort_key,
+          row.last_read_event_id,
+          row.last_read_event_sort_key,
+          row.last_read_at,
+          row.read_reason,
+          row.metadata_json,
+          now,
+          existing.id,
+        );
+    }
+    database.prepare("DELETE FROM chat_reading_cursors WHERE id = ?").run(row.id);
+  }
+  database
+    .prepare("UPDATE chat_reading_cursor_events SET chat_id = ? WHERE chat_id = ?")
+    .run(targetChatId, sourceChatId);
+}
+
+function canonicalizeDmChatForContact(database: Database, input: CanonicalizeDmChatForContactInput): ChatRecord {
+  const contactId = input.contactId.trim();
+  if (!contactId) throw new Error("contactId is required to canonicalize a DM chat");
+  const source = database.prepare("SELECT * FROM chats WHERE id = ?").get(input.chatId) as ChatRow | undefined;
+  if (!source) throw new Error(`Chat not found: ${input.chatId}`);
+  if (source.chat_type !== "dm") return rowToChat(source);
+
+  const now = input.seenAt ?? Date.now();
+  const normalizedChatId = dbContactDmNormalizedChatId(contactId);
+  const target = database
+    .prepare("SELECT * FROM chats WHERE channel = ? AND instance_id = ? AND normalized_chat_id = ?")
+    .get(source.channel, source.instance_id, normalizedChatId) as ChatRow | undefined;
+  const targetRow = target ?? source;
+  const rawProvenance = mergeChatCanonicalizationProvenance(targetRow, target ? source : null, input);
+
+  if (!target || target.id === source.id) {
+    database
+      .prepare(
+        `
+        UPDATE chats
+        SET normalized_chat_id = ?,
+            platform_chat_id = COALESCE(?, platform_chat_id),
+            title = COALESCE(?, title),
+            avatar_url = COALESCE(?, avatar_url),
+            raw_provenance_json = ?,
+            last_seen_at = MAX(last_seen_at, ?),
+            updated_at = ?
+        WHERE id = ?
+      `,
+      )
+      .run(
+        normalizedChatId,
+        input.platformChatId ?? null,
+        input.title ?? null,
+        input.avatarUrl ?? null,
+        cleanJsonRecord(rawProvenance),
+        now,
+        now,
+        source.id,
+      );
+    const row = database.prepare("SELECT * FROM chats WHERE id = ?").get(source.id) as ChatRow;
+    return rowToChat(row);
+  }
+
+  mergeChatMessagesIntoTarget(database, source.id, target.id, now);
+  mergeChatParticipantsIntoTarget(database, source.id, target.id, now);
+  mergeSessionChatBindingsIntoTarget(database, source.id, target.id);
+  mergeSessionChatSubscriptionsIntoTarget(database, source.id, target.id, now);
+  mergeReadingListMembersIntoTarget(database, source.id, target.id, now);
+  mergeReadingCursorsIntoTarget(database, source.id, target.id, now);
+
+  database
+    .prepare("UPDATE message_metadata SET canonical_chat_id = ? WHERE canonical_chat_id = ?")
+    .run(target.id, source.id);
+  database
+    .prepare("UPDATE session_events SET canonical_chat_id = ? WHERE canonical_chat_id = ?")
+    .run(target.id, source.id);
+  database
+    .prepare(
+      `
+      UPDATE chats
+      SET platform_chat_id = COALESCE(?, platform_chat_id),
+          title = COALESCE(?, title),
+          avatar_url = COALESCE(?, avatar_url),
+          raw_provenance_json = ?,
+          first_seen_at = MIN(first_seen_at, ?),
+          last_seen_at = MAX(last_seen_at, ?),
+          updated_at = ?
+      WHERE id = ?
+    `,
+    )
+    .run(
+      input.platformChatId ?? source.platform_chat_id,
+      input.title ?? source.title,
+      input.avatarUrl ?? source.avatar_url,
+      cleanJsonRecord(rawProvenance),
+      source.first_seen_at,
+      Math.max(source.last_seen_at, now),
+      now,
+      target.id,
+    );
+  database.prepare("DELETE FROM chats WHERE id = ?").run(source.id);
+
+  const row = database.prepare("SELECT * FROM chats WHERE id = ?").get(target.id) as ChatRow;
   return rowToChat(row);
 }
 
@@ -4153,6 +4568,12 @@ export function dbUpsertChat(input: UpsertChatInput): ChatRecord {
   return upsertChat(getDb(), input);
 }
 
+export function dbCanonicalizeDmChatForContact(input: CanonicalizeDmChatForContactInput): ChatRecord {
+  return executeWrite(getDb(), (database) => canonicalizeDmChatForContact(database, input), {
+    label: "canonicalize_dm_chat_for_contact",
+  });
+}
+
 export function dbGetChat(id: string): ChatRecord | null {
   const row = getDb().prepare("SELECT * FROM chats WHERE id = ?").get(id) as ChatRow | undefined;
   return row ? rowToChat(row) : null;
@@ -4170,7 +4591,9 @@ export function dbFindChat(input: {
   const row = getDb()
     .prepare("SELECT * FROM chats WHERE channel = ? AND instance_id = ? AND normalized_chat_id = ?")
     .get(channel, instanceId, normalizedChatId) as ChatRow | undefined;
-  return row ? rowToChat(row) : null;
+  if (row) return rowToChat(row);
+  const byPlatform = findChatByPlatformOrAlias(getDb(), channel, instanceId, input.platformChatId);
+  return byPlatform ? rowToChat(byPlatform) : null;
 }
 
 function chatRefCandidates(ref: string): string[] {


### PR DESCRIPTION
## Summary
- canonicalize WhatsApp DM chats by contact id so LID and phone aliases share one chat_id
- preserve platform chat aliases in provenance and resolve future lookups/upserts through those aliases
- merge existing split chat messages, participants, subscriptions, reading-list members, and cursors into the canonical chat

## Root Cause
WhatsApp can deliver the same DM contact under both LID (`@lid`) and phone (`@s.whatsapp.net`) identifiers. The chat upsert path keyed DM identity by platform_chat_id, so the same contact could accumulate two chat rows and fragmented history.

## Validation
- bun test src/router/chat-schema.test.ts src/omni/consumer-context.test.ts src/contacts.identity-model.test.ts
- bun run typecheck
- bun run lint (exits 0; existing warning in src/tag-rules/loader.ts:68)
- bun run build
- pre-push checks: SDK drift check, build, typecheck, broad test suite, SDK check

Fixes #44
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->