### PR TITLE
[codex] refine WhatsApp overlay controls

### DIFF
--- a/extensions/whatsapp-overlay/content.js
+++ b/extensions/whatsapp-overlay/content.js
@@ -8,6 +8,10 @@ const VIEW_STATE_REPUBLISH_MS = 2500;
 const HUMAN_CHAT_NAV_INTENT_TTL_MS = 4000;
 const ROOT_ID = "ravi-wa-overlay-root";
 const DRAWER_ID = "ravi-wa-overlay-drawer";
+const PROFILE_BUTTON_ID = "ravi-wa-profile-toggle";
+const PROFILE_MENU_ID = "ravi-wa-profile-menu";
+const PANEL_TOGGLE_ID = "ravi-wa-panel-toggle";
+const PANEL_RAIL_TOGGLE_ID = "ravi-wa-panel-rail-toggle";
 const SESSION_MAIN_HOST_ID = "ravi-wa-session-main-host";
 const LAYOUT_CLASS = "ravi-wa-layout-active";
 const LAYOUT_HOST_CLASS = "ravi-wa-layout-host";
@@ -36,6 +40,7 @@ const CLIENT_ID_KEY = "ravi-wa-overlay-client-id";
 const ACTIVE_WORKSPACE_KEY_STORAGE = "ravi-wa-overlay-workspace";
 const WORKSPACE_SESSION_KEY_STORAGE = "ravi-wa-overlay-workspace-session";
 const OMNI_INSTANCE_KEY_STORAGE = "ravi-wa-overlay-instance";
+const OVERLAY_PANEL_VISIBLE_KEY_STORAGE = "ravi-wa-overlay-panel-visible";
 const V3_PLACEHOLDERS_KEY_STORAGE = "ravi-wa-overlay-v3-placeholders";
 const OMNI_POLL_INTERVAL_MS = 6000;
 const V3_PLACEHOLDER_POLL_INTERVAL_MS = 5000;
@@ -148,7 +153,9 @@ let chatSessionEditorDraftSessionName = null;
 let chatSessionEditorNotice = null;
 let chatSessionEditorInFlight = false;
 let preferredOmniInstance = loadPreferredOmniInstance();
-let v3PlaceholdersEnabled = loadV3PlaceholdersEnabled();
+let profileMenuOpen = false;
+let overlayPanelVisible = loadOverlayPanelVisible();
+let v3PlaceholdersEnabled = false;
 let selectedOmniChatId = null;
 let selectedOmniSessionKey = null;
 let selectedOmniRouteAgentId = null;
@@ -232,6 +239,8 @@ function boot() {
   document.addEventListener("keydown", handleHumanChatListKeydown, true);
   document.addEventListener("pointerdown", handleChatSessionEditorOutsidePointerDown, true);
   document.addEventListener("keydown", handleChatSessionEditorKeydown, true);
+  document.addEventListener("pointerdown", handleProfileMenuOutsidePointerDown, true);
+  document.addEventListener("keydown", handleProfileMenuKeydown, true);
   ensureShell();
   syncLayoutChrome();
   syncWorkspaceLauncher();
@@ -448,6 +457,8 @@ async function refreshOmniPanel(force = false) {
         shouldRenderSnapshot("workspace:omni", panel, force)
       ) {
         requestRender();
+      } else {
+        syncHeaderConfigControls();
       }
     } else {
       setBridgeErrorFromResponse(panel, "não consegui carregar o painel Omni");
@@ -461,6 +472,11 @@ async function refreshOmniPanel(force = false) {
 
 async function refreshV3Placeholders(force = false) {
   if (pollingStopped || v3PlaceholderInFlight) return;
+  if (!v3PlaceholdersEnabled) {
+    latestV3Placeholders = null;
+    scheduleV3PlaceholderRender();
+    return;
+  }
   if (!force && activeWorkspace !== "ravi") {
     latestV3Placeholders = null;
     scheduleV3PlaceholderRender();
@@ -676,6 +692,7 @@ function refreshAll() {
   refreshTasks(true);
   refreshArtifacts(true);
   refreshCrm(true);
+  refreshOmniPanel(true);
   refreshChatListOverlay();
   refreshMessageChips();
   refreshV3Placeholders();
@@ -3146,11 +3163,8 @@ function createMessageChip() {
   root.setAttribute(MESSAGE_CHIP_ATTR, "true");
   root.className = "ravi-wa-message-chip ravi-wa-message-chip--author";
   root.innerHTML = `
-    <button class="ravi-wa-message-chip__button" type="button">
+    <button class="ravi-wa-message-chip__button" type="button" aria-label="Detalhes Ravi da mensagem">
       <span class="ravi-wa-message-chip__dot ravi-wa-message-chip__dot--idle" data-role="dot"></span>
-      <span class="ravi-wa-message-chip__time" data-role="time-inline"></span>
-      <span class="ravi-wa-message-chip__separator" data-role="separator">•</span>
-      <span class="ravi-wa-message-chip__label">ravi</span>
     </button>
   `;
 
@@ -3179,10 +3193,7 @@ function updateMessageChip(root, message) {
   const session = latestSnapshot?.session;
   const live = session?.live;
   const activity = chipActivityClass(live?.activity);
-  const label = root.querySelector(".ravi-wa-message-chip__label");
   const dot = root.querySelector("[data-role='dot']");
-  const inlineTime = root.querySelector("[data-role='time-inline']");
-  const separator = root.querySelector("[data-role='separator']");
   const variant = message.chipVariant || "author";
   const open = openMessageId === message.id;
   const cacheKey =
@@ -3219,16 +3230,8 @@ function updateMessageChip(root, message) {
     copyState: preservedCopyState,
   };
 
-  if (label) label.textContent = "ravi";
   if (dot) {
     dot.className = `ravi-wa-message-chip__dot ravi-wa-message-chip__dot--${activity}`;
-  }
-  if (inlineTime) {
-    inlineTime.textContent = "";
-    inlineTime.hidden = true;
-  }
-  if (separator) {
-    separator.hidden = true;
   }
 
   if (open) {
@@ -3768,28 +3771,57 @@ function handlePageChatEvent(event) {
 
 function ensureShell() {
   const existingRoot = document.getElementById(ROOT_ID);
-  if (existingRoot?.querySelector?.(`#${DRAWER_ID}`)) return;
+  const shellReady =
+    existingRoot?.querySelector?.(`#${DRAWER_ID}`) &&
+    existingRoot?.querySelector?.(`#${PANEL_TOGGLE_ID}`) &&
+    existingRoot?.querySelector?.(`#${PANEL_RAIL_TOGGLE_ID}`) &&
+    existingRoot?.querySelector?.(`#${PROFILE_BUTTON_ID}`);
+  if (shellReady) return;
   existingRoot?.remove();
 
   const root = document.createElement("div");
   root.id = ROOT_ID;
   root.innerHTML = `
     <div id="${RECENT_STACK_ID}" class="ravi-hidden"></div>
+    <button
+      id="${PANEL_RAIL_TOGGLE_ID}"
+      class="ravi-wa-panel-rail-toggle"
+      type="button"
+      aria-label="Mostrar painel Ravi"
+      title="Mostrar painel Ravi"
+    >
+      R
+    </button>
     <aside id="${DRAWER_ID}">
       <div class="ravi-wa-drawer-header">
         <div class="ravi-wa-drawer-heading">
-          <strong id="ravi-wa-overlay-panel-title">Ravi</strong>
+          <strong id="ravi-wa-overlay-panel-title">Sessões</strong>
           <span id="ravi-wa-overlay-panel-subtitle">cockpit</span>
         </div>
-        <button
-          id="ravi-wa-v3-toggle"
-          class="ravi-wa-toggle${v3PlaceholdersEnabled ? " ravi-wa-toggle--active" : ""}"
-          type="button"
-          aria-pressed="${v3PlaceholdersEnabled ? "true" : "false"}"
-          title="ativar/desativar placeholders do mapa v3"
-        >
-          mapa v3
-        </button>
+        <div class="ravi-wa-drawer-actions">
+          <button
+            id="${PROFILE_BUTTON_ID}"
+            class="ravi-wa-profile-toggle"
+            type="button"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            title="selecionar profile do Ravi"
+          >
+            <span class="ravi-wa-profile-toggle__avatar" aria-hidden="true">R</span>
+            <span class="ravi-wa-profile-toggle__dot" aria-hidden="true"></span>
+          </button>
+          <button
+            id="${PANEL_TOGGLE_ID}"
+            class="ravi-wa-panel-toggle"
+            type="button"
+            aria-pressed="true"
+            aria-label="Ocultar painel Ravi"
+            title="Ocultar painel Ravi"
+          >
+            ×
+          </button>
+          <div id="${PROFILE_MENU_ID}" class="ravi-wa-profile-menu ravi-hidden" role="menu"></div>
+        </div>
       </div>
       <div id="ravi-wa-overlay-body"></div>
     </aside>
@@ -3815,13 +3847,230 @@ function ensureShell() {
     shellKeydownListenerAttached = true;
   }
 
-  const toggle = document.getElementById("ravi-wa-v3-toggle");
-  toggle?.addEventListener("click", () => {
-    v3PlaceholdersEnabled = !v3PlaceholdersEnabled;
-    persistV3PlaceholdersEnabled(v3PlaceholdersEnabled);
-    render();
-    scheduleV3PlaceholderRender();
+  document.getElementById(PANEL_TOGGLE_ID)?.addEventListener("click", () => {
+    setOverlayPanelVisible(false);
   });
+  document.getElementById(PANEL_RAIL_TOGGLE_ID)?.addEventListener("click", () => {
+    setOverlayPanelVisible(true);
+  });
+  const profileToggle = document.getElementById(PROFILE_BUTTON_ID);
+  profileToggle?.addEventListener("click", async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    profileMenuOpen = !profileMenuOpen;
+    syncHeaderConfigControls();
+    if (profileMenuOpen) {
+      await refreshOmniPanel(true);
+      syncHeaderConfigControls();
+    }
+  });
+  syncHeaderConfigControls();
+}
+
+function handleProfileMenuOutsidePointerDown(event) {
+  if (!profileMenuOpen) return;
+  const element = resolveEventElement(event.target);
+  if (!(element instanceof Element)) return;
+  if (element.closest(`#${PROFILE_MENU_ID}, #${PROFILE_BUTTON_ID}`)) return;
+  closeProfileMenu();
+}
+
+function handleProfileMenuKeydown(event) {
+  if (!profileMenuOpen || event.key !== "Escape") return;
+  closeProfileMenu();
+}
+
+function closeProfileMenu() {
+  profileMenuOpen = false;
+  syncHeaderConfigControls();
+}
+
+function syncHeaderConfigControls() {
+  syncOverlayPanelChrome();
+  syncHeaderProfileButton();
+  renderProfileMenu();
+}
+
+function syncOverlayPanelChrome() {
+  const root = document.getElementById(ROOT_ID);
+  const drawer = document.getElementById(DRAWER_ID);
+  const railToggle = document.getElementById(PANEL_RAIL_TOGGLE_ID);
+  const headerToggle = document.getElementById(PANEL_TOGGLE_ID);
+  root?.classList.toggle("ravi-wa-overlay-root--collapsed", !overlayPanelVisible);
+  root?.setAttribute("data-panel-visible", overlayPanelVisible ? "true" : "false");
+  drawer?.classList.toggle("ravi-hidden", !overlayPanelVisible);
+  railToggle?.classList.toggle("ravi-hidden", overlayPanelVisible);
+  if (headerToggle) {
+    headerToggle.setAttribute("aria-pressed", overlayPanelVisible ? "true" : "false");
+    headerToggle.textContent = "×";
+    headerToggle.title = "Ocultar painel Ravi";
+  }
+}
+
+function setOverlayPanelVisible(visible) {
+  overlayPanelVisible = Boolean(visible);
+  if (!overlayPanelVisible) {
+    profileMenuOpen = false;
+    closeMessagePopover();
+  }
+  persistOverlayPanelVisible(overlayPanelVisible);
+  syncOverlayPanelChrome();
+  syncLayoutChrome();
+}
+
+function syncHeaderProfileButton() {
+  const button = document.getElementById(PROFILE_BUTTON_ID);
+  if (!(button instanceof HTMLElement)) return;
+  const instance = getHeaderPreferredInstance();
+  const status = instance ? formatOmniInstanceStatus(instance) : "offline";
+  const label = instance?.profileName || instance?.name || "R";
+  button.setAttribute("aria-expanded", profileMenuOpen ? "true" : "false");
+  button.setAttribute("title", instance ? buildProfileInstanceTitle(instance) : "selecionar profile do Ravi");
+  button.classList.toggle("ravi-wa-profile-toggle--open", profileMenuOpen);
+  button.classList.toggle("ravi-wa-profile-toggle--connected", Boolean(instance?.isConnected));
+  button.classList.toggle("ravi-wa-profile-toggle--active", Boolean(instance?.isActive && !instance?.isConnected));
+  const avatar = button.querySelector(".ravi-wa-profile-toggle__avatar");
+  if (avatar) avatar.textContent = buildProfileAvatarText(label);
+  const dot = button.querySelector(".ravi-wa-profile-toggle__dot");
+  if (dot instanceof HTMLElement) {
+    dot.className = `ravi-wa-profile-toggle__dot ravi-wa-profile-toggle__dot--${status}`;
+  }
+}
+
+function renderProfileMenu() {
+  const menu = document.getElementById(PROFILE_MENU_ID);
+  if (!(menu instanceof HTMLElement)) return;
+  menu.classList.toggle("ravi-hidden", !profileMenuOpen);
+  if (!profileMenuOpen) {
+    menu.innerHTML = "";
+    return;
+  }
+
+  const instances = Array.isArray(latestOmniPanel?.instances)
+    ? latestOmniPanel.instances
+    : [];
+  const preferred = getHeaderPreferredInstance();
+  const rows = instances.length
+    ? instances.map((instance) => renderProfileInstanceRow(instance, preferred)).join("")
+    : `<p class="ravi-wa-profile-menu__empty">${escapeHtml(omniPanelInFlight ? "carregando profiles..." : "nenhuma instância configurada")}</p>`;
+
+  menu.innerHTML = `
+    <div class="ravi-wa-profile-menu__head">
+      <div>
+        <strong>profile</strong>
+        <span>${escapeHtml(preferred ? formatProfileInstanceSummary(preferred) : "sem profile selecionado")}</span>
+      </div>
+      <button type="button" data-ravi-profile-refresh title="Atualizar profiles">atualizar</button>
+    </div>
+    <div class="ravi-wa-profile-menu__rows">
+      ${rows}
+    </div>
+  `;
+
+  menu.querySelector("[data-ravi-profile-refresh]")?.addEventListener("click", async () => {
+    await refreshOmniPanel(true);
+    syncHeaderConfigControls();
+  });
+  menu.querySelectorAll("[data-ravi-profile-instance]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const instanceId = button.getAttribute("data-ravi-profile-instance");
+      if (!instanceId) return;
+      await selectPreferredProfileInstance(instanceId);
+    });
+  });
+}
+
+function renderProfileInstanceRow(instance, preferred) {
+  const id = instance?.id || instance?.name || instance?.instanceId;
+  if (!id) return "";
+  const selected = preferred && [preferred.id, preferred.name, preferred.instanceId].includes(id);
+  const status = formatOmniInstanceStatus(instance);
+  const title = buildProfileInstanceTitle(instance);
+  return `
+    <button
+      type="button"
+      class="ravi-wa-profile-row${selected ? " ravi-wa-profile-row--selected" : ""}"
+      data-ravi-profile-instance="${escapeAttribute(id)}"
+      aria-pressed="${selected ? "true" : "false"}"
+      title="${escapeAttribute(title)}"
+    >
+      <span class="ravi-wa-profile-row__dot ravi-wa-profile-row__dot--${escapeAttribute(status)}" aria-hidden="true"></span>
+      <span class="ravi-wa-profile-row__body">
+        <strong>${escapeHtml(shorten(instance.profileName || instance.name || id, 24))}</strong>
+        <small>${escapeHtml(formatProfileInstanceSummary(instance))}</small>
+      </span>
+      <span class="ravi-wa-profile-row__state">${escapeHtml(status)}</span>
+    </button>
+  `;
+}
+
+async function selectPreferredProfileInstance(instanceId) {
+  preferredOmniInstance = instanceId;
+  persistPreferredOmniInstance(instanceId);
+  selectedOmniChatId = null;
+  selectedOmniSessionKey = null;
+  selectedOmniRouteAgentId = null;
+  syncHeaderConfigControls();
+  await refreshOmniPanel(true);
+  if (activeWorkspace === "omni") {
+    render();
+  } else {
+    syncHeaderConfigControls();
+  }
+}
+
+function getHeaderPreferredInstance() {
+  const instances = Array.isArray(latestOmniPanel?.instances)
+    ? latestOmniPanel.instances
+    : [];
+  const panelPreferred = latestOmniPanel?.preferredInstance || null;
+  const stored = preferredOmniInstance;
+  return (
+    (panelPreferred && matchProfileInstance(panelPreferred, stored)
+      ? panelPreferred
+      : null) ||
+    instances.find((instance) => matchProfileInstance(instance, stored)) ||
+    panelPreferred ||
+    null
+  );
+}
+
+function matchProfileInstance(instance, value) {
+  if (!instance || !value) return false;
+  return [instance.id, instance.name, instance.instanceId].filter(Boolean).includes(value);
+}
+
+function buildProfileInstanceTitle(instance) {
+  if (!instance) return "";
+  return [
+    instance.profileName,
+    instance.name,
+    instance.phone || instance.ownerIdentifier,
+    instance.channel,
+    formatOmniInstanceStatus(instance),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function formatProfileInstanceSummary(instance) {
+  if (!instance) return "-";
+  return [
+    instance.name,
+    instance.phone || shorten(instance.ownerIdentifier || "", 18),
+    instance.channel,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function buildProfileAvatarText(value) {
+  const raw = String(value || "R").trim();
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  const initials = tokens.length > 1
+    ? `${tokens[0][0] || ""}${tokens[1][0] || ""}`
+    : raw.slice(0, 2);
+  return initials.toUpperCase();
 }
 
 function syncLayoutChrome() {
@@ -3856,19 +4105,23 @@ function syncLayoutChrome() {
   }
 
   root.classList.add(LAYOUT_CLASS);
+  root.classList.toggle("ravi-wa-overlay-root--collapsed", !overlayPanelVisible);
   host.classList.add(LAYOUT_HOST_CLASS);
   mainPane.classList.add(MAIN_PANE_CLASS);
   root.setAttribute("data-workspace", activeWorkspace);
-  host.setAttribute("data-ravi-workspace", activeWorkspace);
-  const fullWorkspace =
+  root.setAttribute("data-panel-visible", overlayPanelVisible ? "true" : "false");
+  host.setAttribute("data-ravi-workspace", overlayPanelVisible ? activeWorkspace : "ravi");
+  const fullWorkspace = overlayPanelVisible && (
     activeWorkspace === "omni" ||
     activeWorkspace === "crm" ||
     activeWorkspace === "tasks" ||
-    activeWorkspace === "insights";
+    activeWorkspace === "insights"
+  );
   mainPane.classList.toggle(MAIN_PANE_HIDDEN_CLASS, fullWorkspace);
   sideBranch?.classList.toggle(LAYOUT_BRANCH_HIDDEN_CLASS, fullWorkspace);
   mainBranch?.classList.toggle(LAYOUT_BRANCH_HIDDEN_CLASS, fullWorkspace);
-  drawer.classList.remove("ravi-hidden");
+  drawer.classList.toggle("ravi-hidden", !overlayPanelVisible);
+  document.getElementById(PANEL_RAIL_TOGGLE_ID)?.classList.toggle("ravi-hidden", overlayPanelVisible);
 
   currentLayoutHost = host;
   currentLayoutMain = mainPane;
@@ -4018,17 +4271,10 @@ function render(snapshot = latestSnapshot, context = detectChatContext()) {
     "ravi-wa-overlay-panel-subtitle",
   );
   const recentStack = document.getElementById(RECENT_STACK_ID);
-  const v3Toggle = document.getElementById("ravi-wa-v3-toggle");
   const preservedScrollState = captureWorkspaceScrollState("ravi");
   scheduleV3PlaceholderRender();
   if (!body || !panelTitle || !panelSubtitle || !recentStack) return;
-  if (v3Toggle) {
-    v3Toggle.setAttribute(
-      "aria-pressed",
-      v3PlaceholdersEnabled ? "true" : "false",
-    );
-    v3Toggle.classList.toggle("ravi-wa-toggle--active", v3PlaceholdersEnabled);
-  }
+  syncHeaderConfigControls();
 
   const session = snapshot?.session;
   const view = latestViewState;
@@ -4086,7 +4332,7 @@ function render(snapshot = latestSnapshot, context = detectChatContext()) {
     return;
   }
 
-  panelTitle.textContent = "Ravi";
+  panelTitle.textContent = "Sessões";
   panelSubtitle.textContent = title;
 
   const recentSessions = filterCockpitSessions(
@@ -4588,10 +4834,7 @@ function renderOmniWorkspace(body, context) {
     button.addEventListener("click", async () => {
       const instanceId = button.getAttribute("data-ravi-omni-instance");
       if (!instanceId) return;
-      preferredOmniInstance = instanceId;
-      persistPreferredOmniInstance(instanceId);
-      await refreshOmniPanel(true);
-      render();
+      await selectPreferredProfileInstance(instanceId);
     });
   });
 
@@ -4746,7 +4989,7 @@ function renderOmniWorkspace(body, context) {
               action: "create-session",
               actorSession: getCurrentOmniActorSession(),
               agentId: formState.selectedRouteAgentId,
-              sessionName: formState.draftSessionName || undefined,
+              session: formState.draftSessionName || undefined,
               title: formState.selectedChat.name,
               chatId:
                 formState.selectedChat.externalId ||
@@ -4812,9 +5055,9 @@ function renderOmniWorkspace(body, context) {
               payload: {
                 action: "migrate-session",
                 actorSession: getCurrentOmniActorSession(),
-                session: formState.currentLinkedSession.sessionName,
+                fromSession: formState.currentLinkedSession.sessionName,
                 agentId: formState.selectedRouteAgentId,
-                sessionName: formState.draftSessionName || undefined,
+                session: formState.draftSessionName || undefined,
                 title: formState.selectedChat.name,
                 chatId:
                   formState.selectedChat.externalId ||
@@ -4894,7 +5137,7 @@ function renderOmniWorkspace(body, context) {
                 actorSession: getCurrentOmniActorSession(),
                 createAgent: true,
                 agentId: nextAgentId,
-                sessionName: formState.draftNewAgentSessionName || undefined,
+                session: formState.draftNewAgentSessionName || undefined,
                 title: formState.selectedChat.name,
                 chatId:
                   formState.selectedChat.externalId ||
@@ -14791,6 +15034,14 @@ function loadPreferredOmniInstance() {
   }
 }
 
+function loadOverlayPanelVisible() {
+  try {
+    return window.localStorage.getItem(OVERLAY_PANEL_VISIBLE_KEY_STORAGE) !== "false";
+  } catch {
+    return true;
+  }
+}
+
 function loadV3PlaceholdersEnabled() {
   try {
     return window.localStorage.getItem(V3_PLACEHOLDERS_KEY_STORAGE) === "true";
@@ -14805,6 +15056,18 @@ function persistPreferredOmniInstance(value) {
       window.localStorage.setItem(OMNI_INSTANCE_KEY_STORAGE, value);
     } else {
       window.localStorage.removeItem(OMNI_INSTANCE_KEY_STORAGE);
+    }
+  } catch {
+    // ignore localStorage failures inside WhatsApp Web
+  }
+}
+
+function persistOverlayPanelVisible(value) {
+  try {
+    if (value) {
+      window.localStorage.removeItem(OVERLAY_PANEL_VISIBLE_KEY_STORAGE);
+    } else {
+      window.localStorage.setItem(OVERLAY_PANEL_VISIBLE_KEY_STORAGE, "false");
     }
   } catch {
     // ignore localStorage failures inside WhatsApp Web

--- a/extensions/whatsapp-overlay/lib/compositions.js
+++ b/extensions/whatsapp-overlay/lib/compositions.js
@@ -309,10 +309,11 @@ function buildDispatchState(item, actorSession, dispatchSessions) {
 }
 
 export async function buildOmniPanelSnapshot(client, query) {
-  const [sessionsResult, agentsResult, routesResult, allBindings] = await Promise.all([
+  const [sessionsResult, agentsResult, routesResult, instancesResult, allBindings] = await Promise.all([
     client.sessions.list({ live: true }).catch(() => ({ sessions: [] })),
     listAgents(client),
     client.routes.list().catch(() => ({ routes: [] })),
+    listInstances(client),
     getBindings(),
     ensureLiveStateStream().catch(() => false),
   ]);
@@ -320,6 +321,8 @@ export async function buildOmniPanelSnapshot(client, query) {
   const sessions = normalizeSessions(sessionsResult);
   const agents = mergeAgentsWithSessions(normalizeAgents(agentsResult), sessions);
   const routes = Array.isArray(routesResult?.routes) ? routesResult.routes : [];
+  const instances = normalizeInstances(instancesResult);
+  const preferredInstance = resolvePreferredInstance(instances, query?.instance);
   const binding = await findBinding({ chatId: query?.chatId, title: query?.title });
 
   return {
@@ -336,7 +339,8 @@ export async function buildOmniPanelSnapshot(client, query) {
     routes,
     sessions: sessions.map(toListEntry),
     agents,
-    instances: [],
+    instances,
+    preferredInstance,
   };
 }
 
@@ -344,7 +348,7 @@ export async function executeOmniRoute(client, body) {
   const action = clean(body?.action);
   if (!action) return { ok: false, error: "Missing action", code: "invalid_action" };
 
-  const session = clean(body?.session);
+  const session = clean(body?.session ?? body?.sessionName);
   const chatId = clean(body?.chatId);
   const title = clean(body?.title);
   const instance = clean(body?.instance);
@@ -373,6 +377,24 @@ export async function executeOmniRoute(client, body) {
       const binding = await upsertBinding({ session: sessionName, agentId, chatId, title, instance, chatType, chatName });
       const snapshot = toSessionSnapshot(createSyntheticBindingSession(binding), binding);
       return { ok: true, createdSession: true, binding, runtimeRoute, snapshot: { session: snapshot } };
+    }
+    case "migrate-session": {
+      if (!agentId || !chatId || !instance) {
+        return { ok: false, error: "agentId, chatId and instance required", code: "invalid_args" };
+      }
+      const sessionName = session || buildSyntheticSessionName(agentId, chatName || title || chatId);
+      const runtimeRoute = await upsertRuntimeChatRoute(client, { session: sessionName, agentId, chatId, instance, channel });
+      if (runtimeRoute?.ok === false) return runtimeRoute;
+      const binding = await upsertBinding({ session: sessionName, agentId, chatId, title, instance, chatType, chatName });
+      const snapshot = toSessionSnapshot(createSyntheticBindingSession(binding), binding);
+      return {
+        ok: true,
+        migratedSession: true,
+        fromSession: clean(body?.fromSession) ?? null,
+        binding,
+        runtimeRoute,
+        snapshot: { session: snapshot },
+      };
     }
     case "unbind": {
       if (!chatId && !title) return { ok: false, error: "chatId or title required", code: "invalid_args" };
@@ -538,6 +560,12 @@ function listAgents(client) {
     : Promise.resolve({ agents: [] });
 }
 
+function listInstances(client) {
+  return client?.instances?.list
+    ? client.instances.list({ asJson: true, limit: "100" }).catch(() => ({ instances: [] }))
+    : Promise.resolve({ instances: [] });
+}
+
 function normalizeAgents(result) {
   const list = Array.isArray(result?.agents)
     ? result.agents
@@ -575,6 +603,69 @@ function mergeAgentsWithSessions(agents, sessions) {
     byId.set(id, { id, name: id, displayName: id, inferred: true });
   }
   return [...byId.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function normalizeInstances(result) {
+  const list = Array.isArray(result?.instances)
+    ? result.instances
+    : Array.isArray(result?.items)
+      ? result.items
+      : Array.isArray(result)
+        ? result
+        : [];
+  return list
+    .map((instance) => {
+      if (!instance || typeof instance !== "object") return null;
+      const live = instance.live && typeof instance.live === "object" ? instance.live : {};
+      const name = clean(instance.name ?? instance.id);
+      const id = name ?? clean(instance.id ?? instance.instanceId);
+      if (!id) return null;
+      const profileName = clean(instance.profileName ?? live.profileName ?? instance.profile?.name);
+      const instanceId = clean(instance.instanceId);
+      const channel = clean(instance.channel) ?? "whatsapp";
+      const ownerIdentifier = clean(instance.ownerIdentifier ?? instanceId ?? instance.externalId);
+      const phone = clean(instance.phone ?? live.phone ?? instance.defaults?.phone);
+      const enabled = instance.enabled !== false && instance.raviStatus !== "disabled";
+      const isConnected = Boolean(instance.isConnected ?? live.isConnected);
+      const isActive = enabled && Boolean(instance.isActive ?? live.isActive ?? isConnected);
+      return {
+        ...instance,
+        id,
+        name: name ?? id,
+        instanceId,
+        channel,
+        profileName,
+        phone,
+        ownerIdentifier,
+        isConnected,
+        isActive,
+        raviStatus: instance.raviStatus ?? (enabled ? "enabled" : "disabled"),
+        updatedAt: instance.updatedAt ?? live.updatedAt ?? null,
+        lastSeenAt: instance.lastSeenAt ?? live.lastSeenAt ?? null,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      if (left.isConnected !== right.isConnected) return left.isConnected ? -1 : 1;
+      if (left.isActive !== right.isActive) return left.isActive ? -1 : 1;
+      return left.name.localeCompare(right.name);
+    });
+}
+
+function resolvePreferredInstance(instances, requested) {
+  const preferred = clean(requested);
+  if (preferred) {
+    const exact = instances.find((instance) =>
+      [instance.id, instance.name, instance.instanceId].filter(Boolean).includes(preferred),
+    );
+    if (exact) return exact;
+  }
+  return (
+    instances.find((instance) => instance.isConnected) ??
+    instances.find((instance) => instance.isActive) ??
+    instances[0] ??
+    null
+  );
 }
 
 function normalizeTasks(result) {

--- a/extensions/whatsapp-overlay/styles.css
+++ b/extensions/whatsapp-overlay/styles.css
@@ -52,6 +52,13 @@
     sans-serif;
 }
 
+#ravi-wa-overlay-root.ravi-wa-overlay-root--collapsed {
+  width: 0;
+  min-width: 0;
+  max-width: 0;
+  flex: 0 0 0;
+}
+
 #ravi-wa-overlay-root[data-workspace="omni"],
 #ravi-wa-overlay-root[data-workspace="crm"],
 #ravi-wa-overlay-root[data-workspace="insights"],
@@ -61,6 +68,16 @@
   min-height: 0;
   max-width: none;
   flex: 1 1 auto;
+}
+
+#ravi-wa-overlay-root.ravi-wa-overlay-root--collapsed[data-workspace="omni"],
+#ravi-wa-overlay-root.ravi-wa-overlay-root--collapsed[data-workspace="crm"],
+#ravi-wa-overlay-root.ravi-wa-overlay-root--collapsed[data-workspace="insights"],
+#ravi-wa-overlay-root.ravi-wa-overlay-root--collapsed[data-workspace="tasks"] {
+  width: 0;
+  min-width: 0;
+  max-width: 0;
+  flex: 0 0 0;
 }
 
 .ravi-wa-main-pane-hidden {
@@ -512,38 +529,256 @@
   gap: 2px;
 }
 
-.ravi-wa-toggle {
+.ravi-wa-drawer-actions {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.ravi-wa-profile-toggle {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 74px;
+  width: 30px;
   height: 30px;
-  padding: 0 12px;
+  padding: 0 !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  border-radius: 50% !important;
+  background: linear-gradient(135deg, rgba(37, 211, 102, 0.18), rgba(96, 165, 250, 0.12)) !important;
+  color: #aebac1 !important;
+  font-size: 11px !important;
+  font-weight: 650;
+  line-height: 1;
+  text-transform: lowercase;
+}
+
+.ravi-wa-profile-toggle:hover,
+.ravi-wa-profile-toggle--open {
+  background: rgba(255, 255, 255, 0.075) !important;
+  color: #e9edef !important;
+}
+
+.ravi-wa-profile-toggle--connected {
+  border-color: rgba(37, 211, 102, 0.28) !important;
+}
+
+.ravi-wa-profile-toggle--active {
+  border-color: rgba(250, 204, 21, 0.28) !important;
+}
+
+.ravi-wa-profile-toggle__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: #e9edef;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.ravi-wa-profile-toggle__dot {
+  position: absolute;
+  right: 0;
+  bottom: 1px;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border: 2px solid #111b21;
+  border-radius: 50%;
+  background: #667781;
+}
+
+.ravi-wa-profile-row__dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #667781;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.04);
+}
+
+.ravi-wa-profile-toggle__dot--connected,
+.ravi-wa-profile-row__dot--connected {
+  background: #25d366;
+}
+
+.ravi-wa-profile-toggle__dot--active,
+.ravi-wa-profile-row__dot--active {
+  background: #facc15;
+}
+
+.ravi-wa-panel-toggle,
+.ravi-wa-panel-rail-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0 !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  border-radius: 50% !important;
+  background: rgba(255, 255, 255, 0.04) !important;
+  color: #aebac1 !important;
+  font-size: 18px !important;
+  line-height: 1;
+}
+
+.ravi-wa-panel-toggle:hover,
+.ravi-wa-panel-rail-toggle:hover {
+  background: rgba(37, 211, 102, 0.12) !important;
+  color: #d8fdd2 !important;
+}
+
+.ravi-wa-panel-rail-toggle {
+  position: fixed;
+  top: 72px;
+  right: 14px;
+  z-index: 2147482100;
+  width: 28px;
+  height: 28px;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+  background: rgba(17, 27, 33, 0.72) !important;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(12px);
+  opacity: 0.82;
+  pointer-events: auto;
+  font-size: 11px !important;
+  font-weight: 800;
+}
+
+.ravi-wa-panel-rail-toggle:hover {
+  opacity: 1;
+}
+
+.ravi-wa-profile-menu {
+  position: absolute;
+  top: 38px;
+  right: 0;
+  z-index: 2147482100;
+  width: min(292px, calc(100vw - 24px));
+  padding: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: rgba(17, 27, 33, 0.98);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.36);
+  backdrop-filter: blur(18px);
+}
+
+.ravi-wa-profile-menu__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 2px 8px;
+}
+
+.ravi-wa-profile-menu__head div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ravi-wa-profile-menu__head strong {
+  color: #e9edef;
+  font-size: 12px;
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+
+.ravi-wa-profile-menu__head span,
+.ravi-wa-profile-menu__empty {
+  color: #8696a0;
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.ravi-wa-profile-menu__head button {
+  padding: 4px 7px !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   border-radius: 999px !important;
   background: rgba(255, 255, 255, 0.04) !important;
-  color: #8696a0 !important;
-  font-size: 11px !important;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  text-transform: lowercase;
-  transition:
-    background 140ms ease,
-    color 140ms ease,
-    border-color 140ms ease,
-    transform 140ms ease;
+  color: #aebac1 !important;
+  font-size: 10px !important;
+  line-height: 1;
 }
 
-.ravi-wa-toggle:hover {
-  background: rgba(255, 255, 255, 0.07) !important;
+.ravi-wa-profile-menu__rows {
+  display: flex;
+  max-height: 232px;
+  flex-direction: column;
+  gap: 5px;
+  overflow-y: auto;
+}
+
+.ravi-wa-profile-row {
+  display: grid;
+  grid-template-columns: 9px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 42px;
+  padding: 7px 8px !important;
+  border: 1px solid rgba(255, 255, 255, 0.055) !important;
+  border-radius: 10px !important;
+  background: rgba(255, 255, 255, 0.025) !important;
   color: #d1d7db !important;
-  transform: translateY(-1px);
+  text-align: left;
 }
 
-.ravi-wa-toggle--active {
-  background: rgba(37, 211, 102, 0.12) !important;
-  border-color: rgba(37, 211, 102, 0.24) !important;
-  color: #d8fdd2 !important;
+.ravi-wa-profile-row:hover,
+.ravi-wa-profile-row--selected {
+  border-color: rgba(37, 211, 102, 0.22) !important;
+  background: rgba(37, 211, 102, 0.08) !important;
+}
+
+.ravi-wa-profile-row__body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ravi-wa-profile-row__body strong {
+  overflow: hidden;
+  color: #f0f2f5;
+  font-size: 11px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ravi-wa-profile-row__body small {
+  overflow: hidden;
+  color: #8696a0;
+  font-size: 10px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ravi-wa-profile-row__state {
+  color: #aebac1;
+  font-size: 9px;
+  text-transform: lowercase;
+}
+
+.ravi-wa-profile-menu__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+  padding: 8px 2px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: #aebac1;
+  font-size: 10px;
+  text-transform: lowercase;
 }
 
 .ravi-wa-drawer-header button {
@@ -6783,44 +7018,40 @@ button.ravi-wa-task-gate-card:hover {
   position: relative;
   display: inline-flex;
   align-items: center;
-  margin-left: 6px;
+  margin-left: 4px;
   vertical-align: middle;
 }
 
 .ravi-wa-message-chip__button {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  height: 18px;
-  padding: 0 7px;
-  border: 1px solid rgba(134, 150, 160, 0.14);
-  border-radius: 999px;
-  background: rgba(17, 27, 33, 0.06);
+  justify-content: center;
+  width: 18px;
+  height: 12px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: #8696a0;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 0;
+  font-weight: 400;
   line-height: 1;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
   cursor: pointer;
   transition:
-    background 140ms ease,
-    border-color 140ms ease,
-    color 140ms ease,
     transform 140ms ease;
 }
 
 .ravi-wa-message-chip__button:hover {
-  background: rgba(17, 27, 33, 0.1);
-  border-color: rgba(134, 150, 160, 0.22);
-  color: #d1d7db;
   transform: translateY(-1px);
 }
 
 .ravi-wa-message-chip__dot {
+  display: block;
   width: 6px;
   height: 6px;
-  border-radius: 999px;
   flex-shrink: 0;
+  border-radius: 50%;
   background: #94a3b8;
   box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.1);
 }
@@ -6853,15 +7084,6 @@ button.ravi-wa-task-gate-card:hover {
 .ravi-wa-message-chip__dot--blocked {
   background: #f87171;
   box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.12);
-}
-
-.ravi-wa-message-chip__label {
-  text-transform: lowercase;
-}
-
-.ravi-wa-message-chip__time,
-.ravi-wa-message-chip__separator {
-  display: none;
 }
 
 #ravi-wa-message-popover {
@@ -7007,69 +7229,21 @@ button.ravi-wa-task-gate-card:hover {
   word-break: break-word;
 }
 
-.ravi-wa-message-chip--idle .ravi-wa-message-chip__button {
-  border-color: rgba(148, 163, 184, 0.16);
-}
-
-.ravi-wa-message-chip--thinking .ravi-wa-message-chip__button {
-  border-color: rgba(96, 165, 250, 0.16);
-  color: #93c5fd;
-}
-
-.ravi-wa-message-chip--streaming .ravi-wa-message-chip__button {
-  border-color: rgba(74, 222, 128, 0.18);
-  color: #86efac;
-}
-
-.ravi-wa-message-chip--approval .ravi-wa-message-chip__button {
-  border-color: rgba(250, 204, 21, 0.18);
-  color: #fcd34d;
-}
-
-.ravi-wa-message-chip--compacting .ravi-wa-message-chip__button {
-  border-color: rgba(196, 181, 253, 0.18);
-  color: #c4b5fd;
-}
-
-.ravi-wa-message-chip--blocked .ravi-wa-message-chip__button {
-  border-color: rgba(252, 165, 165, 0.18);
-  color: #fca5a5;
-}
-
 .ravi-wa-message-chip--timestamp {
-  margin-left: 4px;
+  margin-left: 3px;
 }
 
 .ravi-wa-message-chip--timestamp .ravi-wa-message-chip__button {
-  gap: 4px;
-  height: auto;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  color: #8696a0;
-  font-size: 11px;
-  font-weight: 500;
-  box-shadow: none;
+  width: 16px;
 }
 
 .ravi-wa-message-chip--timestamp .ravi-wa-message-chip__button:hover {
-  background: transparent;
-  border-color: transparent;
-  color: #d1d7db;
   transform: none;
 }
 
-.ravi-wa-message-chip--timestamp .ravi-wa-message-chip__separator {
-  display: inline;
-}
-
-.ravi-wa-message-chip--timestamp .ravi-wa-message-chip__separator {
-  color: #8696a0;
-}
-
-.ravi-wa-message-chip--timestamp .ravi-wa-message-chip__label {
-  color: inherit;
+.ravi-wa-message-chip--timestamp .ravi-wa-message-chip__dot {
+  width: 5px;
+  height: 5px;
 }
 
 .ravi-wa-message-popover--thinking {

--- a/src/whatsapp-overlay/extension-compositions.test.js
+++ b/src/whatsapp-overlay/extension-compositions.test.js
@@ -41,9 +41,14 @@ function installChromeStorageMock() {
 
 const chromeStorage = installChromeStorageMock();
 
-const { buildCrmSnapshot, buildSnapshot, buildTasksSnapshot, executeOmniRoute, resolveChatList } = await import(
-  "../../extensions/whatsapp-overlay/lib/compositions.js"
-);
+const {
+  buildCrmSnapshot,
+  buildOmniPanelSnapshot,
+  buildSnapshot,
+  buildTasksSnapshot,
+  executeOmniRoute,
+  resolveChatList,
+} = await import("../../extensions/whatsapp-overlay/lib/compositions.js");
 const { setBindings } = await import("../../extensions/whatsapp-overlay/lib/storage.js");
 const { RaviClient: ExtensionRaviClient } = await import("../../extensions/whatsapp-overlay/lib/sdk/client.js");
 
@@ -308,6 +313,177 @@ describe("whatsapp overlay extension compositions", () => {
       "new-session",
       { allowRuntimeMismatch: true, asJson: true },
     ]);
+  });
+
+  it("honors the editable session name when creating a route-backed session", async () => {
+    const calls = [];
+    const client = {
+      instances: {
+        routes: {
+          show: async (name, pattern) => {
+            calls.push(["show", name, pattern]);
+            throw new Error("not found");
+          },
+          add: async (name, pattern, agent, options) => {
+            calls.push(["add", name, pattern, agent, options]);
+            return { route: { accountId: name, pattern, agent, session: options.session } };
+          },
+        },
+      },
+    };
+
+    const result = await executeOmniRoute(client, {
+      action: "create-session",
+      sessionName: "custom-session",
+      agentId: "dev",
+      chatId: "120363410237809091@g.us",
+      title: "ravi - extension",
+      instance: "main",
+      channel: "whatsapp",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      createdSession: true,
+      binding: {
+        session: "custom-session",
+        agentId: "dev",
+      },
+      snapshot: {
+        session: {
+          sessionName: "custom-session",
+          agentId: "dev",
+        },
+      },
+    });
+    expect(calls[1]).toEqual([
+      "add",
+      "main",
+      "group:120363410237809091",
+      "dev",
+      {
+        allowRuntimeMismatch: true,
+        asJson: true,
+        session: "custom-session",
+        priority: "100",
+        channel: "whatsapp",
+      },
+    ]);
+  });
+
+  it("supports migrating a chat route to a new agent session", async () => {
+    const calls = [];
+    let route = {
+      accountId: "main",
+      pattern: "group:120363410237809091",
+      agent: "dev",
+      session: "old-session",
+      priority: 100,
+      channel: "whatsapp",
+    };
+    const client = {
+      instances: {
+        routes: {
+          show: async (name, pattern) => {
+            calls.push(["show", name, pattern]);
+            return { route };
+          },
+          set: async (name, pattern, key, value, options) => {
+            calls.push(["set", name, pattern, key, value, options]);
+            route = { ...route, [key]: key === "priority" ? Number(value) : value };
+            return { route };
+          },
+        },
+      },
+    };
+
+    const result = await executeOmniRoute(client, {
+      action: "migrate-session",
+      fromSession: "old-session",
+      session: "support-session",
+      agentId: "support",
+      chatId: "120363410237809091@g.us",
+      title: "ravi - extension",
+      instance: "main",
+      channel: "whatsapp",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      migratedSession: true,
+      fromSession: "old-session",
+      binding: {
+        session: "support-session",
+        agentId: "support",
+      },
+      runtimeRoute: {
+        ok: true,
+        action: "updated",
+        route: {
+          agent: "support",
+          session: "support-session",
+        },
+      },
+    });
+    expect(calls).toContainEqual([
+      "set",
+      "main",
+      "group:120363410237809091",
+      "agent",
+      "support",
+      { allowRuntimeMismatch: true, asJson: true },
+    ]);
+  });
+
+  it("loads configured Ravi instances for the overlay profile selector", async () => {
+    const client = {
+      sessions: {
+        list: async () => ({ sessions: [] }),
+      },
+      agents: {
+        list: async () => ({ agents: [] }),
+      },
+      routes: {
+        list: async () => ({ routes: [] }),
+      },
+      instances: {
+        list: async (options) => ({
+          options,
+          instances: [
+            {
+              name: "main",
+              instanceId: "wa-main",
+              channel: "whatsapp",
+              enabled: true,
+              live: { isConnected: true, profileName: "Luis" },
+            },
+            {
+              name: "ops",
+              instanceId: "wa-ops",
+              channel: "whatsapp",
+              enabled: true,
+              live: { isConnected: false, profileName: "Ops" },
+            },
+          ],
+        }),
+      },
+    };
+
+    const snapshot = await buildOmniPanelSnapshot(client, { instance: "ops" });
+
+    expect(snapshot.instances.map((instance) => instance.id)).toEqual(["main", "ops"]);
+    expect(snapshot.instances[0]).toMatchObject({
+      id: "main",
+      name: "main",
+      instanceId: "wa-main",
+      profileName: "Luis",
+      isConnected: true,
+      isActive: true,
+    });
+    expect(snapshot.preferredInstance).toMatchObject({
+      id: "ops",
+      profileName: "Ops",
+    });
   });
 
   it("loads all visible tasks for the workspace and reports status counts", async () => {


### PR DESCRIPTION
## Summary
- Adds a compact avatar-only profile selector backed by Ravi instances.
- Makes the WhatsApp overlay panel hide/show with a floating discreet R button when collapsed.
- Restores message markers to dot-only chips and removes the redundant mapa v3/timestamp label UI.
- Makes chat/session routing persist to runtime routes, including editable session names and migrate-session support.

## Validation
- node --check extensions/whatsapp-overlay/content.js && node --check extensions/whatsapp-overlay/lib/compositions.js
- bun test src/whatsapp-overlay/extension-compositions.test.js src/whatsapp-overlay/extension-live-state.test.js (16 pass)
- bun run build
- git push pre-push hook passed: SDK drift check, build, typecheck, full repo tests, SDK tests