### PR TITLE
fix(ephemeral): task-aware session reaper + post-restart audit (Issue #71)

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -102,15 +102,22 @@ export class RaviBot {
     try {
       const { recoverActiveTasksAfterRestart } = await import("./tasks/service.js");
       const recovery = await recoverActiveTasksAfterRestart();
-      if (recovery.recoveredTaskIds.length === 0 && recovery.skipped.length === 0) {
-        return;
+      if (recovery.recoveredTaskIds.length > 0 || recovery.skipped.length > 0) {
+        log.info("Recovered active tasks after restart", {
+          recovered: recovery.recoveredTaskIds,
+          skipped: recovery.skipped,
+        });
       }
-      log.info("Recovered active tasks after restart", {
-        recovered: recovery.recoveredTaskIds,
-        skipped: recovery.skipped,
-      });
     } catch (error) {
       log.error("Failed to recover active tasks after restart", { error });
+    }
+    // Post-restart audit: abort sessions whose tasks completed during the NATS reconnection
+    // window (~0-5min after restart). Delayed to let re-resumed sessions enter the pool first.
+    await new Promise<void>((resolve) => setTimeout(resolve, 30_000));
+    try {
+      await this.sessionDispatcher.auditTaskSessionsPostRestart();
+    } catch (error) {
+      log.error("Post-restart task session audit failed", { error });
     }
   }
 

--- a/src/ephemeral/runner.ts
+++ b/src/ephemeral/runner.ts
@@ -10,8 +10,10 @@ import { nats } from "../nats.js";
 import { publishSessionPrompt } from "../omni/session-stream.js";
 import { logger } from "../utils/logger.js";
 import { getExpiringSessions, getExpiredSessions } from "../router/sessions.js";
-import { dbCleanupMessageMeta, dbCleanupExpiredSessions, dbPruneStaleRows } from "../router/router-db.js";
+import { dbCleanupMessageMeta, dbCleanupExpiredSessions, dbPruneStaleRows, getDb } from "../router/router-db.js";
 import { rollupDailyMetrics } from "../metrics/rollup.js";
+import { isTaskSessionName } from "../runtime/session-pool.js";
+import { dbHasActiveTaskForSession } from "../tasks/task-db.js";
 
 const log = logger.child("ephemeral");
 
@@ -96,6 +98,38 @@ Sem ação = sessão será excluída automaticamente.`;
     const cleaned = dbCleanupMessageMeta();
     if (cleaned > 0) {
       log.info("Cleaned up old message metadata", { count: cleaned });
+    }
+
+    // 4. Reap orphaned task sessions: pool zombies whose tasks are terminal.
+    // Covers NATS-miss window after daemon restart (RC1/RC2 from Issue #71).
+    try {
+      const db = getDb();
+      const sessionRows = db.prepare("SELECT name FROM sessions WHERE ephemeral = 1 AND name IS NOT NULL").all() as {
+        name: string;
+      }[];
+      const orphanedSlots: string[] = [];
+      for (const { name: sessionName } of sessionRows) {
+        if (!isTaskSessionName(sessionName)) continue;
+        if (!dbHasActiveTaskForSession(sessionName, undefined)) {
+          orphanedSlots.push(sessionName);
+        }
+      }
+      for (const sessionName of orphanedSlots) {
+        await nats.emit("ravi.session.abort", {
+          sessionKey: sessionName,
+          sessionName,
+          source: "ephemeral-runner",
+          action: "orphan-reap",
+          reason: "task_terminal_no_active_task",
+          actor: "system",
+        });
+        log.info("Reaped orphaned task session", { sessionName });
+      }
+      if (orphanedSlots.length > 0) {
+        log.info("Task session orphan reap complete", { count: orphanedSlots.length });
+      }
+    } catch (err) {
+      log.error("Task session orphan reap failed", err);
     }
   } catch (err) {
     log.error("Ephemeral cleanup tick failed", err);

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -37,6 +37,7 @@ import { resolveRuntimeForPrompt, runtimePromptRequiresRestart } from "./task-ru
 import {
   buildRuntimeSessionPoolSnapshot,
   classifyRuntimeSessionStartLane,
+  isTaskSessionName,
   resolveRuntimeStreamingSession,
   type RuntimeSessionPoolSnapshot,
   type RuntimeStreamingSessionIdentity,
@@ -1361,6 +1362,30 @@ export class RuntimeSessionDispatcher {
       });
 
     return "accepted";
+  }
+
+  /** Post-restart audit: abort pool slots whose tasks completed during the NATS reconnection
+   * window after daemon restart. Call once ~30s after startup to catch zombies (Issue #71 RC2). */
+  async auditTaskSessionsPostRestart(): Promise<void> {
+    const orphaned: string[] = [];
+    for (const [sessionName] of this.streamingSessions) {
+      if (!isTaskSessionName(sessionName)) continue;
+      if (!dbHasActiveTaskForSession(sessionName, undefined)) {
+        orphaned.push(sessionName);
+      }
+    }
+    log.info("Post-restart task session audit", {
+      checked: this.streamingSessions.size,
+      zombies: orphaned.length,
+    });
+    for (const sessionName of orphaned) {
+      this.abortSession(sessionName, {
+        source: "session-dispatcher",
+        action: "post-restart-audit",
+        reason: "task_terminal_no_active_task",
+        actor: "system",
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #71 — ephemeral session pool leak (zombies remaining for up to 24h instead of being released when their tasks terminate).

Two complementary fixes:

- **Fix 1 — `src/ephemeral/runner.ts`:** task-aware reaper added to the existing `tick()` (60s interval). Each cycle queries the DB for ephemeral sessions whose name matches `task-*-work` and whose task is no longer in `dispatched|in_progress|blocked`, then emits `ravi.session.abort` for each zombie. Covers the steady-state leak path (RC1).

- **Fix 2 — `src/runtime/session-dispatcher.ts` + `src/bot.ts`:** new `auditTaskSessionsPostRestart()` method, invoked 30s after daemon boot (delayed so re-resumed sessions enter the pool first). Iterates `streamingSessions`, checks `dbHasActiveTaskForSession`, calls `abortSession` on zombies. Covers the post-restart NATS-reconnection window where `task.done` events can be lost (RC2).

## Status — under rework after review. Do not merge as-is.

The reviewer raised two HIGH issues that hold:

- **Reaper not idempotent** — it emits `ravi.session.abort` but does not expire the orphan session row, so it re-aborts on every 60s tick. Fix: expire/mark the row after reaping so cleanup is idempotent.
- **`blocked` treated as active** — `dbHasActiveTaskForSession` includes `blocked`, but the cleanup path (and Issue #71) treat `blocked` as terminal for cleanup. Fix: a cleanup/audit predicate that excludes `blocked`, with a regression test for a `blocked` task whose `task.done` was lost by NATS.

Plus: guard the post-restart audit with `this.running` / a cancelable timer, retarget base `main` → `dev`, and add coverage for the one-shot reap + post-restart audit. Being redone on a branch based on `dev`, with tests, through `code-reviewer` before re-requesting review.

## Files

- `src/ephemeral/runner.ts`
- `src/runtime/session-dispatcher.ts`
- `src/bot.ts`

## Test plan

- [x] `bun test src/runtime/session-dispatcher.test.ts`
- [x] `bun run build` — clean
- [ ] Regression: idempotent one-shot reap (row expired after abort)
- [ ] Regression: `blocked` task not reaped by cleanup/audit
- [ ] `code-reviewer` pass before re-requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
