### PR TITLE
[codex] Suppress repeated provider session limit errors

### DIFF
--- a/src/runtime/context-registry.test.ts
+++ b/src/runtime/context-registry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { clearRelations, grantRelation } from "../permissions/relations.js";
 import { dbCreateAgent, dbDeleteAgent, dbGetContext, getDb } from "../router/router-db.js";
 import { getOrCreateSession } from "../router/sessions.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import {
   ADMIN_BOOTSTRAP_KIND,
   createRuntimeContext,
@@ -16,6 +17,7 @@ import {
 } from "./context-registry.js";
 
 const TEST_AGENT_ID = "test-context-agent";
+let stateDir: string | null = null;
 
 function cleanup(): void {
   const db = getDb();
@@ -32,13 +34,16 @@ function createTestSession(sessionKey: string): void {
 }
 
 describe("runtime context registry", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-runtime-context-registry-");
     cleanup();
     dbCreateAgent({ id: TEST_AGENT_ID, cwd: "/tmp/test-context-agent" });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
   });
 
   it("creates a context with its own identity and resolves it by key", () => {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -73,6 +73,11 @@ const MAX_OUTPUT_LENGTH = 1000;
 const MAX_TURN_FAILURE_LOG_DETAIL = 1800;
 const MAX_TURN_FAILURE_RESPONSE = 320;
 const PROVIDER_TURN_INACTIVITY_REASON = "provider_turn_inactive";
+const USER_FACING_LIMIT_SUPPRESSION_DEFAULT_MS = 60 * 60_000;
+const USER_FACING_LIMIT_SUPPRESSION_MAX_MS = 24 * 60 * 60_000;
+const USER_FACING_LIMIT_SUPPRESSION_RESET_GRACE_MS = 60_000;
+
+const userFacingRuntimeLimitSuppressions = new Map<string, number>();
 
 export type RuntimeSafeEmit = (topic: string, data: Record<string, unknown>) => Promise<void>;
 
@@ -355,6 +360,135 @@ function isRecoverableInterruptionFailure(event: {
     (details.includes("stop_reason=null") || details.includes("stop_reason=tool_use"));
 
   return hasAbortMarker || hasInterruptedDiagnostic;
+}
+
+type UserFacingRuntimeLimitFailure = {
+  kind: "session_limit";
+  windowKey: string;
+  expiresAt: number;
+};
+
+type UserFacingRuntimeLimitSuppressionDecision =
+  | {
+      suppressed: false;
+      classified?: UserFacingRuntimeLimitFailure;
+    }
+  | {
+      suppressed: true;
+      classified: UserFacingRuntimeLimitFailure;
+      previousExpiresAt: number;
+    };
+
+function firstNonEmptyLine(value: string): string {
+  return (
+    value
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function normalizeSuppressionText(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function extractSessionLimitResetDescriptor(error: string): string | undefined {
+  const firstLine = firstNonEmptyLine(error);
+  const match = firstLine.match(/\breset(?:s|ting)?\s+(.+?)(?:$|[.;])/i);
+  const raw = match?.[1]?.trim();
+  if (!raw) return undefined;
+  return normalizeSuppressionText(raw.replace(/^at\s+/i, "")).slice(0, 120);
+}
+
+function parseResetDescriptorTime(descriptor: string, now: number): number | undefined {
+  const match = descriptor.match(/\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b/i);
+  if (!match) return undefined;
+
+  let hour = Number(match[1]);
+  const minute = match[2] === undefined ? 0 : Number(match[2]);
+  const meridiem = match[3]?.toLowerCase();
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23 || !Number.isInteger(minute) || minute < 0 || minute > 59) {
+    return undefined;
+  }
+
+  if (meridiem === "pm" && hour < 12) hour += 12;
+  if (meridiem === "am" && hour === 12) hour = 0;
+
+  const resetAt = new Date(now);
+  resetAt.setHours(hour, minute, 0, 0);
+  if (resetAt.getTime() <= now - USER_FACING_LIMIT_SUPPRESSION_RESET_GRACE_MS) {
+    resetAt.setDate(resetAt.getDate() + 1);
+  }
+  return resetAt.getTime();
+}
+
+export function classifyUserFacingRuntimeLimitFailure(
+  error: string,
+  now = Date.now(),
+): UserFacingRuntimeLimitFailure | undefined {
+  const normalized = normalizeSuppressionText(error);
+  const isExactSessionLimit = /you['’]?ve hit your session limit/i.test(error);
+  const isGenericSessionLimitWithReset = /\bsession limit\b/i.test(error) && /\breset(?:s|ting)?\b/i.test(error);
+  if (!isExactSessionLimit && !isGenericSessionLimitWithReset) return undefined;
+
+  const resetDescriptor = extractSessionLimitResetDescriptor(error);
+  const resetAt = resetDescriptor ? parseResetDescriptorTime(resetDescriptor, now) : undefined;
+  const expiresAt = resetAt
+    ? Math.min(resetAt + USER_FACING_LIMIT_SUPPRESSION_RESET_GRACE_MS, now + USER_FACING_LIMIT_SUPPRESSION_MAX_MS)
+    : now + USER_FACING_LIMIT_SUPPRESSION_DEFAULT_MS;
+  const windowKey = resetDescriptor
+    ? `reset:${resetDescriptor}`
+    : `message:${firstNonEmptyLine(normalized).slice(0, 160)}`;
+
+  return {
+    kind: "session_limit",
+    windowKey,
+    expiresAt,
+  };
+}
+
+export function resetUserFacingRuntimeLimitSuppressionsForTest(): void {
+  userFacingRuntimeLimitSuppressions.clear();
+}
+
+function pruneExpiredUserFacingRuntimeLimitSuppressions(now: number): void {
+  for (const [key, expiresAt] of userFacingRuntimeLimitSuppressions.entries()) {
+    if (expiresAt <= now) {
+      userFacingRuntimeLimitSuppressions.delete(key);
+    }
+  }
+}
+
+export function shouldSuppressUserFacingRuntimeLimitFailure(input: {
+  error: string;
+  scope: string;
+  now?: number;
+}): UserFacingRuntimeLimitSuppressionDecision {
+  const now = input.now ?? Date.now();
+  const classified = classifyUserFacingRuntimeLimitFailure(input.error, now);
+  if (!classified) return { suppressed: false };
+
+  pruneExpiredUserFacingRuntimeLimitSuppressions(now);
+  const key = `${input.scope}:${classified.kind}:${classified.windowKey}`;
+  const previousExpiresAt = userFacingRuntimeLimitSuppressions.get(key);
+  if (previousExpiresAt !== undefined && previousExpiresAt > now) {
+    return { suppressed: true, classified, previousExpiresAt };
+  }
+
+  userFacingRuntimeLimitSuppressions.set(key, classified.expiresAt);
+  return { suppressed: false, classified };
+}
+
+function buildUserFacingFailureSuppressionScope(input: {
+  sessionKey: string;
+  provider: RuntimeProviderId;
+  source?: RuntimeHostStreamingSession["currentSource"];
+}): string {
+  const source = input.source;
+  const outputScope = source
+    ? `${source.channel}:${source.accountId ?? ""}:${source.chatId ?? source.canonicalChatId ?? ""}`
+    : input.sessionKey;
+  return `${input.provider}:${outputScope}`;
 }
 
 export function formatUserFacingTurnFailure(error: string): string {
@@ -1897,7 +2031,25 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         clearRuntimeCredentialAttempt(streaming, failedCredentialAttemptId);
 
         if (streaming.agentMode !== "sentinel") {
-          await emitResponse(formatUserFacingTurnFailure(event.error));
+          const suppression = shouldSuppressUserFacingRuntimeLimitFailure({
+            error: event.error,
+            scope: buildUserFacingFailureSuppressionScope({
+              sessionKey: session.sessionKey,
+              provider: runtimeSession.provider,
+              source: streaming.currentSource,
+            }),
+          });
+          if (suppression.suppressed) {
+            log.info("Suppressing repeated user-facing runtime limit failure", {
+              runId,
+              sessionName,
+              provider: runtimeSession.provider,
+              windowKey: suppression.classified.windowKey,
+              previousExpiresAt: suppression.previousExpiresAt,
+            });
+          } else {
+            await emitResponse(formatUserFacingTurnFailure(event.error));
+          }
         }
         updateRuntimeLiveState(sessionName, {
           activity: "blocked",

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -23,7 +23,12 @@ import {
 import { RUNTIME_CONTEXT_WINDOW_RECOVERY_REASON } from "./context-window-recovery.js";
 import { createQueuedRuntimeUserMessage } from "./delivery-queue.js";
 import type { RuntimeHostStreamingSession, RuntimeMessageTarget, RuntimeUserMessage } from "./host-session.js";
-import { runRuntimeEventLoop } from "./host-event-loop.js";
+import {
+  classifyUserFacingRuntimeLimitFailure,
+  resetUserFacingRuntimeLimitSuppressionsForTest,
+  runRuntimeEventLoop,
+  shouldSuppressUserFacingRuntimeLimitFailure,
+} from "./host-event-loop.js";
 import { getRuntimeLiveStateForSession } from "./live-state.js";
 import { buildRuntimeStartRequest, resolveRuntimeCredentialUpstreamProvider } from "./runtime-request-builder.js";
 import type {
@@ -320,9 +325,11 @@ describe("runtime session trace instrumentation", () => {
   beforeEach(async () => {
     stateDir = await createIsolatedRaviState("ravi-runtime-trace-test-");
     getOrCreateSession(SESSION_KEY, AGENT_ID, stateDir ?? "/tmp");
+    resetUserFacingRuntimeLimitSuppressionsForTest();
   });
 
   afterEach(async () => {
+    resetUserFacingRuntimeLimitSuppressionsForTest();
     await cleanupIsolatedRaviState(stateDir);
     stateDir = null;
   });
@@ -1019,6 +1026,43 @@ describe("runtime session trace instrumentation", () => {
       rawEvent: { type: "error", message: "provider down" },
     });
     expect(getSessionTurn("turn-failed")?.status).toBe("failed");
+  });
+
+  it("deduplicates user-facing provider session limit failures within the same reset window", () => {
+    const now = new Date("2026-06-16T15:56:00-03:00").getTime();
+    const scope = "codex:whatsapp:main:120363424772797713@g.us";
+    const error = "You've hit your session limit - resets 4:20pm (America/Sao_Paulo)";
+
+    const classified = classifyUserFacingRuntimeLimitFailure(error, now);
+    expect(classified?.kind).toBe("session_limit");
+    expect(classified?.windowKey).toContain("4:20pm");
+    expect(classified?.expiresAt ?? 0).toBeGreaterThan(now);
+
+    expect(shouldSuppressUserFacingRuntimeLimitFailure({ error, scope, now }).suppressed).toBe(false);
+    expect(shouldSuppressUserFacingRuntimeLimitFailure({ error, scope, now: now + 1_000 }).suppressed).toBe(true);
+    expect(
+      shouldSuppressUserFacingRuntimeLimitFailure({
+        error: "You've hit your session limit - resets 5:20pm (America/Sao_Paulo)",
+        scope,
+        now: now + 2_000,
+      }).suppressed,
+    ).toBe(false);
+    expect(
+      shouldSuppressUserFacingRuntimeLimitFailure({
+        error,
+        scope: "codex:whatsapp:main:other-chat",
+        now: now + 3_000,
+      }).suppressed,
+    ).toBe(false);
+  });
+
+  it("does not deduplicate ordinary provider failures that mention limits", () => {
+    const scope = "codex:whatsapp:main:120363424772797713@g.us";
+    const error = "Tool output exceeded the size limit.";
+
+    expect(classifyUserFacingRuntimeLimitFailure(error)).toBeUndefined();
+    expect(shouldSuppressUserFacingRuntimeLimitFailure({ error, scope }).suppressed).toBe(false);
+    expect(shouldSuppressUserFacingRuntimeLimitFailure({ error, scope }).suppressed).toBe(false);
   });
 
   it("times out active provider turns that stop emitting runtime events", async () => {


### PR DESCRIPTION
## Summary

- Detect provider session-limit messages and classify them as user-facing retry/window failures.
- Emit the first occurrence, then suppress repeated emissions for the same provider/output/reset window so chats do not get spammed while the limit is still active.
- Keep generic limit failures visible so unrelated capacity or validation errors are not hidden.
- Isolate context-registry.test.ts from live/default Ravi DB state so the pre-push hook is deterministic when runtime env vars are cleared.

Task: task-cb32e187
Worktree: /Users/luis/dev/filipelabs/worktrees/ravi-bot-session-limit-suppression

## Validation

- bun install --frozen-lockfile
- focused session-trace test for provider session limit dedupe
- bun test src/runtime/context-registry.test.ts
- git diff --check origin/dev...HEAD
- bun run build
- bun run typecheck
- git push -u origin codex/session-limit-suppression pre-push hook passed: SDK check, build, typecheck, full bun run test, SDK tests/check