### PR TITLE
feat(whatsapp-overlay): collapsible chat-list sidebar

### DIFF
--- a/extensions/whatsapp-overlay/content.js
+++ b/extensions/whatsapp-overlay/content.js
@@ -47,6 +47,8 @@ const WORKSPACE_SESSION_KEY_STORAGE = "ravi-wa-overlay-workspace-session";
 const OMNI_INSTANCE_KEY_STORAGE = "ravi-wa-overlay-instance";
 const OVERLAY_PANEL_VISIBLE_KEY_STORAGE = "ravi-wa-overlay-panel-visible";
 const NATIVE_SIDEBAR_WIDTH_KEY_STORAGE = "ravi-wa-native-sidebar-width";
+const NATIVE_SIDEBAR_COLLAPSED_KEY_STORAGE = "ravi-wa-native-sidebar-collapsed";
+const NATIVE_SIDEBAR_COLLAPSE_TOGGLE_ID = "ravi-wa-native-sidebar-collapse-toggle";
 const V3_PLACEHOLDERS_KEY_STORAGE = "ravi-wa-overlay-v3-placeholders";
 const OMNI_POLL_INTERVAL_MS = 6000;
 const V3_PLACEHOLDER_POLL_INTERVAL_MS = 5000;
@@ -88,6 +90,12 @@ const NATIVE_SIDEBAR_SEARCH_SELECTOR =
 const NATIVE_SIDEBAR_MIN_WIDTH = 260;
 const NATIVE_SIDEBAR_MAX_WIDTH = 640;
 const NATIVE_SIDEBAR_MIN_MAIN_WIDTH = 420;
+const NATIVE_SIDEBAR_COLLAPSED_WIDTH = 150;
+const NATIVE_SIDEBAR_WIDTH_TRANSITION =
+  "flex-basis 260ms cubic-bezier(0.22, 1, 0.36, 1)," +
+  " width 260ms cubic-bezier(0.22, 1, 0.36, 1)," +
+  " min-width 260ms cubic-bezier(0.22, 1, 0.36, 1)," +
+  " max-width 260ms cubic-bezier(0.22, 1, 0.36, 1)";
 const taskDrawerStateApi = globalThis.__RAVI_WA_TASK_DRAWER_STATE__ || null;
 if (!taskDrawerStateApi) {
   throw new Error("[ravi-wa-overlay] task drawer state helpers unavailable");
@@ -177,6 +185,7 @@ let profileMenuOpen = false;
 let vibesMenuOpen = false;
 let overlayPanelVisible = loadOverlayPanelVisible();
 let nativeSidebarWidth = loadNativeSidebarWidth();
+let nativeSidebarCollapsed = loadNativeSidebarCollapsed();
 let v3PlaceholdersEnabled = false;
 let selectedOmniChatId = null;
 let selectedOmniSessionKey = null;
@@ -4752,6 +4761,7 @@ function syncLayoutChrome() {
   const host = sidePane && mainPane ? findLayoutHost(sidePane, mainPane) : null;
   if (!root || !drawer || !sidePane || !mainPane || !host) {
     syncNativeSidebarResizeControl(null, null, { hidden: true });
+    syncNativeSidebarCollapseToggle(null, null, { hidden: true });
     return;
   }
   const sideBranch = findDirectChildBranch(host, sidePane);
@@ -4796,6 +4806,7 @@ function syncLayoutChrome() {
   drawer.classList.toggle("ravi-hidden", !overlayPanelVisible);
   document.getElementById(PANEL_RAIL_TOGGLE_ID)?.classList.toggle("ravi-hidden", overlayPanelVisible);
   syncNativeSidebarResizeControl(host, sideBranch, { hidden: fullWorkspace });
+  syncNativeSidebarCollapseToggle(host, sideBranch, { hidden: fullWorkspace });
 
   currentLayoutHost = host;
   currentLayoutMain = mainPane;
@@ -4812,10 +4823,6 @@ function syncNativeSidebarResizeControl(host, sideBranch, options = {}) {
   const resized =
     nativeSidebarWidth !== null &&
     nativeSidebarWidth !== undefined;
-  const hidden =
-    Boolean(options.hidden) ||
-    invalidTarget ||
-    window.innerWidth < 760;
 
   if (currentNativeSidebarBranch && currentNativeSidebarBranch !== sideBranch) {
     clearNativeSidebarWidthStyles(currentNativeSidebarBranch);
@@ -4826,7 +4833,25 @@ function syncNativeSidebarResizeControl(host, sideBranch, options = {}) {
       "data-ravi-native-sidebar-resized",
       resized ? "true" : "false",
     );
+    host.setAttribute(
+      "data-ravi-native-sidebar-collapsed",
+      nativeSidebarCollapsed ? "true" : "false",
+    );
   }
+
+  // Apply width/collapse styling whenever we have a valid target, even if the
+  // drag handle itself is hidden (e.g. while collapsed) so the 0-width state
+  // still materializes on the pane.
+  if (!invalidTarget) {
+    currentNativeSidebarBranch = sideBranch;
+    applyNativeSidebarWidth(sideBranch, host);
+  }
+
+  const hidden =
+    Boolean(options.hidden) ||
+    invalidTarget ||
+    nativeSidebarCollapsed ||
+    window.innerWidth < 760;
 
   if (hidden) {
     handle.classList.add("ravi-hidden");
@@ -4834,9 +4859,6 @@ function syncNativeSidebarResizeControl(host, sideBranch, options = {}) {
     handle.removeAttribute("aria-valuenow");
     return;
   }
-
-  currentNativeSidebarBranch = sideBranch;
-  applyNativeSidebarWidth(sideBranch, host);
 
   const sideRect = sideBranch.getBoundingClientRect();
   const bounds = resolveNativeSidebarWidthBounds(host);
@@ -4971,8 +4993,34 @@ function resetNativeSidebarWidth() {
 
 function applyNativeSidebarWidth(sideBranch, host) {
   if (!(sideBranch instanceof HTMLElement)) return;
+
+  // Glide on toggle/reset, but never during an active drag (must track cursor 1:1).
+  sideBranch.style.transition = nativeSidebarResizeState
+    ? "none"
+    : NATIVE_SIDEBAR_WIDTH_TRANSITION;
+
+  if (nativeSidebarCollapsed) {
+    const width = `${NATIVE_SIDEBAR_COLLAPSED_WIDTH}px`;
+    sideBranch.setAttribute("data-ravi-native-sidebar-collapsed", "true");
+    sideBranch.removeAttribute("data-ravi-native-sidebar-width");
+    sideBranch.style.flex = `0 0 ${width}`;
+    sideBranch.style.width = width;
+    sideBranch.style.minWidth = width;
+    sideBranch.style.maxWidth = width;
+    sideBranch.style.overflow = "hidden";
+    return;
+  }
+
+  sideBranch.removeAttribute("data-ravi-native-sidebar-collapsed");
+  sideBranch.style.removeProperty("overflow");
+
   if (nativeSidebarWidth === null || nativeSidebarWidth === undefined) {
-    clearNativeSidebarWidthStyles(sideBranch);
+    // Reset to natural width but keep the transition so the glide still plays.
+    sideBranch.removeAttribute("data-ravi-native-sidebar-width");
+    sideBranch.style.removeProperty("flex");
+    sideBranch.style.removeProperty("width");
+    sideBranch.style.removeProperty("min-width");
+    sideBranch.style.removeProperty("max-width");
     return;
   }
 
@@ -4988,10 +5036,78 @@ function applyNativeSidebarWidth(sideBranch, host) {
 function clearNativeSidebarWidthStyles(sideBranch) {
   if (!(sideBranch instanceof HTMLElement)) return;
   sideBranch.removeAttribute("data-ravi-native-sidebar-width");
+  sideBranch.removeAttribute("data-ravi-native-sidebar-collapsed");
   sideBranch.style.removeProperty("flex");
   sideBranch.style.removeProperty("width");
   sideBranch.style.removeProperty("min-width");
   sideBranch.style.removeProperty("max-width");
+  sideBranch.style.removeProperty("overflow");
+  sideBranch.style.removeProperty("transition");
+}
+
+function syncNativeSidebarCollapseToggle(host, sideBranch, options = {}) {
+  const toggle = ensureNativeSidebarCollapseToggle();
+  const invalidTarget =
+    !(host instanceof HTMLElement) ||
+    !(sideBranch instanceof HTMLElement);
+  const hidden =
+    Boolean(options.hidden) ||
+    invalidTarget ||
+    window.innerWidth < 760;
+
+  if (hidden) {
+    toggle.classList.add("ravi-hidden");
+    return;
+  }
+
+  toggle.classList.remove("ravi-hidden");
+  toggle.classList.toggle(
+    "ravi-wa-native-sidebar-collapse-toggle--collapsed",
+    nativeSidebarCollapsed,
+  );
+  toggle.setAttribute("aria-expanded", nativeSidebarCollapsed ? "false" : "true");
+  const label = nativeSidebarCollapsed
+    ? "Expandir lista de chats"
+    : "Estreitar lista de chats";
+  toggle.setAttribute("aria-label", label);
+  toggle.setAttribute("title", label);
+  const glyph = toggle.firstElementChild;
+  if (glyph) glyph.textContent = nativeSidebarCollapsed ? "»" : "«";
+
+  const sideRect = sideBranch.getBoundingClientRect();
+  const centerY = Math.round(sideRect.top + sideRect.height / 2);
+  toggle.style.top = `${centerY}px`;
+  toggle.style.left = `${Math.round(sideRect.right)}px`;
+}
+
+function ensureNativeSidebarCollapseToggle() {
+  let toggle = document.getElementById(NATIVE_SIDEBAR_COLLAPSE_TOGGLE_ID);
+  if (toggle instanceof HTMLElement) return toggle;
+
+  toggle = document.createElement("button");
+  toggle.id = NATIVE_SIDEBAR_COLLAPSE_TOGGLE_ID;
+  toggle.type = "button";
+  toggle.className = "ravi-wa-native-sidebar-collapse-toggle ravi-hidden";
+  toggle.setAttribute("aria-label", "Recolher lista de chats");
+  toggle.setAttribute("title", "Recolher lista de chats");
+  toggle.innerHTML = `<span aria-hidden="true">«</span>`;
+  toggle.addEventListener("click", handleNativeSidebarCollapseToggleClick);
+  document.body.appendChild(toggle);
+  return toggle;
+}
+
+function handleNativeSidebarCollapseToggleClick(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  toggleNativeSidebarCollapsed();
+}
+
+function toggleNativeSidebarCollapsed(force) {
+  const next = typeof force === "boolean" ? force : !nativeSidebarCollapsed;
+  if (next === nativeSidebarCollapsed) return;
+  nativeSidebarCollapsed = next;
+  persistNativeSidebarCollapsed(next);
+  syncLayoutChrome();
 }
 
 function resolveNativeSidebarResizeDirection(sideBranch) {
@@ -15965,6 +16081,14 @@ function loadNativeSidebarWidth() {
   }
 }
 
+function loadNativeSidebarCollapsed() {
+  try {
+    return window.localStorage.getItem(NATIVE_SIDEBAR_COLLAPSED_KEY_STORAGE) === "true";
+  } catch {
+    return false;
+  }
+}
+
 function loadV3PlaceholdersEnabled() {
   try {
     return window.localStorage.getItem(V3_PLACEHOLDERS_KEY_STORAGE) === "true";
@@ -16006,6 +16130,18 @@ function persistNativeSidebarWidth(value) {
       );
     } else {
       window.localStorage.removeItem(NATIVE_SIDEBAR_WIDTH_KEY_STORAGE);
+    }
+  } catch {
+    // ignore localStorage failures inside WhatsApp Web
+  }
+}
+
+function persistNativeSidebarCollapsed(value) {
+  try {
+    if (value) {
+      window.localStorage.setItem(NATIVE_SIDEBAR_COLLAPSED_KEY_STORAGE, "true");
+    } else {
+      window.localStorage.removeItem(NATIVE_SIDEBAR_COLLAPSED_KEY_STORAGE);
     }
   } catch {
     // ignore localStorage failures inside WhatsApp Web

--- a/extensions/whatsapp-overlay/styles.css
+++ b/extensions/whatsapp-overlay/styles.css
@@ -89,6 +89,8 @@
 }
 
 .ravi-wa-layout-host[data-ravi-native-sidebar-resized="true"]
+  [data-testid="drawer-middle"],
+.ravi-wa-layout-host[data-ravi-native-sidebar-collapsed="true"]
   [data-testid="drawer-middle"] {
   border-inline-start: 0 !important;
   border-inline-start-width: 0 !important;
@@ -158,6 +160,70 @@
 
 @media (max-width: 760px) {
   .ravi-wa-native-sidebar-resize-handle {
+    display: none !important;
+  }
+}
+
+.ravi-wa-native-sidebar-collapse-toggle {
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 40px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 168, 132, 0.85);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  opacity: 0.78;
+  transition:
+    background 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 160ms ease,
+    transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ravi-wa-native-sidebar-collapse-toggle span {
+  pointer-events: none;
+  display: block;
+  transition: transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ravi-wa-native-sidebar-collapse-toggle:hover,
+.ravi-wa-native-sidebar-collapse-toggle:focus-visible {
+  opacity: 1;
+  background: rgba(0, 168, 132, 1);
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.42);
+  transform: translate(-50%, -50%) scale(1.15);
+  outline: none;
+}
+
+/* Secondary action: the chevron leans toward the direction it will move the column. */
+.ravi-wa-native-sidebar-collapse-toggle:hover span,
+.ravi-wa-native-sidebar-collapse-toggle:focus-visible span {
+  transform: translateX(-1.5px);
+}
+
+.ravi-wa-native-sidebar-collapse-toggle--collapsed:hover span,
+.ravi-wa-native-sidebar-collapse-toggle--collapsed:focus-visible span {
+  transform: translateX(1.5px);
+}
+
+.ravi-wa-native-sidebar-collapse-toggle:active {
+  transform: translate(-50%, -50%) scale(0.9);
+}
+
+@media (max-width: 760px) {
+  .ravi-wa-native-sidebar-collapse-toggle {
     display: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a slim toggle (`«`/`»`) on the chat-list divider that collapses WhatsApp's native chat list into a compact rail (~150px), keeping avatars and short contact names visible instead of hiding the list entirely.
- The pane width glides smoothly on toggle (CSS transition, easing matched to the existing resize UX) and the collapsed/expanded state persists across reloads via `localStorage`.
- Hides the resize marker line while collapsed so no leftover divider shows in the conversation area.

## Details
- Builds on the existing native-sidebar resize system (`syncNativeSidebarResizeControl` / `applyNativeSidebarWidth`); collapse is a parallel state that reuses the same branch-resolution and width-application path.
- New `data-ravi-native-sidebar-collapsed` host attribute drives the marker-hiding CSS rule.
- Only `content.js` (+144/-8) and `styles.css` (+66) change.

## Test plan
- [ ] Reload the extension + refresh WhatsApp Web.
- [ ] Click the toggle: chat list narrows to the rail and avatars remain visible.
- [ ] Toggle back: list expands to its previous width.
- [ ] Reload the page: collapsed/expanded state is preserved.
- [ ] Confirm no leftover vertical divider line in the conversation area while collapsed.
- [ ] Confirm manual drag-resize still tracks the cursor 1:1 (no glide during drag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)