### PR TITLE
[codex] Add shell cron jobs

### DIFF
--- a/.ravi/specs/routines/SPEC.md
+++ b/.ravi/specs/routines/SPEC.md
@@ -40,6 +40,8 @@ This domain exists because a cron prompt is too weak as the source of truth for 
 - Cron is a scheduler. It MUST NOT be the full semantic definition of a recurring process.
 - Trigger is an event subscription. It MUST NOT be the full semantic definition of a recurring process.
 - Routine is the durable contract that may use cron, triggers, tasks, sessions, skills, and quality modes.
+- Cron MAY execute deterministic shell jobs directly when the work requires no agent judgment. Shell cron jobs MUST preserve the same lifecycle/status tracking as agent cron jobs and MUST NOT invoke an agent on successful runs.
+- Shell cron jobs MAY notify a session on failure, but the notification MUST be an explicit `on-error` policy.
 
 ## Routine Shape
 

--- a/docs/guides/cron-jobs.mdx
+++ b/docs/guides/cron-jobs.mdx
@@ -5,7 +5,7 @@ description: Schedule recurring and one-shot tasks for your agents using cron ex
 
 ## Overview
 
-Cron jobs are scheduled tasks that send prompts to agents at specified times. They support three schedule types: standard cron expressions, fixed intervals, and one-shot datetimes. The daemon manages all timers and executes jobs automatically.
+Cron jobs are scheduled tasks that run at specified times. They can either send prompts to agents or execute deterministic shell commands directly. They support three schedule types: standard cron expressions, fixed intervals, and one-shot datetimes. The daemon manages all timers and executes jobs automatically.
 
 ## Schedule Types
 
@@ -96,7 +96,7 @@ ravi cron set <id> tz America/New_York
 
 ## Session Targets
 
-Jobs run in one of two session modes:
+Agent jobs run in one of two session modes:
 
 ### Main Session (default)
 
@@ -130,6 +130,37 @@ Generate the daily summary report
 
 This prefix helps the agent understand the context of the prompt — that it originated from a scheduled job rather than a user message.
 
+## Shell Jobs
+
+Use `--shell` or `--exec` for deterministic scripts that do not need agent reasoning. Shell jobs are tracked by `ravi cron list/show/run` like agent jobs, but successful runs do not publish any prompt and do not spend LLM tokens.
+
+```bash
+ravi cron add "ETL batch" \
+  --cron "*/15 * * * *" \
+  --shell "python3 /home/ravi/some-script.py >> /var/log/some.log 2>&1"
+```
+
+On failure, a shell job records `lastStatus=error`, `lastError`, duration, and exit code. To involve an agent only when the command fails, add an explicit error action:
+
+```bash
+ravi cron add "ETL batch" \
+  --cron "*/15 * * * *" \
+  --shell "python3 /home/ravi/some-script.py" \
+  --on-error notify-session:admin-group
+```
+
+Optional shell controls:
+
+```bash
+ravi cron add "Scrape" \
+  --every 30m \
+  --shell "python3 scripts/scrape.py" \
+  --timeout 10m \
+  --env-file /home/ravi/jobs/scrape.env
+```
+
+`--timeout` accepts seconds as a bare number or duration strings like `30s`, `5m`, or `1h`. `--env-file` reads simple dotenv-style `KEY=value` lines and merges them into the shell process environment.
+
 ## Anti-Drift
 
 For interval-based jobs, the next run time is calculated from the **originally scheduled time**, not from when execution finishes. This prevents timing drift caused by variable execution durations.
@@ -148,6 +179,10 @@ Each cron job has the following properties:
 |---|---|---|
 | `name` | Human-readable job name | Yes |
 | `message` | Prompt text sent to the agent | Yes |
+| `shell` / `exec` | Shell command for direct shell jobs | Yes |
+| `timeout` | Shell timeout | Yes |
+| `env-file` | Env file for shell jobs | Yes |
+| `on-error` | Shell failure action, e.g. `notify-session:<session>` | Yes |
 | `schedule` | Schedule configuration (cron/every/at) | Via `cron` or `every` keys |
 | `agent` | Agent that executes the job | Yes |
 | `account` | Account ID for channel delivery | Yes |
@@ -167,6 +202,7 @@ Each cron job has the following properties:
 | `lastStatus` | `ok` or `error` |
 | `lastDurationMs` | Execution time in milliseconds |
 | `lastError` | Error message if last run failed |
+| `lastExitCode` | Shell exit code for shell jobs |
 
 ## CLI Workflows
 
@@ -216,6 +252,10 @@ When a job is re-enabled, its `nextRunAt` is recalculated from the current time 
 
 ```bash
 ravi cron set <id> message "Updated prompt text"
+ravi cron set <id> shell "python3 /home/ravi/job.py"
+ravi cron set <id> timeout 5m
+ravi cron set <id> env-file /home/ravi/job.env
+ravi cron set <id> on-error notify-session:admin-group
 ravi cron set <id> cron "0 10 * * *"
 ravi cron set <id> every 1h
 ravi cron set <id> tz America/New_York

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -1559,9 +1559,14 @@ export class RaviClient {
       cron?: string;
       deleteAfter?: boolean;
       description?: string;
+      envFile?: string;
       every?: string;
+      exec?: string;
       isolated?: boolean;
       message?: string;
+      onError?: string;
+      shell?: string;
+      timeout?: string;
       tz?: string;
     }): Promise<CronAddReturn> => {
       return this.transport.call({

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -3473,8 +3473,16 @@ export const CronAddInputSchema = {
       "description": "Job description",
       "type": "string"
     },
+    "envFile": {
+      "description": "Env file loaded for shell jobs",
+      "type": "string"
+    },
     "every": {
       "description": "Interval (e.g., 30m, 1h)",
+      "type": "string"
+    },
+    "exec": {
+      "description": "Alias for --shell",
       "type": "string"
     },
     "isolated": {
@@ -3487,6 +3495,18 @@ export const CronAddInputSchema = {
     },
     "name": {
       "description": "Job name",
+      "type": "string"
+    },
+    "onError": {
+      "description": "Error action, e.g. notify-session:<session>",
+      "type": "string"
+    },
+    "shell": {
+      "description": "Run a shell command directly without invoking an agent",
+      "type": "string"
+    },
+    "timeout": {
+      "description": "Shell timeout, e.g. 60 or 5m",
       "type": "string"
     },
     "tz": {
@@ -3589,7 +3609,7 @@ export const CronSetInputSchema = {
       "type": "string"
     },
     "key": {
-      "description": "Property: name, message, cron, every, tz, agent, account, description, session, reply-session, delete-after",
+      "description": "Property: name, message, shell, exec, timeout, env-file, on-error, cron, every, tz, agent, account, description, session, reply-session, delete-after",
       "type": "string"
     },
     "value": {

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -1431,10 +1431,15 @@ export type CronAddInput = {
   cron?: string;
   deleteAfter?: boolean;
   description?: string;
+  envFile?: string;
   every?: string;
+  exec?: string;
   isolated?: boolean;
   message?: string;
   name: string;
+  onError?: string;
+  shell?: string;
+  timeout?: string;
   tz?: string;
 };
 

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:427253b8512896f39b07abaec89f39320c5f5ecebf9fd51914908aeac955dd79";
+export const REGISTRY_HASH = "sha256:a5e38f0cb4ec3d8a0037cd6aaa6b5c8903051482625ba132d8d6a3786f815117";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "aa74ffb94324";
+export const GIT_SHA = "92c924dd3c30";

--- a/src/cli/commands/cron-commands.test.ts
+++ b/src/cli/commands/cron-commands.test.ts
@@ -84,8 +84,18 @@ mock.module("../../router/router-db.js", () => ({
 }));
 
 mock.module("../../cron/index.js", () => ({
-  dbCreateCronJob: () => {
-    throw new Error("not used");
+  dbCreateCronJob: (input: Record<string, unknown>) => {
+    cronJob = {
+      id: "cron-created",
+      enabled: true,
+      deleteAfterRun: Boolean(input.deleteAfterRun),
+      sessionTarget: input.sessionTarget ?? "main",
+      createdAt: 1,
+      updatedAt: 1,
+      nextRunAt: 2,
+      ...input,
+    };
+    return cronJob;
   },
   dbGetCronJob: () => cronJob,
   dbListCronJobs: () => (cronJob ? [cronJob] : []),
@@ -106,7 +116,12 @@ mock.module("../../cron/index.js", () => ({
   describeSchedule: (schedule: Record<string, unknown>) =>
     schedule.type === "every" ? "every 30m" : String(schedule.type),
   formatDurationMs: (ms: number) => `${Math.round(ms / 60000)}m`,
-  parseDurationMs: () => 1_800_000,
+  parseDurationMs: (value: string) => {
+    const match = value.match(/^(\d+)(s|m|h)$/);
+    if (!match) return 1_800_000;
+    const n = Number(match[1]);
+    return match[2] === "s" ? n * 1000 : match[2] === "m" ? n * 60_000 : n * 3_600_000;
+  },
   isValidCronExpression: () => true,
 }));
 
@@ -136,6 +151,7 @@ describe("CronCommands --json", () => {
       name: "Daily",
       enabled: true,
       schedule: { type: "every", every: 1_800_000 },
+      executionType: "agent",
       message: "hello",
       sessionTarget: "main",
       deleteAfterRun: false,
@@ -143,6 +159,50 @@ describe("CronCommands --json", () => {
       createdAt: 1,
       updatedAt: 1,
     };
+  });
+
+  it("creates shell jobs without requiring an agent message", async () => {
+    const payload = await captureJson(() =>
+      new CronCommands().add(
+        "Shell ETL",
+        undefined,
+        "30m",
+        undefined,
+        undefined,
+        undefined,
+        "python3 /tmp/etl.py",
+        undefined,
+        "notify-session:ops",
+        "5m",
+        "/tmp/job.env",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "Run deterministic ETL",
+        true,
+      ),
+    );
+
+    expect(payload).toMatchObject({
+      status: "created",
+      target: { type: "cron", id: "cron-created" },
+      job: {
+        id: "cron-created",
+        executionType: "shell",
+        message: "",
+        shellCommand: "python3 /tmp/etl.py",
+        shellTimeoutMs: 300_000,
+        shellEnvFile: "/tmp/job.env",
+        onError: "notify-session:ops",
+      },
+    });
+  });
+
+  it("rejects shell jobs that also provide an agent message", async () => {
+    await expect(
+      new CronCommands().add("Bad", undefined, "30m", undefined, undefined, "hello", "echo no"),
+    ).rejects.toThrow("--message cannot be combined with --shell/--exec");
   });
 
   it("returns updated cron job data for set --json", async () => {

--- a/src/cli/commands/cron.ts
+++ b/src/cli/commands/cron.ts
@@ -27,8 +27,38 @@ import {
   type CronJob,
   type CronSchedule,
 } from "../../cron/index.js";
+import { DEFAULT_CRON_SHELL_TIMEOUT_MS } from "../../cron/shell-executor.js";
 import { filterItemsByCanonicalTag } from "../../tags/helpers.js";
 import { buildCronShowOutput, type CronRoutingResolution, type CronRoutingSource } from "../cron-show-output.js";
+
+function parseCronShellTimeout(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      fail(`Invalid timeout: ${value}`);
+    }
+    return seconds * 1000;
+  }
+  try {
+    return parseDurationMs(trimmed);
+  } catch (err) {
+    fail(`Invalid timeout: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+function normalizeCronOnError(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "-" || trimmed === "null") return undefined;
+
+  const prefix = "notify-session:";
+  if (!trimmed.startsWith(prefix) || !trimmed.slice(prefix.length).trim()) {
+    fail(`Invalid --on-error value: ${value}. Use notify-session:<session>`);
+  }
+  return `${prefix}${trimmed.slice(prefix.length).trim()}`;
+}
 
 function resolveCronRouting(job: CronJob): CronRoutingResolution {
   if (!job.replySession) {
@@ -78,8 +108,11 @@ function printJson(payload: unknown): void {
 function serializeCronJob(job: CronJob) {
   return {
     ...job,
-    effectiveAgentId: job.agentId ?? getDefaultAgentId(),
+    effectiveAgentId: job.executionType === "agent" ? (job.agentId ?? getDefaultAgentId()) : undefined,
+    ownerAgentId: job.executionType === "shell" ? job.agentId : undefined,
     scheduleDescription: describeSchedule(job.schedule),
+    shellTimeoutDescription:
+      job.executionType === "shell" ? formatDurationMs(job.shellTimeoutMs ?? DEFAULT_CRON_SHELL_TIMEOUT_MS) : undefined,
     routing: resolveCronRouting(job),
   };
 }
@@ -199,6 +232,14 @@ export class CronCommands {
     @Option({ flags: "--at <datetime>", description: "One-shot time (e.g., 2025-02-01T15:00)" }) at?: string,
     @Option({ flags: "--tz <timezone>", description: "Timezone (e.g., America/Sao_Paulo)" }) tz?: string,
     @Option({ flags: "--message <text>", description: "Prompt message" }) message?: string,
+    @Option({ flags: "--shell <cmd>", description: "Run a shell command directly without invoking an agent" })
+    shell?: string,
+    @Option({ flags: "--exec <cmd>", description: "Alias for --shell" }) exec?: string,
+    @Option({ flags: "--on-error <action>", description: "Error action, e.g. notify-session:<session>" })
+    onError?: string,
+    @Option({ flags: "--timeout <seconds|duration>", description: "Shell timeout, e.g. 60 or 5m" })
+    timeout?: string,
+    @Option({ flags: "--env-file <path>", description: "Env file loaded for shell jobs" }) envFile?: string,
     @Option({ flags: "--isolated", description: "Run in isolated session" }) isolated?: boolean,
     @Option({ flags: "--delete-after", description: "Delete job after first run" }) deleteAfter?: boolean,
     @Option({ flags: "--agent <id>", description: "Agent ID (default: default agent)" }) agent?: string,
@@ -208,9 +249,28 @@ export class CronCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     const warnings: string[] = [];
+    const shellCommand = shell?.trim() || exec?.trim();
+    const shellFlagCount = [shell, exec].filter((value) => value?.trim()).length;
+    const isShellJob = Boolean(shellCommand);
 
-    // Validate message is provided
-    if (!message) {
+    if (shellFlagCount > 1) {
+      fail("Only one of --shell or --exec can be specified");
+    }
+    if (isShellJob && message) {
+      fail("--message cannot be combined with --shell/--exec");
+    }
+    if (isShellJob && account) {
+      fail("--account is only valid for agent cron jobs");
+    }
+    if (isShellJob && isolated) {
+      fail("--isolated is only valid for agent cron jobs");
+    }
+    if (!isShellJob && (onError || timeout || envFile)) {
+      fail("--on-error, --timeout and --env-file are only valid with --shell/--exec");
+    }
+
+    // Validate message is provided for agent jobs.
+    if (!isShellJob && !message) {
       fail("--message is required");
     }
 
@@ -274,23 +334,29 @@ export class CronCommands {
     // The third step no longer falls back to "first enabled instance" — that
     // silently picked the wrong account in multi-account setups and broke
     // outbound delivery from scheduled jobs.
-    const resolvedAccount =
-      account ?? ctx?.source?.accountId ?? (resolvedAgent ? getAccountForAgent(resolvedAgent) : undefined);
+    const resolvedAccount = isShellJob
+      ? undefined
+      : (account ?? ctx?.source?.accountId ?? (resolvedAgent ? getAccountForAgent(resolvedAgent) : undefined));
 
     // Capture reply session from caller context (e.g., agent:comm:whatsapp:main:group:123)
-    const replySession = ctx?.sessionKey;
+    const replySession = isShellJob ? undefined : ctx?.sessionKey;
 
     // Create job
     const input: CronJobInput = {
       name,
       schedule,
-      message,
+      message: isShellJob ? "" : message!,
       agentId: resolvedAgent,
       accountId: resolvedAccount,
       replySession,
       description,
-      sessionTarget: isolated ? "isolated" : "main",
+      sessionTarget: isShellJob ? "main" : isolated ? "isolated" : "main",
       deleteAfterRun: deleteAfter,
+      executionType: isShellJob ? "shell" : "agent",
+      shellCommand: isShellJob ? shellCommand : undefined,
+      shellTimeoutMs: isShellJob ? parseCronShellTimeout(timeout) : undefined,
+      shellEnvFile: isShellJob ? envFile : undefined,
+      onError: isShellJob ? normalizeCronOnError(onError) : undefined,
     };
 
     try {
@@ -312,7 +378,11 @@ export class CronCommands {
       } else {
         console.log(`\n✓ Created job: ${job.id}`);
         console.log(`  Name:       ${job.name}`);
+        console.log(`  Mode:       ${job.executionType}`);
         console.log(`  Schedule:   ${describeSchedule(job.schedule)}`);
+        if (job.executionType === "shell") {
+          console.log(`  Timeout:    ${formatDurationMs(job.shellTimeoutMs ?? DEFAULT_CRON_SHELL_TIMEOUT_MS)}`);
+        }
         if (job.nextRunAt) {
           console.log(`  Next run:   ${new Date(job.nextRunAt).toLocaleString()}`);
         }
@@ -397,7 +467,7 @@ export class CronCommands {
     @Arg("id", { description: "Job ID" }) id: string,
     @Arg("key", {
       description:
-        "Property: name, message, cron, every, tz, agent, account, description, session, reply-session, delete-after",
+        "Property: name, message, shell, exec, timeout, env-file, on-error, cron, every, tz, agent, account, description, session, reply-session, delete-after",
     })
     key: string,
     @Arg("value", { description: "Property value" }) value: string,
@@ -421,9 +491,59 @@ export class CronCommands {
           break;
 
         case "message":
-          dbUpdateCronJob(id, { message: value });
+          dbUpdateCronJob(id, {
+            executionType: "agent",
+            message: value,
+            shellCommand: undefined,
+            shellTimeoutMs: undefined,
+            shellEnvFile: undefined,
+            onError: undefined,
+          });
           logHuman(`✓ Message set: ${id}`);
           break;
+
+        case "shell":
+        case "exec":
+          dbUpdateCronJob(id, {
+            executionType: "shell",
+            message: "",
+            shellCommand: value,
+          });
+          logHuman(`✓ Shell command set: ${id}`);
+          break;
+
+        case "timeout": {
+          if (job.executionType !== "shell") {
+            fail("timeout only applies to shell cron jobs");
+          }
+          const shellTimeoutMs = value === "null" || value === "-" ? undefined : parseCronShellTimeout(value);
+          dbUpdateCronJob(id, { shellTimeoutMs });
+          normalizedValue = shellTimeoutMs ?? null;
+          logHuman(`✓ Shell timeout set: ${id} -> ${shellTimeoutMs ? formatDurationMs(shellTimeoutMs) : "(default)"}`);
+          break;
+        }
+
+        case "env-file": {
+          if (job.executionType !== "shell") {
+            fail("env-file only applies to shell cron jobs");
+          }
+          const shellEnvFile = value === "null" || value === "-" ? undefined : value;
+          dbUpdateCronJob(id, { shellEnvFile });
+          normalizedValue = shellEnvFile ?? null;
+          logHuman(`✓ Shell env file set: ${id} -> ${shellEnvFile ?? "(none)"}`);
+          break;
+        }
+
+        case "on-error": {
+          if (job.executionType !== "shell") {
+            fail("on-error only applies to shell cron jobs");
+          }
+          const normalizedOnError = normalizeCronOnError(value);
+          dbUpdateCronJob(id, { onError: normalizedOnError });
+          normalizedValue = normalizedOnError ?? null;
+          logHuman(`✓ On-error action set: ${id} -> ${normalizedOnError ?? "(none)"}`);
+          break;
+        }
 
         case "cron": {
           if (!isValidCronExpression(value)) {
@@ -526,7 +646,7 @@ export class CronCommands {
 
         default:
           fail(
-            `Unknown property: ${key}. Valid: name, message, cron, every, tz, agent, account, description, session, reply-session, delete-after`,
+            `Unknown property: ${key}. Valid: name, message, shell, exec, timeout, env-file, on-error, cron, every, tz, agent, account, description, session, reply-session, delete-after`,
           );
       }
 

--- a/src/cli/cron-show-output.test.ts
+++ b/src/cli/cron-show-output.test.ts
@@ -11,6 +11,7 @@ describe("buildCronShowOutput", () => {
         schedule: { type: "every", every: 1_800_000 },
         sessionTarget: "main",
         replySession: "agent:main:whatsapp:main:group:123456",
+        executionType: "agent",
         description: "Reconnect with warm leads",
         deleteAfterRun: false,
         message: "Ping the queue\nShare status",

--- a/src/cli/cron-show-output.ts
+++ b/src/cli/cron-show-output.ts
@@ -1,4 +1,6 @@
 import type { CronJob } from "../cron/index.js";
+import { DEFAULT_CRON_SHELL_TIMEOUT_MS } from "../cron/shell-executor.js";
+import { formatDurationMs } from "../cron/schedule.js";
 import { formatInspectionMeta, formatInspectionSection } from "./inspection-output.js";
 
 const CRON_DB_META = { source: "cron-db", freshness: "persisted" } as const;
@@ -58,6 +60,18 @@ function blockLines(
 }
 
 function buildCronExecutionLines(job: CronJob, agentId: string, routing: CronRoutingResolution): string[] {
+  if (job.executionType === "shell") {
+    const lines = [
+      "The daemon executes this shell command directly; no agent prompt is published for successful runs.",
+    ];
+    if (job.onError) {
+      lines.push(`On failure, \`${job.onError}\` receives a diagnostic prompt with exit code and captured output.`);
+    } else {
+      lines.push("On failure, status and logs are recorded, but no agent/session notification is sent.");
+    }
+    return lines;
+  }
+
   const lines = [
     `agent \`${agentId}\` receives the prompt${job.agentId ? "" : " (resolved from the runtime default agent)"}.`,
   ];
@@ -89,6 +103,14 @@ function buildCronExecutionLines(job: CronJob, agentId: string, routing: CronRou
 
 function buildCronRoutingLines(job: CronJob, routing: CronRoutingResolution): string[] {
   const lines: string[] = [];
+
+  if (job.executionType === "shell") {
+    lines.push("Shell jobs do not use reply routing during successful execution.");
+    if (job.onError) {
+      lines.push("The configured on-error action is the only path that can publish a prompt to a session.");
+    }
+    return lines;
+  }
 
   if (routing.kind === "resolved-session") {
     lines.push(
@@ -150,13 +172,30 @@ export function buildCronShowOutput(
   const lines = [`\nCron Job: ${job.name}\n`];
 
   lines.push(fieldLine("ID", job.id, CRON_DB_META));
-  lines.push(fieldLine("Agent", job.agentId ?? "(default)", CRON_DB_META));
-  lines.push(fieldLine("Account", job.accountId ?? "(auto)", CRON_DB_META));
+  lines.push(fieldLine("Mode", job.executionType, CRON_DB_META));
+  if (job.executionType === "agent") {
+    lines.push(fieldLine("Agent", job.agentId ?? "(default)", CRON_DB_META));
+    lines.push(fieldLine("Account", job.accountId ?? "(auto)", CRON_DB_META));
+  } else if (job.agentId) {
+    lines.push(fieldLine("Owner", job.agentId, CRON_DB_META));
+  }
   lines.push(fieldLine("Enabled", job.enabled ? "yes" : "no", CRON_DB_META));
   lines.push(fieldLine("Schedule", scheduleDescription, CRON_SCHEDULE_META));
-  lines.push(fieldLine("Session", job.sessionTarget, CRON_DB_META));
-  if (job.replySession) {
-    lines.push(fieldLine("Reply session", job.replySession, CRON_DB_META));
+  if (job.executionType === "agent") {
+    lines.push(fieldLine("Session", job.sessionTarget, CRON_DB_META));
+    if (job.replySession) {
+      lines.push(fieldLine("Reply session", job.replySession, CRON_DB_META));
+    }
+  } else {
+    lines.push(
+      fieldLine("Timeout", formatDurationMs(job.shellTimeoutMs ?? DEFAULT_CRON_SHELL_TIMEOUT_MS), CRON_DB_META),
+    );
+    if (job.shellEnvFile) {
+      lines.push(fieldLine("Env file", job.shellEnvFile, CRON_DB_META));
+    }
+    if (job.onError) {
+      lines.push(fieldLine("On error", job.onError, CRON_DB_META));
+    }
   }
   if (job.description) {
     lines.push(fieldLine("Description", job.description, CRON_DB_META));
@@ -173,7 +212,11 @@ export function buildCronShowOutput(
     lines.push(`    - ${line}`);
   }
   lines.push("");
-  lines.push(...blockLines("Message", CRON_DB_META, job.message.split("\n")));
+  if (job.executionType === "shell") {
+    lines.push(...blockLines("Shell", CRON_DB_META, (job.shellCommand ?? "").split("\n")));
+  } else {
+    lines.push(...blockLines("Message", CRON_DB_META, job.message.split("\n")));
+  }
   lines.push("");
   if (job.nextRunAt) {
     lines.push(fieldLine("Next run", new Date(job.nextRunAt).toLocaleString(), CRON_RUNTIME_META));
@@ -183,6 +226,9 @@ export function buildCronShowOutput(
     lines.push(fieldLine("Last status", job.lastStatus ?? "-", CRON_RUNTIME_META));
     if (job.lastDurationMs !== undefined) {
       lines.push(fieldLine("Last duration", `${job.lastDurationMs}ms`, CRON_RUNTIME_META));
+    }
+    if (job.lastExitCode !== undefined) {
+      lines.push(fieldLine("Last exit", job.lastExitCode, CRON_RUNTIME_META));
     }
     if (job.lastError) {
       lines.push(fieldLine("Last error", job.lastError, CRON_RUNTIME_META));

--- a/src/cron/cron-db.test.ts
+++ b/src/cron/cron-db.test.ts
@@ -12,6 +12,30 @@ afterEach(() => {
 });
 
 describe("dbUpdateCronJob", () => {
+  it("persists shell execution fields", () => {
+    const created = dbCreateCronJob({
+      name: `test-shell-cron-${Date.now()}`,
+      schedule: { type: "every", every: 60_000 },
+      message: "",
+      executionType: "shell",
+      shellCommand: "printf ok",
+      shellTimeoutMs: 30_000,
+      shellEnvFile: "/tmp/job.env",
+      onError: "notify-session:ops",
+    });
+    createdJobIds.push(created.id);
+
+    const reloaded = dbGetCronJob(created.id);
+    expect(reloaded).toMatchObject({
+      executionType: "shell",
+      message: "",
+      shellCommand: "printf ok",
+      shellTimeoutMs: 30_000,
+      shellEnvFile: "/tmp/job.env",
+      onError: "notify-session:ops",
+    });
+  });
+
   it("clears nullable fields when explicitly updated to undefined", () => {
     const created = dbCreateCronJob({
       name: `test-cron-${Date.now()}`,
@@ -29,15 +53,27 @@ describe("dbUpdateCronJob", () => {
       accountId: undefined,
       description: undefined,
       replySession: undefined,
+      shellCommand: undefined,
+      shellTimeoutMs: undefined,
+      shellEnvFile: undefined,
+      onError: undefined,
     });
 
     expect(updated.accountId).toBeUndefined();
     expect(updated.description).toBeUndefined();
     expect(updated.replySession).toBeUndefined();
+    expect(updated.shellCommand).toBeUndefined();
+    expect(updated.shellTimeoutMs).toBeUndefined();
+    expect(updated.shellEnvFile).toBeUndefined();
+    expect(updated.onError).toBeUndefined();
 
     const reloaded = dbGetCronJob(created.id);
     expect(reloaded?.accountId).toBeUndefined();
     expect(reloaded?.description).toBeUndefined();
     expect(reloaded?.replySession).toBeUndefined();
+    expect(reloaded?.shellCommand).toBeUndefined();
+    expect(reloaded?.shellTimeoutMs).toBeUndefined();
+    expect(reloaded?.shellEnvFile).toBeUndefined();
+    expect(reloaded?.onError).toBeUndefined();
   });
 });

--- a/src/cron/cron-db.ts
+++ b/src/cron/cron-db.ts
@@ -41,13 +41,19 @@ interface CronJobRow {
 
   session_target: string;
   reply_session: string | null;
+  execution_type: string | null;
   payload_text: string;
+  shell_command: string | null;
+  shell_timeout_ms: number | null;
+  shell_env_file: string | null;
+  on_error: string | null;
 
   next_run_at: number | null;
   last_run_at: number | null;
   last_status: string | null;
   last_error: string | null;
   last_duration_ms: number | null;
+  last_exit_code: number | null;
 
   created_at: number;
   updated_at: number;
@@ -74,6 +80,7 @@ function rowToJob(row: CronJobRow): CronJob {
     deleteAfterRun: row.delete_after_run === 1,
     schedule,
     sessionTarget: row.session_target as SessionTarget,
+    executionType: row.execution_type === "shell" ? "shell" : "agent",
     message: row.payload_text,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -83,11 +90,16 @@ function rowToJob(row: CronJobRow): CronJob {
   if (row.account_id !== null) job.accountId = row.account_id;
   if (row.description !== null) job.description = row.description;
   if (row.reply_session !== null) job.replySession = row.reply_session;
+  if (row.shell_command !== null) job.shellCommand = row.shell_command;
+  if (row.shell_timeout_ms !== null) job.shellTimeoutMs = row.shell_timeout_ms;
+  if (row.shell_env_file !== null) job.shellEnvFile = row.shell_env_file;
+  if (row.on_error !== null) job.onError = row.on_error;
   if (row.next_run_at !== null) job.nextRunAt = row.next_run_at;
   if (row.last_run_at !== null) job.lastRunAt = row.last_run_at;
   if (row.last_status !== null) job.lastStatus = row.last_status as JobStatus;
   if (row.last_error !== null) job.lastError = row.last_error;
   if (row.last_duration_ms !== null) job.lastDurationMs = row.last_duration_ms;
+  if (row.last_exit_code !== null) job.lastExitCode = row.last_exit_code;
 
   return job;
 }
@@ -111,10 +123,11 @@ export function dbCreateCronJob(input: CronJobInput): CronJob {
     INSERT INTO cron_jobs (
       id, agent_id, account_id, name, description, enabled, delete_after_run,
       schedule_type, schedule_at, schedule_every, schedule_cron, schedule_timezone,
-      session_target, reply_session, payload_text,
+      session_target, reply_session, execution_type, payload_text,
+      shell_command, shell_timeout_ms, shell_env_file, on_error,
       next_run_at,
       created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   stmt.run(
@@ -132,7 +145,12 @@ export function dbCreateCronJob(input: CronJobInput): CronJob {
     input.schedule.timezone ?? null,
     input.sessionTarget ?? "main",
     input.replySession ?? null,
+    input.executionType ?? "agent",
     input.message,
+    input.shellCommand ?? null,
+    input.shellTimeoutMs ?? null,
+    input.shellEnvFile ?? null,
+    input.onError ?? null,
     nextRunAt ?? null,
     now,
     now,
@@ -233,9 +251,29 @@ export function dbUpdateCronJob(id: string, updates: Partial<CronJob>): CronJob 
     fields.push("reply_session = ?");
     values.push(updates.replySession ?? null);
   }
+  if (updates.executionType !== undefined) {
+    fields.push("execution_type = ?");
+    values.push(updates.executionType);
+  }
   if (updates.message !== undefined) {
     fields.push("payload_text = ?");
     values.push(updates.message);
+  }
+  if (hasOwn("shellCommand")) {
+    fields.push("shell_command = ?");
+    values.push(updates.shellCommand ?? null);
+  }
+  if (hasOwn("shellTimeoutMs")) {
+    fields.push("shell_timeout_ms = ?");
+    values.push(updates.shellTimeoutMs ?? null);
+  }
+  if (hasOwn("shellEnvFile")) {
+    fields.push("shell_env_file = ?");
+    values.push(updates.shellEnvFile ?? null);
+  }
+  if (hasOwn("onError")) {
+    fields.push("on_error = ?");
+    values.push(updates.onError ?? null);
   }
 
   if (fields.length === 0) {
@@ -311,6 +349,7 @@ export function dbUpdateJobState(id: string, state: JobStateUpdate): void {
       last_error = ?,
       last_duration_ms = ?,
       next_run_at = ?,
+      last_exit_code = ?,
       updated_at = ?
     WHERE id = ?
   `);
@@ -321,6 +360,7 @@ export function dbUpdateJobState(id: string, state: JobStateUpdate): void {
     state.lastError ?? null,
     state.lastDurationMs ?? null,
     state.nextRunAt ?? null,
+    state.lastExitCode ?? null,
     now,
     id,
   );

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -9,6 +9,7 @@ export type {
   ScheduleType,
   SessionTarget,
   JobStatus,
+  CronExecutionType,
   CronSchedule,
   CronJob,
   CronJobInput,

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -22,9 +22,11 @@ import {
 import { getAgent } from "../router/config.js";
 import { dbGetDueJobs, dbGetNextDueJob, dbUpdateJobState, dbDeleteCronJob, dbGetCronJob } from "./cron-db.js";
 import { calculateNextRun } from "./schedule.js";
+import { DEFAULT_CRON_SHELL_TIMEOUT_MS, runShellCronCommand, type ShellCronRunResult } from "./shell-executor.js";
 import type { CronJob } from "./types.js";
 
 const log = logger.child("cron:runner");
+const MAX_NOTIFY_OUTPUT_CHARS = 4000;
 
 /**
  * CronRunner - manages scheduled job execution
@@ -140,7 +142,17 @@ export class CronRunner {
    */
   private async executeJob(job: CronJob): Promise<void> {
     const startTime = Date.now();
-    log.info("Executing job", { jobId: job.id, jobName: job.name, sessionTarget: job.sessionTarget });
+    log.info("Executing job", {
+      jobId: job.id,
+      jobName: job.name,
+      executionType: job.executionType,
+      sessionTarget: job.sessionTarget,
+    });
+
+    if (job.executionType === "shell") {
+      await this.executeShellJob(job, startTime);
+      return;
+    }
 
     try {
       if (job.sessionTarget === "main") {
@@ -184,6 +196,162 @@ export class CronRunner {
       });
 
       log.error("Job failed", { jobId: job.id, jobName: job.name, error: errorMessage });
+    }
+  }
+
+  private calculateFollowupRun(job: CronJob, startTime: number): number | undefined {
+    const baseTime = job.schedule.type === "every" && job.nextRunAt ? job.nextRunAt : startTime;
+    return calculateNextRun(job.schedule, baseTime);
+  }
+
+  private truncateForPrompt(value: string): string {
+    if (value.length <= MAX_NOTIFY_OUTPUT_CHARS) return value;
+    return `${value.slice(0, MAX_NOTIFY_OUTPUT_CHARS)}\n...[truncated]`;
+  }
+
+  private formatShellError(result: ShellCronRunResult): string {
+    if (result.timedOut) {
+      return `Shell command timed out after ${result.durationMs}ms`;
+    }
+    const exit = result.exitCode === null ? `signal ${result.signal ?? "unknown"}` : `exit code ${result.exitCode}`;
+    const stderr = result.stderr.trim();
+    return stderr
+      ? `Shell command failed with ${exit}: ${this.truncateForPrompt(stderr)}`
+      : `Shell command failed with ${exit}`;
+  }
+
+  private async notifyShellError(job: CronJob, result: ShellCronRunResult, errorMessage: string): Promise<void> {
+    if (!job.onError) return;
+    const prefix = "notify-session:";
+    if (!job.onError.startsWith(prefix)) {
+      log.warn("Unsupported cron on-error action", { jobId: job.id, onError: job.onError });
+      return;
+    }
+
+    const sessionRef = job.onError.slice(prefix.length).trim();
+    if (!sessionRef) {
+      log.warn("Cron on-error notify-session missing target", { jobId: job.id });
+      return;
+    }
+
+    const resolved = resolveSession(sessionRef);
+    const sessionName = resolved?.name ?? sessionRef;
+    const stdout = result.stdout.trim();
+    const stderr = result.stderr.trim();
+    const prompt = [
+      `[System] Inform: [from: cron:${job.id}] Cron shell job failed.`,
+      "",
+      `Job: ${job.name}`,
+      `Command: ${job.shellCommand ?? result.command}`,
+      `Error: ${errorMessage}`,
+      `Exit code: ${result.exitCode ?? "(none)"}`,
+      `Signal: ${result.signal ?? "(none)"}`,
+      `Duration: ${result.durationMs}ms`,
+      stderr ? `\nStderr:\n${this.truncateForPrompt(stderr)}` : "",
+      stdout ? `\nStdout:\n${this.truncateForPrompt(stdout)}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    await publishSessionPrompt(sessionName, {
+      prompt,
+      _cron: true,
+      _jobId: job.id,
+      _cronOnError: true,
+    });
+  }
+
+  private async executeShellJob(job: CronJob, startTime: number): Promise<void> {
+    try {
+      if (!job.shellCommand?.trim()) {
+        throw new Error("Shell cron job is missing shellCommand");
+      }
+
+      const result = await runShellCronCommand(job.shellCommand, {
+        timeoutMs: job.shellTimeoutMs ?? DEFAULT_CRON_SHELL_TIMEOUT_MS,
+        envFile: job.shellEnvFile,
+      });
+
+      if (result.stdout.trim()) {
+        log.info("Shell job stdout", { jobId: job.id, output: this.truncateForPrompt(result.stdout.trim()) });
+      }
+      if (result.stderr.trim()) {
+        log.warn("Shell job stderr", { jobId: job.id, output: this.truncateForPrompt(result.stderr.trim()) });
+      }
+
+      const ok = !result.timedOut && result.exitCode === 0;
+      const errorMessage = ok ? undefined : this.formatShellError(result);
+      const nextRunAt = this.calculateFollowupRun(job, startTime);
+
+      dbUpdateJobState(job.id, {
+        lastRunAt: startTime,
+        lastStatus: ok ? "ok" : "error",
+        lastError: errorMessage,
+        lastDurationMs: result.durationMs,
+        nextRunAt,
+        lastExitCode: result.exitCode ?? undefined,
+      });
+
+      if (!ok && errorMessage) {
+        try {
+          await this.notifyShellError(job, result, errorMessage);
+        } catch (notifyError) {
+          log.error("Failed to notify session about cron shell error", {
+            jobId: job.id,
+            error: notifyError instanceof Error ? notifyError.message : String(notifyError),
+          });
+        }
+      }
+
+      log.info("Shell job completed", {
+        jobId: job.id,
+        jobName: job.name,
+        status: ok ? "ok" : "error",
+        exitCode: result.exitCode,
+        signal: result.signal,
+        durationMs: result.durationMs,
+      });
+
+      if (ok && (job.deleteAfterRun || job.schedule.type === "at")) {
+        log.info("Deleting one-shot shell job", { jobId: job.id });
+        dbDeleteCronJob(job.id);
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const nextRunAt = this.calculateFollowupRun(job, startTime);
+
+      dbUpdateJobState(job.id, {
+        lastRunAt: startTime,
+        lastStatus: "error",
+        lastError: errorMessage,
+        lastDurationMs: Date.now() - startTime,
+        nextRunAt,
+      });
+
+      if (job.onError) {
+        try {
+          await this.notifyShellError(
+            job,
+            {
+              command: job.shellCommand ?? "",
+              exitCode: null,
+              signal: null,
+              stdout: "",
+              stderr: errorMessage,
+              durationMs: Date.now() - startTime,
+              timedOut: false,
+            },
+            errorMessage,
+          );
+        } catch (notifyError) {
+          log.error("Failed to notify session about cron shell exception", {
+            jobId: job.id,
+            error: notifyError instanceof Error ? notifyError.message : String(notifyError),
+          });
+        }
+      }
+
+      log.error("Shell job failed", { jobId: job.id, jobName: job.name, error: errorMessage });
     }
   }
 

--- a/src/cron/shell-executor.test.ts
+++ b/src/cron/shell-executor.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "bun:test";
+import { parseEnvFile, runShellCronCommand } from "./shell-executor.js";
+
+describe("parseEnvFile", () => {
+  it("parses simple dotenv-style assignments", () => {
+    expect(parseEnvFile("A=1\nexport B='two words'\n# ignored\nBAD-KEY=no\nC=\"three\"")).toEqual({
+      A: "1",
+      B: "two words",
+      C: "three",
+    });
+  });
+});
+
+describe("runShellCronCommand", () => {
+  it("captures successful shell output", async () => {
+    const result = await runShellCronCommand("printf ok", { timeoutMs: 5_000 });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ok");
+    expect(result.stderr).toBe("");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("captures non-zero exit code and stderr", async () => {
+    const result = await runShellCronCommand("printf fail >&2; exit 7", { timeoutMs: 5_000 });
+
+    expect(result.exitCode).toBe(7);
+    expect(result.stderr).toBe("fail");
+  });
+
+  it("loads env vars from env file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-cron-shell-"));
+    const envFile = join(dir, "job.env");
+    writeFileSync(envFile, "RAVI_CRON_TEST_VALUE=loaded\n");
+
+    try {
+      const result = await runShellCronCommand("printf $RAVI_CRON_TEST_VALUE", { timeoutMs: 5_000, envFile });
+      expect(result.stdout).toBe("loaded");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cron/shell-executor.ts
+++ b/src/cron/shell-executor.ts
@@ -1,0 +1,133 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+export const DEFAULT_CRON_SHELL_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_CAPTURE_CHARS = 64 * 1024;
+
+export interface ShellCronRunOptions {
+  timeoutMs?: number;
+  envFile?: string;
+}
+
+export interface ShellCronRunResult {
+  command: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+function appendLimited(current: string, chunk: Buffer | string): string {
+  const next = current + chunk.toString();
+  if (next.length <= MAX_CAPTURE_CHARS) return next;
+  return next.slice(next.length - MAX_CAPTURE_CHARS);
+}
+
+function unquoteEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const normalized = line.startsWith("export ") ? line.slice("export ".length).trim() : line;
+    const eq = normalized.indexOf("=");
+    if (eq <= 0) continue;
+
+    const key = normalized.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    env[key] = unquoteEnvValue(normalized.slice(eq + 1));
+  }
+  return env;
+}
+
+function loadEnvFile(path: string | undefined): Record<string, string> {
+  if (!path) return {};
+  const resolvedPath = path === "~" ? homedir() : path.startsWith("~/") ? `${homedir()}${path.slice(1)}` : path;
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Env file not found: ${path}`);
+  }
+  return parseEnvFile(readFileSync(resolvedPath, "utf8"));
+}
+
+export async function runShellCronCommand(
+  command: string,
+  options: ShellCronRunOptions = {},
+): Promise<ShellCronRunResult> {
+  const started = Date.now();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CRON_SHELL_TIMEOUT_MS;
+  const env = { ...process.env, ...loadEnvFile(options.envFile) };
+
+  return new Promise((resolve, reject) => {
+    const detached = process.platform !== "win32";
+    const child = spawn(command, {
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      detached,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const killChild = (signal: NodeJS.Signals) => {
+      if (detached && child.pid) {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall through to direct child kill below.
+        }
+      }
+      child.kill(signal);
+    };
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      killChild("SIGTERM");
+      killTimer = setTimeout(() => killChild("SIGKILL"), 5_000);
+      killTimer.unref?.();
+    }, timeoutMs);
+    timeout.unref?.();
+
+    child.stdout?.on("data", (chunk) => {
+      stdout = appendLimited(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr = appendLimited(stderr, chunk);
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      reject(error);
+    });
+
+    child.on("close", (exitCode, signal) => {
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      resolve({
+        command,
+        exitCode,
+        signal,
+        stdout,
+        stderr,
+        durationMs: Date.now() - started,
+        timedOut,
+      });
+    });
+  });
+}

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -10,6 +10,7 @@
 export type ScheduleType = "at" | "every" | "cron";
 export type SessionTarget = "main" | "isolated";
 export type JobStatus = "ok" | "error";
+export type CronExecutionType = "agent" | "shell";
 
 /**
  * Schedule configuration for a cron job
@@ -43,8 +44,18 @@ export interface CronJob {
   sessionTarget: SessionTarget;
   /** Session key to emit prompt to (e.g., agent:comm:whatsapp:main:group:123) */
   replySession?: string;
+  /** Execution mode. Existing rows default to agent. */
+  executionType: CronExecutionType;
   /** The prompt text to send to the agent */
   message: string;
+  /** Shell command for executionType=shell */
+  shellCommand?: string;
+  /** Shell command timeout in milliseconds */
+  shellTimeoutMs?: number;
+  /** Optional env file path to merge into the shell process environment */
+  shellEnvFile?: string;
+  /** Optional error action, currently notify-session:<session> */
+  onError?: string;
 
   // State
   nextRunAt?: number;
@@ -52,6 +63,7 @@ export interface CronJob {
   lastStatus?: JobStatus;
   lastError?: string;
   lastDurationMs?: number;
+  lastExitCode?: number;
 
   createdAt: number;
   updatedAt: number;
@@ -72,8 +84,18 @@ export interface CronJobInput {
   sessionTarget?: SessionTarget;
   /** Session key to emit prompt to (captured from caller context) */
   replySession?: string;
+  /** Execution mode. Defaults to agent. */
+  executionType?: CronExecutionType;
   /** The prompt text to send to the agent */
   message: string;
+  /** Shell command for executionType=shell */
+  shellCommand?: string;
+  /** Shell command timeout in milliseconds */
+  shellTimeoutMs?: number;
+  /** Optional env file path to merge into the shell process environment */
+  shellEnvFile?: string;
+  /** Optional error action, currently notify-session:<session> */
+  onError?: string;
 }
 
 /**
@@ -85,4 +107,5 @@ export interface JobStateUpdate {
   lastError?: string;
   lastDurationMs?: number;
   nextRunAt?: number;
+  lastExitCode?: number;
 }

--- a/src/plugins/internal/ravi-system/skills/cron/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/cron/SKILL.md
@@ -44,6 +44,19 @@ Com intervalo:
 ravi cron add "Check Emails" --every 30m --message "Verifique novos emails"
 ```
 
+Shell direto, sem invocar agent/LLM:
+```bash
+ravi cron add "ETL" --cron "*/15 * * * *" --shell "python3 /home/ravi/job.py"
+```
+
+Shell com agent apenas em erro:
+```bash
+ravi cron add "ETL" \
+  --cron "*/15 * * * *" \
+  --shell "python3 /home/ravi/job.py" \
+  --on-error notify-session:admin-group
+```
+
 One-shot (executa uma vez):
 ```bash
 ravi cron add "Lembrete" --at "2025-02-01T15:00" --message "Lembrar de X" --delete-after
@@ -56,8 +69,14 @@ Opções:
 - `--isolated` - Roda em sessão isolada
 - `--delete-after` - Deleta após primeira execução
 - `--description <text>` - Descrição do job
+- `--shell <cmd>` / `--exec <cmd>` - Executa comando shell direto sem prompt LLM
+- `--timeout <seconds|duration>` - Timeout para shell jobs, ex: `60`, `30s`, `10m`
+- `--env-file <path>` - Arquivo dotenv simples para shell jobs
+- `--on-error notify-session:<session>` - Notifica sessão só quando shell job falhar
 
 Depois de criar job que deve responder em um chat/sessão específica, sempre rode `ravi cron show <id>` e confira `agent`, `account`, `session`/`reply-session` antes de considerar pronto. Não confie no account herdado do contexto atual: se o cron entregar pelo account errado, o agent pode trabalhar e falhar no delivery com `chat not found`.
+
+Para trabalho determinístico (ETL, scraping, sync, scripts idempotentes), prefira `--shell` em vez de pedir para um agent usar Bash. Isso mantém tracking em `ravi cron list/show`, evita custo de tokens em runs bem-sucedidos e só envolve agent quando houver `--on-error`.
 
 Para jobs de monitoramento, faça o prompt comparar o estado atual com a última checagem e responder só quando houver mudança material. Não transforme o mesmo bloqueio em alerta a cada tick: se a causa, impacto e próximo passo continuam iguais, o job deve registrar localmente ou ficar silencioso. Se a repetição do bloqueio indicar risco novo, como retry infinito ou consumo inútil de tentativas, reporte esse risco como decisão operacional necessária em vez de recontar o mesmo erro.
 
@@ -72,7 +91,7 @@ ravi cron disable <id>
 ravi cron set <id> <key> <value>
 ```
 
-Keys: name, message, cron, every, tz, agent, account, description, session, reply-session, delete-after
+Keys: name, message, shell, exec, timeout, env-file, on-error, cron, every, tz, agent, account, description, session, reply-session, delete-after
 
 ### Executar manualmente
 ```bash

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -1978,7 +1978,12 @@ function getDb(): Database {
       -- Execution config
       session_target TEXT DEFAULT 'main',
       reply_session TEXT,
+      execution_type TEXT DEFAULT 'agent',
       payload_text TEXT NOT NULL,
+      shell_command TEXT,
+      shell_timeout_ms INTEGER,
+      shell_env_file TEXT,
+      on_error TEXT,
 
       -- State
       next_run_at INTEGER,
@@ -1986,6 +1991,7 @@ function getDb(): Database {
       last_status TEXT,
       last_error TEXT,
       last_duration_ms INTEGER,
+      last_exit_code INTEGER,
 
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
@@ -2047,6 +2053,30 @@ function getDb(): Database {
   if (!cronColumns.some((c) => c.name === "account_id")) {
     db.exec("ALTER TABLE cron_jobs ADD COLUMN account_id TEXT");
     log.info("Added account_id column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "execution_type")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN execution_type TEXT DEFAULT 'agent'");
+    log.info("Added execution_type column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "shell_command")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN shell_command TEXT");
+    log.info("Added shell_command column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "shell_timeout_ms")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN shell_timeout_ms INTEGER");
+    log.info("Added shell_timeout_ms column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "shell_env_file")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN shell_env_file TEXT");
+    log.info("Added shell_env_file column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "on_error")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN on_error TEXT");
+    log.info("Added on_error column to cron_jobs table");
+  }
+  if (!cronColumns.some((c) => c.name === "last_exit_code")) {
+    db.exec("ALTER TABLE cron_jobs ADD COLUMN last_exit_code INTEGER");
+    log.info("Added last_exit_code column to cron_jobs table");
   }
 
   // Migration: add heartbeat_account_id column to agents


### PR DESCRIPTION

## Summary
- Add shell execution mode for `ravi cron` jobs via `--shell` / `--exec`.
- Persist shell execution metadata and last exit code while preserving existing agent cron behavior.
- Add failure-only `--on-error notify-session:<session>` diagnostics plus timeout/env-file support.
- Update cron docs, routine spec, cron skill, tests, and SDK generated client artifacts.

## Why
Refs #54. The issue asks for deterministic cron jobs that do not spend LLM tokens on every firing, while still using Ravi cron for listing, lifecycle, status, logs, and optional agent notification only on failure.

## Validation
- `bun test src/cron/cron-db.test.ts src/cron/shell-executor.test.ts src/cli/commands/cron-commands.test.ts src/cli/cron-show-output.test.ts`
- `bunx biome check ...`
- `bun run typecheck`
- `bun run build`
- `bun src/cli/index.ts sdk client check`
- pre-push full checks passed
