### PR TITLE
[codex] Document reaction automation recipes

### DIFF
--- a/.ravi/specs/routines/composition/SPEC.md
+++ b/.ravi/specs/routines/composition/SPEC.md
@@ -37,6 +37,8 @@ Routine Composition defines how a recurring loop combines triggers, context, ski
 - Skills MUST be named explicitly when a routine depends on a specialized protocol.
 - Output policy MUST define default silence or default speaking behavior.
 - State writes MUST be explicit and durable.
+- Reaction-driven approval routines MUST record the outbound message id to domain-state mapping before presenting an item for approval. The reaction event is only a signal; it MUST NOT be the only place the routine can recover the approved object.
+- Side-effecting routines SHOULD be idempotent. A routine that posts, publishes, charges, or mutates external state SHOULD persist processed markers and use a lock or equivalent overlap guard.
 - Quality modes SHOULD monitor user-visible routines.
 - Routines SHOULD be decomposed when one trigger tries to drive unrelated outcomes.
 

--- a/.ravi/specs/routines/triggers/SPEC.md
+++ b/.ravi/specs/routines/triggers/SPEC.md
@@ -34,6 +34,8 @@ Trigger filters are the deterministic pre-agent predicate for event payloads. Th
 - Trigger examples in docs, skills, and CLI help MUST use cataloged subjects unless they are explicitly marked as custom publisher subjects.
 - Channel transport aliases such as `whatsapp.*.reaction`, `whatsapp.*.inbound`, and `matrix.*.inbound` MUST NOT be documented as trigger-ready subjects unless a Ravi publisher actually emits them.
 - Emoji reaction triggers MUST use `ravi.inbound.reaction` until a different subject is deliberately added to the catalog and publisher.
+- Reaction trigger payloads MUST be documented as correlation events, not full chat/message records. The current `ravi.inbound.reaction` payload identifies `{ targetMessageId, emoji, senderId }`; it does not guarantee `chatId`, message caption, media metadata, or domain state.
+- Routines that need to publish or approve domain objects from a reaction MUST persist a durable mapping keyed by the outbound message external id before waiting for the reaction. The trigger handler MUST resolve `targetMessageId` against that state and stay silent when there is no match.
 - The CLI MUST NOT block custom NATS subjects. It SHOULD warn when a subject is outside the built-in catalog or looks like a known inferred alias without a Ravi publisher.
 - The catalog SHOULD include payload schema, example command, common filters, and operational notes for each subject.
 - Trigger filters MUST support the comparison operators `==`, `!=`, `startsWith`, `endsWith`, and `includes`.
@@ -50,5 +52,6 @@ Trigger filters are the deterministic pre-agent predicate for event payloads. Th
 - `ravi triggers add --topic "whatsapp.*.reaction"` succeeds with a warning that `ravi.inbound.reaction` is the canonical built-in reaction subject.
 - `ravi triggers add --topic "custom.external.>"` succeeds with a warning that the subject is custom/outside built-in templates.
 - `ravi triggers add --filter 'data.chatId == "X" && (data.status == "approved" || data.status == "manual")'` persists the filter and evaluates correctly.
+- Reaction approval examples filter on fields present in the reaction payload, such as `data.emoji` or `data.senderId`, and tell the agent to load domain state by `data.targetMessageId`.
 - `ravi triggers set <id> filter 'data.ok == true'` fails clearly because values must be quoted.
 - Skills and docs point users to the catalog instead of asking them to infer subjects by symmetry.

--- a/.ravi/specs/runtime/providers/codex/SPEC.md
+++ b/.ravi/specs/runtime/providers/codex/SPEC.md
@@ -81,6 +81,7 @@ The Codex provider adapts the Codex app-server transport into Ravi's canonical r
 - The global Codex Bash hook command MUST resolve to a stable Ravi CLI entrypoint such as `bin/ravi` or the bundled CLI, never to a test file or transient runner script.
 - The global Codex Bash hook matcher MUST cover both Codex tool names currently observed for shell execution: `Bash` and `shell`.
 - The global Codex Bash hook MUST enforce Ravi shell permissions and runtime skill gates only. It MUST NOT rely on `PreToolUse.updatedInput` to inject env because current Codex rejects unsupported updated input for this hook.
+- Ravi REBAC grants such as `full-access` authorize Ravi's permission layer only. They MUST NOT be documented as a bypass for provider-native hooks, global Codex hooks, or external PreToolUse transforms that may still deny a shell command after Ravi allows it.
 - The shell env bridge MUST NOT print or embed `RAVI_CONTEXT_KEY` directly in user-visible command text or traces.
 - Ravi operations requested by the model MUST execute through the shell/CLI path under the current Ravi context.
 - Command/file/permission/user-input approval requests MUST route through Ravi approval handlers.

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -70,6 +70,7 @@ Sessions do NOT own:
 - A session MAY have one or more attached chats (see `sessions/attach`). The original `session_chat_bindings` row identifies the primary chat for legacy compatibility.
 - A session MUST have at most one attached output chat. Output delivery MUST resolve to that output attachment. The inbound source chat MUST NOT be used as an implicit output fallback.
 - If a session has no output attachment, it MUST NOT emit externally.
+- `ravi sessions send` and related inter-session commands inject prompt/context into a Ravi session. They MUST NOT be documented as direct external channel delivery primitives. Visible outbound channel delivery belongs to the session response path or to explicit channel/media/outbound commands.
 - Session reset MUST clear provider continuity state (per `runtime/session-continuity`) but MUST NOT silently drop attach subscriptions — those are routing/wiring, not provider state.
 - Deletion of a session MUST cascade to delete its subscriptions.
 

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -104,7 +104,7 @@ Event-driven triggers that subscribe to NATS topics and fire agent prompts when 
 
 **Anti-loop protection:**
 
-- Blocked prefixes: topics starting with `ravi.session.` are rejected at subscription time
+- Blocked prefixes: topics starting with `ravi.session.` can be saved by the CLI for compatibility, but the runner refuses to arm them
 - Session filter: events from trigger sessions (`:trigger:` in topic) are skipped
 - Data flag: events with `_trigger: true` are skipped
 - Cooldown: per-trigger cooldown (default 5s) prevents rapid re-firing. Cooldown is set in-memory immediately on first match to prevent race conditions with concurrent events
@@ -123,7 +123,7 @@ data.permission_mode != "bypassPermissions"
 data.cwd startsWith "/workspace/ravi"
 data.hook_event_name endsWith "Submit"
 data.tool includes "Bash"
-data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")
+data.senderId == "5511999999999" && (data.emoji == "👍" || data.emoji == "👍🏻")
 ```
 
 Precedence is `!` before `&&` before `||`. If the filter is empty or missing, the trigger always fires. CLI commands reject invalid filter syntax before persisting it. Runtime evaluation still fails open for legacy invalid filters and logs a warning. If the data path doesn't exist, the filter returns false (no match).

--- a/docs/guides/permissions.mdx
+++ b/docs/guides/permissions.mdx
@@ -192,6 +192,8 @@ ravi permissions init agent:dev safe-executables
 ravi permissions init agent:dev full-access
 ```
 
+`full-access` only answers the Ravi REBAC question. A command can still be denied later by provider-native hooks, workspace hooks, external PreToolUse filters, or other runtime policies outside the REBAC store. When `ravi permissions check` says allowed but Bash still fails, inspect the denial source before changing more permissions.
+
 ### Safe Executables List
 
 The `safe-executables` template grants access to commonly needed development binaries: `ls`, `cat`, `head`, `tail`, `find`, `mkdir`, `cp`, `mv`, `touch`, `git`, `grep`, `rg`, `awk`, `sed`, `jq`, `node`, `npm`, `bun`, `python3`, `make`, `cargo`, `go`, `jest`, `vitest`, `eslint`, `prettier`, `echo`, `date`, `pwd`, `which`, and others.

--- a/docs/guides/sessions.mdx
+++ b/docs/guides/sessions.mdx
@@ -314,6 +314,8 @@ ravi sessions send <name> -i
 
 By default, `send` is still fire-and-forget. Internally it injects an informational prompt with source attribution. Use `-w` only when the caller needs to wait for and stream the response.
 
+`sessions send` is not a direct external-message primitive. It prompts a Ravi session; it does not itself publish visible text to WhatsApp, Telegram, Matrix, or another channel. For visible channel delivery, use the session's normal response path or an explicit channel/media/outbound command.
+
 Use `-a <agent>` to auto-create the session if it does not exist:
 
 ```bash
@@ -367,6 +369,8 @@ All messaging commands support channel and target overrides:
 ```bash
 ravi sessions send <name> "message" --channel whatsapp --to 5511999999999
 ```
+
+These overrides describe the prompt/source context used to resolve or create the session. They should not be treated as "send this literal text to that phone number".
 
 ### Source Attribution
 

--- a/docs/guides/triggers.mdx
+++ b/docs/guides/triggers.mdx
@@ -62,6 +62,8 @@ Use `ravi triggers topics` to inspect the trigger-ready topic catalog with paylo
 
 Channel message aliases such as `whatsapp.*.inbound` and channel reaction aliases such as `whatsapp.*.reaction` are not trigger-ready subjects. Inbound channel messages are consumed by the session router from Omni streams; reaction triggers use `ravi.inbound.reaction`.
 
+Reaction payloads are correlation events, not full message records. `ravi.inbound.reaction` currently carries `targetMessageId`, `emoji`, and `senderId`; it does not guarantee `chatId`, caption, media metadata, or business/domain state. If a routine needs that state, persist a mapping keyed by the outbound message id before waiting for the reaction.
+
 ### Contacts and Approvals
 
 | Pattern | Description |
@@ -101,7 +103,7 @@ The trigger system includes multiple layers of protection against infinite loops
 
 ### 1. Blocked Topic Prefixes
 
-Topics starting with `ravi.session.` are rejected at subscription time. This prevents triggers from reacting to internal session events that could create prompt-trigger-prompt loops.
+Topics starting with `ravi.session.` are accepted by the CLI for persistence compatibility, but the runner refuses to arm them. This prevents triggers from reacting to internal session events that could create prompt-trigger-prompt loops.
 
 ### 2. Session Filter
 
@@ -115,9 +117,9 @@ Events with `_trigger: true` in their data payload are skipped. This flag is set
 
 Each trigger has a configurable cooldown (default: 5 seconds). After a trigger fires, it will not fire again until the cooldown period elapses, regardless of how many matching events arrive.
 
-### Disallowed Topic Aliases
+### Topic Alias Warnings
 
-The CLI rejects topics that are known to be inferred aliases rather than real publishers:
+The CLI accepts custom NATS subjects, but warns when a topic looks like an inferred alias rather than a Ravi publisher. Prefer the canonical built-in subjects in maintained examples:
 
 ```
 whatsapp.*.reaction     # use ravi.inbound.reaction
@@ -176,8 +178,8 @@ ravi triggers set <id> filter 'data.output includes "error"'
 # Match events ending with a suffix
 ravi triggers set <id> filter 'data.tool endsWith "_list"'
 
-# Match a WhatsApp approval reaction in one chat
-ravi triggers set <id> filter 'data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")'
+# Match an approval reaction from one sender
+ravi triggers set <id> filter 'data.senderId == "5511999999999" && (data.emoji == "👍" || data.emoji == "👍🏻")'
 
 # Exclude one source
 ravi triggers set <id> filter '!(data.source == "test")'
@@ -407,10 +409,24 @@ Trigger on approved reactions:
 ravi triggers add "Reaction Approval" \
   --topic "ravi.inbound.reaction" \
   --filter 'data.emoji includes "👍"' \
-  --message "Reaction received for {{data.targetMessageId}}. Resolve local state and continue if approved." \
+  --message "Reaction received for {{data.targetMessageId}}. Resolve local state by targetMessageId and continue only if a pending item matches." \
   --session isolated \
   --cooldown 5s
 ```
+
+For approval-by-reaction workflows, store enough state before posting the review message:
+
+```json
+{
+  "external_msg_123": {
+    "domainId": "item_123",
+    "destinationChatId": "chat_public",
+    "status": "pending"
+  }
+}
+```
+
+The trigger agent should load that state by `{{data.targetMessageId}}`, publish at most once, mark the item processed, and stay silent when there is no match.
 
 ## Debugging Triggers
 
@@ -473,7 +489,7 @@ The filter must match the restricted parser syntax. Double or single quotes arou
 data.cwd == "/workspace/ravi"
 data.tool startsWith "contacts"
 data.output includes 'error'
-data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")
+data.senderId == "5511999999999" && (data.emoji == "👍" || data.emoji == "👍🏻")
 !(data.source == "test")
 
 # Invalid (CLI add/set reject these)

--- a/docs/reference/nats-events.mdx
+++ b/docs/reference/nats-events.mdx
@@ -38,6 +38,8 @@ The prompt topic goes via JetStream WorkQueue stream (`SESSION_PROMPTS`). All ot
 
 Inbound channel messages arrive through Omni JetStream subjects such as `message.received.{channelType}.{instanceId}` and are routed into sessions by `OmniConsumer`, not published as Ravi pub/sub aliases like `whatsapp.*.inbound`. Emoji reactions are normalized to the canonical trigger subject `ravi.inbound.reaction`; `whatsapp.*.reaction` is not published.
 
+Reaction events are correlation signals. Use `targetMessageId` to look up routine-owned state; do not assume the event includes the original chat, caption, media metadata, or domain object.
+
 ## Delivery Events (Bot to Gateway)
 
 | Topic | Payload |

--- a/src/plugins/internal/ravi-system/skills/agents/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/agents/SKILL.md
@@ -195,6 +195,19 @@ ravi permissions grant agent:<id> execute executable:git
 
 Ver skill `permissions-manager` para documentação completa.
 
+### REBAC vs hooks do provider
+
+`full-access` libera a camada de permissões do Ravi: tools, grupos e executáveis. Isso não desativa automaticamente hooks globais do provider, denylist local, PreToolUse externo ou políticas instaladas fora do Ravi.
+
+Quando Bash ainda é negado depois de `ravi permissions check` permitir:
+
+1. Leia a mensagem de denial e identifique se veio do Ravi ou do provider/hook externo.
+2. Verifique hooks locais do workspace do agent antes de mudar grants.
+3. Se o agent precisa executar scripts próprios, prefira permitir o script/binário específico em vez de contornar tudo.
+4. Um bypass local de hook só deve ser usado como decisão explícita do operador, em workspace controlado, e documentado no `AGENTS.md` do agent.
+
+Agents podem editar código/scripts próprios dentro do seu `cwd` quando a tarefa permitir, mas não devem reverter mudanças feitas por outro agente/operador sem inspecionar o diff e confirmar a intenção.
+
 ## Debounce de Mensagens
 
 Agrupa mensagens rápidas antes de processar:

--- a/src/plugins/internal/ravi-system/skills/automation-recipes/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/automation-recipes/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: automation-recipes
+description: |
+  Receitas operacionais de automacao do Ravi. Use quando precisar:
+  - Montar rotinas compostas com cron, triggers, sessions, media e state local
+  - Implementar aprovacao por reaction sem perder correlacao de estado
+  - Evitar automacoes que disparam LLM ou efeito externo sem necessidade
+  - Documentar padroes reutilizaveis de rotina
+---
+
+# Automation Recipes
+
+Use esta skill para compor primitives do Ravi em rotinas repetiveis. Uma receita nao substitui specs: quando a rotina vira padrao do produto, registre tambem em `.ravi/specs/routines`.
+
+## Principios
+
+- Separe trigger de contexto: o evento que acorda a rotina raramente contem todo o estado necessario.
+- Grave state duravel antes de esperar eventos externos.
+- Prefira `ravi cron --shell` para trabalho deterministico e envolva agent apenas em erro ou decisao.
+- Defina a politica de fala: default silencioso, falar apenas quando houver acao ou falha relevante.
+- Toda acao externa deve ser idempotente ou ter marcador de processamento.
+
+## Receita: Cron Sentinela + Reaction De Aprovacao
+
+Use quando um script periodico encontra candidatos, posta uma previa para revisao humana e publica somente quando alguem reage com aprovacao.
+
+### Componentes
+
+1. Cron shell deterministico
+   - roda ETL, scraping, sync ou geracao de cards;
+   - nao invoca LLM em sucesso;
+   - usa `--on-error notify-session:<session>` para erro operacional.
+2. Store local da rotina
+   - JSON, SQLite ou outro arquivo sob o workspace do agent;
+   - chave principal: external message id da previa enviada;
+   - valor: domain id, destino final, payload necessario para publicar, status e timestamps.
+3. Trigger de reaction
+   - topic canonico: `ravi.inbound.reaction`;
+   - filtro somente sobre campos existentes: `data.emoji`, `data.senderId`, `data.targetMessageId`;
+   - prompt manda resolver `data.targetMessageId` no store local.
+4. Publicador
+   - se `targetMessageId` nao existe no store, responda `@@SILENT@@`;
+   - se ja foi processado, responda `@@SILENT@@`;
+   - se e valido, publica no canal final e marca processed.
+
+### Exemplo de cron shell
+
+```bash
+ravi cron add "approval-candidates" \
+  --cron "*/15 * * * *" \
+  --shell "python3 ./scripts/build_candidates.py" \
+  --timeout 10m \
+  --on-error notify-session:ops
+```
+
+O script deve salvar incrementalmente. Para rotinas que podem sobrepor execucoes, use lock file ou mecanismo equivalente.
+
+### Exemplo de trigger
+
+```bash
+ravi triggers add "approval reaction" \
+  --topic "ravi.inbound.reaction" \
+  --filter 'data.emoji includes "👍"' \
+  --message "Reaction {{data.emoji}} on {{data.targetMessageId}} from {{data.senderId}}. Load local approval state by targetMessageId. If no matching item exists or it was already processed, respond @@SILENT@@. If it is pending, publish it once and mark processed."
+```
+
+Nao filtre por `data.chatId` nesse topic: reaction events normalizados carregam `targetMessageId`, `emoji` e `senderId`. Se a rotina precisa restringir por chat, grave o chat no state associado ao `targetMessageId` quando enviar a previa.
+
+### State minimo
+
+```json
+{
+  "external_msg_123": {
+    "domainId": "item_123",
+    "reviewChatId": "chat_ops",
+    "destinationChatId": "chat_public",
+    "status": "pending",
+    "createdAt": "2026-05-24T12:00:00Z",
+    "processedAt": null
+  }
+}
+```
+
+### Checklist
+
+- O cron de sucesso nao chama agent.
+- O store sobrevive restart.
+- Cada previa enviada grava `targetMessageId -> domain state`.
+- O trigger usa `ravi.inbound.reaction`.
+- O filtro usa apenas campos do payload real.
+- O publicador e idempotente.
+- Falhas do cron notificam uma sessao; sucessos ficam silenciosos.
+- Dados sensiveis nao entram em prompt, logs ou docs.

--- a/src/plugins/internal/ravi-system/skills/events/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/events/SKILL.md
@@ -90,6 +90,7 @@ Para timeline completa de sessão, use `RAVI_EVENTS` junto de `MESSAGE`/`REACTIO
 
 > As mensagens inbound dos canais chegam via **omni JetStream** nos subjects `message.received.{channelType}.{instanceId}`, não via pub/sub ravi. O `OmniConsumer` consome esses streams e traduz para prompts de sessão.
 > Reações são normalizadas em `ravi.inbound.reaction`. Aliases como `whatsapp.*.reaction` não são publicados.
+> O payload de reaction e deliberadamente pequeno: use `targetMessageId` como chave de correlacao. Se uma rotina precisa recuperar chat, caption, produto, campanha ou outro estado de dominio, esse estado deve ter sido gravado pela rotina quando a mensagem-alvo foi enviada.
 
 ### Delivery (bot → gateway → omni)
 

--- a/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
@@ -249,6 +249,8 @@ ravi permissions init agent:dev safe-executables
 ravi permissions init agent:dev full-access
 ```
 
+`full-access` significa "permitido pelo Ravi". Ele não promete que hooks globais do provider, policies locais, RTK, Codex/Claude PreToolUse ou outras integrações externas vão permitir o comando final. Se `permissions check` retorna permitido mas a tool ainda falha, trate como fronteira de runtime/hook e investigue a mensagem de denial antes de adicionar mais grants.
+
 ## Comandos
 
 ### Listar permissões

--- a/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
@@ -199,6 +199,8 @@ ravi sessions execute <name> "tarefa"
 ravi sessions inform <name> "info"
 ```
 
+`sessions send` envia prompt/contexto para a sessão do agent; ele não publica texto visível diretamente em WhatsApp, Telegram, Matrix ou outro canal externo. Se o objetivo é falar com uma pessoa/canal, deixe a sessão responder normalmente ou use uma CLI explícita de canal/mídia/outbound apropriada.
+
 ### Session Trace
 
 Use `ravi sessions trace` quando precisar entender uma sessão real ponta a ponta:

--- a/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/triggers/SKILL.md
@@ -70,6 +70,8 @@ Use `ravi triggers topics` para ver templates built-in com schema de payload, ex
 
 Aliases como `whatsapp.*.reaction`, `whatsapp.*.inbound` e `matrix.*.inbound` não são templates built-in e recebem aviso do CLI. Eles ainda são aceitos como subjects custom; para reações Ravi normais, use `ravi.inbound.reaction`.
 
+**Importante para reactions:** `ravi.inbound.reaction` é um evento de correlação, não uma mensagem completa. O payload atual não garante `chatId`, caption, mídia ou estado de negócio. Se a automação precisa saber "qual item foi aprovado", grave antes um mapping durável `targetMessageId -> domain state` quando enviar a mensagem-alvo.
+
 ### Contatos e Aprovações
 
 | Pattern | Descrição |
@@ -113,7 +115,7 @@ Triggers suportam filtros opcionais que impedem o disparo quando o evento não c
 ravi triggers add "..." --filter 'data.cwd startsWith "/path/to/workspace"'
 ravi triggers set <id> filter 'data.cwd != "/path/to/ignored-workspace"'
 ravi triggers set <id> filter 'data.permission_mode == "bypassPermissions"'
-ravi triggers set <id> filter 'data.chatId == "120363424@g.us" && (data.emoji == "👍" || data.emoji == "👍🏻")'
+ravi triggers set <id> filter 'data.senderId == "5511999999999" && (data.emoji == "👍" || data.emoji == "👍🏻")'
 ```
 
 **Sintaxe:** `data.<path> <operador> "<valor>"`, com composicao opcional por `&&`, `||`, `!` e parenteses.
@@ -158,6 +160,16 @@ Criar trigger para monitorar erros:
 ```bash
 ravi triggers add "Permission Alert" --topic "ravi.audit.denied" --message "Analise o erro e sugira correção" --cooldown 1m
 ```
+
+Criar trigger para aprovação por reaction:
+```bash
+ravi triggers add "Approval Reaction" \
+  --topic "ravi.inbound.reaction" \
+  --filter 'data.emoji includes "👍"' \
+  --message "Reaction {{data.emoji}} on {{data.targetMessageId}}. Load local approval state by targetMessageId. If there is no pending item or it was already processed, respond @@SILENT@@. Otherwise publish once and mark processed."
+```
+
+Para receitas completas com cron, state local e publicação idempotente, use a skill `automation-recipes`.
 
 ## Relação com NATS
 


### PR DESCRIPTION
## Summary
- document `ravi.inbound.reaction` as a correlation event and update trigger examples to avoid non-existent reaction `chatId` assumptions
- add `automation-recipes` skill for cron + reaction approval + durable state patterns
- document REBAC vs provider hooks and clarify that `sessions send` is prompt/context injection, not direct external delivery

## Validation
- bun run build
- bin/ravi skills list --json | rg automation-recipes
- bin/ravi specs sync --json
- bunx markdownlint-cli2 docs/guides/triggers.mdx docs/guides/sessions.mdx docs/guides/permissions.mdx docs/features/overview.mdx docs/reference/nats-events.mdx src/plugins/internal/ravi-system/skills/agents/SKILL.md src/plugins/internal/ravi-system/skills/automation-recipes/SKILL.md src/plugins/internal/ravi-system/skills/events/SKILL.md src/plugins/internal/ravi-system/skills/permissions/SKILL.md src/plugins/internal/ravi-system/skills/sessions/SKILL.md src/plugins/internal/ravi-system/skills/triggers/SKILL.md
- git diff --check
- bun test src/triggers src/cli/commands/triggers.test.ts src/plugins/codex-skills.test.ts
- pre-push hook: sdk client check, build, typecheck, full test suite, sdk check

Closes #52
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->