### PR TITLE
feat(runtime): add product runtime contract

### DIFF
--- a/.ravi/specs/runtime/SPEC.md
+++ b/.ravi/specs/runtime/SPEC.md
@@ -10,6 +10,7 @@ capabilities:
   - event-loop
   - session-continuity
   - context-keys
+  - product-runtime-layer
   - observation-plane
   - traces
   - cloud-trace-export
@@ -52,6 +53,7 @@ The runtime abstraction exists so new execution engines can be added without cop
 - `RuntimeSessionContinuity`: resume, fork, rebase, and replay planning from Ravi-owned prompt atoms and provider state.
 - `RuntimeEvent`: canonical event stream consumed by the Ravi host event loop.
 - `RuntimeEventLoop`: canonical event consumer that emits NATS events, traces, tool events, responses, cost/tokens, and provider state.
+- `ProductRuntimePort`: product-facing runtime contract for consumers such as Jarvis; it carries cognitive bounded context but does not make Ravi own product semantics.
 - `CloudTraceExport`: optional exporter that mirrors selected local runtime traces to a linked remote control plane without making remote storage required for local execution.
 
 ## Lifecycle
@@ -75,6 +77,10 @@ The runtime abstraction exists so new execution engines can be added without cop
 - User prompts MUST be saved before provider handoff; assistant messages MUST be saved only after a non-interrupted terminal turn.
 - Tool start/end lifecycle MUST be recorded through canonical `tool.started` and `tool.completed` events.
 - Runtime permissions MUST flow through Ravi host services or host hooks. Providers MUST NOT create a parallel permission model.
+- Product-facing runtime calls MUST go through a port/contract and MUST NOT depend on router/session/database internals.
+- Product-facing runtime requests MUST carry cognitive bounded context and ubiquitous language metadata when crossing product or agent semantic boundaries.
+- Product-facing runtime requests that cross cognitive bounded contexts SHOULD carry Bridge Contract, Semantic Abstraction Layer and Semantic Event refs as envelope metadata.
+- Ravi MUST validate product runtime envelopes for presence/correlation but MUST NOT interpret product-specific semantics.
 - `adapter.request` trace MUST be recorded before provider handoff, including prompt hashes, system prompt hashes, model, provider, resume/fork state, delivery barrier, source, and capability summary.
 - Runtime pool backpressure MUST be represented as its own dispatch state. A session waiting for a pool slot MUST NOT be reported as an in-flight cold start until a slot has actually been reserved.
 - Dispatch trace rows MUST use the canonical `session_key` when a session row exists. `session_name` MAY be included as a secondary lookup field, but MUST NOT replace the canonical key.
@@ -86,6 +92,7 @@ The runtime abstraction exists so new execution engines can be added without cop
 ## Validation
 
 - `bun test src/runtime/provider-contract.test.ts`
+- `bun test src/runtime/product-runtime-contract.test.ts`
 - `bun test src/runtime/session-dispatcher.test.ts src/runtime/delivery-queue.test.ts`
 - `bun test src/runtime/session-trace.test.ts`
 - `bun test src/runtime/runtime-session-continuity.test.ts src/runtime/session-resolver.test.ts`

--- a/.ravi/specs/runtime/product-runtime-layer/CHECKS.md
+++ b/.ravi/specs/runtime/product-runtime-layer/CHECKS.md
@@ -1,0 +1,25 @@
+# Checks
+
+Run these checks after changing the product runtime layer:
+
+```bash
+bun test src/runtime/product-runtime-contract.test.ts
+ravi specs sync --json
+git diff --check
+```
+
+Run the full runtime typecheck/build when dependencies are installed:
+
+```bash
+bun run typecheck
+bun run build
+```
+
+Review rules:
+
+- Product runtime code must not import router, session, database or channel
+  internals as product-facing dependencies.
+- Runtime events must remain operational Ravi events.
+- Product-level Semantic Events, Bridge Contracts and SAL must remain product
+  or framework-owned semantics.
+- Bridge refs must not be represented as generic CRUD endpoints exposed by Ravi.

--- a/.ravi/specs/runtime/product-runtime-layer/SPEC.md
+++ b/.ravi/specs/runtime/product-runtime-layer/SPEC.md
@@ -1,0 +1,77 @@
+---
+id: runtime/product-runtime-layer
+title: "Product Runtime Layer"
+kind: capability
+domain: runtime
+capability: product-runtime-layer
+tags:
+  - runtime
+  - products
+  - contracts
+  - semantic-context
+applies_to:
+  - src/runtime/product-runtime-contract.ts
+  - docs/product-runtime-layer.md
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+## Product Runtime Layer
+
+## Intent
+
+Define a narrow runtime port for products to use Ravi without importing Ravi
+internals.
+
+This is a runtime contract, not a public API. It exists so Jarvis can use Ravi
+for channels, sessions, providers, tools, approvals and trace while keeping
+product semantics outside Ravi.
+
+## Rules
+
+- Product consumers MUST NOT import Ravi router/session/database internals.
+- Product consumers SHOULD call a runtime port/contract, SDK or adapter surface.
+- Ravi MUST own operational execution: session, provider, tools, approvals,
+  runtime events, traces and normalized errors.
+- Product code MUST own domain semantics, Bridge Contracts, Semantic Events and
+  Semantic Abstraction Layers.
+- A product runtime request MUST carry a cognitive bounded context envelope.
+- The cognitive bounded context MUST include context id, context version, owner
+  product and ubiquitous language id/version.
+- The cognitive bounded context MUST include concrete ubiquitous language terms
+  so the receiving product or agent can reason with the sender's vocabulary.
+- When a product runtime request crosses cognitive bounded contexts, it SHOULD
+  carry Bridge Contract, Semantic Abstraction Layer and Semantic Event refs.
+- Ravi MUST validate presence/correlation of the cognitive bounded context but
+  MUST NOT interpret product-specific semantics.
+- Product runtime events MUST stay operational. Product-level Semantic Events
+  remain owned by the product/framework.
+
+## Cognitive Bounded Context
+
+The envelope should carry:
+
+- context id and version;
+- owner product;
+- ubiquitous language id/version/terms;
+- Bridge Contract refs;
+- Semantic Abstraction Layer refs;
+- Semantic Event refs;
+- assumptions;
+- constraints;
+- claims;
+- provenance refs;
+- trace/correlation refs.
+
+Bridge Contract refs describe the semantic agreement between two cognitive
+bounded contexts. They MUST NOT be treated as generic CRUD endpoints or a public
+API exposed by Ravi.
+
+## Non-Goals
+
+- Do not expose a public HTTP API in this step.
+- Do not encode RBBT semantics in Ravi.
+- Do not replace Bridge Contracts or SAL.
+- Do not implement real Jarvis or Sentinela execution here.

--- a/.ravi/specs/runtime/product-runtime-layer/WHY.md
+++ b/.ravi/specs/runtime/product-runtime-layer/WHY.md
@@ -1,0 +1,17 @@
+# Why
+
+Jarvis should be able to use Ravi as an execution runtime without making Ravi
+the owner of RBBT product semantics.
+
+The important boundary is not a technical HTTP/API boundary. It is a semantic
+boundary between cognitive bounded contexts. When one product or agent asks
+another to reason or act, the request must preserve the sender's ubiquitous
+language, assumptions, constraints, claims, SAL projection, semantic event refs
+and bridge contract refs.
+
+Ravi should validate and transport that envelope because it owns runtime
+execution, tracing, tools, approvals and provider adaptation. Ravi should not
+interpret the envelope because the product/framework owns the semantics.
+
+This keeps the first Jarvis integration narrow while leaving room for other
+products to reuse the same runtime contract later.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,7 +105,7 @@
           },
           {
             "group": "Architecture",
-            "pages": ["architecture"]
+            "pages": ["architecture", "product-runtime-layer"]
           },
           {
             "group": "NATS",

--- a/docs/product-runtime-layer.md
+++ b/docs/product-runtime-layer.md
@@ -1,0 +1,117 @@
+---
+title: Product Runtime Layer
+description: Product-facing Ravi runtime contract for semantic product execution.
+---
+
+## Product Runtime Layer
+
+This document defines the first contract for using Ravi as a runtime layer for a
+product such as Jarvis.
+
+It is **not** a public HTTP API and it is not a promise that product domains
+should depend on Ravi internals. It is a runtime port: a narrow contract between
+product logic and Ravi's channel/session/provider/tool/approval/trace runtime.
+
+## Position
+
+```text
+Product Core
+  -> Product Runtime Port
+  -> Ravi Runtime
+  -> Runtime Provider
+```
+
+The product owns domain semantics. Ravi owns runtime execution.
+
+This is deliberately a product runtime contract, not an exposed product API. A
+bridge between products is a semantic boundary between cognitive bounded
+contexts, so the runtime request must carry the meaning needed to reason across
+that boundary.
+
+## Core Rule
+
+Ravi must not become the product's semantic boundary.
+
+When one agent/product asks another context to act or reason, the runtime request
+must carry the semantic context that gives the target enough meaning to answer.
+That context includes the source cognitive bounded context, its ubiquitous
+language, bridge contract refs, semantic abstraction layer refs, semantic event
+refs, assumptions, claims, constraints, provenance, and correlation ids.
+
+Ravi validates and transports that envelope. Ravi does not interpret product
+semantics.
+
+## Contract Layers
+
+### Product Runtime Request
+
+The request tells Ravi what to execute operationally:
+
+- request id;
+- source product;
+- actor;
+- intent;
+- input;
+- execution options;
+- trace/correlation refs;
+- cognitive bounded context.
+
+### Cognitive Bounded Context
+
+The cognitive bounded context tells another product or agent what language and
+understanding the request is carrying:
+
+- context id and version;
+- owner product;
+- ubiquitous language id/version/terms;
+- bridge contract ref;
+- semantic abstraction layer ref;
+- semantic event refs;
+- assumptions;
+- constraints;
+- semantic claims;
+- provenance refs.
+
+This layer is required because product bridges are semantic boundaries, not just
+transport boundaries.
+
+The target side should be able to tell which cognitive bounded context produced
+the request, which ubiquitous language is being used, which contract governs the
+interaction, which SAL projection shaped the data, and which semantic events
+created the current interpretation.
+
+### Product Runtime Events
+
+Ravi returns normalized runtime events:
+
+- accepted;
+- context loaded;
+- approval requested;
+- response delta;
+- response completed;
+- failed.
+
+These are operational runtime events. Product-level Semantic Events remain owned
+by the product/framework using Ravi. Ravi may carry references to those events in
+the cognitive context, but it must not reinterpret or rewrite them.
+
+## Non-Goals
+
+- Do not expose a public Ravi HTTP API in this step.
+- Do not make Jarvis import Ravi router/session/database internals.
+- Do not encode RBBT product semantics inside Ravi.
+- Do not replace product Bridge Contracts, Semantic Events or SAL.
+- Do not treat Bridge Contracts as CRUD endpoints or low-level integration APIs.
+
+## First Consumer
+
+The first intended consumer is Jarvis.
+
+The first target flow is:
+
+```text
+WhatsApp -> Ravi Runtime -> Jarvis Runtime Port -> Jarvis Core -> SAL fixture
+```
+
+Real product integration should happen after the product publishes stable
+semantic contracts.

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -10,4 +10,5 @@ export * from "./codex-provider.js";
 export * from "./pi-provider.js";
 export * from "./context-registry.js";
 export * from "./model-validation.js";
+export * from "./product-runtime-contract.js";
 export * from "./provider-registry.js";

--- a/src/runtime/product-runtime-contract.test.ts
+++ b/src/runtime/product-runtime-contract.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import {
+  productRuntimeCapabilitiesFromRuntimeCapabilities,
+  validateProductRuntimeRequest,
+  type ProductRuntimeRequest,
+} from "./product-runtime-contract.js";
+import type { RuntimeCapabilities } from "./types.js";
+
+function baseRequest(overrides: Partial<ProductRuntimeRequest> = {}): ProductRuntimeRequest {
+  return {
+    requestId: "req_1",
+    sourceProduct: {
+      productId: "jarvis",
+      productVersion: "0.1.0",
+    },
+    targetRuntime: "ravi",
+    actor: {
+      id: "user_1",
+      kind: "user",
+    },
+    intent: "ask_status",
+    input: {
+      text: "status executivo",
+    },
+    cognitiveContext: {
+      contextId: "cbc_exec",
+      contextVersion: "1.0.0",
+      ownerProduct: {
+        productId: "jarvis",
+      },
+      ubiquitousLanguage: {
+        languageId: "jarvis-executive",
+        version: "1.0.0",
+        terms: [
+          {
+            term: "risco",
+            meaning: "condicao que pode exigir atencao executiva",
+          },
+        ],
+      },
+      bridgeContract: {
+        contractId: "jarvis-exec-v1",
+        contractVersion: "1.0.0",
+        sourceContextId: "cbc_exec",
+        targetContextId: "cbc_runtime",
+      },
+      semanticAbstractionLayer: {
+        layerId: "jarvis-executive-sal",
+        layerVersion: "1.0.0",
+        ownerProduct: {
+          productId: "jarvis",
+        },
+        projectionName: "executive-summary",
+      },
+      semanticEventRefs: [
+        {
+          eventId: "evt_1",
+          eventType: "jarvis.intent.received",
+          eventVersion: "1.0.0",
+          sourceProduct: {
+            productId: "jarvis",
+          },
+        },
+      ],
+    },
+    execution: {
+      mode: "interactive",
+      approvalMode: "may_request",
+    },
+    ...overrides,
+  };
+}
+
+describe("product runtime contract", () => {
+  it("requires cognitive bounded context and ubiquitous language metadata", () => {
+    const issues = validateProductRuntimeRequest(
+      baseRequest({
+        cognitiveContext: {
+          contextId: "",
+          contextVersion: "1.0.0",
+          ownerProduct: {
+            productId: "jarvis",
+          },
+          ubiquitousLanguage: {
+            languageId: "",
+            version: "",
+            terms: [],
+          },
+        },
+      }),
+    );
+
+    expect(issues.map((issue) => issue.code)).toEqual([
+      "missing_cognitive_context",
+      "missing_ubiquitous_language",
+      "missing_ubiquitous_language_terms",
+    ]);
+  });
+
+  it("does not treat semantic context as provider-specific runtime state", () => {
+    const issues = validateProductRuntimeRequest(baseRequest());
+
+    expect(issues).toEqual([]);
+  });
+
+  it("validates bridge, semantic abstraction layer and semantic event refs as envelope metadata", () => {
+    const issues = validateProductRuntimeRequest(
+      baseRequest({
+        cognitiveContext: {
+          ...baseRequest().cognitiveContext,
+          bridgeContract: {
+            contractId: "",
+            contractVersion: "",
+            sourceContextId: "",
+          },
+          semanticAbstractionLayer: {
+            layerId: "",
+            layerVersion: "",
+            ownerProduct: {
+              productId: "",
+            },
+          },
+          semanticEventRefs: [
+            {
+              eventId: "",
+              eventType: "",
+              eventVersion: "",
+              sourceProduct: {
+                productId: "",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(issues.map((issue) => issue.code)).toEqual([
+      "invalid_bridge_contract_ref",
+      "invalid_semantic_abstraction_layer_ref",
+      "invalid_semantic_event_ref",
+    ]);
+  });
+
+  it("derives product runtime capabilities from the generic runtime capability matrix", () => {
+    const runtimeCapabilities: RuntimeCapabilities = {
+      runtimeControl: { supported: false, operations: [] },
+      dynamicTools: { mode: "host" },
+      execution: { mode: "sdk" },
+      sessionState: { mode: "provider-session-id" },
+      usage: { semantics: "terminal-event" },
+      tools: {
+        permissionMode: "ravi-host",
+        accessRequirement: "tool_and_executable",
+        supportsParallelCalls: false,
+      },
+      systemPrompt: { mode: "append" },
+      terminalEvents: { guarantee: "adapter" },
+      skillVisibility: { availability: "none", loadedState: "none" },
+      supportsSessionResume: true,
+      supportsSessionFork: false,
+      supportsPartialText: true,
+      supportsToolHooks: true,
+      supportsPlugins: false,
+      supportsMcpServers: false,
+      supportsRemoteSpawn: false,
+    };
+
+    const capabilities = productRuntimeCapabilitiesFromRuntimeCapabilities(runtimeCapabilities);
+
+    expect(capabilities).toMatchObject({
+      supportsInteractiveExecution: true,
+      supportsBackgroundExecution: true,
+      supportsEventDrivenExecution: true,
+      supportsApprovals: true,
+      supportsTools: true,
+      supportsTrace: true,
+      supportsConversationMemory: true,
+    });
+  });
+});

--- a/src/runtime/product-runtime-contract.ts
+++ b/src/runtime/product-runtime-contract.ts
@@ -1,0 +1,250 @@
+import type { RuntimeCapabilities, RuntimeEffort, RuntimeThinking, RuntimeUsage } from "./types.js";
+
+export type ProductRuntimeExecutionMode = "interactive" | "background" | "event_driven";
+export type ProductRuntimeApprovalMode = "none" | "may_request" | "required";
+export type ProductRuntimeEventType =
+  | "product_runtime.accepted"
+  | "product_runtime.context_loaded"
+  | "product_runtime.approval_requested"
+  | "product_runtime.response_delta"
+  | "product_runtime.response_completed"
+  | "product_runtime.failed";
+
+export interface ProductRuntimeActor {
+  readonly id: string;
+  readonly kind: "user" | "agent" | "system";
+  readonly displayName?: string;
+}
+
+export interface ProductRuntimeProductRef {
+  readonly productId: string;
+  readonly productVersion?: string;
+  readonly instanceId?: string;
+}
+
+export interface ProductRuntimeBridgeContractRef {
+  readonly contractId: string;
+  readonly contractVersion: string;
+  readonly sourceContextId: string;
+  readonly targetContextId?: string;
+}
+
+export interface ProductRuntimeSemanticAbstractionLayerRef {
+  readonly layerId: string;
+  readonly layerVersion: string;
+  readonly ownerProduct: ProductRuntimeProductRef;
+  readonly projectionName?: string;
+}
+
+export interface ProductRuntimeSemanticEventRef {
+  readonly eventId: string;
+  readonly eventType: string;
+  readonly eventVersion: string;
+  readonly sourceProduct: ProductRuntimeProductRef;
+  readonly occurredAt?: string;
+}
+
+export interface ProductRuntimeLanguageTerm {
+  readonly term: string;
+  readonly meaning: string;
+  readonly aliases?: readonly string[];
+}
+
+export interface ProductRuntimeSemanticClaim {
+  readonly kind: "fact" | "inference" | "recommendation" | "decision" | "policy";
+  readonly statement: string;
+  readonly confidence?: number;
+  readonly evidenceRefs?: readonly string[];
+}
+
+export interface ProductRuntimeUbiquitousLanguage {
+  readonly languageId: string;
+  readonly version: string;
+  readonly terms: readonly ProductRuntimeLanguageTerm[];
+}
+
+export interface ProductRuntimeCognitiveBoundedContext {
+  readonly contextId: string;
+  readonly contextVersion: string;
+  readonly ownerProduct: ProductRuntimeProductRef;
+  readonly name?: string;
+  readonly ubiquitousLanguage: ProductRuntimeUbiquitousLanguage;
+  readonly bridgeContract?: ProductRuntimeBridgeContractRef;
+  readonly semanticAbstractionLayer?: ProductRuntimeSemanticAbstractionLayerRef;
+  readonly semanticEventRefs?: readonly ProductRuntimeSemanticEventRef[];
+  readonly assumptions?: readonly string[];
+  readonly constraints?: readonly string[];
+  readonly claims?: readonly ProductRuntimeSemanticClaim[];
+  readonly provenanceRefs?: readonly string[];
+}
+
+export interface ProductRuntimeTraceRef {
+  readonly traceId?: string;
+  readonly correlationId?: string;
+  readonly semanticEventId?: string;
+}
+
+export interface ProductRuntimeExecutionOptions {
+  readonly mode: ProductRuntimeExecutionMode;
+  readonly approvalMode: ProductRuntimeApprovalMode;
+  readonly model?: string;
+  readonly effort?: RuntimeEffort;
+  readonly thinking?: RuntimeThinking;
+  readonly timeoutMs?: number;
+}
+
+export interface ProductRuntimeRequest<TInput extends Record<string, unknown> = Record<string, unknown>> {
+  readonly requestId: string;
+  readonly sourceProduct: ProductRuntimeProductRef;
+  readonly targetRuntime: "ravi";
+  readonly actor: ProductRuntimeActor;
+  readonly intent: string;
+  readonly input: TInput;
+  readonly cognitiveContext: ProductRuntimeCognitiveBoundedContext;
+  readonly execution: ProductRuntimeExecutionOptions;
+  readonly trace?: ProductRuntimeTraceRef;
+}
+
+export interface ProductRuntimeEvent<TPayload extends Record<string, unknown> = Record<string, unknown>> {
+  readonly eventId: string;
+  readonly requestId: string;
+  readonly type: ProductRuntimeEventType;
+  readonly occurredAt: string;
+  readonly payload: TPayload;
+  readonly trace?: ProductRuntimeTraceRef;
+}
+
+export interface ProductRuntimeResult<TOutput extends Record<string, unknown> = Record<string, unknown>> {
+  readonly requestId: string;
+  readonly status: "completed" | "failed" | "interrupted";
+  readonly output?: TOutput;
+  readonly responseText?: string;
+  readonly events: readonly ProductRuntimeEvent[];
+  readonly usage?: RuntimeUsage;
+  readonly error?: string;
+  readonly trace?: ProductRuntimeTraceRef;
+}
+
+export interface ProductRuntimeCapabilities {
+  readonly supportsInteractiveExecution: boolean;
+  readonly supportsBackgroundExecution: boolean;
+  readonly supportsEventDrivenExecution: boolean;
+  readonly supportsApprovals: boolean;
+  readonly supportsTools: boolean;
+  readonly supportsTrace: boolean;
+  readonly supportsConversationMemory: boolean;
+}
+
+export interface ProductRuntimePort {
+  readonly id: "ravi";
+  getCapabilities(): ProductRuntimeCapabilities;
+  execute<TInput extends Record<string, unknown>, TOutput extends Record<string, unknown>>(
+    request: ProductRuntimeRequest<TInput>,
+  ): Promise<ProductRuntimeResult<TOutput>>;
+}
+
+export interface ProductRuntimeValidationIssue {
+  readonly code:
+    | "missing_request_id"
+    | "missing_intent"
+    | "missing_actor"
+    | "missing_source_product"
+    | "missing_cognitive_context"
+    | "missing_ubiquitous_language"
+    | "missing_ubiquitous_language_terms"
+    | "invalid_bridge_contract_ref"
+    | "invalid_semantic_abstraction_layer_ref"
+    | "invalid_semantic_event_ref"
+    | "unsupported_target_runtime";
+  readonly message: string;
+}
+
+export function productRuntimeCapabilitiesFromRuntimeCapabilities(
+  capabilities: RuntimeCapabilities,
+): ProductRuntimeCapabilities {
+  return {
+    supportsInteractiveExecution: true,
+    supportsBackgroundExecution: true,
+    supportsEventDrivenExecution: true,
+    supportsApprovals: capabilities.dynamicTools.mode === "host" || capabilities.supportsToolHooks,
+    supportsTools: capabilities.dynamicTools.mode === "host" || capabilities.tools.permissionMode === "ravi-host",
+    supportsTrace: true,
+    supportsConversationMemory: capabilities.sessionState.mode !== "none",
+  };
+}
+
+export function validateProductRuntimeRequest(request: ProductRuntimeRequest): ProductRuntimeValidationIssue[] {
+  const issues: ProductRuntimeValidationIssue[] = [];
+
+  if (!request.requestId.trim()) {
+    issues.push({ code: "missing_request_id", message: "Product runtime request id is required." });
+  }
+  if (!request.intent.trim()) {
+    issues.push({ code: "missing_intent", message: "Product runtime intent is required." });
+  }
+  if (!request.actor.id.trim()) {
+    issues.push({ code: "missing_actor", message: "Product runtime actor id is required." });
+  }
+  if (!request.sourceProduct.productId.trim()) {
+    issues.push({ code: "missing_source_product", message: "Source product id is required." });
+  }
+  if (request.targetRuntime !== "ravi") {
+    issues.push({ code: "unsupported_target_runtime", message: "Only the Ravi runtime target is supported." });
+  }
+  if (!request.cognitiveContext.contextId.trim()) {
+    issues.push({ code: "missing_cognitive_context", message: "Cognitive bounded context id is required." });
+  }
+  if (
+    !request.cognitiveContext.ubiquitousLanguage.languageId.trim() ||
+    !request.cognitiveContext.ubiquitousLanguage.version.trim()
+  ) {
+    issues.push({
+      code: "missing_ubiquitous_language",
+      message: "Cognitive bounded context must include ubiquitous language id and version.",
+    });
+  }
+  if (request.cognitiveContext.ubiquitousLanguage.terms.length === 0) {
+    issues.push({
+      code: "missing_ubiquitous_language_terms",
+      message: "Cognitive bounded context must include ubiquitous language terms.",
+    });
+  }
+  if (
+    request.cognitiveContext.bridgeContract &&
+    (!request.cognitiveContext.bridgeContract.contractId.trim() ||
+      !request.cognitiveContext.bridgeContract.contractVersion.trim() ||
+      !request.cognitiveContext.bridgeContract.sourceContextId.trim())
+  ) {
+    issues.push({
+      code: "invalid_bridge_contract_ref",
+      message: "Bridge contract refs must include contract id, contract version and source context id.",
+    });
+  }
+  if (
+    request.cognitiveContext.semanticAbstractionLayer &&
+    (!request.cognitiveContext.semanticAbstractionLayer.layerId.trim() ||
+      !request.cognitiveContext.semanticAbstractionLayer.layerVersion.trim() ||
+      !request.cognitiveContext.semanticAbstractionLayer.ownerProduct.productId.trim())
+  ) {
+    issues.push({
+      code: "invalid_semantic_abstraction_layer_ref",
+      message: "Semantic abstraction layer refs must include layer id, layer version and owner product.",
+    });
+  }
+  for (const semanticEventRef of request.cognitiveContext.semanticEventRefs ?? []) {
+    if (
+      !semanticEventRef.eventId.trim() ||
+      !semanticEventRef.eventType.trim() ||
+      !semanticEventRef.eventVersion.trim() ||
+      !semanticEventRef.sourceProduct.productId.trim()
+    ) {
+      issues.push({
+        code: "invalid_semantic_event_ref",
+        message: "Semantic event refs must include event id, event type, event version and source product.",
+      });
+      break;
+    }
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- add a product-facing Ravi runtime contract for Jarvis-style consumers
- carry cognitive bounded context, ubiquitous language, Bridge Contract refs, SAL refs, and Semantic Event refs without making Ravi own product semantics
- document the runtime boundary and add durable Ravi specs/checks

## Validation
- bun test src/runtime/product-runtime-contract.test.ts src/runtime/provider-contract.test.ts src/runtime/index.test.ts
- bun run typecheck
- bun run build
- bunx biome check src/runtime/product-runtime-contract.ts src/runtime/product-runtime-contract.test.ts
- bunx markdownlint-cli2 docs/product-runtime-layer.md .ravi/specs/runtime/product-runtime-layer/*.md
- ravi specs sync
- pre-push full suite passed