### PR TITLE
[codex] add native Slack channel runtime

### DIFF
--- a/src/channels/native/types.ts
+++ b/src/channels/native/types.ts
@@ -1,0 +1,51 @@
+import type { MessageTarget } from "../../runtime/message-types.js";
+
+export interface NativeTextDeliveryRequest {
+  readonly sessionName: string;
+  readonly emitId?: string;
+  readonly target: MessageTarget;
+  readonly text: string;
+}
+
+export interface NativeTextDeliveryResult {
+  readonly provider: string;
+  readonly messageId?: string;
+  readonly platformMessageId?: string;
+  readonly raw?: Record<string, unknown>;
+}
+
+export interface NativeTextDelivery {
+  readonly channelId: string;
+  supports(target: MessageTarget): boolean;
+  deliverText(request: NativeTextDeliveryRequest): Promise<NativeTextDeliveryResult>;
+}
+
+export interface NativeSpeechDeliveryRequest {
+  readonly sessionName: string;
+  readonly emitId?: string;
+  readonly target: MessageTarget;
+  readonly text: string;
+  readonly voice?: string;
+  readonly interrupt?: boolean;
+  readonly rawProvenance?: unknown;
+}
+
+export interface NativeSpeechDeliveryResult {
+  readonly provider: string;
+  readonly speechId?: string;
+  readonly platformMessageId?: string;
+  readonly startedAt?: string;
+  readonly endedAt?: string;
+  readonly raw?: Record<string, unknown>;
+}
+
+export interface NativeMeetingDelivery extends NativeTextDelivery {
+  readonly channelId: "meet";
+  deliverSpeech(request: NativeSpeechDeliveryRequest): Promise<NativeSpeechDeliveryResult>;
+  leave?(request: {
+    readonly sessionName: string;
+    readonly target: MessageTarget;
+    readonly reason?: string;
+    readonly rawProvenance?: unknown;
+  }): Promise<{ readonly provider: string; readonly raw?: Record<string, unknown> }>;
+}

--- a/src/channels/slack/client.ts
+++ b/src/channels/slack/client.ts
@@ -1,0 +1,100 @@
+export interface SlackWebApiClientOptions {
+  readonly appToken: string;
+  readonly botToken: string;
+  readonly apiBaseUrl?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface SlackPostMessageInput {
+  readonly channel: string;
+  readonly text: string;
+  readonly threadTs?: string;
+}
+
+export interface SlackPostMessageResult {
+  readonly channel: string;
+  readonly ts: string;
+  readonly messageId: string;
+  readonly raw: Record<string, unknown>;
+}
+
+interface SlackApiResponse {
+  readonly ok?: boolean;
+  readonly error?: string;
+  readonly [key: string]: unknown;
+}
+
+interface SlackConnectionsOpenResponse extends SlackApiResponse {
+  readonly url?: string;
+}
+
+interface SlackPostMessageResponse extends SlackApiResponse {
+  readonly channel?: string;
+  readonly ts?: string;
+}
+
+export class SlackWebApiClient {
+  private readonly appToken: string;
+  private readonly botToken: string;
+  private readonly apiBaseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: SlackWebApiClientOptions) {
+    this.appToken = options.appToken;
+    this.botToken = options.botToken;
+    this.apiBaseUrl = options.apiBaseUrl ?? "https://slack.com/api";
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async openSocketConnection(): Promise<string> {
+    const response = await this.apiRequest<SlackConnectionsOpenResponse>("apps.connections.open", this.appToken, {});
+    if (!response.url) {
+      throw new Error("Slack apps.connections.open did not return a WebSocket URL");
+    }
+    return response.url;
+  }
+
+  async postMessage(input: SlackPostMessageInput): Promise<SlackPostMessageResult> {
+    const body: Record<string, unknown> = {
+      channel: input.channel,
+      text: input.text,
+    };
+    if (input.threadTs) {
+      body.thread_ts = input.threadTs;
+    }
+
+    const response = await this.apiRequest<SlackPostMessageResponse>("chat.postMessage", this.botToken, body);
+    if (!response.channel || !response.ts) {
+      throw new Error("Slack chat.postMessage did not return channel and ts");
+    }
+
+    return {
+      channel: response.channel,
+      ts: response.ts,
+      messageId: response.ts,
+      raw: response,
+    };
+  }
+
+  private async apiRequest<T extends SlackApiResponse>(
+    method: string,
+    token: string,
+    body: Record<string, unknown>,
+  ): Promise<T> {
+    const res = await this.fetchImpl(`${this.apiBaseUrl}/${method}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const payload = (await res.json()) as T;
+    if (!res.ok || payload.ok !== true) {
+      const error = payload.error ?? `${res.status} ${res.statusText}`;
+      throw new Error(`Slack ${method} failed: ${error}`);
+    }
+    return payload;
+  }
+}

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -1,0 +1,30 @@
+export { SlackWebApiClient } from "./client.js";
+export type { SlackPostMessageInput, SlackPostMessageResult, SlackWebApiClientOptions } from "./client.js";
+export {
+  DEFAULT_SLACK_ROUTING_POLICY,
+  cleanSlackId,
+  envelopeEvent,
+  normalizeSlackRoutingPolicy,
+  resolveSlackThreadContext,
+  shouldIgnoreSlackMessageEvent,
+  slackPeerKindForChannelType,
+  slackRoutingPolicyFromEnv,
+  slackTsToMs,
+} from "./routing.js";
+export {
+  SlackSocketModeService,
+  SlackTextDelivery,
+  createSlackNativeRuntimeFromEnv,
+} from "./socket-mode.js";
+export type { SlackNativeRuntime, SlackSocketModeServiceOptions } from "./socket-mode.js";
+export type {
+  SlackEventPayload,
+  SlackEventsApiPayload,
+  SlackNormalizedMessage,
+  SlackRootReplyMode,
+  SlackRoutingPolicy,
+  SlackSocketEnvelope,
+  SlackSubscriptionScope,
+  SlackThreadContext,
+  SlackThreadReplyMode,
+} from "./types.js";

--- a/src/channels/slack/routing.test.ts
+++ b/src/channels/slack/routing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_SLACK_ROUTING_POLICY,
+  normalizeSlackRoutingPolicy,
+  resolveSlackThreadContext,
+  shouldIgnoreSlackMessageEvent,
+  slackPeerKindForChannelType,
+} from "./routing.js";
+
+describe("Slack routing policy", () => {
+  it("keeps threaded messages in the same thread by default", () => {
+    const thread = resolveSlackThreadContext(
+      { ts: "1710000000.000200", thread_ts: "1710000000.000100" },
+      DEFAULT_SLACK_ROUTING_POLICY,
+    );
+
+    expect(thread).toEqual({
+      inboundThreadTs: "1710000000.000100",
+      routeThreadTs: "1710000000.000100",
+      outboundThreadTs: "1710000000.000100",
+    });
+  });
+
+  it("can route a root message into a new thread for reply policy", () => {
+    const policy = normalizeSlackRoutingPolicy({ rootReplyMode: "new_thread" });
+    const thread = resolveSlackThreadContext({ ts: "1710000000.000300" }, policy);
+
+    expect(thread).toEqual({
+      routeThreadTs: "1710000000.000300",
+      outboundThreadTs: "1710000000.000300",
+    });
+  });
+
+  it("can subscribe at chat scope while still replying into the inbound thread", () => {
+    const policy = normalizeSlackRoutingPolicy({ subscriptionScope: "chat" });
+    const thread = resolveSlackThreadContext({ ts: "1710000000.000400", thread_ts: "1710000000.000100" }, policy);
+
+    expect(thread).toEqual({
+      inboundThreadTs: "1710000000.000100",
+      outboundThreadTs: "1710000000.000100",
+    });
+  });
+
+  it("maps Slack IMs to dm sessions and channels to channel sessions", () => {
+    expect(slackPeerKindForChannelType("im")).toBe("dm");
+    expect(slackPeerKindForChannelType("channel")).toBe("channel");
+    expect(slackPeerKindForChannelType(undefined)).toBe("channel");
+  });
+
+  it("ignores bot and non-message events", () => {
+    expect(shouldIgnoreSlackMessageEvent({ type: "reaction_added", user: "U1", channel: "C1", ts: "1.0" })).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ type: "message", bot_id: "B1", channel: "C1", ts: "1.0" })).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ type: "message", user: "U1", channel: "C1", ts: "1.0" })).toBe(false);
+  });
+});

--- a/src/channels/slack/routing.ts
+++ b/src/channels/slack/routing.ts
@@ -1,0 +1,111 @@
+import type {
+  SlackEventPayload,
+  SlackRootReplyMode,
+  SlackRoutingPolicy,
+  SlackSocketEnvelope,
+  SlackSubscriptionScope,
+  SlackThreadContext,
+  SlackThreadReplyMode,
+} from "./types.js";
+
+export const DEFAULT_SLACK_ROUTING_POLICY: SlackRoutingPolicy = {
+  subscriptionScope: "thread",
+  threadReplyMode: "same_thread",
+  rootReplyMode: "channel_root",
+};
+
+export function normalizeSlackRoutingPolicy(input: Partial<SlackRoutingPolicy> = {}): SlackRoutingPolicy {
+  return {
+    subscriptionScope: isSlackSubscriptionScope(input.subscriptionScope)
+      ? input.subscriptionScope
+      : DEFAULT_SLACK_ROUTING_POLICY.subscriptionScope,
+    threadReplyMode: isSlackThreadReplyMode(input.threadReplyMode)
+      ? input.threadReplyMode
+      : DEFAULT_SLACK_ROUTING_POLICY.threadReplyMode,
+    rootReplyMode: isSlackRootReplyMode(input.rootReplyMode)
+      ? input.rootReplyMode
+      : DEFAULT_SLACK_ROUTING_POLICY.rootReplyMode,
+  };
+}
+
+export function slackRoutingPolicyFromEnv(env: NodeJS.ProcessEnv = process.env): SlackRoutingPolicy {
+  return normalizeSlackRoutingPolicy({
+    subscriptionScope: env.RAVI_SLACK_SUBSCRIPTION_SCOPE as SlackSubscriptionScope | undefined,
+    threadReplyMode: env.RAVI_SLACK_THREAD_REPLY_MODE as SlackThreadReplyMode | undefined,
+    rootReplyMode: env.RAVI_SLACK_ROOT_REPLY_MODE as SlackRootReplyMode | undefined,
+  });
+}
+
+export function resolveSlackThreadContext(
+  event: Pick<SlackEventPayload, "ts" | "thread_ts">,
+  policy: SlackRoutingPolicy,
+): SlackThreadContext {
+  const ts = cleanSlackId(event.ts);
+  const threadTs = cleanSlackId(event.thread_ts);
+  const isThreadReply = Boolean(threadTs && ts && threadTs !== ts);
+
+  if (isThreadReply) {
+    const outboundThreadTs = policy.threadReplyMode === "channel_root" ? undefined : threadTs;
+    return {
+      inboundThreadTs: threadTs,
+      routeThreadTs: policy.subscriptionScope === "chat" ? undefined : threadTs,
+      ...(outboundThreadTs ? { outboundThreadTs } : {}),
+    };
+  }
+
+  if (ts && policy.rootReplyMode === "new_thread") {
+    return {
+      routeThreadTs: policy.subscriptionScope === "chat" ? undefined : ts,
+      outboundThreadTs: ts,
+    };
+  }
+
+  return {};
+}
+
+export function slackPeerKindForChannelType(channelType: string | undefined): "dm" | "channel" {
+  return channelType === "im" ? "dm" : "channel";
+}
+
+export function shouldIgnoreSlackMessageEvent(event: SlackEventPayload): boolean {
+  if (event.type !== "message") return true;
+  if (event.hidden === true) return true;
+  if (!cleanSlackId(event.channel)) return true;
+  if (!cleanSlackId(event.ts)) return true;
+  if (event.bot_id) return true;
+  if (event.subtype && event.subtype !== "thread_broadcast") return true;
+  return !cleanSlackId(event.user);
+}
+
+export function slackTsToMs(ts: string | undefined, fallback = Date.now()): number {
+  const cleaned = cleanSlackId(ts);
+  if (!cleaned) return fallback;
+  const seconds = Number(cleaned);
+  if (!Number.isFinite(seconds)) return fallback;
+  return Math.trunc(seconds * 1000);
+}
+
+export function cleanSlackId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function envelopeEvent(envelope: SlackSocketEnvelope): SlackEventPayload | undefined {
+  const payload = envelope.payload;
+  if (!payload || typeof payload !== "object") return undefined;
+  const maybeEvent = (payload as { event?: unknown }).event;
+  return maybeEvent && typeof maybeEvent === "object" ? (maybeEvent as SlackEventPayload) : undefined;
+}
+
+function isSlackSubscriptionScope(value: unknown): value is SlackSubscriptionScope {
+  return value === "chat" || value === "thread" || value === "chat_and_thread";
+}
+
+function isSlackThreadReplyMode(value: unknown): value is SlackThreadReplyMode {
+  return value === "same_thread" || value === "channel_root" || value === "policy_default";
+}
+
+function isSlackRootReplyMode(value: unknown): value is SlackRootReplyMode {
+  return value === "channel_root" || value === "new_thread" || value === "policy_default";
+}

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,0 +1,438 @@
+import { configStore } from "../../config-store.js";
+import { publishSessionPrompt } from "../../omni/session-stream.js";
+import { commitMatchedRoute, matchRoute } from "../../router/index.js";
+import {
+  dbBindSessionToChat,
+  dbUpsertChat,
+  dbUpsertChatMessage,
+  dbUpsertChatParticipant,
+} from "../../router/router-db.js";
+import type { RouterConfig } from "../../router/types.js";
+import type { MessageContext, MessageTarget } from "../../runtime/message-types.js";
+import { logger } from "../../utils/logger.js";
+import type { NativeTextDelivery, NativeTextDeliveryRequest, NativeTextDeliveryResult } from "../native/types.js";
+import { SlackWebApiClient } from "./client.js";
+import {
+  cleanSlackId,
+  envelopeEvent,
+  resolveSlackThreadContext,
+  shouldIgnoreSlackMessageEvent,
+  slackPeerKindForChannelType,
+  slackRoutingPolicyFromEnv,
+  slackTsToMs,
+} from "./routing.js";
+import type { SlackNormalizedMessage, SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
+
+const log = logger.child("channels:slack");
+
+type PublishPrompt = typeof publishSessionPrompt;
+type WebSocketFactory = (url: string) => WebSocket;
+
+export interface SlackSocketModeServiceOptions {
+  readonly appToken: string;
+  readonly botToken: string;
+  readonly accountId: string;
+  readonly routeAccountId?: string;
+  readonly instanceId?: string;
+  readonly routingPolicy?: Partial<SlackRoutingPolicy>;
+  readonly webClient?: SlackWebApiClient;
+  readonly getRouterConfig?: () => RouterConfig;
+  readonly publishPrompt?: PublishPrompt;
+  readonly openWebSocket?: WebSocketFactory;
+  readonly reconnectDelayMs?: number;
+}
+
+export interface SlackNativeRuntime {
+  readonly delivery: NativeTextDelivery;
+  readonly socketMode: SlackSocketModeService;
+}
+
+class RecentIdCache {
+  private readonly ids = new Set<string>();
+  private readonly order: string[] = [];
+
+  constructor(private readonly maxSize = 1_000) {}
+
+  has(id: string): boolean {
+    return this.ids.has(id);
+  }
+
+  add(id: string): void {
+    if (this.ids.has(id)) return;
+    this.ids.add(id);
+    this.order.push(id);
+    while (this.order.length > this.maxSize) {
+      const oldest = this.order.shift();
+      if (oldest) this.ids.delete(oldest);
+    }
+  }
+}
+
+export class SlackTextDelivery implements NativeTextDelivery {
+  readonly channelId = "slack";
+
+  constructor(
+    private readonly webClient: SlackWebApiClient,
+    private readonly routingPolicy: SlackRoutingPolicy,
+  ) {}
+
+  supports(target: MessageTarget): boolean {
+    return target.channel.toLowerCase() === this.channelId;
+  }
+
+  async deliverText(request: NativeTextDeliveryRequest): Promise<NativeTextDeliveryResult> {
+    const threadTs = this.routingPolicy.threadReplyMode === "channel_root" ? undefined : request.target.threadId;
+    const result = await this.webClient.postMessage({
+      channel: request.target.chatId,
+      text: request.text,
+      ...(threadTs ? { threadTs } : {}),
+    });
+    return {
+      provider: "slack",
+      messageId: result.messageId,
+      platformMessageId: result.ts,
+      raw: result.raw,
+    };
+  }
+}
+
+export class SlackSocketModeService {
+  private readonly webClient: SlackWebApiClient;
+  private readonly getRouterConfig: () => RouterConfig;
+  private readonly publishPrompt: PublishPrompt;
+  private readonly openWebSocket: WebSocketFactory;
+  private readonly routingPolicy: SlackRoutingPolicy;
+  private readonly reconnectDelayMs: number;
+  private readonly seenEnvelopeIds = new RecentIdCache();
+  private running = false;
+  private socket: WebSocket | null = null;
+  private loopPromise: Promise<void> | null = null;
+
+  constructor(private readonly options: SlackSocketModeServiceOptions) {
+    this.routingPolicy = slackRoutingPolicyFromEnv({
+      ...process.env,
+      ...(options.routingPolicy?.subscriptionScope
+        ? { RAVI_SLACK_SUBSCRIPTION_SCOPE: options.routingPolicy.subscriptionScope }
+        : {}),
+      ...(options.routingPolicy?.threadReplyMode
+        ? { RAVI_SLACK_THREAD_REPLY_MODE: options.routingPolicy.threadReplyMode }
+        : {}),
+      ...(options.routingPolicy?.rootReplyMode
+        ? { RAVI_SLACK_ROOT_REPLY_MODE: options.routingPolicy.rootReplyMode }
+        : {}),
+    });
+    this.webClient =
+      options.webClient ??
+      new SlackWebApiClient({
+        appToken: options.appToken,
+        botToken: options.botToken,
+      });
+    this.getRouterConfig = options.getRouterConfig ?? (() => configStore.getConfig());
+    this.publishPrompt = options.publishPrompt ?? publishSessionPrompt;
+    this.openWebSocket = options.openWebSocket ?? ((url) => new WebSocket(url));
+    this.reconnectDelayMs = options.reconnectDelayMs ?? 5_000;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.loopPromise = this.runLoop();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.socket?.close();
+    this.socket = null;
+    await this.loopPromise?.catch(() => {});
+    this.loopPromise = null;
+  }
+
+  async handleEnvelope(
+    envelope: SlackSocketEnvelope,
+    ack: (envelopeId: string) => Promise<void> | void = async () => {},
+  ): Promise<"duplicate" | "ignored" | "processed"> {
+    const envelopeId = cleanSlackId(envelope.envelope_id);
+    if (envelopeId) {
+      await ack(envelopeId);
+      if (this.seenEnvelopeIds.has(envelopeId)) {
+        log.debug("Duplicate Slack Socket Mode envelope ignored", { envelopeId });
+        return "duplicate";
+      }
+      this.seenEnvelopeIds.add(envelopeId);
+    }
+
+    const normalized = this.normalizeEnvelope(envelope);
+    if (!normalized) return "ignored";
+
+    await this.routeMessage(normalized);
+    return "processed";
+  }
+
+  private async runLoop(): Promise<void> {
+    while (this.running) {
+      try {
+        const url = await this.webClient.openSocketConnection();
+        await this.runSocket(url);
+      } catch (error) {
+        if (!this.running) return;
+        log.warn("Slack Socket Mode loop failed; reconnecting", { error });
+        await delay(this.reconnectDelayMs);
+      }
+    }
+  }
+
+  private runSocket(url: string): Promise<void> {
+    return new Promise((resolve) => {
+      const socket = this.openWebSocket(url);
+      this.socket = socket;
+
+      socket.onopen = () => {
+        log.info("Slack Socket Mode connected", { accountId: this.options.accountId });
+      };
+      socket.onmessage = (event) => {
+        this.handleSocketMessage(event.data, socket).catch((error) => {
+          log.error("Failed to handle Slack Socket Mode message", { error });
+        });
+      };
+      socket.onerror = (event) => {
+        log.warn("Slack Socket Mode socket error", { event });
+      };
+      socket.onclose = () => {
+        if (this.socket === socket) this.socket = null;
+        log.info("Slack Socket Mode disconnected", { accountId: this.options.accountId });
+        resolve();
+      };
+    });
+  }
+
+  private async handleSocketMessage(raw: unknown, socket: WebSocket): Promise<void> {
+    const text = typeof raw === "string" ? raw : raw instanceof Buffer ? raw.toString("utf-8") : String(raw);
+    const envelope = JSON.parse(text) as SlackSocketEnvelope;
+    await this.handleEnvelope(envelope, async (envelopeId) => {
+      socket.send(JSON.stringify({ envelope_id: envelopeId }));
+    });
+  }
+
+  private normalizeEnvelope(envelope: SlackSocketEnvelope): SlackNormalizedMessage | null {
+    const event = envelopeEvent(envelope);
+    if (!event || shouldIgnoreSlackMessageEvent(event)) return null;
+
+    const channelId = cleanSlackId(event.channel);
+    const userId = cleanSlackId(event.user);
+    const ts = cleanSlackId(event.ts);
+    if (!channelId || !userId || !ts) return null;
+
+    const payload = envelope.payload as { team_id?: string; event_id?: string; event_time?: number } | undefined;
+    const teamId = cleanSlackId(event.team) ?? cleanSlackId(payload?.team_id) ?? this.options.accountId;
+    const thread = resolveSlackThreadContext(event, this.routingPolicy);
+    const eventTimeMs = payload?.event_time ? payload.event_time * 1000 : slackTsToMs(ts);
+
+    return {
+      teamId,
+      channelId,
+      channelType: cleanSlackId(event.channel_type) ?? "channel",
+      userId,
+      text: typeof event.text === "string" ? event.text : "",
+      ts,
+      thread,
+      eventId: cleanSlackId(payload?.event_id),
+      envelopeId: cleanSlackId(envelope.envelope_id),
+      eventTimeMs,
+      rawEnvelope: envelope,
+    };
+  }
+
+  private async routeMessage(message: SlackNormalizedMessage): Promise<void> {
+    const routerConfig = this.getRouterConfig();
+    const peerKind = slackPeerKindForChannelType(message.channelType);
+    const routeThreadId = message.thread.routeThreadTs;
+    const matched = matchRoute(routerConfig, {
+      phone: message.channelId,
+      channel: "slack",
+      accountId: this.options.routeAccountId,
+      peerKind,
+      threadId: routeThreadId,
+    });
+    if (!matched) {
+      log.info("Slack inbound skipped: no route matched", {
+        accountId: this.options.accountId,
+        channelId: message.channelId,
+        threadId: routeThreadId,
+      });
+      return;
+    }
+
+    const resolved = commitMatchedRoute(matched, {
+      phone: message.channelId,
+      peerKind,
+      threadId: routeThreadId,
+    });
+    const sessionName = resolved.sessionName ?? resolved.sessionKey;
+    const canonicalChat = dbUpsertChat({
+      channel: "slack",
+      instanceId: this.options.instanceId ?? this.options.accountId,
+      platformChatId: routeThreadId ? `${message.channelId}#${routeThreadId}` : message.channelId,
+      chatType: routeThreadId ? "thread" : peerKind,
+      title: message.channelId,
+      rawProvenance: {
+        source: "slack.socket_mode",
+        teamId: message.teamId,
+        channelId: message.channelId,
+        threadTs: routeThreadId ?? null,
+        envelopeId: message.envelopeId ?? null,
+        eventId: message.eventId ?? null,
+      },
+      seenAt: message.eventTimeMs,
+    });
+
+    dbBindSessionToChat({
+      sessionKey: resolved.sessionKey,
+      chatId: canonicalChat.id,
+      agentId: resolved.agent.id,
+      routeId: null,
+      bindingReason: "slack_socket_mode",
+      seenAt: message.eventTimeMs,
+    });
+    dbUpsertChatMessage({
+      chatId: canonicalChat.id,
+      channel: "slack",
+      instanceId: this.options.instanceId ?? this.options.accountId,
+      providerMessageId: message.ts,
+      rawChatId: message.channelId,
+      rawSenderId: message.userId,
+      normalizedSenderId: message.userId,
+      actorType: "unknown",
+      messageType: "text",
+      content: {
+        type: "text",
+        text: message.text,
+        threadTs: message.thread.inboundThreadTs ?? null,
+        outboundThreadTs: message.thread.outboundThreadTs ?? null,
+      },
+      rawProvenance: {
+        source: "slack.socket_mode",
+        teamId: message.teamId,
+        eventId: message.eventId ?? null,
+        envelopeId: message.envelopeId ?? null,
+      },
+      providerTimestamp: message.eventTimeMs,
+      ingestedAt: Date.now(),
+    });
+    dbUpsertChatParticipant({
+      chatId: canonicalChat.id,
+      rawPlatformUserId: message.userId,
+      normalizedPlatformUserId: message.userId,
+      role: "member",
+      status: "active",
+      source: "inbound_message",
+      metadata: {
+        slackTeamId: message.teamId,
+        slackChannelType: message.channelType,
+      },
+      seenAt: message.eventTimeMs,
+    });
+
+    if (this.routingPolicy.subscriptionScope === "chat_and_thread" && routeThreadId) {
+      const rootChat = dbUpsertChat({
+        channel: "slack",
+        instanceId: this.options.instanceId ?? this.options.accountId,
+        platformChatId: message.channelId,
+        chatType: peerKind,
+        title: message.channelId,
+        rawProvenance: {
+          source: "slack.socket_mode",
+          teamId: message.teamId,
+          channelId: message.channelId,
+        },
+        seenAt: message.eventTimeMs,
+      });
+      dbBindSessionToChat({
+        sessionKey: resolved.sessionKey,
+        chatId: rootChat.id,
+        agentId: resolved.agent.id,
+        routeId: null,
+        bindingReason: "slack_socket_mode:chat_and_thread",
+        seenAt: message.eventTimeMs,
+      });
+    }
+
+    const source: MessageTarget = {
+      channel: "slack",
+      accountId: this.options.accountId,
+      instanceId: this.options.instanceId ?? this.options.accountId,
+      chatId: message.channelId,
+      canonicalChatId: canonicalChat.id,
+      ...(message.thread.outboundThreadTs ? { threadId: message.thread.outboundThreadTs } : {}),
+      sourceMessageId: message.ts,
+      actorType: "unknown",
+      rawSenderId: message.userId,
+      normalizedSenderId: message.userId,
+      suppressPresence: true,
+    };
+    const context: MessageContext = {
+      channelId: "slack",
+      channelName: "Slack",
+      accountId: this.options.accountId,
+      instanceId: this.options.instanceId ?? this.options.accountId,
+      chatId: message.channelId,
+      messageId: message.ts,
+      senderId: message.userId,
+      senderName: `<@${message.userId}>`,
+      isGroup: peerKind !== "dm",
+      groupId: peerKind !== "dm" ? message.channelId : undefined,
+      groupName: peerKind !== "dm" ? message.channelId : undefined,
+      timestamp: message.eventTimeMs,
+      canonicalChatId: canonicalChat.id,
+      actorType: "unknown",
+      rawSenderId: message.userId,
+      normalizedSenderId: message.userId,
+    };
+
+    await this.publishPrompt(sessionName, {
+      prompt: formatSlackPrompt(message),
+      source,
+      context,
+    });
+  }
+}
+
+export function createSlackNativeRuntimeFromEnv(env: NodeJS.ProcessEnv = process.env): SlackNativeRuntime | null {
+  if (env.RAVI_SLACK_SOCKET_MODE !== "1" && env.RAVI_SLACK_SOCKET_MODE !== "true") return null;
+  const appToken = env.SLACK_APP_TOKEN?.trim();
+  const botToken = env.SLACK_BOT_TOKEN?.trim();
+  if (!appToken || !botToken) {
+    log.warn("Slack native runtime disabled: SLACK_APP_TOKEN and SLACK_BOT_TOKEN are required");
+    return null;
+  }
+
+  const accountId = env.RAVI_SLACK_ACCOUNT?.trim() || "slack";
+  const routeAccountId = env.RAVI_SLACK_ROUTE_ACCOUNT?.trim() || undefined;
+  const instanceId = env.RAVI_SLACK_INSTANCE?.trim() || accountId;
+  const routingPolicy = slackRoutingPolicyFromEnv(env);
+  const webClient = new SlackWebApiClient({ appToken, botToken });
+  const socketMode = new SlackSocketModeService({
+    appToken,
+    botToken,
+    accountId,
+    routeAccountId,
+    instanceId,
+    routingPolicy,
+    webClient,
+  });
+  const delivery = new SlackTextDelivery(webClient, routingPolicy);
+  return { delivery, socketMode };
+}
+
+function formatSlackPrompt(message: SlackNormalizedMessage): string {
+  const parts = [
+    `Slack ${message.channelId}`,
+    message.thread.inboundThreadTs ? `thread:${message.thread.inboundThreadTs}` : undefined,
+    `mid:${message.ts}`,
+    new Date(message.eventTimeMs).toISOString(),
+  ].filter(Boolean);
+  return `[${parts.join(" ")}]\n<@${message.userId}>: ${message.text}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/channels/slack/types.ts
+++ b/src/channels/slack/types.ts
@@ -1,0 +1,66 @@
+export type SlackSubscriptionScope = "chat" | "thread" | "chat_and_thread";
+export type SlackThreadReplyMode = "same_thread" | "channel_root" | "policy_default";
+export type SlackRootReplyMode = "channel_root" | "new_thread" | "policy_default";
+
+export interface SlackRoutingPolicy {
+  readonly subscriptionScope: SlackSubscriptionScope;
+  readonly threadReplyMode: SlackThreadReplyMode;
+  readonly rootReplyMode: SlackRootReplyMode;
+}
+
+export interface SlackThreadContext {
+  readonly inboundThreadTs?: string;
+  readonly routeThreadTs?: string;
+  readonly outboundThreadTs?: string;
+}
+
+export interface SlackSocketEnvelope {
+  readonly envelope_id?: string;
+  readonly type?: string;
+  readonly accepts_response_payload?: boolean;
+  readonly payload?: SlackEventsApiPayload | Record<string, unknown>;
+  readonly retry_attempt?: number;
+  readonly retry_reason?: string;
+}
+
+export interface SlackEventsApiPayload {
+  readonly token?: string;
+  readonly team_id?: string;
+  readonly api_app_id?: string;
+  readonly event?: SlackEventPayload;
+  readonly type?: string;
+  readonly event_id?: string;
+  readonly event_time?: number;
+  readonly authorizations?: readonly Record<string, unknown>[];
+}
+
+export interface SlackEventPayload {
+  readonly type?: string;
+  readonly subtype?: string;
+  readonly channel?: string;
+  readonly channel_type?: string;
+  readonly user?: string;
+  readonly bot_id?: string;
+  readonly text?: string;
+  readonly ts?: string;
+  readonly thread_ts?: string;
+  readonly team?: string;
+  readonly event_ts?: string;
+  readonly edited?: Record<string, unknown>;
+  readonly hidden?: boolean;
+  readonly [key: string]: unknown;
+}
+
+export interface SlackNormalizedMessage {
+  readonly teamId: string;
+  readonly channelId: string;
+  readonly channelType: string;
+  readonly userId: string;
+  readonly text: string;
+  readonly ts: string;
+  readonly thread: SlackThreadContext;
+  readonly eventId?: string;
+  readonly envelopeId?: string;
+  readonly eventTimeMs: number;
+  readonly rawEnvelope: SlackSocketEnvelope;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -44,6 +44,7 @@ import { hasLiveAdminContext } from "./runtime/context-registry.js";
 import type { MessageTarget } from "./runtime/message-types.js";
 import { dbHasActiveAssignedTaskForSession } from "./tasks/task-db.js";
 import { startWorkObjectNatsService, type WorkObjectNatsServiceHandle } from "./work-objects/index.js";
+import { createSlackNativeRuntimeFromEnv, type SlackNativeRuntime } from "./channels/slack/index.js";
 import {
   tryAcquireLeadership,
   startLeadershipRenewal,
@@ -181,6 +182,7 @@ let shuttingDown = false;
 let omniConsumer: OmniConsumer | null = null;
 let webhookHttpServer: WebhookHttpServerHandle | null = null;
 let workObjectNatsService: WorkObjectNatsServiceHandle | null = null;
+let slackNativeRuntime: SlackNativeRuntime | null = null;
 
 /** Get the bot instance (for in-process access like /reset) */
 export function getBotInstance(): RaviBot | null {
@@ -242,6 +244,11 @@ async function shutdown(signal: string) {
     // Stop gateway
     if (gateway) {
       await gateway.stop();
+    }
+
+    if (slackNativeRuntime) {
+      await slackNativeRuntime.socketMode.stop();
+      slackNativeRuntime = null;
     }
 
     if (sessionAdapterBus) {
@@ -323,6 +330,9 @@ export async function startDaemon() {
   log.info("Bot started");
 
   // Step 6: Set up omni sender + consumer + gateway
+  slackNativeRuntime = createSlackNativeRuntimeFromEnv();
+  const nativeTextDeliveries = slackNativeRuntime ? [slackNativeRuntime.delivery] : [];
+
   if (omniApiUrl && omniApiKey) {
     const sender = new OmniSender(omniApiUrl, omniApiKey);
     omniConsumer = new OmniConsumer(sender, omniApiUrl, omniApiKey, {
@@ -341,6 +351,7 @@ export async function startDaemon() {
       logLevel: config.logLevel,
       omniSender: sender,
       omniConsumer,
+      nativeTextDeliveries,
     });
   } else {
     // No omni — create a stub gateway that handles internal routing only
@@ -351,11 +362,17 @@ export async function startDaemon() {
       logLevel: config.logLevel,
       omniSender: stubSender,
       omniConsumer: stubConsumer,
+      nativeTextDeliveries,
     });
   }
 
   await gateway.start();
   log.info("Gateway started");
+
+  if (slackNativeRuntime) {
+    slackNativeRuntime.socketMode.start();
+    log.info("Slack native Socket Mode runtime started");
+  }
 
   // Step 7: Start runners — leader election ensures only one daemon runs heartbeat/cron
   // Trigger, ephemeral, and inbox are per-daemon (each daemon handles its own).

--- a/src/gateway-native-delivery.test.ts
+++ b/src/gateway-native-delivery.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Gateway } from "./gateway.js";
+import type { NativeTextDelivery } from "./channels/native/types.js";
+import { getOrCreateSession } from "./router/index.js";
+import { dbFindChatMessage, dbUpsertChat } from "./router/router-db.js";
+import type { ResponseMessage } from "./runtime/message-types.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "./test/ravi-state.js";
+
+let stateDir: string | null = null;
+
+beforeEach(async () => {
+  stateDir = await createIsolatedRaviState("ravi-gateway-native-test-");
+});
+
+afterEach(async () => {
+  await cleanupIsolatedRaviState(stateDir);
+  stateDir = null;
+});
+
+async function handleResponse(gateway: unknown, sessionName: string, response: ResponseMessage): Promise<void> {
+  await (
+    gateway as {
+      handleResponseEvent(sessionName: string, response: ResponseMessage): Promise<void>;
+    }
+  ).handleResponseEvent(sessionName, response);
+}
+
+describe("Gateway native text delivery", () => {
+  it("delivers Slack responses through native delivery instead of Omni", async () => {
+    const omniSend = mock(async () => ({ messageId: "omni-1" }));
+    const deliveredText: string[] = [];
+    const chat = dbUpsertChat({
+      channel: "slack",
+      instanceId: "slack-main",
+      platformChatId: "C123",
+      chatType: "group",
+      title: "C123",
+      rawProvenance: { source: "test" },
+      seenAt: Date.now(),
+    });
+    getOrCreateSession("session:main-slack", "dev", "/tmp/ravi-dev", {
+      name: "main-slack",
+      channel: "slack",
+      accountId: "slack-main",
+      groupId: "C123",
+    });
+    const nativeDelivery: NativeTextDelivery = {
+      channelId: "slack",
+      supports: (target) => target.channel === "slack",
+      deliverText: async (request) => {
+        deliveredText.push(request.text);
+        return {
+          provider: "slack",
+          messageId: "1710000000.000200",
+          platformMessageId: "1710000000.000200",
+        };
+      },
+    };
+    const emitted: Array<[string, Record<string, unknown>]> = [];
+    const gateway = new Gateway({
+      omniSender: {
+        send: omniSend,
+        sendTyping: mock(async () => {}),
+        sendReaction: mock(async () => {}),
+        deleteMessage: mock(async () => {}),
+        editMessage: mock(async () => {}),
+        sendMedia: mock(async () => ({})),
+        markRead: mock(async () => {}),
+      } as never,
+      omniConsumer: {
+        getActiveTarget: () => undefined,
+        clearActiveTarget: () => {},
+        renewActiveTarget: mock(async () => false),
+      } as never,
+      nativeTextDeliveries: [nativeDelivery],
+      emitEvent: mock(async (topic: string, payload: Record<string, unknown>) => {
+        emitted.push([topic, payload]);
+      }),
+    });
+
+    await handleResponse(gateway, "main-slack", {
+      _emitId: "emit-1",
+      response: "oi slack",
+      target: {
+        channel: "slack",
+        accountId: "slack",
+        instanceId: "slack-main",
+        chatId: "C123",
+        canonicalChatId: chat.id,
+        threadId: "1710000000.000100",
+      },
+    });
+
+    expect(omniSend).not.toHaveBeenCalled();
+    expect(deliveredText).toEqual(["oi slack"]);
+    expect(emitted[0]?.[0]).toBe("ravi.session.main-slack.delivery");
+    expect(emitted[0]?.[1]).toMatchObject({
+      status: "delivered",
+      provider: "slack",
+      messageId: "1710000000.000200",
+      platformMessageId: "1710000000.000200",
+    });
+    const saved = dbFindChatMessage({
+      channel: "slack",
+      instanceId: "slack-main",
+      chatId: chat.id,
+      providerMessageId: "1710000000.000200",
+    });
+    expect(saved).toMatchObject({
+      chatId: chat.id,
+      channel: "slack",
+      instanceId: "slack-main",
+      providerMessageId: "1710000000.000200",
+      actorType: "agent",
+      agentId: "dev",
+      messageType: "text",
+    });
+    expect(saved?.content).toEqual({ type: "text", text: "oi slack" });
+  });
+});

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -43,6 +43,7 @@ import { prepareOmniMentionMessage, type OmniUserMention } from "./omni/mentions
 import { resolveOmniConnection } from "./omni-config.js";
 import { resolveOmniGroupMetadata } from "./omni/group-metadata-cache.js";
 import { buildRaviTtsRequest, handleRaviTtsRequest, RAVI_TTS_TOPIC, shouldAutoTtsForAgent } from "./audio/tts.js";
+import type { NativeTextDelivery } from "./channels/native/types.js";
 
 const log = logger.child("gateway");
 const PRESENCE_RENEW_THROTTLE_MS = 4_000;
@@ -89,6 +90,7 @@ export interface GatewayOptions {
   omniSender: OmniSender;
   omniConsumer: OmniConsumer;
   emitEvent?: typeof nats.emit;
+  nativeTextDeliveries?: readonly NativeTextDelivery[];
 }
 
 type PresenceTarget = {
@@ -123,6 +125,7 @@ export class Gateway {
   private omniSender: OmniSender;
   private omniConsumer: OmniConsumer;
   private emitEvent: typeof nats.emit;
+  private nativeTextDeliveries: readonly NativeTextDelivery[];
   private activeSubscriptions = new Set<string>();
   private typingTracker = new SessionTypingTracker();
   private presenceRenewedAt = new Map<string, number>();
@@ -135,6 +138,7 @@ export class Gateway {
     this.omniSender = options.omniSender;
     this.omniConsumer = options.omniConsumer;
     this.emitEvent = options.emitEvent ?? nats.emit;
+    this.nativeTextDeliveries = options.nativeTextDeliveries ?? [];
     if (options.logLevel) {
       logger.setLevel(options.logLevel);
     }
@@ -538,6 +542,12 @@ export class Gateway {
       return;
     }
 
+    const nativeDelivery = this.nativeTextDeliveries.find((delivery) => delivery.supports(target));
+    if (nativeDelivery) {
+      await this.handleNativeTextResponse(sessionName, response, nativeDelivery, emitDelivery);
+      return;
+    }
+
     const instanceId = configStore.resolveInstanceId(target.accountId);
     if (!instanceId) {
       await emitDelivery({ status: "dropped", reason: "missing_instance", target });
@@ -621,6 +631,81 @@ export class Gateway {
         target,
         instanceId,
         chatId,
+        textLen: text.length,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - t0,
+      });
+    }
+  }
+
+  private async handleNativeTextResponse(
+    sessionName: string,
+    response: ResponseMessage,
+    delivery: NativeTextDelivery,
+    emitDelivery: (data: Record<string, unknown>) => Promise<void>,
+  ): Promise<void> {
+    const target = response.target;
+    if (!target) {
+      await emitDelivery({ status: "dropped", reason: "missing_target" });
+      return;
+    }
+
+    const text = response.error ? `Error: ${response.error}` : response.response;
+    if (text && text.trim() === SILENT_TOKEN) {
+      log.debug("Silent native response, not sending to channel", { sessionName, channel: target.channel });
+      await emitDelivery({ status: "dropped", reason: "silent", target });
+      return;
+    }
+    if (!text) {
+      await emitDelivery({ status: "dropped", reason: "empty_response", target });
+      return;
+    }
+    if (!response._emitId) {
+      log.warn("GHOST NATIVE RESPONSE DROPPED", {
+        sessionName,
+        channel: target.channel,
+        textPreview: text.slice(0, 200),
+      });
+      await emitDelivery({ status: "dropped", reason: "missing_emit_id", target, textLen: text.length });
+      return;
+    }
+
+    const t0 = Date.now();
+    try {
+      const delivered = await delivery.deliverText({
+        sessionName,
+        emitId: response._emitId,
+        target,
+        text,
+      });
+      const instanceId = target.instanceId ?? target.accountId;
+      const providerMessageId = delivered.messageId ?? delivered.platformMessageId;
+      this.saveOutboundMessageActorMetadata(sessionName, target, instanceId, target.chatId, providerMessageId, text);
+      this.recordOutboundContactInteraction(sessionName, target);
+      await emitDelivery({
+        status: "delivered",
+        provider: delivered.provider,
+        emitId: response._emitId,
+        messageId: delivered.messageId,
+        platformMessageId: delivered.platformMessageId,
+        target,
+        deliveredAt: Date.now(),
+        durationMs: Date.now() - t0,
+        textLen: text.length,
+      });
+      log.info("Native response delivered", {
+        sessionName,
+        channel: target.channel,
+        provider: delivered.provider,
+        durationMs: Date.now() - t0,
+      });
+    } catch (err) {
+      log.error("Failed to send native response", { channel: target.channel, error: err });
+      await emitDelivery({
+        status: "failed",
+        reason: "native_send_error",
+        provider: delivery.channelId,
+        target,
         textLen: text.length,
         error: err instanceof Error ? err.message : String(err),
         durationMs: Date.now() - t0,


### PR DESCRIPTION
## Summary
- adds a native text-delivery abstraction so Gateway can deliver channel-native replies without Omni
- adds Slack Web API + Socket Mode runtime behind `RAVI_SLACK_SOCKET_MODE=1`, `SLACK_APP_TOKEN`, and `SLACK_BOT_TOKEN`
- supports Slack thread/chat routing policy via `RAVI_SLACK_SUBSCRIPTION_SCOPE`, `RAVI_SLACK_THREAD_REPLY_MODE`, and `RAVI_SLACK_ROOT_REPLY_MODE`
- persists inbound/outbound Slack messages in Ravi chat/session metadata and records delivery telemetry

## Tests
- `bun test src/channels/slack/routing.test.ts src/gateway-native-delivery.test.ts`
- `bun run typecheck`
- pre-push hook: SDK drift check, build, typecheck, configured test suite, `test:sdk`