### PR TITLE
[codex] Clarify route requirement before session attach

### DIFF
--- a/src/plugins/internal/ravi-system/skills/routes/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/routes/SKILL.md
@@ -109,20 +109,31 @@ Route e attach (`sessions/attach`) operam em camadas diferentes — confundi-las
 | Camada | Define | Resultado |
 |--------|--------|-----------|
 | **Route** | Qual *agent* atende o chat | matchRoute escolhe agent, session_key é derivado de (agent, channel, instance, dmScope, peer). Cada combinação vira sessão própria. |
-| **Attach** (`sessions attach`) | Qual chat recebe output da sessão e qual sessão recebe inbound daquele chat | Seleciona output target da sessão e cria subscription para o chat. |
+| **Attach** (`sessions attach`) | Qual chat fica ligado a uma sessão já escolhida | Seleciona output target da sessão e cria subscription para o chat, mas não cria nem corrige route. |
+
+**Regra crítica:** `sessions attach` pressupõe que o chat já está chegando no agent correto. Se a rota ainda aponta para outro agent, para o default da instância, ou não existe, configure `ravi instances routes add` primeiro. Para usar uma sessão canônica específica desde a route, use `--session <name>`.
+
+```bash
+# Chat novo que deve ir para agent dev e sessão dev
+ravi instances routes add main "group:<id>" dev --session dev --priority 10
+
+# Depois, se necessário, ajustar fala/output da sessão no chat
+ravi sessions attach dev --chat <chat-id> --reason "unificar chat na sessão dev"
+```
 
 **Cuidado com a interação:**
 
 - Se um chat tem subscription ativa (atachado a sessão X), o consumer **ignora** o agent escolhido pela route e dispatcha pra sessão X. A route não troca o destino sozinha.
 - Inbound-route bookkeeping pode criar subscription, mas não deve mudar o output target escolhido por `sessions attach`.
 - `routes add` faz cleanup automático de sessões conflitantes (apaga sessão paralela do agent antigo e libera o chat). Quando isso roda, a próxima inbound segue a nova route normalmente.
-- `routes add ... --session <name>` (redirect estático) força a sessão alvo e cria subscription automaticamente — funciona ao lado do attach.
+- `routes add ... --session <name>` (redirect estático) força a sessão alvo e cria subscription automaticamente — é o caminho certo quando o requisito já é "este chat deve cair nesta sessão".
 
 **Quando usar cada um:**
 
 - "Quero outro agent atendendo esse chat, com histórico próprio" → `routes add`
-- "Quero a MESMA sessão respondendo em um chat específico" → `sessions attach`
+- "Quero a MESMA sessão em um chat cuja route já está correta" → `sessions attach`
+- "Quero a MESMA sessão em um chat novo ou com route errada" → `routes add ... --session <name>` e depois `sessions attach` apenas se precisar ajustar fala/output
 
-Focus foi removido: `attach` é o primitive que escolhe o chat de output da sessão. Ver skill `ravi-system:sessions` (seção Attach) pras receitas práticas e diagrama de fluxo.
+Focus foi removido: `attach` é o primitive que escolhe o chat de output da sessão; não é substituto de route. Ver skill `ravi-system:sessions` (seção Attach) pras receitas práticas e diagrama de fluxo.
 
 Para gerenciar contacts: use a skill `ravi-system:contacts`

--- a/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
@@ -95,6 +95,8 @@ Sem `--execute`, `prune` é sempre dry-run. Use o dry-run antes de apagar em lot
 
 **Diferença chave vs routes:** `routes` decide qual *agent* atende um chat; `attach` decide quais chats alimentam uma sessão e qual superfície é o default de fala. Cada subscription tem `speech=speak|muted`: `muted` continua escutando sem responder naquele chat; `speak` permite que uma resposta ao inbound daquele chat saia ali.
 
+**Regra crítica:** `sessions attach` NÃO cria, corrige nem troca a route do chat. Use attach apenas quando a route já resolve para o agent correto, ou depois de criar uma route explícita para esse agent. Para chat novo/rota errada, configure a rota primeiro; se quiser forçar a mesma sessão já na route, use `ravi instances routes add <instance> <pattern> <agent> --session <session>`.
+
 Ver spec `sessions/attach` pro modelo completo.
 
 ```bash
@@ -122,8 +124,11 @@ ravi sessions detach <session> --chat <chat-id>
    - O comando imprime o hint de detach para desligar esse output depois.
 
 2. **Unificar histórico de N grupos numa sessão.** Caso: dev atende o grupo `ravi - dev` e você quer que o mesmo dev também receba inbound de `ravi - dev - test`.
-   - Se o grupo novo já criou uma sessão paralela (`dev-2`, vazia): `sessions delete dev-2` → `sessions attach dev --chat <chat-id-do-test>`.
-   - Próxima inbound do test cai na sessão dev existente via subscription override. Use `sessions mute dev --chat <chat-id-do-test>` se o test deve ser listen-only.
+   - Primeiro garanta que a route do grupo novo aponta para o agent `dev`: `ravi instances routes add <instance> "group:<id>" dev --priority 10`.
+   - Se a intenção é fixar a sessão canônica já na route, prefira: `ravi instances routes add <instance> "group:<id>" dev --session dev --priority 10`.
+   - Se o grupo novo já criou uma sessão paralela (`dev-2`, vazia), apague a paralela (`sessions delete dev-2`) antes de consolidar.
+   - Depois use `sessions attach dev --chat <chat-id-do-test>` para ligar o chat à sessão existente e ajustar fala/output.
+   - Use `sessions mute dev --chat <chat-id-do-test>` se o test deve ser listen-only.
 
 3. **Migrar grupo de um agent pra outro (sem unificar sessão).** Caso: grupo nasceu na sessão de onboarding (auto-criada pelo default agent da instance), você quer mover pro agent `dev` com sessão SEPARADA.
    - `ravi instances routes add <instance> group:<id> <novo-agent> --priority 10`
@@ -153,6 +158,7 @@ inbound chega ─► consumer normaliza chat
 **Anti-patterns:**
 
 - ❌ Adicionar route pra "trocar destino" quando o chat já está atachado em outra sessão. A subscription override puxa o inbound de volta. Use detach/delete da sessão antiga antes, ou attach explícito na nova.
+- ❌ Usar `sessions attach` como se ele configurasse route. Attach não muda o agent que atende o chat; ele só liga o chat a uma sessão quando a route/agent já está correta.
 - ❌ Tentar usar `focus` pra responder em outro chat. Focus foi removido; `attach` é o primitive que escolhe o chat de output.
 - ❌ Deixar inbound-route bookkeeping roubar output. Inbound pode criar subscription `muted`, mas não deve mudar o output target escolhido por operador.
 - ❌ Narrar mute/unmute/attach/routing para usuários finais; esse controle é interno.
@@ -163,7 +169,8 @@ inbound chega ─► consumer normaliza chat
 | Você quer | Use |
 |-----------|-----|
 | Outro agent atender o chat (histórico isolado) | `instances routes add` |
-| Mesma sessão responder em um chat específico | `sessions attach` |
+| Mesma sessão em chat cuja route já aponta para o agent correto | `sessions attach` |
+| Mesma sessão em chat novo ou com route errada | `instances routes add ... --session <name>` e depois `sessions attach` se precisar ajustar fala/output |
 | Forçar uma sessão específica num chat | `routes add ... --session <name>` (redirect estático) |
 
 ### Sessões Efêmeras


### PR DESCRIPTION
## Summary

- Clarifies that `sessions attach` binds a chat to an existing session but does not configure message routing.
- Adds the correct sequence for shared-session setup: configure the route first, then attach the chat to the canonical session.
- Adds cross-references between the sessions and routes skills so agents stop treating attach as a route replacement.

## Validation

- `git diff --check`
- pre-push checks with isolated `RAVI_STATE_DIR`: SDK drift check, build, typecheck, full test suite, SDK check

## Notes

The first pre-push attempt hit local DB lock contention in `runtime/context-registry.test.ts` because that test was using the live local state. Re-running the push with an isolated `RAVI_STATE_DIR` passed cleanly.
