### PR TITLE
fix(crm): add --pipeline flag to opportunity create for configurable pipeline support

### DIFF
--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -1257,6 +1257,7 @@ export class RaviClient {
         currency?: string;
         idempotencyKey?: string;
         owner?: string;
+        pipeline?: string;
         stage?: string;
         value?: string;
       }): Promise<CrmOpportunityCreateReturn> => {

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -2738,6 +2738,10 @@ export const CrmOpportunityCreateInputSchema = {
       "description": "Owner, e.g. agent:main",
       "type": "string"
     },
+    "pipeline": {
+      "description": "Pipeline ID or name (overrides default)",
+      "type": "string"
+    },
     "stage": {
       "description": "Pipeline stage key or ID",
       "type": "string"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -1147,6 +1147,7 @@ export type CrmOpportunityCreateInput = {
   currency?: string;
   idempotencyKey?: string;
   owner?: string;
+  pipeline?: string;
   stage?: string;
   title: string;
   value?: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:7b4e32b3cc40b554c4425c747932c2c0d4356fca88ee96cecc0531c069e6285e";
+export const REGISTRY_HASH = "sha256:eeaf75d7a1dc067b5cf2ae1af6528386d8c4ec4ba9fee52aa82ff847e3882ddd";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "217625846a59";
+export const GIT_SHA = "67335ee660c5";

--- a/src/cli/commands/crm.test.ts
+++ b/src/cli/commands/crm.test.ts
@@ -96,7 +96,17 @@ mock.module("../../contacts.js", () => ({
       : null,
   createCrmOpportunity: (input: Record<string, unknown>) => {
     lastOpportunityCreateInput = input;
-    return { id: "crm_opp_1", title: input.title, accountId: input.accountId ?? null };
+    if (input.pipelineRef === "archived-pipeline") throw new Error("CRM pipeline is archived: archived-pipeline");
+    if (input.pipelineRef === "ambiguous-pipeline")
+      throw new Error("Ambiguous pipeline name: ambiguous-pipeline — use pipeline ID to disambiguate");
+    if (input.pipelineRef === "sde-cobranca" && input.stageKey === "stage-other-pipeline")
+      throw new Error("Stage stage-other-pipeline does not belong to pipeline sde-cobranca");
+    return {
+      id: "crm_opp_1",
+      title: input.title,
+      accountId: input.accountId ?? null,
+      pipelineRef: input.pipelineRef ?? null,
+    };
   },
   moveCrmOpportunityStage: (input: Record<string, unknown>) => ({
     id: input.opportunityId,
@@ -407,5 +417,124 @@ describe("CRM commands", () => {
     expect(() => {
       new CrmContactCommands().show("missing-contact", true);
     }).toThrow(/Contact not found: missing-contact/);
+  });
+
+  // AC1: --pipeline without --stage uses pipeline's first stage
+  it("AC1: --pipeline sde-cobranca without --stage passes pipelineRef to service", () => {
+    silenceLogs(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        undefined,
+        "100000",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        "sde-cobranca",
+      );
+    });
+    expect(lastOpportunityCreateInput).toMatchObject({ pipelineRef: "sde-cobranca", stageKey: undefined });
+  });
+
+  // AC2: --pipeline + --stage both forwarded to service
+  it("AC2: --pipeline sde-cobranca --stage 1-a-contactar passes both to service", () => {
+    silenceLogs(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        "1-a-contactar",
+        "100000",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        "sde-cobranca",
+      );
+    });
+    expect(lastOpportunityCreateInput).toMatchObject({ pipelineRef: "sde-cobranca", stageKey: "1-a-contactar" });
+  });
+
+  // AC3: --stage without --pipeline preserves backward compat (no pipelineRef)
+  it("AC3: --stage without --pipeline sends no pipelineRef (backward compat)", () => {
+    silenceLogs(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        "1-a-contactar",
+        "100000",
+        undefined,
+        undefined,
+        true,
+      );
+    });
+    expect(lastOpportunityCreateInput).toMatchObject({ stageKey: "1-a-contactar" });
+    expect(lastOpportunityCreateInput?.pipelineRef).toBeUndefined();
+  });
+
+  // AC4: no --pipeline no --stage still works (backward compat)
+  it("AC4: no --pipeline no --stage creates on default pipeline (backward compat)", () => {
+    silenceLogs(() => {
+      new CrmOpportunityCommands().create("X", undefined, "contact-1", undefined, "100000", undefined, undefined, true);
+    });
+    expect(lastOpportunityCreateInput?.pipelineRef).toBeUndefined();
+    expect(lastOpportunityCreateInput?.stageKey).toBeUndefined();
+  });
+
+  // AC5: archived pipeline rejected by service
+  it("AC5: --pipeline archived-pipeline throws archived error", () => {
+    expect(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        undefined,
+        "100000",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        "archived-pipeline",
+      );
+    }).toThrow(/CRM pipeline is archived/);
+  });
+
+  // AC6: stage from wrong pipeline rejected by service
+  it("AC6: --pipeline sde-cobranca --stage from other pipeline throws mismatch error", () => {
+    expect(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        "stage-other-pipeline",
+        "100000",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        "sde-cobranca",
+      );
+    }).toThrow(/does not belong to pipeline/);
+  });
+
+  // AC7: ambiguous pipeline name rejected by service
+  it("AC7: --pipeline ambiguous-pipeline throws disambiguation error", () => {
+    expect(() => {
+      new CrmOpportunityCommands().create(
+        "X",
+        undefined,
+        "contact-1",
+        undefined,
+        "100000",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        "ambiguous-pipeline",
+      );
+    }).toThrow(/Ambiguous pipeline name/);
   });
 });

--- a/src/cli/commands/crm.ts
+++ b/src/cli/commands/crm.ts
@@ -468,11 +468,14 @@ export class CrmOpportunityCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
     @Option({ flags: "--idempotency-key <key>", description: "Deduplicate repeated opportunity creation" })
     idempotencyKey?: string,
+    @Option({ flags: "--pipeline <pipeline>", description: "Pipeline ID or name (overrides default)" })
+    pipeline?: string,
   ) {
     const opportunity = createCrmOpportunity({
       title,
       accountId,
       contactRef,
+      pipelineRef: pipeline,
       stageKey: stage,
       valueCents: parseOptionalNumber(value, "value") ?? undefined,
       currency,

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1685,6 +1685,7 @@ export interface CreateCrmOpportunityInput extends CrmMutationOptions {
   title: string;
   accountId?: string | null;
   contactRef?: string | null;
+  pipelineRef?: string | null;
   pipelineId?: string | null;
   stageId?: string | null;
   stageKey?: string | null;
@@ -4421,8 +4422,36 @@ function resolveCrmStage(database: Database, stageRef?: string | null, pipelineI
     : (database
         .prepare("SELECT * FROM crm_pipeline_stages WHERE pipeline_id = ? ORDER BY sort_order LIMIT 1")
         .get(resolvedPipelineId) as CrmPipelineStageRow | undefined);
-  if (!row) throw new Error(`CRM pipeline stage not found: ${ref ?? "default"}`);
+  if (!row) {
+    if (ref && pipelineId) {
+      const inOther = database
+        .prepare("SELECT pipeline_id FROM crm_pipeline_stages WHERE id = ? OR key = ? LIMIT 1")
+        .get(ref, ref) as { pipeline_id: string } | undefined;
+      if (inOther) throw new Error(`Stage ${ref} does not belong to pipeline ${pipelineId}`);
+    }
+    throw new Error(`CRM pipeline stage not found: ${ref ?? "default"}`);
+  }
   return rowToCrmPipelineStage(row);
+}
+
+function resolveCrmPipelineRef(database: Database, ref: string): string {
+  const trimmed = ref.trim();
+  const byId = database.prepare("SELECT id, status FROM crm_pipelines WHERE id = ?").get(trimmed) as
+    | { id: string; status: string }
+    | undefined;
+  if (byId) {
+    if (byId.status === "archived") throw new Error(`CRM pipeline is archived: ${trimmed}`);
+    return byId.id;
+  }
+  const byName = database.prepare("SELECT id, status FROM crm_pipelines WHERE name = ?").all(trimmed) as Array<{
+    id: string;
+    status: string;
+  }>;
+  if (byName.length === 0) throw new Error(`CRM pipeline not found: ${trimmed}`);
+  const active = byName.filter((p) => p.status !== "archived");
+  if (active.length === 0) throw new Error(`CRM pipeline is archived: ${trimmed}`);
+  if (active.length > 1) throw new Error(`Ambiguous pipeline name: ${trimmed} — use pipeline ID to disambiguate`);
+  return active[0].id;
 }
 
 function opportunityStatusForStage(stage: CrmPipelineStage, currentStatus: CrmOpportunityStatus): CrmOpportunityStatus {
@@ -4439,7 +4468,10 @@ export function createCrmOpportunity(input: CreateCrmOpportunityInput): CrmOppor
   const contactId = input.contactRef ? resolveRequiredCanonicalContactId(database, input.contactRef) : null;
   if (!accountId && !contactId) throw new Error("CRM opportunity requires an account or contact target");
   if (accountId) requireCrmAccount(database, accountId);
-  const stage = resolveCrmStage(database, input.stageId ?? input.stageKey, input.pipelineId);
+  const pipelineId = input.pipelineRef
+    ? resolveCrmPipelineRef(database, input.pipelineRef)
+    : (input.pipelineId ?? null);
+  const stage = resolveCrmStage(database, input.stageId ?? input.stageKey, pipelineId);
   const owner = normalizeOptionalCrmOwner({ ownerType: input.ownerType, ownerId: input.ownerId });
   const idempotencyKey = normalizeCrmIdempotencyKey(input.idempotencyKey);
   if (idempotencyKey) {


### PR DESCRIPTION
## Summary

- Adds `--pipeline <id-or-name>` flag to `ravi crm opportunity create`, enabling allocation of opportunities into a configurable (non-default) pipeline instead of leaving them orphaned on the default one
- Resolves the pipeline by ID or unique name, rejecting archived and ambiguous pipelines with structured errors
- Scopes stage lookup to the specified pipeline when `--pipeline` is present; backward compatible when the flag is absent

## Status — under rework after review

The reviewer found a HIGH issue that holds: `resolveCrmPipelineRef` does not constrain resolution to `entity_type = "opportunity"` pipelines (both the by-ID and by-name paths). Being redone on a branch based on `dev`, with real service-level tests (resolution by id/name, archived pipeline, ambiguous name, stage from another pipeline, divergent `entity_type`) and a `code-reviewer` pass before re-requesting review. See the review thread for the full plan.

## Acceptance criteria (target)

- AC1: `--pipeline <slug>` without `--stage` uses that pipeline's first stage
- AC2: `--pipeline <slug> --stage <stage>` passes both to the service
- AC3: `--stage` without `--pipeline` preserves backward compat (no pipelineRef)
- AC4: no flags creates on the default pipeline (backward compat)
- AC5: archived pipeline rejected with a structured error
- AC6: stage from a different pipeline rejected with a mismatch error
- AC7: ambiguous pipeline name rejected with a disambiguation error

## Test plan

- [x] `bun run typecheck` — zero errors
- [x] `bunx biome check src/` — zero new findings
- [ ] Service-level tests: id/name resolution, archived, ambiguous, cross-pipeline stage, divergent `entity_type` (rework)
- [ ] `code-reviewer` pass before re-requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
