### PR TITLE
fix(permissions): full-access template covers all 11 REBAC object types (was only 2)

### DIFF
--- a/src/cli/commands/permissions.ts
+++ b/src/cli/commands/permissions.ts
@@ -333,9 +333,46 @@ export class PermissionsCommands {
         return count;
       },
       "full-access": () => {
-        grantRelation(subjectType, subjectId, "use", "tool", "*", "manual");
-        grantRelation(subjectType, subjectId, "execute", "executable", "*", "manual");
-        return 2;
+        // Wildcards across every (relation, objectType) pair the REBAC engine recognises.
+        // Covers SDK tools, system executables, tool groups, AND the in-process REBAC types
+        // used by command/scope checks (agent, contact, cron, group, session, system, team,
+        // toolgroup, trigger). Prior versions of this template only granted use:tool:* and
+        // execute:executable:*, which left agents unable to operate against the runtime even
+        // though the template name promised "full". Pairs listed here mirror what
+        // `ravi permissions list` shows in production.
+        const wildcards: Array<[string, string]> = [
+          ["use", "tool"],
+          ["execute", "executable"],
+          ["use", "toolgroup"],
+          ["access", "toolgroup"],
+          ["admin", "toolgroup"],
+          ["access", "agent"],
+          ["admin", "agent"],
+          ["access", "contact"],
+          ["admin", "contact"],
+          ["write_contacts", "contact"],
+          ["access", "cron"],
+          ["admin", "cron"],
+          ["access", "group"],
+          ["admin", "group"],
+          ["execute", "group"],
+          ["access", "session"],
+          ["modify", "session"],
+          ["use", "session"],
+          ["access", "system"],
+          ["admin", "system"],
+          ["read_own_contacts", "system"],
+          ["read_tagged_contacts", "system"],
+          ["write_contacts", "system"],
+          ["access", "team"],
+          ["admin", "team"],
+          ["access", "trigger"],
+          ["admin", "trigger"],
+        ];
+        for (const [relation, objectType] of wildcards) {
+          grantRelation(subjectType, subjectId, relation, objectType, "*", "manual");
+        }
+        return wildcards.length;
       },
       "tool-groups": () => {
         let count = 0;

--- a/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
@@ -245,9 +245,14 @@ ravi permissions init agent:dev tool-groups
 # Executáveis seguros (git, node, bun, ravi, etc.)
 ravi permissions init agent:dev safe-executables
 
-# Tudo: todas tools + todos executáveis
+# Cobertura completa: wildcards em TODOS os object types reconhecidos pelo engine
+# (tool, executable, toolgroup, agent, contact, cron, group, session, system, team, trigger).
+# Use quando o agent precisa operar livremente em todas as superfícies (sessions, contatos,
+# triggers, crons, agents, system admin), não só rodar tools SDK + binários do sistema.
 ravi permissions init agent:dev full-access
 ```
+
+> **Nota histórica:** antes deste PR, `full-access` aplicava apenas `use tool:*` + `execute executable:*` (2 grants) — o nome prometia "tudo" mas deixava de fora as superfícies in-process do REBAC (sessions, contacts, agents, etc), forçando o operador a aplicar 24 wildcards adicionais via `permissions grant`. Agora `full-access` cobre os 27 pares (relation, objectType) válidos em um único comando.
 
 ## Comandos
 


### PR DESCRIPTION
## Summary

`ravi permissions init <agent> full-access` only granted `use:tool:*` + `execute:executable:*` (2 grants). The template name promised "full" but in practice the agent still couldn't access sessions, contacts, agents, triggers, crons, groups, system admin scopes, toolgroups, or teams — all of which exist as REBAC object types in production.

Operators ended up running ~24 additional `permissions grant` commands manually after every `init full-access` to reach actual full access.

## Fix

Expand the `full-access` template to apply wildcards on every `(relation, objectType)` pair the engine recognises:

```
use:tool:*  execute:executable:*
use:toolgroup:*  access:toolgroup:*  admin:toolgroup:*
access:agent:*  admin:agent:*
access:contact:*  admin:contact:*  write_contacts:contact:*
access:cron:*  admin:cron:*
access:group:*  admin:group:*  execute:group:*
access:session:*  modify:session:*  use:session:*
access:system:*  admin:system:*  read_own_contacts:system:*  read_tagged_contacts:system:*  write_contacts:system:*
access:team:*  admin:team:*
access:trigger:*  admin:trigger:*
```

= **27 wildcards in 1 command**.

The pairs are not invented — they were derived by querying the production REBAC database (7065 rows, full pagination) for every `(objectType, relation)` actually in use.

## Empirical validation

```bash
ravi permissions init agent:permissions-test-<ts> full-access
# → "✓ Applied template "full-access" to agent:permissions-test-... (27 relation(s))"

ravi permissions list --subject agent:permissions-test-<ts>
# → 27 wildcards covering 11 object types
```

## Files

- `src/cli/commands/permissions.ts` (+38/-3) — template expanded
- `src/plugins/internal/ravi-system/skills/permissions/SKILL.md` (+8/-1) — doc updated with new behaviour + historical note about the limitation

## Test plan

- [x] Built `bun run build` clean
- [x] Lint clean (`biome` shows 1 unrelated pre-existing warning in `tag-rules-loader.ts`)
- [x] Spike: applying `full-access` to a synthetic agent produces 27 grants matching the survey of valid combos
- [ ] Reviewer suggestion: add unit test asserting `init <subject> full-access` produces exactly the 27 (relation, objectType) wildcards — out of scope for this fix, can follow up

🤖 Generated with [Claude Code](https://claude.com/claude-code)