### PR TITLE
Fix session usage metrics

### DIFF
--- a/src/cli/commands/agents.test.ts
+++ b/src/cli/commands/agents.test.ts
@@ -43,6 +43,27 @@ let mainSession: SessionLike | null = null;
 let sessionsByAgent: SessionLike[] = [];
 let transcriptPath: string | null = null;
 const instructionStates = new Map<string, string>();
+const sessionTurnUsageSummaries = new Map<string, Record<string, unknown>>();
+
+function defaultTurnUsageSummary(): Record<string, unknown> {
+  return {
+    lastTurn: null,
+    recent: {
+      windowMs: 86_400_000,
+      completeTurns: 0,
+      inputTokensAvg: 0,
+      outputTokensAvg: 0,
+      effectiveContextTokensAvg: 0,
+      effectiveContextTokensMax: 0,
+      durationMsAvg: null,
+      costUsdTotal: 0,
+    },
+  };
+}
+
+beforeEach(() => {
+  sessionTurnUsageSummaries.clear();
+});
 
 mock.module("../decorators.js", () => ({
   Group: () => () => {},
@@ -149,6 +170,8 @@ mock.module("../../router/router-db.js", () => ({
 mock.module("../../router/sessions.js", () => ({
   ...actualRouterSessionsModule,
   deleteSession: () => true,
+  getSessionTurnUsageSummary: (sessionKey: string) =>
+    sessionTurnUsageSummaries.get(sessionKey) ?? defaultTurnUsageSummary(),
   getSessionsByAgent: () => sessionsByAgent,
   getMainSession: () => mainSession,
   resolveSession: () => resolvedSession,
@@ -414,6 +437,83 @@ describe("AgentsCommands permissions", () => {
       "Invalid runtime permission profile: superuser",
     );
     expect(updateAgentCalls).toEqual([]);
+  });
+});
+
+describe("AgentsCommands session", () => {
+  beforeEach(() => {
+    currentAgent = { id: "dev", cwd: "/tmp/dev" };
+    allAgents = [];
+    createAgentCalls = [];
+    updateAgentCalls = [];
+    resolvedSession = null;
+    mainSession = null;
+    sessionsByAgent = [];
+    transcriptPath = null;
+    instructionStates.clear();
+  });
+
+  it("labels lifetime tokens separately from recent turn context", () => {
+    sessionsByAgent = [
+      {
+        sessionKey: "agent:dev:main",
+        name: "dev",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        providerSessionId: "provider-1",
+        inputTokens: 82_000_000,
+        outputTokens: 150_000,
+        totalTokens: 82_150_000,
+        contextTokens: 375_000,
+        createdAt: 1000,
+        updatedAt: 2000,
+      },
+    ];
+    sessionTurnUsageSummaries.set("agent:dev:main", {
+      lastTurn: {
+        runId: "run_1",
+        status: "complete",
+        startedAt: 1000,
+        completedAt: 90_000,
+        durationMs: 89_000,
+        inputTokens: 188_000,
+        outputTokens: 120,
+        cacheReadTokens: 187_000,
+        cacheCreationTokens: 0,
+        effectiveContextTokens: 375_000,
+        costUsd: 1.23,
+      },
+      recent: {
+        windowMs: 86_400_000,
+        completeTurns: 34,
+        inputTokensAvg: 170_000,
+        outputTokensAvg: 300,
+        effectiveContextTokensAvg: 293_000,
+        effectiveContextTokensMax: 466_000,
+        durationMsAvg: 101_000,
+        costUsdTotal: 31.37,
+      },
+    });
+
+    const commands = new AgentsCommands();
+    const logCalls: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logCalls.push(args.map((arg) => String(arg)).join(" "));
+    };
+
+    try {
+      commands.session("dev");
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = logCalls.join("\n");
+    expect(output).toContain("Lifetime tokens: 82,150,000");
+    expect(output).toContain("Effective context: 375,000");
+    expect(output).toContain("Last turn: context=375,000 input=188,000 cache=187,000 output=120 duration=1.5m");
+    expect(output).toContain("Recent 24h: turns=34 avgContext=293,000 maxContext=466,000 avgInput=170,000 cost=$31.37");
+    expect(output).not.toContain("Tokens: 82150000");
   });
 });
 

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -37,7 +37,14 @@ import {
   setAgentSpecMode,
 } from "../../router/config.js";
 import { DmScopeSchema } from "../../router/router-db.js";
-import { deleteSession, getSessionsByAgent, getMainSession, resolveSession } from "../../router/sessions.js";
+import {
+  deleteSession,
+  getSessionTurnUsageSummary,
+  getSessionsByAgent,
+  getMainSession,
+  resolveSession,
+  type SessionTurnUsageSummary,
+} from "../../router/sessions.js";
 import { DEFAULT_RUNTIME_PROVIDER_ID } from "../../runtime/provider-registry.js";
 import { validateRuntimeModelSelector } from "../../runtime/model-validation.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
@@ -99,6 +106,13 @@ interface DebugSessionSummary {
   outputTokens?: number;
   totalTokens?: number;
   contextTokens?: number;
+  lifetimeTokens?: {
+    input: number;
+    output: number;
+    total: number;
+    context: number;
+  };
+  turnUsage?: SessionTurnUsageSummary;
   compactionCount?: number;
   tags: TagBinding[];
   createdAt: number;
@@ -193,6 +207,32 @@ function describeRuntimePermissionConfig(config: AgentRuntimePermissionsConfig |
   return parts.join(" + ");
 }
 
+function sessionLifetimeTokens(session: {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  totalTokens?: number | null;
+}): number {
+  return session.totalTokens ?? (session.inputTokens ?? 0) + (session.outputTokens ?? 0);
+}
+
+function formatTokenCount(value: number | null | undefined): string {
+  return Math.round(value ?? 0).toLocaleString("en-US");
+}
+
+function formatDurationMs(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "-";
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60_000) return `${(value / 1000).toFixed(1)}s`;
+  return `${(value / 60_000).toFixed(1)}m`;
+}
+
+function formatCostUsd(value: number | null | undefined): string {
+  const n = value ?? 0;
+  if (n <= 0) return "$0";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
 function buildDebugSessionSummary(session: {
   sessionKey: string;
   name?: string | null;
@@ -211,6 +251,10 @@ function buildDebugSessionSummary(session: {
   createdAt: number;
   updatedAt: number;
 }): DebugSessionSummary {
+  const input = session.inputTokens ?? 0;
+  const output = session.outputTokens ?? 0;
+  const context = session.contextTokens ?? 0;
+  const turnUsage = getSessionTurnUsageSummary(session.sessionKey);
   return {
     sessionKey: session.sessionKey,
     ...(session.name ? { name: session.name } : {}),
@@ -230,6 +274,13 @@ function buildDebugSessionSummary(session: {
     ...(session.contextTokens !== undefined && session.contextTokens !== null
       ? { contextTokens: session.contextTokens }
       : {}),
+    lifetimeTokens: {
+      input,
+      output,
+      total: session.totalTokens ?? input + output,
+      context,
+    },
+    turnUsage,
     ...(session.compactionCount !== undefined && session.compactionCount !== null
       ? { compactionCount: session.compactionCount }
       : {}),
@@ -1034,12 +1085,28 @@ export class AgentsCommands {
     }
 
     for (const session of sessions) {
-      const tokens = (session.inputTokens || 0) + (session.outputTokens || 0);
+      const turnUsage = getSessionTurnUsageSummary(session.sessionKey);
+      const lifetimeTokens = sessionLifetimeTokens(session);
+      const effectiveContextTokens =
+        session.contextTokens && session.contextTokens > 0
+          ? session.contextTokens
+          : (turnUsage.lastTurn?.effectiveContextTokens ?? 0);
       const updated = new Date(session.updatedAt).toLocaleString();
 
       console.log(`  ${session.name ?? session.sessionKey}`);
       console.log(`    Runtime: ${session.providerSessionId ?? session.sdkSessionId ?? "(none)"}`);
-      console.log(`    Tokens: ${tokens}`);
+      console.log(`    Lifetime tokens: ${formatTokenCount(lifetimeTokens)}`);
+      console.log(`    Effective context: ${formatTokenCount(effectiveContextTokens)}`);
+      if (turnUsage.lastTurn) {
+        console.log(
+          `    Last turn: context=${formatTokenCount(turnUsage.lastTurn.effectiveContextTokens)} input=${formatTokenCount(turnUsage.lastTurn.inputTokens)} cache=${formatTokenCount(turnUsage.lastTurn.cacheReadTokens + turnUsage.lastTurn.cacheCreationTokens)} output=${formatTokenCount(turnUsage.lastTurn.outputTokens)} duration=${formatDurationMs(turnUsage.lastTurn.durationMs)}`,
+        );
+      }
+      if (turnUsage.recent.completeTurns > 0) {
+        console.log(
+          `    Recent 24h: turns=${turnUsage.recent.completeTurns} avgContext=${formatTokenCount(turnUsage.recent.effectiveContextTokensAvg)} maxContext=${formatTokenCount(turnUsage.recent.effectiveContextTokensMax)} avgInput=${formatTokenCount(turnUsage.recent.inputTokensAvg)} cost=${formatCostUsd(turnUsage.recent.costUsdTotal)}`,
+        );
+      }
       console.log(`    Updated: ${updated}`);
       console.log();
     }
@@ -1232,7 +1299,7 @@ export class AgentsCommands {
       console.log(`  Runtime ID:  ${session.providerSessionId ?? session.sdkSessionId ?? "(none)"}`);
       console.log(`  Channel:     ${session.lastChannel ?? "-"} → ${session.lastTo ?? "-"}`);
       console.log(
-        `  Tokens:      in=${session.inputTokens} out=${session.outputTokens} total=${session.totalTokens} ctx=${session.contextTokens}`,
+        `  Lifetime:    in=${session.inputTokens} out=${session.outputTokens} total=${session.totalTokens} ctx=${session.contextTokens}`,
       );
       console.log(`  Compactions:  ${session.compactionCount}`);
       console.log(`  Created:     ${new Date(session.createdAt).toLocaleString()}`);

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -40,6 +40,27 @@ let renameSessionNameCalls: Array<{ sessionKey: string; newName: string }> = [];
 let renameSessionNameError: Error | null = null;
 let renameRouteReferencesUpdated = 0;
 const runtimeLiveStates = new Map<string, Record<string, unknown>>();
+const sessionTurnUsageSummaries = new Map<string, Record<string, unknown>>();
+
+function defaultTurnUsageSummary(): Record<string, unknown> {
+  return {
+    lastTurn: null,
+    recent: {
+      windowMs: 86_400_000,
+      completeTurns: 0,
+      inputTokensAvg: 0,
+      outputTokensAvg: 0,
+      effectiveContextTokensAvg: 0,
+      effectiveContextTokensMax: 0,
+      durationMsAvg: null,
+      costUsdTotal: 0,
+    },
+  };
+}
+
+beforeEach(() => {
+  sessionTurnUsageSummaries.clear();
+});
 
 function makeSubscription<T extends Record<string, unknown>>(events: T[]) {
   return (async function* () {
@@ -104,6 +125,8 @@ mock.module("../../router/sessions.js", () => ({
   ...actualRouterSessionsModule,
   listSessions: () => listedSessions,
   getSessionsByAgent: (agentId: string) => listedSessions.filter((session) => session.agentId === agentId),
+  getSessionTurnUsageSummary: (sessionKey: string) =>
+    sessionTurnUsageSummaries.get(sessionKey) ?? defaultTurnUsageSummary(),
   deleteSession: (sessionKey: string) => {
     deletedSessionKeys.push(sessionKey);
     listedSessions = listedSessions.filter((session) => session.sessionKey !== sessionKey);
@@ -1070,6 +1093,31 @@ describe("SessionCommands info", () => {
         lastError: null,
       },
     });
+    sessionTurnUsageSummaries.set("agent:main:whatsapp:main:group:123456", {
+      lastTurn: {
+        runId: "run_1",
+        status: "complete",
+        startedAt: 1000,
+        completedAt: 90_000,
+        durationMs: 89_000,
+        inputTokens: 188_000,
+        outputTokens: 120,
+        cacheReadTokens: 187_000,
+        cacheCreationTokens: 0,
+        effectiveContextTokens: 375_000,
+        costUsd: 1.23,
+      },
+      recent: {
+        windowMs: 86_400_000,
+        completeTurns: 34,
+        inputTokensAvg: 170_000,
+        outputTokensAvg: 300,
+        effectiveContextTokensAvg: 293_000,
+        effectiveContextTokensMax: 466_000,
+        durationMsAvg: 101_000,
+        costUsdTotal: 31.37,
+      },
+    });
 
     const output = captureLogs(() => {
       new SessionCommands().info("support-group");
@@ -1084,6 +1132,15 @@ describe("SessionCommands info", () => {
     expect(output).toContain("Runtime:      codex  [source=runtime-snapshot freshness=persisted]");
     expect(output).toContain(
       'Runtime ctx:  {"sessionId":"resp_123","cwd":"/tmp/main"}  [source=runtime-snapshot freshness=persisted]',
+    );
+    expect(output).toContain(
+      "Lifetime toks:input=1.2k output=300 total=1.5k context=2.2k  [source=runtime-snapshot freshness=persisted]",
+    );
+    expect(output).toContain(
+      "Last turn:    context=375,000 input=188,000 cache=187,000 output=120 duration=1.5m  [source=runtime-snapshot freshness=persisted]",
+    );
+    expect(output).toContain(
+      "Recent 24h:   turns=34 avgContext=293,000 maxContext=466,000 avgInput=170,000 cost=$31.37  [source=runtime-snapshot freshness=persisted]",
     );
     expect(output).toContain("Derived route:[source=resolver freshness=derived-now via=session-key]");
     expect(output).toContain("thread=thread-1");

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -29,6 +29,7 @@ import {
 import {
   listSessions,
   getSessionsByAgent,
+  getSessionTurnUsageSummary,
   deleteSession,
   resetSession,
   resolveSession,
@@ -569,12 +570,21 @@ function sessionMatchesTag(session: SessionEntry, tagSlug: string | undefined): 
 
 function buildSessionJson(session: SessionEntry, options: { live?: boolean } = {}): Record<string, unknown> {
   const runtimeId = session.providerSessionId ?? session.sdkSessionId ?? null;
+  const lifetimeInput = session.inputTokens ?? 0;
+  const lifetimeOutput = session.outputTokens ?? 0;
+  const lifetimeContext = session.contextTokens ?? 0;
+  const lifetimeTotal = session.totalTokens ?? lifetimeInput + lifetimeOutput;
   return {
     ...session,
     label: session.name ?? session.sessionKey,
     runtimeId,
-    tokenTotal:
-      session.totalTokens ?? (session.inputTokens ?? 0) + (session.outputTokens ?? 0) + (session.contextTokens ?? 0),
+    tokenTotal: lifetimeTotal,
+    lifetimeTokens: {
+      input: lifetimeInput,
+      output: lifetimeOutput,
+      total: lifetimeTotal,
+      context: lifetimeContext,
+    },
     ephemeral: Boolean(session.ephemeral),
     expiresAt: session.expiresAt ?? null,
     tags: listSessionTags(session),
@@ -889,6 +899,24 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+function formatTokenCount(value: number | null | undefined): string {
+  return Math.round(value ?? 0).toLocaleString("en-US");
+}
+
+function formatDurationMs(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "-";
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60_000) return `${(value / 1000).toFixed(1)}s`;
+  return `${(value / 60_000).toFixed(1)}m`;
+}
+
+function formatCostUsd(value: number | null | undefined): string {
+  const n = value ?? 0;
+  if (n <= 0) return "$0";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
 }
 
 function parseDurationMs(str: string): number | null {
@@ -1861,7 +1889,7 @@ export class SessionCommands {
       }
     } else {
       console.log(
-        "  NAME                                  AGENT     TOKENS    ACTIVITY   TYPE       EXPIRES             TAGS             DISPLAY",
+        "  NAME                                  AGENT     LIFETIME  ACTIVITY   TYPE       EXPIRES             TAGS             DISPLAY",
       );
       console.log(
         "  ────────────────────────────────────  ────────  ────────  ─────────  ─────────  ──────────────────  ───────────────  ──────────────────",
@@ -1922,6 +1950,7 @@ export class SessionCommands {
     const relatedContexts = dbListContexts({ sessionKey: s.sessionKey, includeInactive: true });
     const relatedAdapters = listSessionAdapters({ sessionKey: s.sessionKey });
     const suggestedCommands = buildSuggestedDebugCommands(s, relatedContexts, relatedAdapters);
+    const turnUsage = getSessionTurnUsageSummary(s.sessionKey);
 
     if (asJson) {
       const adapters = relatedAdapters.map((adapter) => {
@@ -1938,6 +1967,7 @@ export class SessionCommands {
         derivedSource: derivedSource ?? null,
         contexts: relatedContexts.map(buildRelatedContextJson),
         adapters,
+        turnUsage,
         commands: suggestedCommands,
       };
       printJson(payload);
@@ -1964,11 +1994,27 @@ export class SessionCommands {
       });
     }
     printInspectionField(
-      "Tokens",
+      "Lifetime toks",
       `input=${formatTokens(s.inputTokens ?? 0)} output=${formatTokens(s.outputTokens ?? 0)} total=${formatTokens(s.totalTokens ?? 0)} context=${formatTokens(s.contextTokens ?? 0)}`,
       RUNTIME_SNAPSHOT_META,
       { labelWidth: 14 },
     );
+    if (turnUsage.lastTurn) {
+      printInspectionField(
+        "Last turn",
+        `context=${formatTokenCount(turnUsage.lastTurn.effectiveContextTokens)} input=${formatTokenCount(turnUsage.lastTurn.inputTokens)} cache=${formatTokenCount(turnUsage.lastTurn.cacheReadTokens + turnUsage.lastTurn.cacheCreationTokens)} output=${formatTokenCount(turnUsage.lastTurn.outputTokens)} duration=${formatDurationMs(turnUsage.lastTurn.durationMs)}`,
+        RUNTIME_SNAPSHOT_META,
+        { labelWidth: 14 },
+      );
+    }
+    if (turnUsage.recent.completeTurns > 0) {
+      printInspectionField(
+        "Recent 24h",
+        `turns=${turnUsage.recent.completeTurns} avgContext=${formatTokenCount(turnUsage.recent.effectiveContextTokensAvg)} maxContext=${formatTokenCount(turnUsage.recent.effectiveContextTokensMax)} avgInput=${formatTokenCount(turnUsage.recent.inputTokensAvg)} cost=${formatCostUsd(turnUsage.recent.costUsdTotal)}`,
+        RUNTIME_SNAPSHOT_META,
+        { labelWidth: 14 },
+      );
+    }
 
     if (s.lastChannel || s.lastTo) {
       const routing = [s.lastChannel, s.lastTo].filter(Boolean).join(" -> ");

--- a/src/router/sessions.ts
+++ b/src/router/sessions.ts
@@ -81,6 +81,49 @@ interface SessionRow {
   updated_at: number;
 }
 
+interface SessionTurnUsageRow {
+  run_id: string | null;
+  status: string;
+  started_at: number;
+  completed_at: number | null;
+  duration_ms: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cache_creation_tokens: number | null;
+  cost_usd: number | null;
+}
+
+export interface SessionTurnUsage {
+  runId: string | null;
+  status: string;
+  startedAt: number;
+  completedAt: number | null;
+  durationMs: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  effectiveContextTokens: number;
+  costUsd: number;
+}
+
+export interface SessionRecentTurnUsage {
+  windowMs: number;
+  completeTurns: number;
+  inputTokensAvg: number;
+  outputTokensAvg: number;
+  effectiveContextTokensAvg: number;
+  effectiveContextTokensMax: number;
+  durationMsAvg: number | null;
+  costUsdTotal: number;
+}
+
+export interface SessionTurnUsageSummary {
+  lastTurn: SessionTurnUsage | null;
+  recent: SessionRecentTurnUsage;
+}
+
 function rowToEntry(row: SessionRow): SessionEntry {
   const runtimeSessionParams = parseRuntimeSessionParams(row.runtime_session_json);
   const providerSessionId = row.runtime_session_display_id ?? row.sdk_session_id ?? undefined;
@@ -125,6 +168,36 @@ function rowToEntry(row: SessionRow): SessionEntry {
     expiresAt: row.expires_at ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  };
+}
+
+function numberFromRow(row: Record<string, unknown> | undefined, key: string): number {
+  const value = row?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function nullableNumberFromRow(row: Record<string, unknown> | undefined, key: string): number | null {
+  const value = row?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function turnUsageFromRow(row: SessionTurnUsageRow): SessionTurnUsage {
+  const inputTokens = row.input_tokens ?? 0;
+  const outputTokens = row.output_tokens ?? 0;
+  const cacheReadTokens = row.cache_read_tokens ?? 0;
+  const cacheCreationTokens = row.cache_creation_tokens ?? 0;
+  return {
+    runId: row.run_id,
+    status: row.status,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    durationMs: row.duration_ms,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    effectiveContextTokens: inputTokens + cacheReadTokens + cacheCreationTokens,
+    costUsd: row.cost_usd ?? 0,
   };
 }
 
@@ -475,6 +548,74 @@ export function clearProviderSession(sessionKey: string): void {
 export function updateTokens(sessionKey: string, input: number, output: number, context?: number): void {
   const s = getStatements();
   s.updateTokens.run(input, output, input + output, context ?? 0, Date.now(), sessionKey);
+}
+
+export function getSessionTurnUsageSummary(
+  sessionKey: string,
+  options: { windowMs?: number } = {},
+): SessionTurnUsageSummary {
+  const windowMs = options.windowMs ?? 86_400_000;
+  const since = Date.now() - windowMs;
+  const db = getDb();
+  const lastTurnRow = db
+    .prepare(
+      `
+      SELECT
+        run_id,
+        status,
+        started_at,
+        completed_at,
+        CASE
+          WHEN completed_at IS NOT NULL THEN completed_at - started_at
+          ELSE NULL
+        END AS duration_ms,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        cost_usd
+      FROM session_turns
+      WHERE session_key = ?
+      ORDER BY started_at DESC
+      LIMIT 1
+    `,
+    )
+    .get(sessionKey) as SessionTurnUsageRow | undefined;
+  const recentRow = db
+    .prepare(
+      `
+      SELECT
+        COUNT(*) AS complete_turns,
+        AVG(input_tokens) AS input_tokens_avg,
+        AVG(output_tokens) AS output_tokens_avg,
+        AVG(input_tokens + cache_read_tokens + cache_creation_tokens) AS effective_context_tokens_avg,
+        MAX(input_tokens + cache_read_tokens + cache_creation_tokens) AS effective_context_tokens_max,
+        AVG(CASE
+          WHEN completed_at IS NOT NULL THEN completed_at - started_at
+          ELSE NULL
+        END) AS duration_ms_avg,
+        COALESCE(SUM(cost_usd), 0) AS cost_usd_total
+      FROM session_turns
+      WHERE session_key = ?
+        AND status = 'complete'
+        AND started_at >= ?
+    `,
+    )
+    .get(sessionKey, since) as Record<string, unknown> | undefined;
+
+  return {
+    lastTurn: lastTurnRow ? turnUsageFromRow(lastTurnRow) : null,
+    recent: {
+      windowMs,
+      completeTurns: numberFromRow(recentRow, "complete_turns"),
+      inputTokensAvg: numberFromRow(recentRow, "input_tokens_avg"),
+      outputTokensAvg: numberFromRow(recentRow, "output_tokens_avg"),
+      effectiveContextTokensAvg: numberFromRow(recentRow, "effective_context_tokens_avg"),
+      effectiveContextTokensMax: numberFromRow(recentRow, "effective_context_tokens_max"),
+      durationMsAvg: nullableNumberFromRow(recentRow, "duration_ms_avg"),
+      costUsdTotal: numberFromRow(recentRow, "cost_usd_total"),
+    },
+  };
 }
 
 /**

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -1590,7 +1590,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           session.runtimeProvider = runtimeSession.provider;
         }
         clearRuntimeCredentialAttempt(streaming, completedCredentialAttemptId);
-        updateTokens(session.sessionKey, inputTokens, outputTokens);
+        updateTokens(session.sessionKey, inputTokens, outputTokens, inputTokens + cacheRead + cacheCreation);
 
         const executionModel = resolveCostTrackingModel(runtimeSession.provider, event.execution?.model, model);
         const cost = executionModel


### PR DESCRIPTION
## Summary
- persist effective per-turn context tokens (`input + cache read + cache creation`) when runtime turns complete
- add session turn usage summaries from `session_turns` for last turn and recent 24h diagnostics
- relabel session CLI output so lifetime token accumulators are not mistaken for live context size
- expose `lifetimeTokens` / `turnUsage` in JSON output and cover the new display behavior in tests

## Checks
- `bun test src/cli/commands/agents.test.ts src/cli/commands/sessions.test.ts src/runtime/session-trace.test.ts`
- `bun run typecheck`
- pre-push checks: SDK drift check, build, typecheck, full configured test suite, SDK check
