### PR TITLE
[codex] enforce clear PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+## Objetivo
+
+<!-- Explique em 2-4 frases o que esta PR muda e por que isso deve existir. -->
+
+## Problema
+
+<!-- Liste o problema observavel que motivou a mudanca. Evite historico irrelevante. -->
+
+- 
+
+## Solucao
+
+<!-- Descreva a decisao tecnica/produto principal. Foque no comportamento novo. -->
+
+- 
+
+## O que muda na pratica
+
+<!-- Diga quem/qual fluxo sera afetado apos o merge. -->
+
+- 
+
+## O que NAO muda
+
+<!-- Deixe claro o que permanece igual para reduzir ambiguidade de review. -->
+
+- 
+
+## Validacao
+
+<!-- Liste comandos, testes, checks, dry-runs ou validacoes reais executadas. -->
+
+- 
+
+## Riscos
+
+<!-- Liste riscos conhecidos, compatibilidade, migracao, privacidade ou edge cases. -->
+
+- 
+
+## Rollback
+
+<!-- Explique como desfazer ou mitigar rapidamente se algo falhar em producao. -->
+
+- 
+
+## Follow-ups
+
+<!-- Opcional: itens fora do escopo desta PR. -->
+
+- 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,47 +4,47 @@
 
 ## Problema
 
-<!-- Liste o problema observavel que motivou a mudanca. Evite historico irrelevante. -->
+<!-- Liste o problema observável que motivou a mudança. Evite histórico irrelevante. -->
 
 - 
 
-## Solucao
+## Solução
 
-<!-- Descreva a decisao tecnica/produto principal. Foque no comportamento novo. -->
-
-- 
-
-## O que muda na pratica
-
-<!-- Diga quem/qual fluxo sera afetado apos o merge. -->
+<!-- Descreva a decisão técnica/produto principal. Foque no comportamento novo. -->
 
 - 
 
-## O que NAO muda
+## O que muda na prática
 
-<!-- Deixe claro o que permanece igual para reduzir ambiguidade de review. -->
+<!-- Diga quem/qual fluxo será afetado após o merge. -->
 
 - 
 
-## Validacao
+## O que NÃO muda
 
-<!-- Liste comandos, testes, checks, dry-runs ou validacoes reais executadas. -->
+<!-- Deixe claro o que permanece igual para reduzir ambiguidade na revisão. -->
+
+- 
+
+## Validação
+
+<!-- Liste comandos, testes, checks, execuções simuladas ou validações reais executadas. -->
 
 - 
 
 ## Riscos
 
-<!-- Liste riscos conhecidos, compatibilidade, migracao, privacidade ou edge cases. -->
+<!-- Liste riscos conhecidos, compatibilidade, migração, privacidade ou casos-limite. -->
 
 - 
 
 ## Rollback
 
-<!-- Explique como desfazer ou mitigar rapidamente se algo falhar em producao. -->
+<!-- Explique como desfazer ou mitigar rapidamente se algo falhar em produção. -->
 
 - 
 
-## Follow-ups
+## Pendências
 
 <!-- Opcional: itens fora do escopo desta PR. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,51 +1,51 @@
-## Objetivo
+## Objective
 
-<!-- Explique em 2-4 frases o que esta PR muda e por que isso deve existir. -->
+<!-- Explain in 2-4 sentences what this PR changes and why it should exist. -->
 
-## Problema
+## Problem
 
-<!-- Liste o problema observável que motivou a mudança. Evite histórico irrelevante. -->
-
-- 
-
-## Solução
-
-<!-- Descreva a decisão técnica/produto principal. Foque no comportamento novo. -->
+<!-- List the observable problem that motivated the change. Avoid irrelevant history. -->
 
 - 
 
-## O que muda na prática
+## Solution
 
-<!-- Diga quem/qual fluxo será afetado após o merge. -->
-
-- 
-
-## O que NÃO muda
-
-<!-- Deixe claro o que permanece igual para reduzir ambiguidade na revisão. -->
+<!-- Describe the main technical/product decision. Focus on the new behavior. -->
 
 - 
 
-## Validação
+## Practical impact
 
-<!-- Liste comandos, testes, checks, execuções simuladas ou validações reais executadas. -->
+<!-- Say who or what workflow is affected after merge. -->
 
 - 
 
-## Riscos
+## What does NOT change
 
-<!-- Liste riscos conhecidos, compatibilidade, migração, privacidade ou casos-limite. -->
+<!-- Make unchanged behavior explicit to reduce review ambiguity. -->
+
+- 
+
+## Validation
+
+<!-- List commands, tests, checks, dry-runs, or real validations executed. -->
+
+- 
+
+## Risks
+
+<!-- List known risks, compatibility, migration, privacy, or edge cases. -->
 
 - 
 
 ## Rollback
 
-<!-- Explique como desfazer ou mitigar rapidamente se algo falhar em produção. -->
+<!-- Explain how to revert or mitigate quickly if something fails in production. -->
 
 - 
 
-## Pendências
+## Follow-ups
 
-<!-- Opcional: itens fora do escopo desta PR. -->
+<!-- Optional: items intentionally left outside this PR scope. -->
 
 - 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+# GitHub Copilot Instructions
+
+## Pull request review
+
+When reviewing a pull request, inspect the PR description before reviewing code.
+
+A reviewable PR description must clearly answer:
+
+- What problem does this solve?
+- What behavior changes after merge?
+- What does not change?
+- Who or what is affected?
+- How was it validated?
+- What are the risks?
+- How can it be rolled back?
+
+Flag the PR when the description is vague, generic, or mostly implementation history.
+Ask for a rewrite before deep code review when the description does not make the
+merge decision obvious to a reviewer.
+
+Prefer comments that identify the missing decision-critical detail. Do not ask for
+business-sensitive details when a safe technical summary is enough.
+
+Watch for these PR-description issues:
+
+- missing problem statement;
+- missing concrete behavior change;
+- missing validation commands or evidence;
+- missing risk or rollback section;
+- irrelevant logs, chat history, or implementation chronology;
+- claims such as "tested" without naming what was tested;
+- sensitive business/customer data that should be summarized safely instead.
+
+For code review, keep feedback actionable and scoped to behavior, safety,
+compatibility, tests, and maintainability.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,35 +1,35 @@
-# GitHub Copilot Instructions
+# Instruções do GitHub Copilot
 
-## Pull request review
+## Revisão de pull requests
 
-When reviewing a pull request, inspect the PR description before reviewing code.
+Ao revisar uma pull request, inspecione a descrição da PR antes de revisar o código.
 
-A reviewable PR description must clearly answer:
+Uma descrição revisável precisa responder com clareza:
 
-- What problem does this solve?
-- What behavior changes after merge?
-- What does not change?
-- Who or what is affected?
-- How was it validated?
-- What are the risks?
-- How can it be rolled back?
+- Qual problema esta PR resolve?
+- Qual comportamento muda depois do merge?
+- O que não muda?
+- Quem ou qual fluxo é afetado?
+- Como a mudança foi validada?
+- Quais são os riscos?
+- Como desfazer ou mitigar a mudança?
 
-Flag the PR when the description is vague, generic, or mostly implementation history.
-Ask for a rewrite before deep code review when the description does not make the
-merge decision obvious to a reviewer.
+Marque a PR quando a descrição estiver vaga, genérica ou focada demais em histórico
+de implementação. Peça uma reescrita antes de uma revisão profunda de código quando
+a descrição não deixar a decisão de merge óbvia para quem revisa.
 
-Prefer comments that identify the missing decision-critical detail. Do not ask for
-business-sensitive details when a safe technical summary is enough.
+Prefira comentários que identifiquem o detalhe decisivo que está faltando. Não peça
+detalhes sensíveis de negócio quando um resumo técnico seguro for suficiente.
 
-Watch for these PR-description issues:
+Procure estes problemas na descrição da PR:
 
-- missing problem statement;
-- missing concrete behavior change;
-- missing validation commands or evidence;
-- missing risk or rollback section;
-- irrelevant logs, chat history, or implementation chronology;
-- claims such as "tested" without naming what was tested;
-- sensitive business/customer data that should be summarized safely instead.
+- ausência de problema claro;
+- ausência de mudança concreta de comportamento;
+- ausência de comandos ou evidências de validação;
+- ausência de seção de riscos ou rollback;
+- logs, histórico de chat ou cronologia de implementação irrelevantes;
+- afirmações como "testado" sem dizer o que foi testado;
+- dados sensíveis de negócio ou cliente que deveriam ser resumidos com segurança.
 
-For code review, keep feedback actionable and scoped to behavior, safety,
-compatibility, tests, and maintainability.
+Na revisão de código, mantenha o feedback acionável e focado em comportamento,
+segurança, compatibilidade, testes e manutenibilidade.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,35 +1,35 @@
-# Instruções do GitHub Copilot
+# GitHub Copilot Instructions
 
-## Revisão de pull requests
+## Pull request review
 
-Ao revisar uma pull request, inspecione a descrição da PR antes de revisar o código.
+When reviewing a pull request, inspect the PR description before reviewing code.
 
-Uma descrição revisável precisa responder com clareza:
+A reviewable PR description must clearly answer:
 
-- Qual problema esta PR resolve?
-- Qual comportamento muda depois do merge?
-- O que não muda?
-- Quem ou qual fluxo é afetado?
-- Como a mudança foi validada?
-- Quais são os riscos?
-- Como desfazer ou mitigar a mudança?
+- What problem does this PR solve?
+- What behavior changes after merge?
+- What does not change?
+- Who or what workflow is affected?
+- How was the change validated?
+- What are the risks?
+- How can the change be rolled back or mitigated?
 
-Marque a PR quando a descrição estiver vaga, genérica ou focada demais em histórico
-de implementação. Peça uma reescrita antes de uma revisão profunda de código quando
-a descrição não deixar a decisão de merge óbvia para quem revisa.
+Flag the PR when the description is vague, generic, or mostly implementation history.
+Ask for a rewrite before deep code review when the description does not make the
+merge decision obvious to a reviewer.
 
-Prefira comentários que identifiquem o detalhe decisivo que está faltando. Não peça
-detalhes sensíveis de negócio quando um resumo técnico seguro for suficiente.
+Prefer comments that identify the missing decision-critical detail. Do not ask for
+business-sensitive details when a safe technical summary is enough.
 
-Procure estes problemas na descrição da PR:
+Watch for these PR-description issues:
 
-- ausência de problema claro;
-- ausência de mudança concreta de comportamento;
-- ausência de comandos ou evidências de validação;
-- ausência de seção de riscos ou rollback;
-- logs, histórico de chat ou cronologia de implementação irrelevantes;
-- afirmações como "testado" sem dizer o que foi testado;
-- dados sensíveis de negócio ou cliente que deveriam ser resumidos com segurança.
+- missing problem statement;
+- missing concrete behavior change;
+- missing validation commands or evidence;
+- missing risk or rollback section;
+- irrelevant logs, chat history, or implementation chronology;
+- claims such as "tested" without naming what was tested;
+- sensitive business/customer data that should be summarized safely instead.
 
-Na revisão de código, mantenha o feedback acionável e focado em comportamento,
-segurança, compatibilidade, testes e manutenibilidade.
+For code review, keep feedback actionable and scoped to behavior, safety,
+compatibility, tests, and maintainability.

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,103 @@
+name: PR Description
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  required-sections:
+    name: PR Description Required Sections
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate PR body
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+          const body = event.pull_request?.body ?? "";
+
+          const required = [
+            "Objetivo",
+            "Problema",
+            "Solucao",
+            "O que muda na pratica",
+            "O que NAO muda",
+            "Validacao",
+            "Riscos",
+            "Rollback",
+          ];
+
+          const normalize = (value) =>
+            value
+              .normalize("NFD")
+              .replace(/[\u0300-\u036f]/g, "")
+              .replace(/\s+/g, " ")
+              .trim()
+              .toLowerCase();
+
+          const sections = new Map();
+          const headingRegex = /^##\s+(.+?)\s*$/gm;
+          const matches = [...body.matchAll(headingRegex)];
+
+          for (let index = 0; index < matches.length; index += 1) {
+            const current = matches[index];
+            const next = matches[index + 1];
+            const title = normalize(current[1]);
+            const contentStart = current.index + current[0].length;
+            const contentEnd = next?.index ?? body.length;
+            sections.set(title, body.slice(contentStart, contentEnd).trim());
+          }
+
+          const missing = [];
+          const empty = [];
+          const placeholder = [];
+          const placeholderPatterns = [
+            /<!--[\s\S]*?-->/,
+            /\b(todo|tbd|preencher|preencha)\b/i,
+            /^\s*-\s*$/m,
+          ];
+
+          for (const section of required) {
+            const key = normalize(section);
+            const content = sections.get(key);
+            if (content === undefined) {
+              missing.push(section);
+              continue;
+            }
+
+            const withoutComments = content.replace(/<!--[\s\S]*?-->/g, "").trim();
+            if (withoutComments.length < 20) {
+              empty.push(section);
+            }
+
+            if (placeholderPatterns.some((pattern) => pattern.test(content))) {
+              placeholder.push(section);
+            }
+          }
+
+          const errors = [];
+          if (missing.length > 0) {
+            errors.push(`Missing required sections: ${missing.join(", ")}`);
+          }
+          if (empty.length > 0) {
+            errors.push(`Sections need concrete content: ${empty.join(", ")}`);
+          }
+          if (placeholder.length > 0) {
+            errors.push(`Remove template placeholders from: ${placeholder.join(", ")}`);
+          }
+
+          if (errors.length > 0) {
+            console.error(errors.join("\n"));
+            process.exit(1);
+          }
+
+          console.log("PR description has the required sections and concrete content.");
+          NODE

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,4 +1,4 @@
-name: PR Description
+name: Descrição da PR
 
 on:
   pull_request:
@@ -10,12 +10,12 @@ permissions:
 
 jobs:
   required-sections:
-    name: PR Description Required Sections
+    name: Seções obrigatórias da descrição da PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Validate PR body
+      - name: Validar descrição da PR
         shell: bash
         run: |
           node <<'NODE'
@@ -27,10 +27,10 @@ jobs:
           const required = [
             "Objetivo",
             "Problema",
-            "Solucao",
-            "O que muda na pratica",
-            "O que NAO muda",
-            "Validacao",
+            "Solução",
+            "O que muda na prática",
+            "O que NÃO muda",
+            "Validação",
             "Riscos",
             "Rollback",
           ];
@@ -85,13 +85,13 @@ jobs:
 
           const errors = [];
           if (missing.length > 0) {
-            errors.push(`Missing required sections: ${missing.join(", ")}`);
+            errors.push(`Seções obrigatórias ausentes: ${missing.join(", ")}`);
           }
           if (empty.length > 0) {
-            errors.push(`Sections need concrete content: ${empty.join(", ")}`);
+            errors.push(`Seções precisam de conteúdo concreto: ${empty.join(", ")}`);
           }
           if (placeholder.length > 0) {
-            errors.push(`Remove template placeholders from: ${placeholder.join(", ")}`);
+            errors.push(`Remova marcadores do template em: ${placeholder.join(", ")}`);
           }
 
           if (errors.length > 0) {
@@ -99,5 +99,5 @@ jobs:
             process.exit(1);
           }
 
-          console.log("PR description has the required sections and concrete content.");
+          console.log("A descrição da PR tem as seções obrigatórias e conteúdo concreto.");
           NODE

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,4 +1,4 @@
-name: Descrição da PR
+name: PR Description
 
 on:
   pull_request:
@@ -10,12 +10,12 @@ permissions:
 
 jobs:
   required-sections:
-    name: Seções obrigatórias da descrição da PR
+    name: PR Description Required Sections
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Validar descrição da PR
+      - name: Validate PR body
         shell: bash
         run: |
           node <<'NODE'
@@ -25,13 +25,13 @@ jobs:
           const body = event.pull_request?.body ?? "";
 
           const required = [
-            "Objetivo",
-            "Problema",
-            "Solução",
-            "O que muda na prática",
-            "O que NÃO muda",
-            "Validação",
-            "Riscos",
+            "Objective",
+            "Problem",
+            "Solution",
+            "Practical impact",
+            "What does NOT change",
+            "Validation",
+            "Risks",
             "Rollback",
           ];
 
@@ -85,13 +85,13 @@ jobs:
 
           const errors = [];
           if (missing.length > 0) {
-            errors.push(`Seções obrigatórias ausentes: ${missing.join(", ")}`);
+            errors.push(`Missing required sections: ${missing.join(", ")}`);
           }
           if (empty.length > 0) {
-            errors.push(`Seções precisam de conteúdo concreto: ${empty.join(", ")}`);
+            errors.push(`Sections need concrete content: ${empty.join(", ")}`);
           }
           if (placeholder.length > 0) {
-            errors.push(`Remova marcadores do template em: ${placeholder.join(", ")}`);
+            errors.push(`Remove template markers from: ${placeholder.join(", ")}`);
           }
 
           if (errors.length > 0) {
@@ -99,5 +99,5 @@ jobs:
             process.exit(1);
           }
 
-          console.log("A descrição da PR tem as seções obrigatórias e conteúdo concreto.");
+          console.log("PR description has the required sections and concrete content.");
           NODE


### PR DESCRIPTION
## Objective

Add GitHub pull request governance so reviewers get clear, decision-ready PR descriptions before merge. This PR adds a standard PR template, Copilot review instructions, and an automated status check that can be made required through branch protection or a ruleset.

## Problem

- Vague PR descriptions reduce reviewer confidence and slow down merges.
- The repository does not currently provide a PR template, so every author chooses a different structure.
- Copilot can review code, but it needs repository instructions to flag unclear PR descriptions consistently.
- Without a status check, this rule depends on human memory and cannot block incomplete descriptions.

## Solution

- Add `.github/PULL_REQUEST_TEMPLATE.md` with merge-decision sections.
- Add `.github/copilot-instructions.md` with Copilot review rules for PR-description clarity.
- Add `.github/workflows/pr-description.yml` with the `PR Description Required Sections` check.
- Validate required headings, concrete non-empty content, and template markers left behind.

## Practical impact

- New PRs get a standard structure for objective, problem, solution, impact, validation, risk, and rollback.
- Copilot is instructed to review PR-description clarity before deep code review.
- The new status check can be configured as required on `dev` or `main` to block incomplete descriptions.
- The PR template becomes automatic once this configuration reaches the repository default branch.

## What does NOT change

- This does not change Ravi runtime, CLI, SDK, permissions, or product behavior.
- This does not configure branch protection automatically because that lives in GitHub repository settings.
- This does not guarantee perfect semantic quality; the workflow validates minimum structure and non-empty concrete content.
- This does not require exposing sensitive business data; Copilot is instructed to accept safe technical summaries.

## Validation

- Checked GitHub official documentation for PR templates, Copilot custom instructions/code review, and required status checks.
- Ran `git diff --check`.
- Parsed the workflow YAML locally with Ruby and got `yaml ok`.
- Simulated a pull request event locally and executed the workflow parser; a valid English body passed.

## Risks

- Older PRs may fail the new check when edited or synchronized until their descriptions are updated.
- The PR template only appears automatically after the file reaches the repository default branch.
- The check may be too strict for very small PRs; the content-length rule can be relaxed later if it creates friction.
- If the status check is made required before the team is ready, merges may be blocked until descriptions are updated.

## Rollback

Revert this PR to remove the template, Copilot instructions, and workflow. If the check has been made required in GitHub, remove `PR Description Required Sections` from the branch protection rule or ruleset as well.

## Follow-ups

- After merge, configure branch protection/rulesets to require `PR Description Required Sections` on the target branch.
- Enable Copilot code review with custom instructions for the repository if it is not already enabled.
- Promote this configuration to the default branch `main` if PR templates must appear automatically for all new PRs.
