### PR TITLE
[codex] fix session prompt recovery

### DIFF
--- a/src/omni/session-stream.test.ts
+++ b/src/omni/session-stream.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let currentJsm: PromptJsm;
+
+const { ensureSessionConsumer, ensureSessionPromptInfrastructure, ensureSessionPromptsStream } = await import(
+  "./session-stream.js"
+);
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  currentJsm = makePromptJsm();
+});
+
+describe("session prompt JetStream infrastructure", () => {
+  it("shares concurrent infrastructure recovery in one process", async () => {
+    const streamAddGate = deferred<void>();
+    const calls = {
+      streamAdds: 0,
+      consumerAdds: 0,
+    };
+    let streamExists = false;
+    let consumerExists = false;
+
+    currentJsm = makePromptJsm({
+      streams: {
+        info: mock(async () => {
+          if (!streamExists) throw new Error("stream not found");
+          return {};
+        }),
+        add: mock(async () => {
+          calls.streamAdds++;
+          await streamAddGate.promise;
+          streamExists = true;
+          return {};
+        }),
+      },
+      consumers: {
+        info: mock(async () => {
+          if (!consumerExists) throw new Error("consumer not found");
+          return {};
+        }),
+        add: mock(async () => {
+          calls.consumerAdds++;
+          consumerExists = true;
+          return {};
+        }),
+      },
+    });
+
+    const firstEnsure = ensureSessionPromptInfrastructure(currentJsm as never);
+    await waitUntil(() => calls.streamAdds === 1);
+    const secondEnsure = ensureSessionPromptInfrastructure(currentJsm as never);
+
+    streamAddGate.resolve();
+    await Promise.all([firstEnsure, secondEnsure]);
+
+    expect(calls.streamAdds).toBe(1);
+    expect(calls.consumerAdds).toBe(1);
+  });
+
+  it("treats stream add conflicts as success when the stream now exists", async () => {
+    let streamExists = false;
+    const streamInfo = mock(async () => {
+      if (!streamExists) throw new Error("stream not found");
+      return {};
+    });
+    const streamAdd = mock(async () => {
+      streamExists = true;
+      throw new Error("stream name already in use");
+    });
+    currentJsm = makePromptJsm({
+      streams: {
+        info: streamInfo,
+        add: streamAdd,
+      },
+    });
+
+    await ensureSessionPromptsStream(currentJsm as never);
+
+    expect(streamAdd).toHaveBeenCalledTimes(1);
+    expect(streamInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats consumer add conflicts as success when the consumer now exists", async () => {
+    let consumerExists = false;
+    const consumerInfo = mock(async () => {
+      if (!consumerExists) throw new Error("consumer not found");
+      return {};
+    });
+    const consumerAdd = mock(async () => {
+      consumerExists = true;
+      throw new Error("consumer already exists");
+    });
+    currentJsm = makePromptJsm({
+      consumers: {
+        info: consumerInfo,
+        add: consumerAdd,
+      },
+    });
+
+    await ensureSessionConsumer(currentJsm as never);
+
+    expect(consumerAdd).toHaveBeenCalledTimes(1);
+    expect(consumerInfo).toHaveBeenCalledTimes(2);
+  });
+});
+
+function makePromptJsm(overrides: PromptJsmOverrides = {}): PromptJsm {
+  return {
+    streams: {
+      info: mock(async () => ({})),
+      add: mock(async () => ({})),
+      ...(overrides.streams ?? {}),
+    },
+    consumers: {
+      list: mock(() => ({
+        next: mock(async () => []),
+      })),
+      delete: mock(async () => true),
+      info: mock(async () => ({})),
+      add: mock(async () => ({})),
+      ...(overrides.consumers ?? {}),
+    },
+  };
+}
+
+interface PromptJsm {
+  streams: {
+    info: ReturnType<typeof mock>;
+    add: ReturnType<typeof mock>;
+  };
+  consumers: {
+    list: ReturnType<typeof mock>;
+    delete: ReturnType<typeof mock>;
+    info: ReturnType<typeof mock>;
+    add: ReturnType<typeof mock>;
+  };
+}
+
+interface PromptJsmOverrides {
+  streams?: Partial<PromptJsm["streams"]>;
+  consumers?: Partial<PromptJsm["consumers"]>;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/src/omni/session-stream.ts
+++ b/src/omni/session-stream.ts
@@ -28,6 +28,9 @@ export const SESSION_SUBJECT_FILTER = "ravi.session.*.prompt";
 
 /** Shared consumer name — all daemons pull from this single consumer. */
 const CONSUMER_NAME = "ravi-prompts";
+let legacyConsumerCleanupComplete = false;
+let legacyConsumerCleanupInFlight: Promise<void> | null = null;
+let sessionPromptInfrastructureInFlight: Promise<void> | null = null;
 
 export function getConsumerName(): string {
   return CONSUMER_NAME;
@@ -38,9 +41,8 @@ export function getConsumerName(): string {
  * Safe to call multiple times — idempotent.
  * Called once during daemon startup before bot and omni consumer start.
  */
-export async function ensureSessionPromptsStream(): Promise<void> {
-  const nc = getNats();
-  const jsm = await nc.jetstreamManager();
+export async function ensureSessionPromptsStream(existingJsm?: JetStreamManager): Promise<void> {
+  const jsm = existingJsm ?? (await getNats().jetstreamManager());
 
   try {
     await jsm.streams.info(SESSION_STREAM);
@@ -50,14 +52,19 @@ export async function ensureSessionPromptsStream(): Promise<void> {
     // Stream doesn't exist — create it
   }
 
-  await jsm.streams.add({
-    name: SESSION_STREAM,
-    subjects: [SESSION_SUBJECT_FILTER],
-    retention: RetentionPolicy.Workqueue,
-    storage: "memory" as never, // prompts are ephemeral — no need for disk persistence
-    max_age: 60_000_000_000, // 60s in nanoseconds — drop stale prompts
-    num_replicas: 1,
-  });
+  try {
+    await jsm.streams.add({
+      name: SESSION_STREAM,
+      subjects: [SESSION_SUBJECT_FILTER],
+      retention: RetentionPolicy.Workqueue,
+      storage: "memory" as never, // prompts are ephemeral — no need for disk persistence
+      max_age: 60_000_000_000, // 60s in nanoseconds — drop stale prompts
+      num_replicas: 1,
+    });
+  } catch (err) {
+    await ensureStreamExistsAfterRace(jsm, err);
+    return;
+  }
 
   log.info("Created SESSION_PROMPTS JetStream stream", {
     subjects: [SESSION_SUBJECT_FILTER],
@@ -73,21 +80,40 @@ export async function ensureSessionPromptsStream(): Promise<void> {
  * WorkQueue only allows one consumer — delete them before creating the shared one.
  */
 async function cleanupLegacyConsumers(jsm: JetStreamManager): Promise<void> {
-  try {
-    const consumers = await jsm.consumers.list(SESSION_STREAM).next();
-    for (const c of consumers) {
-      if (c.name !== CONSUMER_NAME && c.name.startsWith("ravi-prompts")) {
-        try {
-          await jsm.consumers.delete(SESSION_STREAM, c.name);
-          log.info("Deleted legacy consumer", { name: c.name });
-        } catch (err) {
-          log.warn("Failed to delete legacy consumer", { name: c.name, error: err });
+  const consumers = await jsm.consumers.list(SESSION_STREAM).next();
+  for (const c of consumers) {
+    if (c.name !== CONSUMER_NAME && c.name.startsWith("ravi-prompts")) {
+      try {
+        await jsm.consumers.delete(SESSION_STREAM, c.name);
+        log.info("Deleted legacy consumer", { name: c.name });
+      } catch (err) {
+        if (isNotFoundError(err)) {
+          log.debug("Legacy consumer already gone", { name: c.name });
+          continue;
         }
+        log.warn("Failed to delete legacy consumer", { name: c.name, error: err });
+        throw err;
       }
     }
-  } catch (err) {
-    log.warn("Failed to list consumers for cleanup", { error: err });
   }
+}
+
+async function ensureLegacyConsumersCleaned(jsm: JetStreamManager): Promise<void> {
+  if (legacyConsumerCleanupComplete) return;
+  if (!legacyConsumerCleanupInFlight) {
+    legacyConsumerCleanupInFlight = cleanupLegacyConsumers(jsm)
+      .then(() => {
+        legacyConsumerCleanupComplete = true;
+      })
+      .catch((err) => {
+        log.warn("Legacy consumer cleanup failed", { error: err });
+        throw err;
+      })
+      .finally(() => {
+        legacyConsumerCleanupInFlight = null;
+      });
+  }
+  await legacyConsumerCleanupInFlight;
 }
 
 /**
@@ -98,8 +124,9 @@ async function cleanupLegacyConsumers(jsm: JetStreamManager): Promise<void> {
  * across active pull subscribers automatically (round-robin).
  */
 export async function ensureSessionConsumer(jsm: JetStreamManager): Promise<void> {
-  // One-time migration: delete old per-daemon consumers (non-blocking — don't delay startup)
-  cleanupLegacyConsumers(jsm).catch((err) => log.warn("Legacy consumer cleanup failed", { error: err }));
+  // One-time migration: delete old per-daemon consumers before adding the shared one.
+  // If cleanup fails, the next recovery pass retries instead of permanently skipping it.
+  await ensureLegacyConsumersCleaned(jsm);
 
   try {
     await jsm.consumers.info(SESSION_STREAM, CONSUMER_NAME);
@@ -109,13 +136,18 @@ export async function ensureSessionConsumer(jsm: JetStreamManager): Promise<void
     // Consumer doesn't exist — create it
   }
 
-  await jsm.consumers.add(SESSION_STREAM, {
-    durable_name: CONSUMER_NAME,
-    ack_policy: AckPolicy.Explicit,
-    deliver_policy: DeliverPolicy.All,
-    // ack_wait: 5 minutes (in nanoseconds) — long turns shouldn't timeout
-    ack_wait: 300_000_000_000,
-  });
+  try {
+    await jsm.consumers.add(SESSION_STREAM, {
+      durable_name: CONSUMER_NAME,
+      ack_policy: AckPolicy.Explicit,
+      deliver_policy: DeliverPolicy.All,
+      // ack_wait: 5 minutes (in nanoseconds) — long turns shouldn't timeout
+      ack_wait: 300_000_000_000,
+    });
+  } catch (err) {
+    await ensureConsumerExistsAfterRace(jsm, err);
+    return;
+  }
 
   log.info("Created session JetStream consumer", {
     stream: SESSION_STREAM,
@@ -125,12 +157,35 @@ export async function ensureSessionConsumer(jsm: JetStreamManager): Promise<void
 }
 
 /**
+ * Ensure both sides of the prompt work queue exist.
+ *
+ * This is intentionally safe to call from publishers and health checks. If NATS
+ * restarts, the memory-backed stream and durable consumer can disappear while
+ * the daemon process stays alive; re-ensuring both pieces lets the pull loop
+ * recover without requiring a full daemon restart.
+ */
+export async function ensureSessionPromptInfrastructure(existingJsm?: JetStreamManager): Promise<void> {
+  if (sessionPromptInfrastructureInFlight) return sessionPromptInfrastructureInFlight;
+
+  sessionPromptInfrastructureInFlight = ensureSessionPromptInfrastructureOnce(existingJsm).finally(() => {
+    sessionPromptInfrastructureInFlight = null;
+  });
+  return sessionPromptInfrastructureInFlight;
+}
+
+async function ensureSessionPromptInfrastructureOnce(existingJsm?: JetStreamManager): Promise<void> {
+  const jsm = existingJsm ?? (await getNats().jetstreamManager());
+  await ensureSessionPromptsStream(jsm);
+  await ensureSessionConsumer(jsm);
+}
+
+/**
  * Publish a session prompt to the JetStream work queue.
  * Replaces: nats.emit(`ravi.session.${sessionName}.prompt`, payload)
  */
 export async function publishSessionPrompt(sessionName: string, payload: Record<string, unknown>): Promise<void> {
   const nc = await ensureConnected();
-  await ensureSessionPromptsStream();
+  await ensureSessionPromptInfrastructure();
   const js = nc.jetstream();
   const explicitDeliveryBarrier = typeof payload.deliveryBarrier === "string" ? payload.deliveryBarrier : undefined;
   const hasExplicitBarrier = Boolean(explicitDeliveryBarrier?.trim());
@@ -158,4 +213,27 @@ export async function publishSessionPrompt(sessionName: string, payload: Record<
 
 function isDeliveryBarrierSource(value: string): value is DeliveryBarrierSource {
   return value === "explicit" || value === "default" || value === "inferred";
+}
+
+async function ensureStreamExistsAfterRace(jsm: JetStreamManager, originalError: unknown): Promise<void> {
+  try {
+    await jsm.streams.info(SESSION_STREAM);
+    log.debug("SESSION_PROMPTS stream created concurrently");
+  } catch {
+    throw originalError;
+  }
+}
+
+async function ensureConsumerExistsAfterRace(jsm: JetStreamManager, originalError: unknown): Promise<void> {
+  try {
+    await jsm.consumers.info(SESSION_STREAM, CONSUMER_NAME);
+    log.debug("Session consumer created concurrently", { consumerName: CONSUMER_NAME });
+  } catch {
+    throw originalError;
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  return message.includes("not found") || message.includes("deleted");
 }

--- a/src/runtime/prompt-subscription.test.ts
+++ b/src/runtime/prompt-subscription.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const consumeCalls: Array<Record<string, unknown>> = [];
+const ensureInfrastructureMock = mock(async () => {});
+const emitCalls: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+
+let running = false;
+
+const fakeConsumer = {
+  consume: mock(async (options: Record<string, unknown>) => {
+    consumeCalls.push(options);
+    running = false;
+    return (async function* () {})();
+  }),
+};
+
+const fakeJetStream = {
+  consumers: {
+    get: mock(async () => fakeConsumer),
+  },
+};
+
+mock.module("../nats.js", () => ({
+  ensureConnected: mock(async () => ({
+    jetstream: () => fakeJetStream,
+  })),
+  getNats: mock(() => ({
+    jetstream: () => fakeJetStream,
+  })),
+  publish: mock(async (topic: string, payload: Record<string, unknown>) => {
+    emitCalls.push({ topic, payload });
+  }),
+  subscribe: mock(async function* () {}),
+  closeNats: mock(async () => {}),
+  nats: {
+    emit: mock(async (topic: string, payload: Record<string, unknown>) => {
+      emitCalls.push({ topic, payload });
+    }),
+    subscribe: mock(async function* () {}),
+    close: mock(async () => {}),
+  },
+}));
+
+const { RuntimePromptSubscription } = await import("./prompt-subscription.js");
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  running = true;
+  consumeCalls.length = 0;
+  emitCalls.length = 0;
+  ensureInfrastructureMock.mockClear();
+  fakeConsumer.consume.mockClear();
+  fakeJetStream.consumers.get.mockClear();
+});
+
+describe("RuntimePromptSubscription", () => {
+  it("aborts the pull loop when SESSION_PROMPTS resources disappear", async () => {
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt: mock(async () => {}),
+    });
+
+    subscription.subscribe();
+
+    await waitUntil(() => consumeCalls.length === 1 && !subscription.active);
+
+    expect(ensureInfrastructureMock).toHaveBeenCalled();
+    expect(fakeJetStream.consumers.get).toHaveBeenCalledWith("SESSION_PROMPTS", "ravi-prompts");
+    expect(consumeCalls[0]).toMatchObject({
+      expires: 2000,
+      abort_on_missing_resource: true,
+    });
+  });
+});
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -1,11 +1,6 @@
 import { StringCodec } from "nats";
 import { getNats, nats } from "../nats.js";
-import {
-  SESSION_STREAM,
-  ensureSessionConsumer,
-  ensureSessionPromptsStream,
-  getConsumerName,
-} from "../omni/session-stream.js";
+import { SESSION_STREAM, ensureSessionPromptInfrastructure, getConsumerName } from "../omni/session-stream.js";
 import { logger } from "../utils/logger.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
@@ -16,6 +11,7 @@ export interface RuntimePromptSubscriptionOptions {
   isRunning(): boolean;
   getStreamingSessionCount(): number;
   getRuntimeSessionPoolSnapshot?(): RuntimeSessionPoolSnapshot;
+  ensurePromptInfrastructure?(): Promise<void>;
   markConsumerReady(): void;
   handlePrompt(sessionName: string, prompt: RuntimeLaunchPrompt): Promise<void>;
 }
@@ -24,6 +20,7 @@ export class RuntimePromptSubscription {
   active = false;
   promptsReceived = 0;
   private healthTimer: ReturnType<typeof setInterval> | null = null;
+  private healthProbeInFlight = false;
 
   constructor(private readonly options: RuntimePromptSubscriptionOptions) {}
 
@@ -55,6 +52,7 @@ export class RuntimePromptSubscription {
           pendingStarts: runtimeSessionPool?.pendingStarts,
         });
         this.emitRuntimeSessionPoolGauge(runtimeSessionPool);
+        this.ensurePromptInfrastructureForHealthCheck();
       }
     }, healthCheckIntervalMs);
   }
@@ -80,17 +78,21 @@ export class RuntimePromptSubscription {
 
     try {
       const nc = getNats();
-      const jsm = await nc.jetstreamManager();
       const js = nc.jetstream();
 
       const consumerName = getConsumerName();
-      await ensureSessionPromptsStream();
-      await ensureSessionConsumer(jsm);
+      await this.ensurePromptInfrastructure();
 
       while (this.options.isRunning()) {
         try {
           const consumer = await js.consumers.get(SESSION_STREAM, consumerName);
-          const messages = await consumer.consume({ expires: 2000 });
+          const messages = await consumer.consume({
+            expires: 2000,
+            // The nats.js default keeps a consume loop alive while stream/consumer
+            // resources are missing. Ravi owns this durable, so fail fast and let
+            // the outer loop recreate the JetStream infrastructure.
+            abort_on_missing_resource: true,
+          });
 
           this.options.markConsumerReady();
 
@@ -158,8 +160,7 @@ export class RuntimePromptSubscription {
 
           if (isPromptBootstrapError(err)) {
             log.warn("Prompt pull unavailable during bootstrap, re-ensuring stream/consumer", { error: err });
-            await ensureSessionPromptsStream();
-            await ensureSessionConsumer(jsm);
+            await this.ensurePromptInfrastructure();
           } else {
             log.error("Prompt subscription error - will reconnect pull", {
               error: err,
@@ -194,11 +195,32 @@ export class RuntimePromptSubscription {
         log.warn("Failed to emit runtime session pool gauge", { error });
       });
   }
+
+  private ensurePromptInfrastructureForHealthCheck(): void {
+    if (this.healthProbeInFlight) return;
+    this.healthProbeInFlight = true;
+    this.ensurePromptInfrastructure()
+      .catch((error) => {
+        log.warn("Subscriber health check: failed to verify prompt infrastructure", { error });
+      })
+      .finally(() => {
+        this.healthProbeInFlight = false;
+      });
+  }
+
+  private ensurePromptInfrastructure(): Promise<void> {
+    return this.options.ensurePromptInfrastructure?.() ?? ensureSessionPromptInfrastructure();
+  }
 }
 
 function isPromptBootstrapError(err: unknown): boolean {
   const message = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
-  return message.includes("stream not found") || message.includes("consumer not found");
+  return (
+    message.includes("stream not found") ||
+    message.includes("consumer not found") ||
+    message.includes("consumer deleted") ||
+    message.includes("no responders")
+  );
 }
 
 async function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Rebuild SESSION_PROMPTS stream and ravi-prompts consumer before publishing prompts and while the subscriber is active.
- Serialize prompt infrastructure recovery so concurrent publishes share one in-flight ensure call.
- Treat stream/consumer add races as success when a follow-up info call confirms the resource exists.
- Re-run recovery when prompt subscription bootstrap detects missing/deleted resources, and use abort_on_missing_resource for faster failure.

## Why
NATS can lose the memory-backed SESSION_PROMPTS stream/consumer while the Ravi daemon stays alive. In that state prompt.published events can expire without a live prompt consumer, leaving Ravi apparently online but unable to process prompts until restart.

## Validation
- bun test src/omni/session-stream.test.ts src/runtime/prompt-subscription.test.ts
- bun test src/omni/
- bunx biome check src/omni/session-stream.ts src/omni/session-stream.test.ts src/runtime/prompt-subscription.ts src/runtime/prompt-subscription.test.ts
- bun run typecheck
- bun run build
- pre-push hook: SDK check, build, typecheck, full package test suite, SDK client check
- Live daemon restarted after build; SESSION_PROMPTS/ravi-prompts reported Ack Pending 0 and Unprocessed 0

## Notes
Created from a clean worktree based on origin/main. The original working tree had unrelated local changes that were not included.