### PR TITLE
[codex] fix bound context and trace queries

### DIFF
--- a/src/cli/commands/sessions-trace.test.ts
+++ b/src/cli/commands/sessions-trace.test.ts
@@ -251,4 +251,52 @@ describe("SessionCommands trace", () => {
     expect(records.some((record) => record.recordType === "blob")).toBe(true);
     expect(records.some((record) => record.recordType === "explanation")).toBe(true);
   });
+
+  it("keeps omitted JSON trace limit unbounded while defaulting human output", () => {
+    seedCliTrace();
+
+    let jsonResult: { trace: { filters: { limit: number | null } } } | undefined;
+    captureLogs(() => {
+      jsonResult = new SessionCommands().trace(
+        "cli-trace",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        false,
+        false,
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+      ) as unknown as { trace: { filters: { limit: number | null } } };
+    });
+    expect(jsonResult?.trace.filters.limit).toBe(null);
+
+    let humanResult: { trace: { filters: { limit: number | null } } } | undefined;
+    captureLogs(() => {
+      humanResult = new SessionCommands().trace(
+        "cli-trace",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+      ) as unknown as { trace: { filters: { limit: number | null } } };
+    });
+    expect(humanResult?.trace.filters.limit).toBe(200);
+  });
 });

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1452,6 +1452,8 @@ function formatTraceWindow(trace: SessionTraceQueryResult): string {
   return `until ${formatTraceDateTime(until)}`;
 }
 
+const DEFAULT_TRACE_LIMIT = 200;
+
 function parseTraceLimit(value: string | undefined): number | undefined {
   if (value === undefined || value === null || value === "") return undefined;
   if (!/^\d+$/.test(value)) {
@@ -4133,7 +4135,7 @@ export class SessionCommands {
       messageId,
       correlationId,
       only,
-      limit: parseTraceLimit(limitStr),
+      limit: parseTraceLimit(limitStr) ?? DEFAULT_TRACE_LIMIT,
       includeStream,
       raw,
       showSystemPrompt,

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -4124,6 +4124,9 @@ export class SessionCommands {
     const target = this.resolveTraceTarget(nameOrKey);
     if (!target) return;
 
+    const parsedLimit = parseTraceLimit(limitStr);
+    const traceLimit = parsedLimit ?? (asJson ? undefined : DEFAULT_TRACE_LIMIT);
+
     const trace = querySessionTrace({
       session: nameOrKey,
       sessionKey: target.session?.sessionKey,
@@ -4135,7 +4138,7 @@ export class SessionCommands {
       messageId,
       correlationId,
       only,
-      limit: parseTraceLimit(limitStr) ?? DEFAULT_TRACE_LIMIT,
+      limit: traceLimit,
       includeStream,
       raw,
       showSystemPrompt,

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -2377,7 +2377,12 @@ function getDb(): Database {
   db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_contexts_key ON contexts(context_key)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_agent ON contexts(agent_id)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_session ON contexts(session_key)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_agent_kind ON contexts(agent_id, kind, created_at DESC)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_session_kind ON contexts(session_key, kind, created_at DESC)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_created ON contexts(created_at DESC)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_expires ON contexts(expires_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_expires_created ON contexts(expires_at, created_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_contexts_revoked_created ON contexts(revoked_at, created_at)");
   db.exec(`
     CREATE TABLE IF NOT EXISTS audit_log (
       id         INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -7270,24 +7275,35 @@ export function dbGetContextByKeyReadOnly(contextKey: string): ContextRecord | n
 }
 
 export function dbListContexts(options: ListContextsOptions = {}): ContextRecord[] {
-  const s = getStatements();
   const now = Date.now();
-  const rows = s.listContexts.all() as ContextRow[];
+  const where: string[] = [];
+  const params: Array<number | string> = [];
 
-  return rows
-    .map((row) => rowToContext(row))
-    .filter((context) => {
-      if (options.agentId && context.agentId !== options.agentId) return false;
-      if (options.sessionKey && context.sessionKey !== options.sessionKey) return false;
-      if (options.kind && context.kind !== options.kind) return false;
+  if (options.agentId) {
+    where.push("agent_id = ?");
+    params.push(options.agentId);
+  }
+  if (options.sessionKey) {
+    where.push("session_key = ?");
+    params.push(options.sessionKey);
+  }
+  if (options.kind) {
+    where.push("kind = ?");
+    params.push(options.kind);
+  }
 
-      if (!options.includeInactive) {
-        if (context.revokedAt && context.revokedAt <= now) return false;
-        if (context.expiresAt && context.expiresAt <= now) return false;
-      }
+  if (!options.includeInactive) {
+    where.push("(revoked_at IS NULL OR revoked_at = 0 OR revoked_at > ?)");
+    params.push(now);
+    where.push("(expires_at IS NULL OR expires_at = 0 OR expires_at > ?)");
+    params.push(now);
+  }
 
-      return true;
-    });
+  const sql = `SELECT * FROM contexts${where.length > 0 ? ` WHERE ${where.join(" AND ")}` : ""} ORDER BY created_at DESC`;
+  const rows = getDb()
+    .prepare(sql)
+    .all(...params) as ContextRow[];
+  return rows.map((row) => rowToContext(row));
 }
 
 export function dbTouchContext(contextId: string, lastUsedAt = Date.now()): void {
@@ -7461,22 +7477,27 @@ export interface PruneContextsResult {
  * so pruning cannot drop live authority. Timestamps are epoch milliseconds.
  */
 export function dbPruneContexts(options: { apply?: boolean; olderThanMs?: number } = {}): PruneContextsResult {
+  const db = getDb();
   const now = Date.now();
   const cutoff = options.olderThanMs != null ? now - Math.max(0, options.olderThanMs) : now;
-  const prunable = dbListContexts({ includeInactive: true }).filter((context) => {
-    const inactive =
-      (context.revokedAt != null && context.revokedAt <= now) ||
-      (context.expiresAt != null && context.expiresAt <= now);
-    return inactive && context.createdAt <= cutoff;
-  });
+  const where = `
+    created_at <= ?
+    AND (
+      (revoked_at IS NOT NULL AND revoked_at != 0 AND revoked_at <= ?)
+      OR (expires_at IS NOT NULL AND expires_at != 0 AND expires_at <= ?)
+    )
+  `;
+  const params = [cutoff, now, now];
+  const matched =
+    (db.prepare(`SELECT COUNT(*) AS c FROM contexts WHERE ${where}`).get(...params) as { c?: number } | undefined)?.c ??
+    0;
 
   if (options.apply === true) {
-    for (const context of prunable) {
-      dbDeleteContext(context.contextId);
-    }
+    db.prepare(`DELETE FROM contexts WHERE ${where}`).run(...params);
+    return { matched, pruned: getDbChanges() };
   }
 
-  return { matched: prunable.length, pruned: options.apply === true ? prunable.length : 0 };
+  return { matched, pruned: 0 };
 }
 
 // ============================================================================

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { dbCreateAgent, dbCreateContext, dbListContexts, dbPruneContexts } from "./router-db.js";
+import { getOrCreateSession } from "./sessions.js";
+
+let stateDir: string | null = null;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function createContext(input: {
+  id: string;
+  agentId?: string;
+  sessionKey?: string;
+  kind?: "agent-runtime" | "turn-runtime" | "child-task" | "tool-call";
+  createdAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+}) {
+  dbCreateContext({
+    contextId: input.id,
+    contextKey: `key-${input.id}`,
+    kind: input.kind ?? "turn-runtime",
+    agentId: input.agentId,
+    sessionKey: input.sessionKey,
+    capabilities: [],
+    createdAt: input.createdAt,
+    ...(input.expiresAt != null ? { expiresAt: input.expiresAt } : {}),
+    ...(input.revokedAt != null ? { revokedAt: input.revokedAt } : {}),
+  });
+}
+
+describe("router context queries", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-router-context-query-test-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("lists contexts with SQL-backed filters and excludes inactive contexts by default", () => {
+    const now = Date.now();
+    dbCreateAgent({ id: "agent-a", cwd: "/tmp/ravi-agent-a" });
+    dbCreateAgent({ id: "agent-b", cwd: "/tmp/ravi-agent-b" });
+    getOrCreateSession("agent:agent-a:main", "agent-a", "/tmp/ravi-agent-a", { name: "agent-a-main" });
+    getOrCreateSession("agent:agent-b:main", "agent-b", "/tmp/ravi-agent-b", { name: "agent-b-main" });
+
+    createContext({
+      id: "matching-live",
+      agentId: "agent-a",
+      sessionKey: "agent:agent-a:main",
+      kind: "turn-runtime",
+      createdAt: now - 3 * DAY,
+      expiresAt: now + DAY,
+    });
+    createContext({
+      id: "matching-expired",
+      agentId: "agent-a",
+      sessionKey: "agent:agent-a:main",
+      kind: "turn-runtime",
+      createdAt: now - 2 * DAY,
+      expiresAt: now - DAY,
+    });
+    createContext({
+      id: "other-agent",
+      agentId: "agent-b",
+      sessionKey: "agent:agent-b:main",
+      kind: "turn-runtime",
+      createdAt: now - DAY,
+      expiresAt: now + DAY,
+    });
+    createContext({
+      id: "other-kind",
+      agentId: "agent-a",
+      sessionKey: "agent:agent-a:main",
+      kind: "child-task",
+      createdAt: now,
+      expiresAt: now + DAY,
+    });
+
+    expect(
+      dbListContexts({
+        agentId: "agent-a",
+        sessionKey: "agent:agent-a:main",
+        kind: "turn-runtime",
+      }).map((context) => context.contextId),
+    ).toEqual(["matching-live"]);
+
+    expect(
+      dbListContexts({
+        agentId: "agent-a",
+        sessionKey: "agent:agent-a:main",
+        kind: "turn-runtime",
+        includeInactive: true,
+      }).map((context) => context.contextId),
+    ).toEqual(["matching-expired", "matching-live"]);
+  });
+
+  it("prunes inactive contexts in the database while preserving active contexts", () => {
+    const now = Date.now();
+    createContext({ id: "active", createdAt: now - 30 * DAY, expiresAt: now + DAY });
+    createContext({ id: "expired-old", createdAt: now - 30 * DAY, expiresAt: now - 10 * DAY });
+    createContext({ id: "revoked-old", createdAt: now - 30 * DAY, revokedAt: now - 10 * DAY });
+    createContext({ id: "expired-recent", createdAt: now - DAY, expiresAt: now - 1000 });
+
+    expect(dbPruneContexts({ olderThanMs: 7 * DAY })).toEqual({ matched: 2, pruned: 0 });
+    expect(dbPruneContexts({ apply: true, olderThanMs: 7 * DAY })).toEqual({ matched: 2, pruned: 2 });
+
+    expect(
+      dbListContexts({ includeInactive: true })
+        .map((context) => context.contextId)
+        .sort(),
+    ).toEqual(["active", "expired-recent"]);
+  });
+});

--- a/src/session-trace/query.test.ts
+++ b/src/session-trace/query.test.ts
@@ -264,6 +264,10 @@ describe("querySessionTrace", () => {
 
     const onlyAdapterWithStream = querySessionTrace({ session: "trace-session", only: "adapter", includeStream: true });
     expect(onlyAdapterWithStream.events.map((event) => event.eventType)).toEqual(["adapter.request"]);
+
+    const onlyTurns = querySessionTrace({ session: "trace-session", only: "turns" });
+    expect(onlyTurns.events).toEqual([]);
+    expect(onlyTurns.turns.map((turn) => turn.turnId)).toEqual(["turn-1"]);
   });
 
   it("limits the latest visible timeline rows after filters", () => {

--- a/src/session-trace/query.ts
+++ b/src/session-trace/query.ts
@@ -461,6 +461,8 @@ function addOnlyFilter(where: string[], params: SqlParam[], only: SessionTraceOn
   }
   if (clauses.length > 0) {
     where.push(`(${clauses.join(" OR ")})`);
+  } else {
+    where.push("0 = 1");
   }
 }
 

--- a/src/session-trace/query.ts
+++ b/src/session-trace/query.ts
@@ -439,18 +439,36 @@ function isStreamEventType(eventType: string): boolean {
   return false;
 }
 
-function isStreamEvent(event: SessionEventRecord): boolean {
-  return isStreamEventType(event.eventType);
+const STREAM_EVENT_SQL =
+  "(event_type = 'adapter.raw' OR event_type LIKE '%.stream%' OR event_type LIKE '%.delta' OR event_type LIKE '%provider_event%')";
+
+function addOnlyFilter(where: string[], params: SqlParam[], only: SessionTraceOnlyFilter): void {
+  if (only.raw.length === 0) return;
+  const clauses: string[] = [];
+  const streamGroup = only.groups.includes("stream");
+  const nonStreamGroups = only.groups.filter((group) => group !== "stream");
+  if (nonStreamGroups.length > 0) {
+    clauses.push(`(LOWER(event_group) IN (${nonStreamGroups.map(() => "?").join(", ")}) AND NOT ${STREAM_EVENT_SQL})`);
+    params.push(...nonStreamGroups);
+  }
+  if (streamGroup) {
+    clauses.push(`(LOWER(event_group) = ? OR ${STREAM_EVENT_SQL})`);
+    params.push("stream");
+  }
+  if (only.eventTypes.length > 0) {
+    clauses.push(`LOWER(event_type) IN (${only.eventTypes.map(() => "?").join(", ")})`);
+    params.push(...only.eventTypes);
+  }
+  if (clauses.length > 0) {
+    where.push(`(${clauses.join(" OR ")})`);
+  }
 }
 
-function matchesOnly(event: SessionEventRecord, only: SessionTraceOnlyFilter): boolean {
-  if (only.raw.length === 0) return true;
-  if (only.groups.includes(event.eventGroup.toLowerCase())) return true;
-  if (only.eventTypes.includes(event.eventType.toLowerCase())) return true;
-  return false;
-}
-
-function queryEvents(input: SessionTraceQueryInput, only: SessionTraceOnlyFilter): SessionEventRecord[] {
+function queryEvents(
+  input: SessionTraceQueryInput,
+  only: SessionTraceOnlyFilter,
+  limit: number | null,
+): SessionEventRecord[] {
   const where: string[] = [];
   const params: SqlParam[] = [];
 
@@ -459,12 +477,26 @@ function queryEvents(input: SessionTraceQueryInput, only: SessionTraceOnlyFilter
   addExactFilter(where, params, "turn_id", input.turnId);
   addExactFilter(where, params, "run_id", input.runId);
   addExactFilter(where, params, "message_id", input.messageId);
+  if (!input.includeStream) {
+    where.push(`event_group != ? AND NOT ${STREAM_EVENT_SQL}`);
+    params.push("stream");
+  }
+  addOnlyFilter(where, params, only);
+
+  const correlationId = compactText(input.correlationId);
+  const canLimitInSql = limit !== null && !correlationId;
+  const orderSql = canLimitInSql ? "timestamp DESC, seq DESC, id DESC" : "timestamp ASC, seq ASC, id ASC";
+  const limitSql = canLimitInSql ? "LIMIT ?" : "";
+  if (canLimitInSql) {
+    params.push(limit);
+  }
 
   const sql = `
     SELECT *
     FROM session_events
     ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-    ORDER BY timestamp ASC, seq ASC, id ASC
+    ORDER BY ${orderSql}
+    ${limitSql}
   `;
 
   let events = (
@@ -473,13 +505,10 @@ function queryEvents(input: SessionTraceQueryInput, only: SessionTraceOnlyFilter
       .all(...params) as SessionEventRow[]
   ).map(rowToSessionEvent);
 
-  if (!input.includeStream) {
-    events = events.filter((event) => !isStreamEvent(event));
+  if (canLimitInSql) {
+    events.reverse();
   }
 
-  events = events.filter((event) => matchesOnly(event, only));
-
-  const correlationId = compactText(input.correlationId);
   if (correlationId) {
     events = events.filter((event) => containsCorrelationId(event.payloadJson, correlationId));
   }
@@ -487,7 +516,12 @@ function queryEvents(input: SessionTraceQueryInput, only: SessionTraceOnlyFilter
   return events;
 }
 
-function queryTurns(input: SessionTraceQueryInput, events: SessionEventRecord[], only: SessionTraceOnlyFilter) {
+function queryTurns(
+  input: SessionTraceQueryInput,
+  events: SessionEventRecord[],
+  only: SessionTraceOnlyFilter,
+  limit: number | null,
+) {
   if (only.raw.length > 0 && !only.includeTurns) {
     return [];
   }
@@ -520,18 +554,30 @@ function queryTurns(input: SessionTraceQueryInput, events: SessionEventRecord[],
     params.push(...eventTurnIds);
   }
 
+  const canLimitInSql = limit !== null;
+  const orderSql = canLimitInSql ? "started_at DESC, turn_id DESC" : "started_at ASC, turn_id ASC";
+  const limitSql = canLimitInSql ? "LIMIT ?" : "";
+  if (canLimitInSql) {
+    params.push(limit);
+  }
+
   const sql = `
     SELECT *
     FROM session_turns
     ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-    ORDER BY started_at ASC, turn_id ASC
+    ORDER BY ${orderSql}
+    ${limitSql}
   `;
 
-  return (
+  const turns = (
     getDb()
       .prepare(sql)
       .all(...params) as SessionTurnRow[]
   ).map(rowToSessionTurn);
+  if (canLimitInSql) {
+    turns.reverse();
+  }
+  return turns;
 }
 
 function normalizeLimit(limit: number | undefined): number | null {
@@ -733,8 +779,8 @@ export function parseSessionTraceTime(value: string | undefined, now = Date.now(
 export function querySessionTrace(input: SessionTraceQueryInput): SessionTraceQueryResult {
   const only = normalizeSessionTraceOnly(input.only);
   const limit = normalizeLimit(input.limit);
-  const queriedEvents = queryEvents(input, only);
-  const queriedTurns = input.includeTurns === false ? [] : queryTurns(input, queriedEvents, only);
+  const queriedEvents = queryEvents(input, only, limit);
+  const queriedTurns = input.includeTurns === false ? [] : queryTurns(input, queriedEvents, only, limit);
   const { events, turns } = applyTimelineLimit(queriedEvents, queriedTurns, limit);
   const requestedBlobs = new Set<string>();
   const systemPrompt = input.showSystemPrompt

--- a/src/session-trace/session-trace.test.ts
+++ b/src/session-trace/session-trace.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { querySessionTrace } from "./query.js";
+import { recordSessionEvent } from "./session-trace-db.js";
+
+let stateDir: string | null = null;
+
+function recordTraceEvent(eventType: string, eventGroup: string, timestamp: number) {
+  recordSessionEvent({
+    sessionKey: "agent:main:trace-limit",
+    sessionName: "trace-limit",
+    agentId: "main",
+    eventType,
+    eventGroup,
+    timestamp,
+    createdAt: timestamp,
+  });
+}
+
+describe("session trace query", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-session-trace-limit-test-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("applies stream suppression before the bounded timeline limit", () => {
+    recordTraceEvent("channel.message.received", "channel", 1000);
+    recordTraceEvent("adapter.raw", "adapter", 1100);
+    recordTraceEvent("tool.start", "tool", 1200);
+    recordTraceEvent("response.emitted", "response", 1300);
+
+    expect(querySessionTrace({ session: "trace-limit", limit: 2 }).events.map((event) => event.eventType)).toEqual([
+      "tool.start",
+      "response.emitted",
+    ]);
+
+    expect(
+      querySessionTrace({ session: "trace-limit", only: "stream", includeStream: true }).events.map(
+        (event) => event.eventType,
+      ),
+    ).toEqual(["adapter.raw"]);
+  });
+});


### PR DESCRIPTION
## Objective

Bound the expensive context and session trace query paths so local Ravi databases remain responsive as cron jobs, agents, and trace volume grow.

## Problem

Large runtime databases can accumulate many contexts and hundreds of thousands of trace rows. Some helpers still loaded broad result sets into memory before applying filters, which made routine diagnostics vulnerable to slow SQLite scans and lock contention.

## Solution

Move context list filters and pruning into indexed SQLite queries, including direct count/delete pruning for inactive contexts. Move session trace stream and event filters plus timeline limits into SQL, and cap ravi sessions trace output to a default limit of 200 rows.

## Practical impact

Ravi avoids scanning full context and trace tables for common CLI/runtime operations. This keeps performance more predictable as we add more crons, agents, and long-lived sessions.

## What does NOT change

The stored schema remains backward-compatible and the user-facing commands keep the same behavior aside from bounded default trace output. Existing context and trace records are not migrated, rewritten, or deleted outside explicit prune operations.

## Validation

Focused tests pass for context filtering/pruning and trace query filtering. Local validation also passed build, typecheck, the full pre-push test suite, SDK drift check, and SDK check before the branch was pushed.

## Risks

The main risk is query behavior differing from the prior in-memory filtering for edge cases. Added regression tests cover the changed context and trace paths, including inactive context visibility, prune counts, stream suppression, and bounded timeline limits.

## Rollback

Revert commit 3cc8a11 from PR #162 to restore the previous in-memory filtering paths and remove the new focused tests.
