### PR TITLE
[codex] Warn instead of rejecting custom trigger topics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,15 +246,16 @@ ravi triggers rm <id>
 ```
 
 **Topic Catalog:**
-- `ravi triggers topics` - Inspect trigger-ready subjects, payload schemas, examples, and notes
+- `ravi triggers topics` - Inspect built-in topic templates, payload schemas, examples, and notes
 - `ravi.*.cli.{group}.{command}` - CLI command audit events emitted from an agent session
 - `ravi._cli.cli.{group}.{command}` - CLI command audit events emitted outside an agent session
 - `ravi.inbound.reaction` - Normalized emoji reactions
 - `ravi.audit.denied` - Permission or policy denial events
-- Custom publisher subjects are allowed when explicitly emitted by local code
+- The catalog is hints/templates, not a whitelist. Custom publisher subjects are allowed when emitted by local code or another NATS publisher.
 
-**Blocked Topics (anti-loop):**
-- `ravi.session.*` - Reserved session runtime subjects
+**Topic Warnings:**
+- Unknown topics are accepted, but the CLI may warn when they are not in the built-in templates.
+- `ravi.session.*` topics are accepted by the CLI, but the trigger runner skips internal session subscriptions to prevent loops.
 
 **Options:**
 - `--topic <pattern>` - NATS topic pattern to subscribe to (required)
@@ -281,7 +282,7 @@ Um contato foi alterado. Notifica o grupo do Slack e atualiza o CRM.
 - `main`: `agent:{agentId}:main`
 
 **Anti-Loop Protection:**
-1. Blocked topics: `.prompt`, `.response`, `.claude` topics are rejected at subscription time
+1. Internal session topics: `ravi.session.*` can be configured, but the runner skips those subscriptions to prevent loops
 2. Session filter: events from trigger sessions (`:trigger:` in topic) are skipped
 3. Data flag: events with `_trigger: true` are skipped
 4. Cooldown: per-trigger cooldown (default 5s) prevents rapid re-firing

--- a/src/cli/commands/triggers.test.ts
+++ b/src/cli/commands/triggers.test.ts
@@ -144,30 +144,54 @@ async function captureJson(run: () => Promise<unknown>): Promise<Record<string, 
   return JSON.parse(lines.join("\n")) as Record<string, unknown>;
 }
 
-describe("TriggersCommands topic validation", () => {
+async function captureWarnings(run: () => Promise<unknown>): Promise<string[]> {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(" "));
+  };
+
+  try {
+    await run();
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  return warnings;
+}
+
+describe("TriggersCommands topic guidance", () => {
   beforeEach(() => {
     createdTriggers.length = 0;
     updatedTriggers.length = 0;
   });
 
-  it("rejects ravi.session topics on add", async () => {
+  it("allows ravi.session topics on add but prints an internal topic warning", async () => {
     const commands = new TriggersCommands();
 
-    await expect(commands.add("loop", "ravi.session.agent-main.prompt", "hello")).rejects.toThrow(
-      "Triggers cannot subscribe",
-    );
+    const warnings = await captureWarnings(() => commands.add("loop", "ravi.session.agent-main.prompt", "hello"));
 
-    expect(createdTriggers).toHaveLength(0);
+    expect(createdTriggers).toContainEqual(
+      expect.objectContaining({
+        name: "loop",
+        topic: "ravi.session.agent-main.prompt",
+      }),
+    );
+    expect(warnings.join("\n")).toContain("runner skips ravi.session.*");
   });
 
-  it("rejects channel reaction aliases with canonical topic hint", async () => {
+  it("allows channel reaction aliases with canonical topic warning", async () => {
     const commands = new TriggersCommands();
 
-    await expect(commands.add("reaction", "whatsapp.*.reaction", "hello")).rejects.toThrow(
-      "Use 'ravi.inbound.reaction'",
-    );
+    const warnings = await captureWarnings(() => commands.add("reaction", "whatsapp.*.reaction", "hello"));
 
-    expect(createdTriggers).toHaveLength(0);
+    expect(createdTriggers).toContainEqual(
+      expect.objectContaining({
+        name: "reaction",
+        topic: "whatsapp.*.reaction",
+      }),
+    );
+    expect(warnings.join("\n")).toContain("ravi.inbound.reaction");
   });
 
   it("allows session CLI topics", async () => {
@@ -183,14 +207,16 @@ describe("TriggersCommands topic validation", () => {
     );
   });
 
-  it("rejects ravi.session topics on set", async () => {
+  it("allows ravi.session topics on set but prints an internal topic warning", async () => {
     const commands = new TriggersCommands();
 
-    await expect(commands.set("trg_1", "topic", "ravi.session.agent-main.runtime")).rejects.toThrow(
-      "Triggers cannot subscribe",
-    );
+    const warnings = await captureWarnings(() => commands.set("trg_1", "topic", "ravi.session.agent-main.runtime"));
 
-    expect(updatedTriggers).toHaveLength(0);
+    expect(updatedTriggers).toContainEqual({
+      id: "trg_1",
+      patch: { topic: "ravi.session.agent-main.runtime" },
+    });
+    expect(warnings.join("\n")).toContain("runner skips ravi.session.*");
   });
 
   it("prints created trigger data in --json mode", async () => {
@@ -214,6 +240,7 @@ describe("TriggersCommands topic validation", () => {
       status: "created",
       target: { type: "trigger", id: "trg_1" },
       changedCount: 1,
+      warnings: [expect.stringContaining("custom NATS subject")],
       trigger: {
         id: "trg_1",
         name: "json trigger",

--- a/src/cli/commands/triggers.ts
+++ b/src/cli/commands/triggers.ts
@@ -21,7 +21,7 @@ import {
   type Trigger,
 } from "../../triggers/index.js";
 import { getTriggerTopicCatalog, type TriggerTopicCatalogEntry } from "../../triggers/topic-catalog.js";
-import { getDisallowedTriggerTopicReason } from "../../triggers/topic-policy.js";
+import { getTriggerTopicWarnings } from "../../triggers/topic-policy.js";
 import { filterItemsByCanonicalTag } from "../../tags/helpers.js";
 
 function printJson(payload: unknown): void {
@@ -60,6 +60,12 @@ function printTopicCatalog(topics: TriggerTopicCatalogEntry[]): void {
     if (entry.notes?.length) {
       for (const note of entry.notes) console.log(`    note: ${note}`);
     }
+  }
+}
+
+function printTopicWarnings(warnings: string[]): void {
+  for (const warning of warnings) {
+    console.warn(`Warning: ${warning}`);
   }
 }
 
@@ -244,10 +250,7 @@ export class TriggersCommands {
     if (!message) {
       fail("--message is required");
     }
-    const disallowedReason = getDisallowedTriggerTopicReason(topic);
-    if (disallowedReason) {
-      fail(disallowedReason);
-    }
+    const topicWarnings = getTriggerTopicWarnings(topic);
 
     // Validate agent if provided
     if (agent) {
@@ -333,10 +336,12 @@ export class TriggersCommands {
         target: { type: "trigger" as const, id: trigger.id },
         changedCount: 1,
         trigger: serializeTrigger(trigger),
+        ...(topicWarnings.length ? { warnings: topicWarnings } : {}),
       };
       if (asJson) {
         printJson(payload);
       } else {
+        printTopicWarnings(topicWarnings);
         console.log(`\n✓ Created trigger: ${trigger.id}`);
         console.log(`  Name:       ${trigger.name}`);
         console.log(`  Topic:      ${trigger.topic}`);
@@ -427,6 +432,7 @@ export class TriggersCommands {
     try {
       let updated: Trigger | null = null;
       let normalizedValue: unknown = value;
+      let warnings: string[] = [];
       const logHuman = (message: string) => {
         if (!asJson) console.log(message);
       };
@@ -443,11 +449,9 @@ export class TriggersCommands {
           break;
 
         case "topic": {
-          const disallowedReason = getDisallowedTriggerTopicReason(value);
-          if (disallowedReason) {
-            fail(disallowedReason);
-          }
+          warnings = getTriggerTopicWarnings(value);
           updated = dbUpdateTrigger(id, { topic: value });
+          if (!asJson) printTopicWarnings(warnings);
           logHuman(`✓ Topic set: ${id} -> ${value}`);
           break;
         }
@@ -515,6 +519,7 @@ export class TriggersCommands {
         property: key,
         value: normalizedValue,
         trigger: current ? serializeTrigger(current) : null,
+        ...(warnings.length ? { warnings } : {}),
       };
       if (asJson) {
         printJson(payload);

--- a/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
@@ -58,7 +58,7 @@ ravi triggers rm <id>
 
 ## Banco de Tópicos
 
-Use `ravi triggers topics` para ver subjects trigger-ready com schema de payload, exemplos, filtros comuns e notas operacionais. Skills e docs devem usar esse catálogo como fonte de hints, em vez de inferir topics por simetria.
+Use `ravi triggers topics` para ver templates built-in com schema de payload, exemplos, filtros comuns e notas operacionais. O catálogo é fonte de hints, não whitelist: topics externos/custom publicados no NATS são aceitos.
 
 ### Inbound e Canais
 
@@ -68,7 +68,7 @@ Use `ravi triggers topics` para ver subjects trigger-ready com schema de payload
 | `ravi.inbound.reply` | Replies a mensagens do bot. Payload: `{ targetMessageId, text, senderId }` |
 | `ravi.inbound.pollVote` | Votos em enquetes. Payload: `{ pollMessageId, votes: [{ name, voters[] }] }` |
 
-Aliases como `whatsapp.*.reaction`, `whatsapp.*.inbound` e `matrix.*.inbound` não são subjects publicados para triggers. Mensagens de canal entram pelo router de sessão; reação usa `ravi.inbound.reaction`.
+Aliases como `whatsapp.*.reaction`, `whatsapp.*.inbound` e `matrix.*.inbound` não são templates built-in e recebem aviso do CLI. Eles ainda são aceitos como subjects custom; para reações Ravi normais, use `ravi.inbound.reaction`.
 
 ### Contatos e Aprovações
 
@@ -103,7 +103,7 @@ Aliases como `whatsapp.*.reaction`, `whatsapp.*.inbound` e `matrix.*.inbound` n�
 | `ravi.audit.denied` | Permissão negada |
 | `ravi.instances.unregistered` | Evento de instância Omni não registrada |
 
-**Bloqueados (anti-loop):** Triggers em tópicos `ravi.session.*` são rejeitados para evitar loops internos.
+**Avisos:** O CLI aceita topics fora do catálogo e apenas alerta. O runner ignora assinaturas em `ravi.session.*` para evitar loops internos.
 
 ## Filtros
 

--- a/src/triggers/__tests__/topic-catalog.test.ts
+++ b/src/triggers/__tests__/topic-catalog.test.ts
@@ -11,21 +11,24 @@ describe("trigger topic catalog", () => {
     );
   });
 
-  it("rejects inferred channel reaction aliases", () => {
+  it("warns about inferred channel reaction aliases", () => {
     expect(getTriggerTopicDiagnostic("whatsapp.*.reaction")).toMatchObject({
-      level: "error",
+      level: "warning",
       suggestedPattern: "ravi.inbound.reaction",
     });
   });
 
-  it("rejects inferred channel inbound aliases", () => {
+  it("warns about inferred channel inbound aliases", () => {
     expect(getTriggerTopicDiagnostic("whatsapp.*.inbound")).toMatchObject({
-      level: "error",
+      level: "warning",
     });
   });
 
-  it("allows custom publisher subjects", () => {
-    expect(getTriggerTopicDiagnostic("doma.rdp.>")).toBeUndefined();
+  it("warns but allows custom publisher subjects", () => {
+    expect(getTriggerTopicDiagnostic("doma.rdp.>")).toMatchObject({
+      level: "warning",
+      message: expect.stringContaining("custom NATS subject"),
+    });
   });
 
   it("allows session CLI command subjects", () => {

--- a/src/triggers/topic-catalog.ts
+++ b/src/triggers/topic-catalog.ts
@@ -13,7 +13,7 @@ export interface TriggerTopicCatalogEntry {
 }
 
 export interface TriggerTopicDiagnostic {
-  level: "error";
+  level: "warning";
   message: string;
   suggestedPattern?: string;
 }
@@ -184,6 +184,21 @@ const TOPICS: readonly TriggerTopicCatalogEntry[] = [
 
 const CHANNEL_ALIAS_RE = /^(whatsapp|matrix)(?:\.([*.>]|[^.]+))?\.(inbound|reaction)$/;
 
+function matchesTopicPattern(topic: string, pattern: string): boolean {
+  const topicParts = topic.split(".");
+  const patternParts = pattern.split(".");
+
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const patternPart = patternParts[i];
+    if (patternPart === ">") return true;
+    if (i >= topicParts.length) return false;
+    if (patternPart === "*") continue;
+    if (patternPart !== topicParts[i]) return false;
+  }
+
+  return topicParts.length === patternParts.length;
+}
+
 export function getTriggerTopicCatalog(): TriggerTopicCatalogEntry[] {
   return TOPICS.map((entry) => ({
     ...entry,
@@ -193,6 +208,11 @@ export function getTriggerTopicCatalog(): TriggerTopicCatalogEntry[] {
   }));
 }
 
+export function isTriggerTopicInCatalog(topic: string): boolean {
+  const trimmed = topic.trim();
+  return TOPICS.some((entry) => trimmed === entry.pattern || matchesTopicPattern(trimmed, entry.pattern));
+}
+
 export function getTriggerTopicDiagnostic(topic: string): TriggerTopicDiagnostic | undefined {
   const trimmed = topic.trim();
   const channelAlias = trimmed.match(CHANNEL_ALIAS_RE);
@@ -200,21 +220,28 @@ export function getTriggerTopicDiagnostic(topic: string): TriggerTopicDiagnostic
     const [, channel, , eventKind] = channelAlias;
     if (eventKind === "reaction") {
       return {
-        level: "error",
+        level: "warning",
         suggestedPattern: "ravi.inbound.reaction",
-        message: `Channel alias '${trimmed}' is not published. Use 'ravi.inbound.reaction' for ${channel} emoji reactions.`,
+        message: `Topic '${trimmed}' is not in the built-in templates. Ravi reactions are normally published as 'ravi.inbound.reaction' for ${channel} emoji reactions.`,
       };
     }
     return {
-      level: "error",
-      message: `Channel alias '${trimmed}' is not a trigger-ready subject. Channel messages are consumed by the session router; use a published Ravi topic from 'ravi triggers topics'.`,
+      level: "warning",
+      message: `Topic '${trimmed}' is not in the built-in templates. Channel messages are normally consumed by the session router; custom NATS subjects are still accepted.`,
     };
   }
 
   if (/^ravi\.\*\.tool$/.test(trimmed) || /^ravi\.\*\.response$/.test(trimmed)) {
     return {
-      level: "error",
-      message: `Pattern '${trimmed}' does not match a trigger-ready publisher. Session runtime subjects live under 'ravi.session.*' and are blocked for triggers to prevent loops.`,
+      level: "warning",
+      message: `Topic '${trimmed}' is not in the built-in templates. Session runtime publishers usually live under 'ravi.session.*'; custom NATS subjects are still accepted.`,
+    };
+  }
+
+  if (!isTriggerTopicInCatalog(trimmed)) {
+    return {
+      level: "warning",
+      message: `Topic '${trimmed}' is not in the built-in trigger topic templates. It will be accepted as a custom NATS subject; make sure a publisher emits it.`,
     };
   }
 

--- a/src/triggers/topic-policy.ts
+++ b/src/triggers/topic-policy.ts
@@ -8,12 +8,16 @@ export function isBlockedTriggerTopic(topic: string): boolean {
 
 export function getBlockedTriggerTopicReason(topic: string): string | undefined {
   if (!isBlockedTriggerTopic(topic)) return undefined;
-  return `Triggers cannot subscribe to '${topic}' because ravi.session.* topics are reserved and skipped by the trigger runner to prevent loops`;
+  return `Topic '${topic}' is an internal session subject. The trigger runner skips ravi.session.* subscriptions to prevent loops.`;
 }
 
-export function getDisallowedTriggerTopicReason(topic: string): string | undefined {
+export function getTriggerTopicWarnings(topic: string): string[] {
+  const warnings: string[] = [];
   const blockedReason = getBlockedTriggerTopicReason(topic);
-  if (blockedReason) return blockedReason;
+  if (blockedReason) warnings.push(blockedReason);
 
-  return getTriggerTopicDiagnostic(topic)?.message;
+  const diagnostic = getTriggerTopicDiagnostic(topic);
+  if (diagnostic) warnings.push(diagnostic.message);
+
+  return warnings;
 }


### PR DESCRIPTION
## Summary
- Downgrade trigger topic catalog diagnostics from blocking validation to warnings.
- Allow `ravi triggers add` and `ravi triggers set topic` to accept custom/external NATS subjects.
- Include topic warnings in JSON payloads and update trigger docs/skills to clarify the catalog is templates/hints, not a whitelist.

## Impact
This keeps built-in topic guidance for known Ravi subjects, but no longer blocks external subjects such as provider topics or custom NATS publishers.

## Validation
- `bun test src/triggers/__tests__/topic-catalog.test.ts src/cli/commands/triggers.test.ts`
- `bun run build`
- `bun run typecheck`
- pre-push full gate

Refs #48
Refs #52

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->