### PR TITLE
[codex] Add boolean trigger filters

### DIFF
--- a/.ravi/specs/routines/triggers/SPEC.md
+++ b/.ravi/specs/routines/triggers/SPEC.md
@@ -1,6 +1,6 @@
 ---
 id: routines/triggers
-title: "Trigger Topics"
+title: "Trigger Topics And Filters"
 kind: capability
 domain: routines
 capability: triggers
@@ -17,13 +17,16 @@ tags:
   - triggers
   - nats
   - topics
+  - filters
 ---
 
-# Trigger Topics
+# Trigger Topics And Filters
 
 ## Intent
 
 Trigger topics are the event subjects a routine can observe. The trigger topic catalog is the durable bank of examples, schemas, notes, and patterns that humans and agents should consult before creating a trigger.
+
+Trigger filters are the deterministic pre-agent predicate for event payloads. They prevent avoidable agent runs and MUST be safe to evaluate without `eval` or arbitrary code execution.
 
 ## Invariants
 
@@ -31,11 +34,21 @@ Trigger topics are the event subjects a routine can observe. The trigger topic c
 - Trigger examples in docs, skills, and CLI help MUST use cataloged subjects unless they are explicitly marked as custom publisher subjects.
 - Channel transport aliases such as `whatsapp.*.reaction`, `whatsapp.*.inbound`, and `matrix.*.inbound` MUST NOT be documented as trigger-ready subjects unless a Ravi publisher actually emits them.
 - Emoji reaction triggers MUST use `ravi.inbound.reaction` until a different subject is deliberately added to the catalog and publisher.
-- The CLI SHOULD reject known inferred aliases that do not have publishers, while still allowing custom subjects such as `doma.rdp.>`.
+- The CLI MUST NOT block custom NATS subjects. It SHOULD warn when a subject is outside the built-in catalog or looks like a known inferred alias without a Ravi publisher.
 - The catalog SHOULD include payload schema, example command, common filters, and operational notes for each subject.
+- Trigger filters MUST support the comparison operators `==`, `!=`, `startsWith`, `endsWith`, and `includes`.
+- Trigger filters MUST support boolean composition with `&&`, `||`, unary `!`, and parentheses.
+- Trigger filter precedence MUST be `!` before `&&` before `||`.
+- Trigger filter values MUST be quoted strings; event values are coerced to strings for comparison.
+- Trigger filter evaluation MUST NOT use JavaScript `eval`, `new Function`, or shell execution.
+- The CLI MUST reject invalid filter syntax before persisting a new or updated trigger filter.
+- Runtime evaluation MAY fail open for legacy persisted invalid filters, but it MUST log a warning with the parse error.
 
 ## Acceptance Criteria
 
 - `ravi triggers topics --json` exposes the catalog in machine-readable form.
-- `ravi triggers add --topic "whatsapp.*.reaction"` fails with a hint to use `ravi.inbound.reaction`.
+- `ravi triggers add --topic "whatsapp.*.reaction"` succeeds with a warning that `ravi.inbound.reaction` is the canonical built-in reaction subject.
+- `ravi triggers add --topic "custom.external.>"` succeeds with a warning that the subject is custom/outside built-in templates.
+- `ravi triggers add --filter 'data.chatId == "X" && (data.status == "approved" || data.status == "manual")'` persists the filter and evaluates correctly.
+- `ravi triggers set <id> filter 'data.ok == true'` fails clearly because values must be quoted.
 - Skills and docs point users to the catalog instead of asking them to infer subjects by symmetry.

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -111,9 +111,9 @@ Event-driven triggers that subscribe to NATS topics and fire agent prompts when 
 
 ### Trigger Filters
 
-A restricted expression syntax for filtering events. No `eval` or `new Function()` — uses a safe regex-based parser.
+A restricted expression syntax for filtering events. No `eval` or `new Function()` — uses a safe parser.
 
-**Syntax:** `data.<path> <operator> "<value>"`
+**Syntax:** `data.<path> <operator> "<value>"`, optionally composed with `&&`, `||`, unary `!`, and parentheses.
 
 **Operators:** `==`, `!=`, `startsWith`, `endsWith`, `includes`
 
@@ -123,9 +123,10 @@ data.permission_mode != "bypassPermissions"
 data.cwd startsWith "/workspace/ravi"
 data.hook_event_name endsWith "Submit"
 data.tool includes "Bash"
+data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")
 ```
 
-If the filter is empty or missing, the trigger always fires. If the filter syntax is invalid, it fails open (fires with a warning logged). If the data path doesn't exist, the filter returns false (no match).
+Precedence is `!` before `&&` before `||`. If the filter is empty or missing, the trigger always fires. CLI commands reject invalid filter syntax before persisting it. Runtime evaluation still fails open for legacy invalid filters and logs a warning. If the data path doesn't exist, the filter returns false (no match).
 
 ### Message Templates
 

--- a/docs/guides/triggers.mdx
+++ b/docs/guides/triggers.mdx
@@ -133,7 +133,10 @@ Filters are optional expressions that evaluate against the event data. If the fi
 
 ```
 data.<path> <operator> "<value>"
+data.<path> <operator> "<value>" && (data.<path> <operator> "<value>" || !data.<path> <operator> "<value>")
 ```
+
+Use `&&`, `||`, unary `!`, and parentheses for boolean composition. Precedence is `!`, then `&&`, then `||`.
 
 ### Operators
 
@@ -151,9 +154,9 @@ The `data.<path>` notation uses dot-separated keys to traverse into the event da
 
 Values are coerced to strings for comparison. If the path does not exist in the event data, the filter evaluates to false (trigger does not fire).
 
-### Fail-Open Behavior
+### Invalid Syntax
 
-If a filter expression has invalid syntax (does not match the expected format), the trigger fires anyway and a warning is logged. This prevents misconfigured filters from silently disabling triggers.
+`ravi triggers add --filter ...` and `ravi triggers set <id> filter ...` reject invalid syntax before saving it. Existing legacy filters that are already persisted still fail open at runtime and log a warning, which prevents old bad filters from silently disabling triggers.
 
 ### Filter Examples
 
@@ -172,6 +175,12 @@ ravi triggers set <id> filter 'data.output includes "error"'
 
 # Match events ending with a suffix
 ravi triggers set <id> filter 'data.tool endsWith "_list"'
+
+# Match a WhatsApp approval reaction in one chat
+ravi triggers set <id> filter 'data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")'
+
+# Exclude one source
+ravi triggers set <id> filter '!(data.source == "test")'
 
 # Remove a filter
 ravi triggers set <id> filter -
@@ -457,16 +466,19 @@ ravi daemon logs -f
 
 ### Verify filter syntax
 
-The filter must match the regex pattern `data.<path> <operator> "<value>"`. Double or single quotes around the value are both accepted:
+The filter must match the restricted parser syntax. Double or single quotes around the value are both accepted, and boolean expressions can be composed with `&&`, `||`, `!`, and parentheses:
 
 ```bash
 # Valid
 data.cwd == "/workspace/ravi"
 data.tool startsWith "contacts"
 data.output includes 'error'
+data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")
+!(data.source == "test")
 
-# Invalid (will fail open with a warning)
+# Invalid (CLI add/set reject these)
 cwd == "/workspace"          # Missing data. prefix
 data.cwd = "/workspace"      # Single = is not valid
 data.cwd == /workspace       # Missing quotes around value
+data.cwd == "/workspace" &&  # Missing right side
 ```

--- a/src/cli/commands/triggers.test.ts
+++ b/src/cli/commands/triggers.test.ts
@@ -87,6 +87,7 @@ mock.module("../../triggers/index.js", () => ({
       accountId: input.accountId,
       cooldownMs: input.cooldownMs,
       session: input.session,
+      filter: input.filter,
       enabled: true,
       fireCount: 0,
       createdAt: 1,
@@ -207,6 +208,46 @@ describe("TriggersCommands topic guidance", () => {
     );
   });
 
+  it("accepts composed boolean filters on add", async () => {
+    const commands = new TriggersCommands();
+
+    await commands.add(
+      "filtered",
+      "ravi.inbound.reaction",
+      "hello",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")`,
+    );
+
+    expect(createdTriggers).toContainEqual(
+      expect.objectContaining({
+        name: "filtered",
+        filter: `data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")`,
+      }),
+    );
+  });
+
+  it("rejects invalid filters on add before persisting", async () => {
+    const commands = new TriggersCommands();
+
+    await expect(
+      commands.add(
+        "bad",
+        "ravi.inbound.reaction",
+        "hello",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "data.ok == true",
+      ),
+    ).rejects.toThrow("Invalid filter");
+    expect(createdTriggers).toEqual([]);
+  });
+
   it("allows ravi.session topics on set but prints an internal topic warning", async () => {
     const commands = new TriggersCommands();
 
@@ -274,18 +315,25 @@ describe("TriggersCommands topic guidance", () => {
   it("prints updated trigger data in --json mode", async () => {
     const commands = new TriggersCommands();
 
-    const payload = await captureJson(() => commands.set("trg_1", "filter", "data.ok == true", true));
+    const payload = await captureJson(() => commands.set("trg_1", "filter", `data.ok == "true"`, true));
 
     expect(payload).toMatchObject({
       status: "updated",
       target: { type: "trigger", id: "trg_1" },
       changedCount: 1,
       property: "filter",
-      value: "data.ok == true",
+      value: `data.ok == "true"`,
       trigger: {
         id: "trg_1",
-        filter: "data.ok == true",
+        filter: `data.ok == "true"`,
       },
     });
+  });
+
+  it("rejects invalid filters on set before updating", async () => {
+    const commands = new TriggersCommands();
+
+    await expect(commands.set("trg_1", "filter", `data.ok == "true" &&`)).rejects.toThrow("Invalid filter");
+    expect(updatedTriggers).toEqual([]);
   });
 });

--- a/src/cli/commands/triggers.ts
+++ b/src/cli/commands/triggers.ts
@@ -22,6 +22,7 @@ import {
 } from "../../triggers/index.js";
 import { getTriggerTopicCatalog, type TriggerTopicCatalogEntry } from "../../triggers/topic-catalog.js";
 import { getTriggerTopicWarnings } from "../../triggers/topic-policy.js";
+import { validateFilter } from "../../triggers/filter.js";
 import { filterItemsByCanonicalTag } from "../../tags/helpers.js";
 
 function printJson(payload: unknown): void {
@@ -66,6 +67,15 @@ function printTopicCatalog(topics: TriggerTopicCatalogEntry[]): void {
 function printTopicWarnings(warnings: string[]): void {
   for (const warning of warnings) {
     console.warn(`Warning: ${warning}`);
+  }
+}
+
+function assertValidTriggerFilter(filter: string | undefined): void {
+  const validation = validateFilter(filter);
+  if (!validation.ok) {
+    fail(
+      `Invalid filter: ${validation.error}. Use data.<path> <operator> "value"; combine with &&, ||, !, and parentheses.`,
+    );
   }
 }
 
@@ -251,6 +261,7 @@ export class TriggersCommands {
       fail("--message is required");
     }
     const topicWarnings = getTriggerTopicWarnings(topic);
+    assertValidTriggerFilter(filter);
 
     // Validate agent if provided
     if (agent) {
@@ -500,6 +511,7 @@ export class TriggersCommands {
 
         case "filter": {
           const filterValue = value === "null" || value === "-" ? undefined : value;
+          assertValidTriggerFilter(filterValue);
           updated = dbUpdateTrigger(id, { filter: filterValue });
           normalizedValue = filterValue ?? null;
           logHuman(`✓ Filter set: ${id} -> ${filterValue ?? "(none)"}`);

--- a/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
@@ -113,13 +113,16 @@ Triggers suportam filtros opcionais que impedem o disparo quando o evento não c
 ravi triggers add "..." --filter 'data.cwd startsWith "/path/to/workspace"'
 ravi triggers set <id> filter 'data.cwd != "/path/to/ignored-workspace"'
 ravi triggers set <id> filter 'data.permission_mode == "bypassPermissions"'
+ravi triggers set <id> filter 'data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")'
 ```
 
-**Sintaxe:** `data.<path> <operador> "<valor>"`
+**Sintaxe:** `data.<path> <operador> "<valor>"`, com composicao opcional por `&&`, `||`, `!` e parenteses.
 
 Operadores: `==`, `!=`, `startsWith`, `endsWith`, `includes`
 
-Filtro inválido = fail open (trigger dispara mesmo assim, log de warning).
+Precedencia: `!` antes de `&&` antes de `||`.
+
+Valores devem ser strings com aspas. O CLI rejeita filtros invalidos em `add` e `set` antes de salvar. Filtros legados invalidos ja persistidos continuam em fail open no runtime, com log de warning.
 
 ## Template Variables
 

--- a/src/triggers/__tests__/filter.test.ts
+++ b/src/triggers/__tests__/filter.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "bun:test";
-import { evaluateFilter } from "../filter.js";
+import { evaluateFilter, validateFilter } from "../filter.js";
 
 const data = {
   cwd: "/workspace/fm",
+  chatId: "120363424@g.us",
+  emoji: "👍",
   session_id: "381f8b5c-3961-4bde-86d6-96e6a15c0176",
   permission_mode: "bypassPermissions",
   hook_event_name: "Stop",
+  target: { type: "reaction", source: "whatsapp" },
   nested: { level: "deep" },
 };
 
@@ -97,6 +100,41 @@ describe("evaluateFilter", () => {
     });
   });
 
+  describe("boolean operators", () => {
+    it("supports && expressions", () => {
+      expect(evaluateFilter(`data.chatId == "120363424@g.us" && data.emoji includes "👍"`, data)).toBe(true);
+      expect(evaluateFilter(`data.chatId == "120363424@g.us" && data.emoji == "👎"`, data)).toBe(false);
+    });
+
+    it("supports || expressions", () => {
+      expect(evaluateFilter(`data.emoji == "👎" || data.emoji == "👍"`, data)).toBe(true);
+      expect(evaluateFilter(`data.emoji == "👎" || data.emoji == "👍🏻"`, data)).toBe(false);
+    });
+
+    it("supports parentheses and operator precedence", () => {
+      expect(
+        evaluateFilter(`data.target.source == "whatsapp" && (data.emoji == "👎" || data.emoji == "👍")`, data),
+      ).toBe(true);
+      expect(
+        evaluateFilter(
+          `(data.target.source == "telegram" || data.target.source == "matrix") && data.emoji == "👍"`,
+          data,
+        ),
+      ).toBe(false);
+      expect(evaluateFilter(`data.emoji == "👍" || data.chatId == "wrong" && data.cwd == "wrong"`, data)).toBe(true);
+    });
+
+    it("supports unary negation", () => {
+      expect(evaluateFilter(`!(data.emoji == "👎")`, data)).toBe(true);
+      expect(evaluateFilter(`!data.emoji includes "👍"`, data)).toBe(false);
+    });
+
+    it("does not treat trailing boolean syntax as part of a string value", () => {
+      expect(evaluateFilter(`data.chatId == "120363424@g.us" && data.emoji == "👍"`, data)).toBe(true);
+      expect(evaluateFilter(`data.chatId == "120363424@g.us" && data.emoji == "👍🏻"`, data)).toBe(false);
+    });
+  });
+
   describe("invalid syntax", () => {
     it("returns true (fail open) for completely invalid expression", () => {
       expect(evaluateFilter("this is not valid", data)).toBe(true);
@@ -121,5 +159,50 @@ describe("evaluateFilter", () => {
       const dataWithBool = { active: true };
       expect(evaluateFilter(`data.active == "true"`, dataWithBool)).toBe(true);
     });
+  });
+});
+
+describe("validateFilter", () => {
+  it("accepts empty filters", () => {
+    expect(validateFilter(undefined)).toEqual({ ok: true });
+    expect(validateFilter("")).toEqual({ ok: true });
+  });
+
+  it("accepts composed boolean filters", () => {
+    expect(validateFilter(`data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")`)).toEqual({
+      ok: true,
+    });
+  });
+
+  it("rejects missing quoted values", () => {
+    const result = validateFilter("data.active == true");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Expected quoted string value");
+    }
+  });
+
+  it("rejects empty path segments", () => {
+    const result = validateFilter(`data.target. == "reaction"`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Expected data.<path>");
+    }
+  });
+
+  it("rejects incomplete boolean expressions", () => {
+    const result = validateFilter(`data.emoji == "👍" &&`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Expected data.<path>");
+    }
+  });
+
+  it("rejects unbalanced parentheses", () => {
+    const result = validateFilter(`(data.emoji == "👍"`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Expected ')'");
+    }
   });
 });

--- a/src/triggers/filter.ts
+++ b/src/triggers/filter.ts
@@ -1,28 +1,317 @@
 /**
  * Trigger Filter Evaluator
  *
- * Evaluates filter expressions against event data.
- * Uses a restricted expression parser — no eval, no new Function().
+ * Evaluates restricted boolean filter expressions against event data.
+ * No eval, no new Function().
  *
  * Syntax:
  *   data.<path> <operator> "<value>"
+ *   !<expression>
+ *   <expression> && <expression>
+ *   <expression> || <expression>
+ *   (<expression>)
  *
  * Operators: ==, !=, startsWith, endsWith, includes
- *
- * Examples:
- *   data.cwd == "/workspace/fm"
- *   data.permission_mode != "bypassPermissions"
- *   data.cwd startsWith "/workspace/ravi"
- *   data.cwd endsWith "/copilot"
- *   data.cwd includes "Dev"
  */
 
 import { logger } from "../utils/logger.js";
 
 const log = logger.child("triggers:filter");
 
-// Regex: captures `data.<path>`, operator, and quoted string (single or double)
-const FILTER_RE = /^(data\.[a-zA-Z_][a-zA-Z0-9_.]*)\s+(==|!=|startsWith|endsWith|includes)\s+(['"])(.*?)\3\s*$/;
+type ComparisonOperator = "==" | "!=" | "startsWith" | "endsWith" | "includes";
+
+type FilterAst =
+  | { type: "comparison"; path: string; operator: ComparisonOperator; expected: string }
+  | { type: "and"; left: FilterAst; right: FilterAst }
+  | { type: "or"; left: FilterAst; right: FilterAst }
+  | { type: "not"; expression: FilterAst };
+
+type Token =
+  | { type: "path"; value: string; position: number }
+  | { type: "operator"; value: ComparisonOperator; position: number }
+  | { type: "string"; value: string; position: number }
+  | { type: "and"; position: number }
+  | { type: "or"; position: number }
+  | { type: "not"; position: number }
+  | { type: "lparen"; position: number }
+  | { type: "rparen"; position: number }
+  | { type: "word"; value: string; position: number }
+  | { type: "eof"; position: number };
+
+type ParseResult = { ok: true; ast: FilterAst } | { ok: false; error: string };
+
+export type FilterValidationResult = { ok: true } | { ok: false; error: string };
+
+const COMPARISON_OPERATORS = new Set<string>(["==", "!=", "startsWith", "endsWith", "includes"]);
+const PATH_RE = /^data\.[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+function isComparisonOperator(value: string): value is ComparisonOperator {
+  return COMPARISON_OPERATORS.has(value);
+}
+
+function syntaxError(message: string, position: number): string {
+  return `${message} at character ${position}`;
+}
+
+function tokenize(input: string): Token[] | string {
+  const tokens: Token[] = [];
+  let index = 0;
+
+  while (index < input.length) {
+    const char = input[index];
+    if (!char) break;
+
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (input.startsWith("&&", index)) {
+      tokens.push({ type: "and", position: index });
+      index += 2;
+      continue;
+    }
+
+    if (input.startsWith("||", index)) {
+      tokens.push({ type: "or", position: index });
+      index += 2;
+      continue;
+    }
+
+    if (input.startsWith("!=", index)) {
+      tokens.push({ type: "operator", value: "!=", position: index });
+      index += 2;
+      continue;
+    }
+
+    if (input.startsWith("==", index)) {
+      tokens.push({ type: "operator", value: "==", position: index });
+      index += 2;
+      continue;
+    }
+
+    if (char === "!") {
+      tokens.push({ type: "not", position: index });
+      index += 1;
+      continue;
+    }
+
+    if (char === "(") {
+      tokens.push({ type: "lparen", position: index });
+      index += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      tokens.push({ type: "rparen", position: index });
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const quote = char;
+      const position = index;
+      index += 1;
+      let value = "";
+      let closed = false;
+      while (index < input.length) {
+        const next = input[index];
+        if (next === "\\") {
+          const escaped = input[index + 1];
+          if (escaped === undefined) {
+            return syntaxError("Unterminated escape sequence", index);
+          }
+          value += escaped;
+          index += 2;
+          continue;
+        }
+        if (next === quote) {
+          index += 1;
+          closed = true;
+          tokens.push({ type: "string", value, position });
+          break;
+        }
+        value += next;
+        index += 1;
+      }
+      if (!closed) {
+        return syntaxError("Unterminated quoted string", position);
+      }
+      continue;
+    }
+
+    const wordStart = index;
+    while (
+      index < input.length &&
+      !/\s/.test(input[index] ?? "") &&
+      !["(", ")", "!", "=", "&", "|", '"', "'"].includes(input[index] ?? "")
+    ) {
+      index += 1;
+    }
+
+    if (index === wordStart) {
+      return syntaxError(`Unexpected character '${char}'`, index);
+    }
+
+    const value = input.slice(wordStart, index);
+    if (isComparisonOperator(value)) {
+      tokens.push({ type: "operator", value, position: wordStart });
+    } else if (PATH_RE.test(value)) {
+      tokens.push({ type: "path", value, position: wordStart });
+    } else {
+      tokens.push({ type: "word", value, position: wordStart });
+    }
+  }
+
+  tokens.push({ type: "eof", position: input.length });
+  return tokens;
+}
+
+class FilterParser {
+  private index = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parse(): ParseResult {
+    const ast = this.parseOr();
+    if (typeof ast === "string") return { ok: false, error: ast };
+
+    const current = this.current();
+    if (current.type !== "eof") {
+      return { ok: false, error: syntaxError(`Unexpected token '${this.describe(current)}'`, current.position) };
+    }
+
+    return { ok: true, ast };
+  }
+
+  private parseOr(): FilterAst | string {
+    let left = this.parseAnd();
+    if (typeof left === "string") return left;
+
+    while (this.match("or")) {
+      const right = this.parseAnd();
+      if (typeof right === "string") return right;
+      left = { type: "or", left, right };
+    }
+
+    return left;
+  }
+
+  private parseAnd(): FilterAst | string {
+    let left = this.parseUnary();
+    if (typeof left === "string") return left;
+
+    while (this.match("and")) {
+      const right = this.parseUnary();
+      if (typeof right === "string") return right;
+      left = { type: "and", left, right };
+    }
+
+    return left;
+  }
+
+  private parseUnary(): FilterAst | string {
+    if (this.match("not")) {
+      const expression = this.parseUnary();
+      if (typeof expression === "string") return expression;
+      return { type: "not", expression };
+    }
+
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): FilterAst | string {
+    if (this.match("lparen")) {
+      const expression = this.parseOr();
+      if (typeof expression === "string") return expression;
+      if (!this.match("rparen")) {
+        return syntaxError("Expected ')'", this.current().position);
+      }
+      return expression;
+    }
+
+    return this.parseComparison();
+  }
+
+  private parseComparison(): FilterAst | string {
+    const path = this.consume("path", "Expected data.<path>");
+    if (typeof path === "string") return path;
+
+    const operator = this.consume("operator", "Expected comparison operator");
+    if (typeof operator === "string") return operator;
+
+    const expected = this.consume("string", "Expected quoted string value");
+    if (typeof expected === "string") return expected;
+
+    return {
+      type: "comparison",
+      path: path.value,
+      operator: operator.value,
+      expected: expected.value,
+    };
+  }
+
+  private match(type: Token["type"]): boolean {
+    if (this.current().type !== type) return false;
+    this.index += 1;
+    return true;
+  }
+
+  private consume<T extends Token["type"]>(type: T, message: string): Extract<Token, { type: T }> | string {
+    const token = this.current();
+    if (token.type !== type) {
+      return syntaxError(`${message}, got '${this.describe(token)}'`, token.position);
+    }
+    this.index += 1;
+    return token as Extract<Token, { type: T }>;
+  }
+
+  private current(): Token {
+    return this.tokens[this.index] ?? this.tokens[this.tokens.length - 1] ?? { type: "eof", position: 0 };
+  }
+
+  private describe(token: Token): string {
+    switch (token.type) {
+      case "path":
+      case "operator":
+      case "string":
+      case "word":
+        return token.value;
+      case "and":
+        return "&&";
+      case "or":
+        return "||";
+      case "not":
+        return "!";
+      case "lparen":
+        return "(";
+      case "rparen":
+        return ")";
+      case "eof":
+        return "end of input";
+    }
+  }
+}
+
+function parseFilter(filter: string): ParseResult {
+  const tokens = tokenize(filter);
+  if (typeof tokens === "string") {
+    return { ok: false, error: tokens };
+  }
+  return new FilterParser(tokens).parse();
+}
+
+/**
+ * Validate a filter expression before persisting it through CLI commands.
+ */
+export function validateFilter(filter: string | undefined): FilterValidationResult {
+  if (!filter || filter.trim() === "") {
+    return { ok: true };
+  }
+
+  const parsed = parseFilter(filter.trim());
+  return parsed.ok ? { ok: true } : { ok: false, error: parsed.error };
+}
 
 /**
  * Resolve a dot-notation path into an object.
@@ -30,15 +319,44 @@ const FILTER_RE = /^(data\.[a-zA-Z_][a-zA-Z0-9_.]*)\s+(==|!=|startsWith|endsWith
  * The leading "data." is stripped before resolution.
  */
 function resolvePath(obj: unknown, path: string): unknown {
-  // Strip leading "data."
   const parts = path.replace(/^data\./, "").split(".");
   let current: unknown = obj;
   for (const part of parts) {
+    if (!part) return undefined;
     if (current === null || current === undefined) return undefined;
     if (typeof current !== "object") return undefined;
     current = (current as Record<string, unknown>)[part];
   }
   return current;
+}
+
+function evaluateAst(ast: FilterAst, data: unknown): boolean {
+  switch (ast.type) {
+    case "and":
+      return evaluateAst(ast.left, data) && evaluateAst(ast.right, data);
+    case "or":
+      return evaluateAst(ast.left, data) || evaluateAst(ast.right, data);
+    case "not":
+      return !evaluateAst(ast.expression, data);
+    case "comparison": {
+      const rawValue = resolvePath(data, ast.path);
+      if (rawValue === undefined) return false;
+
+      const value = String(rawValue);
+      switch (ast.operator) {
+        case "==":
+          return value === ast.expected;
+        case "!=":
+          return value !== ast.expected;
+        case "startsWith":
+          return value.startsWith(ast.expected);
+        case "endsWith":
+          return value.endsWith(ast.expected);
+        case "includes":
+          return value.includes(ast.expected);
+      }
+    }
+  }
 }
 
 /**
@@ -52,43 +370,15 @@ function resolvePath(obj: unknown, path: string): unknown {
  * Returns false if the filter expression evaluates to false.
  */
 export function evaluateFilter(filter: string | undefined, data: unknown): boolean {
-  // No filter = always fire
   if (!filter || filter.trim() === "") {
     return true;
   }
 
-  const match = FILTER_RE.exec(filter.trim());
-  if (!match) {
-    log.warn("Trigger filter: invalid syntax, failing open", { filter });
+  const parsed = parseFilter(filter.trim());
+  if (!parsed.ok) {
+    log.warn("Trigger filter: invalid syntax, failing open", { filter, error: parsed.error });
     return true;
   }
 
-  const [, path, operator, , expected] = match;
-
-  const rawValue = resolvePath(data, path);
-
-  // Non-existent path = no match (not a crash)
-  if (rawValue === undefined) {
-    return false;
-  }
-
-  // Coerce value to string for comparison
-  const value = String(rawValue);
-
-  switch (operator) {
-    case "==":
-      return value === expected;
-    case "!=":
-      return value !== expected;
-    case "startsWith":
-      return value.startsWith(expected);
-    case "endsWith":
-      return value.endsWith(expected);
-    case "includes":
-      return value.includes(expected);
-    default:
-      // Should not happen given the regex, but fail open
-      log.warn("Trigger filter: unknown operator, failing open", { operator, filter });
-      return true;
-  }
+  return evaluateAst(parsed.ast, data);
 }

--- a/src/triggers/topic-catalog.ts
+++ b/src/triggers/topic-catalog.ts
@@ -29,7 +29,11 @@ const TOPICS: readonly TriggerTopicCatalogEntry[] = [
     examples: [
       'ravi triggers add "Approval by reaction" --topic "ravi.inbound.reaction" --filter \'data.emoji includes "👍"\' --message "..."',
     ],
-    filters: ['data.emoji includes "👍"', 'data.senderId == "5511999999999"'],
+    filters: [
+      'data.emoji includes "👍"',
+      'data.senderId == "5511999999999"',
+      'data.senderId == "5511999999999" && data.emoji includes "👍"',
+    ],
     notes: [
       "This is the canonical reaction trigger subject.",
       "The payload identifies the reacted message as targetMessageId. Keep domain mappings keyed by external message id when a routine needs to recover business state.",


### PR DESCRIPTION
## Summary

- Replaces the single-regex trigger filter evaluator with a restricted boolean parser.
- Supports `&&`, `||`, unary `!`, and parentheses while keeping comparisons limited to safe string operators.
- Validates trigger filters in the CLI before persistence and documents the supported grammar in specs/docs/skill guidance.

## Root Cause

`evaluateFilter` accepted only one comparison expression. Composed filters with `&&`, `||`, or parentheses were persisted but evaluated as invalid syntax at runtime, so triggers could behave unexpectedly.

## Validation

- `bun test src/triggers/__tests__/filter.test.ts src/triggers/__tests__/topic-catalog.test.ts src/cli/commands/triggers.test.ts src/tasks/automations.test.ts`
- `bunx biome check src/triggers/filter.ts src/triggers/__tests__/filter.test.ts src/triggers/topic-catalog.ts src/cli/commands/triggers.ts src/cli/commands/triggers.test.ts`
- `bun run typecheck && bun run build`
- pre-push hook: generated SDK drift check, build, typecheck, full test suite, SDK check

Closes #51.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->