### PR TITLE
fix(tasks): prevent tasks list crash on legacy/unknown task status

### DIFF
--- a/src/cli/commands/tasks.test.ts
+++ b/src/cli/commands/tasks.test.ts
@@ -1823,6 +1823,58 @@ describe("TaskCommands create", () => {
     ]);
   });
 
+  it("renders the table list without throwing when a task has a legacy/unknown status", async () => {
+    // Status is stored as plain TEXT in the DB with no CHECK constraint, so older
+    // rows can carry a value outside the current enum. The non-JSON table render
+    // formats the status before calling `.padEnd`, which used to crash with
+    // "undefined is not an object" when the formatter returned undefined.
+    taskListMock = [
+      {
+        id: "task-legacy-1",
+        title: "legacy task",
+        status: "cancelled",
+        priority: "normal",
+        progress: 0,
+        createdAt: 1,
+        updatedAt: 100,
+      },
+    ];
+
+    const commands = new TaskCommands();
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (value?: unknown) => {
+      if (typeof value === "string") logs.push(value);
+    };
+
+    try {
+      // asJson (13th positional) is false here so the table render path executes.
+      expect(() =>
+        commands.list(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+          undefined,
+          false,
+          false,
+          false,
+          undefined,
+          false,
+        ),
+      ).not.toThrow();
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = logs.join("\n");
+    expect(output).toContain("task-legacy-1");
+    expect(output).toContain("cancelled");
+  });
+
   it("rejects conflicting parent and root filters on list", () => {
     const commands = new TaskCommands();
     expect(() =>

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -96,6 +96,12 @@ function formatTaskStatus(status: TaskStatus | "waiting"): string {
       return "done";
     case "failed":
       return "failed";
+    default:
+      // Defensive fallback: legacy/unknown statuses are stored as plain TEXT in
+      // the DB and may fall outside the current enum, which would otherwise make
+      // this switch return `undefined` and crash callers that immediately format
+      // the result (e.g. `.padEnd`). Render whatever string is present instead.
+      return String(status ?? "unknown");
   }
 }
 


### PR DESCRIPTION
### Problem

`ravi tasks list` (and `tasks/list` over the HTTP API) returns a 500 with
`undefined is not an object (evaluating '…padEnd')` when the result set includes a
task whose `status` is not part of the current `TaskStatus` enum. The crash only
appears once the listing window is wide enough (e.g. a large `--since`) to surface
older tasks; narrow windows work fine.

### Root cause

`formatTaskStatus()` is a `switch` over `TaskStatus` with no `default` branch, so an
out-of-enum status makes it return `undefined`. The non-JSON table renderer then calls
`formatTaskStatus(visualStatus).padEnd(10)`, which throws on `undefined`.

Task status is persisted as `TEXT NOT NULL` with no CHECK constraint, and
`deriveTaskReadStatus` returns it verbatim — so rows written by older runtime versions
can carry a status string outside the current enum, which is what triggers the crash.

### Fix

Add a defensive `default` branch to `formatTaskStatus()` that returns the raw status
string (or `"unknown"` when nullish), making the formatter total. Output for known
statuses is unchanged.

### Tests

Added a CLI command test that renders the table list for a task carrying an out-of-enum
status. It reproduces the original `…padEnd` `TypeError` before the fix and passes after.
`tsc --noEmit` is clean and the `tasks` command test suite is green.
