### PR TITLE
Add native Slack skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,25 @@
 # Ravi Bot
 
-The daemon that gives Claude a life. Multi-channel messaging (WhatsApp, Telegram, Discord) via omni-v2, running entirely locally with embedded NATS JetStream and omni API server as child processes.
+The daemon that gives Claude a life. Ravi runs local agent sessions, native Slack channels, and legacy transport bridges with embedded NATS JetStream.
 
 ## Architecture
 
 ```
 ravi daemon start
   ├── nats-server :4222 (JetStream)
-  ├── omni API    :8882 (child process bun)
+  ├── legacy channel bridge :8882 (child process bun)
   │     ├── WhatsApp (Baileys)
   │     ├── Telegram
   │     └── Discord
   └── ravi bot
-        ├── OmniConsumer  → JetStream pull consumer (message.received.>)
+        ├── Native Slack adapter → Socket Mode, Web API, Canvas, files, threads
+        ├── Channel consumer      → JetStream pull consumer (message.received.>)
         ├── Claude Agent SDK (sessions, tools)
-        ├── OmniSender    → HTTP POST /api/v2/messages/send
+        ├── Channel sender        → native Slack delivery + bridge delivery
         └── Runners (cron, heartbeat, triggers)
 ```
 
-**Infrastructure:** nats-server (JetStream enabled) and omni API server start automatically as child processes. The omni API key is bootstrapped on first run and stored in `~/.ravi/omni-api-key`. Configure omni in `~/.ravi/.env` via `OMNI_DIR`, `DATABASE_URL`, `OMNI_API_PORT`.
+**Infrastructure:** nats-server starts automatically for local eventing. Slack runs through the native Ravi Slack adapter. Legacy transport bridges may also start as child processes for channels that have not moved to native adapters yet.
 
 ## Quick Start
 
@@ -29,11 +30,9 @@ bun install
 # 2. Run setup wizard (downloads nats-server, configures auth, creates agent)
 ravi setup
 
-# 3. Configure omni in ~/.ravi/.env:
-# OMNI_DIR=/path/to/omni-v2
-# DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/omni
+# 3. Configure channel credentials in the Ravi credential broker / ~/.ravi/.env
 
-# 4. Start daemon (nats-server + omni + bot + gateway)
+# 4. Start daemon (nats-server + bot + gateway + configured channel adapters)
 ravi daemon start
 
 # 5. Connect WhatsApp
@@ -69,7 +68,7 @@ artifact upload/publish pipeline internally.
 
 For full topic reference with payloads, see the **events** skill (`src/plugins/internal/ravi-system/skills/events/SKILL.md`).
 
-**omni NATS subjects (JetStream stream: MESSAGE):**
+**Legacy bridge NATS subjects (JetStream stream: MESSAGE):**
 - `message.received.{channelType}.{instanceId}` — inbound message
 - `reaction.received.{channelType}.{instanceId}` — inbound reaction
 - `instance.connected.{channelType}.{instanceId}` — account connected
@@ -438,7 +437,7 @@ ravi whatsapp connect --account suporte --agent suporte --mode sentinel
 ~/.ravi/
 ├── ravi.db          # Config and sessions (SQLite)
 ├── .env             # Environment variables (loaded by daemon)
-├── omni-api-key     # Auto-generated omni API key
+├── omni-api-key     # Auto-generated legacy bridge API key
 ├── jetstream/       # NATS JetStream storage
 ├── bin/
 │   └── nats-server  # nats-server binary (auto-downloaded)
@@ -481,7 +480,7 @@ This keeps three truths aligned:
 ravi setup             # Interactive setup wizard
 
 # Daemon (recommended)
-ravi daemon start      # Start nats + omni + bot + gateway
+ravi daemon start      # Start nats + bot + gateway + configured channel adapters
 ravi daemon stop       # Stop daemon
 ravi daemon restart    # Restart daemon
 ravi daemon status     # Show status
@@ -691,7 +690,7 @@ Images, videos, documents, and stickers are downloaded to `/tmp/ravi-media/` and
 CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xxx
 ANTHROPIC_API_KEY=sk-ant-xxx
 
-# Omni (required for channel support)
+# Legacy transport bridge (only for channels still using the bridge)
 OMNI_DIR=/path/to/omni-v2
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/omni
 OMNI_API_PORT=8882          # Default
@@ -760,7 +759,7 @@ alias nats-local='nats --server nats://127.0.0.1:4222'
 nats stream ls --server nats://127.0.0.1:4222
 ```
 
-Omni streams: `MESSAGE`, `INSTANCE`, `REACTION`, `MEDIA`, `ACCESS`, `IDENTITY`, `CUSTOM`, `SYSTEM`.
+Legacy bridge streams: `MESSAGE`, `INSTANCE`, `REACTION`, `MEDIA`, `ACCESS`, `IDENTITY`, `CUSTOM`, `SYSTEM`.
 
 ### Inspect a stream
 
@@ -834,7 +833,7 @@ ravi daemon restart
 
 ### Live subscribe (plain pub/sub — no JetStream)
 
-Watch events in real time as they arrive from omni:
+Watch legacy bridge events in real time:
 
 ```bash
 # All message events

--- a/src/plugins/internal/ravi-system/skills/channels/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/channels/SKILL.md
@@ -11,8 +11,7 @@ description: |
 
 # Channels Manager
 
-Canais são gerenciados por adapters do Ravi. WhatsApp ainda pode passar pelo
-Omni como compatibilidade de transporte, mas Slack deve usar a skill nativa
+Canais são gerenciados por adapters do Ravi. Para Slack, use a skill nativa
 `ravi-system:slack` / `ravi-system-slack` e os comandos `ravi slack ...`.
 
 Cada conta conectada é uma **instância** — a entidade central de configuração do Ravi.
@@ -54,7 +53,7 @@ ravi instances set <name> dmScope per-peer
 ravi instances disconnect <name>
 ```
 
-### Ver status omni
+### Ver status da instância
 ```bash
 ravi instances status <name>
 ```
@@ -97,11 +96,11 @@ ravi instances set suporte groupPolicy allowlist
 ```bash
 ravi instances status main    # Ver estado da instância
 ravi instances connect main   # Reconectar (mostra QR se necessário)
-ravi daemon logs              # Ver logs do daemon e omni
+ravi daemon logs              # Ver logs do daemon
 ```
 
 ### Daemon não inicia
 ```bash
 ravi daemon logs              # Ver erros de startup
-# Verificar OMNI_DIR em ~/.ravi/.env
+# Verificar configuração da instância e credenciais em ~/.ravi/.env
 ```

--- a/src/plugins/internal/ravi-system/skills/channels/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/channels/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: channels-manager
 description: |
-  Gerencia canais de comunicação do Ravi via omni. Use quando o usuário quiser:
-  - Ver status das instâncias WhatsApp, Discord, Telegram
+  Gerencia canais de comunicação do Ravi. Use quando o usuário quiser:
+  - Ver status das instâncias WhatsApp, Slack, Discord, Telegram
   - Conectar ou desconectar contas
   - Configurar policies de DM e grupo por instância
   - Verificar QR code de pareamento
@@ -11,7 +11,21 @@ description: |
 
 # Channels Manager
 
-Canais são gerenciados pelo omni API server (processo filho do daemon). Cada conta conectada é uma **instância** — a entidade central de configuração do Ravi.
+Canais são gerenciados por adapters do Ravi. WhatsApp ainda pode passar pelo
+Omni como compatibilidade de transporte, mas Slack deve usar a skill nativa
+`ravi-system:slack` / `ravi-system-slack` e os comandos `ravi slack ...`.
+
+Cada conta conectada é uma **instância** — a entidade central de configuração do Ravi.
+
+## Slack Nativo
+
+Para qualquer tarefa de Slack, Canvas, threads, topology, replay, delivery ou
+presenca nativa, use a skill `ravi-system:slack`.
+
+```bash
+ravi skills show slack --json
+ravi slack --help
+```
 
 ## Instâncias (central config)
 

--- a/src/plugins/internal/ravi-system/skills/slack/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/slack/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: slack
+description: |
+  Opera o canal Slack nativo do Ravi. Use quando o usuario quiser:
+  - Criar, listar, inspecionar, renomear ou convidar pessoas para canais Slack
+  - Enviar, ler, inspecionar ou dar replay em mensagens Slack
+  - Criar, publicar, editar ou gerenciar Slack Canvas
+  - Publicar artifacts Markdown como Slack Canvas
+  - Entender rotas, sessoes, threads, presenca/status ou topology do Slack nativo
+  - Ver scopes/permissoes Slack e diagnosticar capacidades da integracao nativa
+---
+
+# Slack Nativo
+
+Slack e um canal nativo do Ravi. Para Slack, prefira sempre `ravi slack ...`
+e as specs `channels/slack/*`. Nao use Omni como caminho normal para novas
+operacoes Slack.
+
+## Principios
+
+- Ravi e dono de `chat`, `thread`, `session`, `message`, `delivery`,
+  `presence`, `route`, `artifact` e `policy`.
+- Slack e adapter/plataforma: workspace, channel, DM, thread, files, Canvas e
+  assistant status sao projetados para o modelo Ravi.
+- Mutacoes Slack devem ser dry-run por padrao e executar somente com
+  `--execute`.
+- Use `--json` quando outro agent ou workflow for consumir a resposta.
+- Nunca exponha tokens Slack, scopes sensiveis brutos ou secrets. Use o broker
+  de credenciais/connections.
+- Antes de uma mutacao incerta, verifique scopes com:
+
+```bash
+ravi slack permissions-list --json
+```
+
+## Descoberta Rapida
+
+```bash
+ravi slack --help
+ravi slack permissions-list --json
+ravi slack channels-list --json
+ravi slack topology --json
+```
+
+## Mapa De Capabilities
+
+Leia apenas a referencia relevante para a tarefa:
+
+- `references/canvas.md` - Slack Canvas, showcase e artifact -> Canvas.
+- `references/operations.md` - criar/renomear/convidar canais, membros, files.
+- `references/messages-replay.md` - envio, historico, inspect e replay.
+- `references/topology.md` - rotas, sessoes, ownership e diagnostico.
+- `references/threads-routing.md` - forks de sessao por Slack thread.
+- `references/presence.md` - status nativo/assistant status e delivery boundary.
+- `references/credentials.md` - connections, scopes e seguranca de tokens.
+- `references/runner-delivery.md` - runner, outbound jobs e idempotencia.
+
+## Comandos Principais
+
+### Read-only
+
+```bash
+ravi slack channels-list --json
+ravi slack channels-info <channel> --json
+ravi slack channels-history <channel> --json
+ravi slack members-list <channel> --json
+ravi slack files-list --json
+ravi slack topology --json
+ravi slack permissions-list --json
+```
+
+### Mensagens
+
+```bash
+ravi slack messages-send <channel> "texto" --execute --json
+ravi slack messages-inspect <channel> <ts> --json
+ravi slack messages-replay <channel> <ts> --execute --json
+```
+
+### Canais
+
+```bash
+ravi slack channels-create "nome-canal" --execute --json
+ravi slack channels-rename <channel> "novo-nome" --execute --json
+ravi slack channels-invite <channel> <userIds> --execute --json
+```
+
+### Canvas
+
+```bash
+ravi slack canvas-create --title "Titulo" --artifact <artifactId> --execute --json
+ravi slack canvas-channel-create <channel> --title "Titulo" --artifact <artifactId> --ensure --execute --json
+ravi slack canvas-edit <canvas> replace --artifact <artifactId> --execute --json
+ravi slack canvas-artifact-status <artifactId> --json
+```
+
+## Fonte De Verdade Para Canvas
+
+Para Canvas, o source canonico deve ser um Ravi artifact Markdown. O Slack Canvas
+e a projecao publicada. Nesta fase, edicoes manuais feitas no Slack sao
+out-of-band e podem ser sobrescritas em novo publish do Ravi.
+
+## Specs Relacionadas
+
+```bash
+ravi specs get channels/slack --mode rules --json
+ravi specs get channels/slack/canvas --mode rules --json
+ravi specs get channels/slack/operations --mode rules --json
+ravi specs get channels/slack/threads --mode rules --json
+ravi specs get channels/slack/presence --mode rules --json
+ravi specs get channels/slack/topology --mode rules --json
+ravi specs get channels/slack/message-replay --mode rules --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/slack/SKILL.md
@@ -12,9 +12,8 @@ description: |
 
 # Slack Nativo
 
-Slack e um canal nativo do Ravi. Para Slack, prefira sempre `ravi slack ...`
-e as specs `channels/slack/*`. Nao use Omni como caminho normal para novas
-operacoes Slack.
+Slack e um canal nativo do Ravi. Para Slack, use `ravi slack ...` e as specs
+`channels/slack/*` como fonte operacional.
 
 ## Principios
 

--- a/src/plugins/internal/ravi-system/skills/slack/references/canvas.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/canvas.md
@@ -1,0 +1,55 @@
+# Slack Canvas
+
+Use esta referencia quando a tarefa envolver Slack Canvas, showcase, artifacts
+Markdown, publish, patch de secao, acesso ou remocao de Canvas.
+
+## Regra Central
+
+O Ravi artifact Markdown e a fonte canonica. O Slack Canvas e a projecao
+publicada.
+
+Nao prometa sync bidirecional automatico. A API atual usada pelo Ravi permite
+criar, editar, procurar secoes e gerenciar acesso, mas nao oferece export
+Markdown completo confiavel para reconciliacao Slack -> Ravi.
+
+## Comandos
+
+```bash
+ravi slack canvas-create --title "Titulo" --artifact <artifactId> --execute --json
+ravi slack canvas-create --title "Titulo" --markdown-file ./canvas.md --execute --json
+
+ravi slack canvas-channel-create <channel> --title "Titulo" --artifact <artifactId> --ensure --execute --json
+ravi slack canvas-channel-showcase <channel> --execute --json
+
+ravi slack canvas-edit <canvas> replace --artifact <artifactId> --execute --json
+ravi slack canvas-sections-lookup <canvas> --section-types h1,h2 --contains-text "Status" --json
+ravi slack canvas-edit <canvas> replace --section-id <sectionId> --markdown-file ./status.md --execute --json
+
+ravi slack canvas-access-set <canvas> write --channels <channelIds> --execute --json
+ravi slack canvas-access-delete <canvas> --users <userIds> --execute --json
+ravi slack canvas-delete <canvas> --execute --json
+ravi slack canvas-artifact-status <artifactId> --json
+```
+
+## Dry-run
+
+Mutacoes de Canvas sao dry-run por padrao. Adicione `--execute` somente quando a
+acao estiver correta.
+
+## Artifact Metadata
+
+Quando o publish usa `--artifact` e publica o documento inteiro, o Ravi deve
+registrar:
+
+- `slackCanvas.current`
+- evento `slack.canvas.published`
+- link do artifact para `slack_canvas`
+- link do artifact para `slack_channel` quando houver canal
+
+Patch por secao com `--artifact` nao deve sobrescrever `slackCanvas.current`.
+
+## Specs
+
+```bash
+ravi specs get channels/slack/canvas --mode full --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/credentials.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/credentials.md
@@ -1,0 +1,28 @@
+# Slack Credentials And Scopes
+
+Use esta referencia para diagnosticar credenciais, scopes, connections e
+permissoes Slack.
+
+## Comandos
+
+```bash
+ravi slack permissions-list --json
+ravi credentials connections list --json
+```
+
+## Regras
+
+- Nao exiba token Slack bruto (`xox`, `xapp`) em resposta, log ou spec.
+- O CLI comum deve trabalhar com connection/secret ref, nao com segredo.
+- Se scopes foram alterados no app Slack, o app precisa ser reinstalado e a
+  connection deve apontar para o token atualizado.
+- Falta de credencial deve desabilitar adapter/operacao de forma fechada, nao
+  cair em token desconhecido.
+- Env fallback so deve ser usado quando houver opt-in explicito.
+
+## Specs
+
+```bash
+ravi specs get channels/credentials --mode full --json
+ravi specs get channels/adapters/slack --mode rules --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/messages-replay.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/messages-replay.md
@@ -1,0 +1,46 @@
+# Slack Messages And Replay
+
+Use esta referencia para envio, leitura, inspecao ou replay de mensagens Slack.
+
+## Comandos
+
+```bash
+ravi slack messages-send <channel> "texto" --execute --json
+ravi slack channels-history <channel> --json
+ravi slack messages-inspect <channel> <ts> --json
+ravi slack messages-replay <channel> <ts> --execute --json
+```
+
+## Quando Usar Replay
+
+Use `messages-replay` quando uma mensagem Slack chegou na plataforma, mas parece
+nao ter produzido turno, delivery ou resposta no Ravi.
+
+Fluxo recomendado:
+
+1. Inspecionar a mensagem:
+   ```bash
+   ravi slack messages-inspect <channel> <ts> --json
+   ```
+2. Se a mensagem existe e o replay for seguro, executar:
+   ```bash
+   ravi slack messages-replay <channel> <ts> --execute --json
+   ```
+3. Conferir trace da sessao quando o replay nao produzir terminal state:
+   ```bash
+   ravi sessions trace <session>
+   ```
+
+## Regras
+
+- `messages-send` e `messages-replay` sao mutacoes; use `--execute`.
+- Nao fazer replay em loop sem entender idempotencia e efeito externo.
+- Para audio/file_share, confirme que o arquivo foi ingerido e associado ao
+  actor correto antes de reexecutar.
+
+## Specs
+
+```bash
+ravi specs get channels/slack/message-replay --mode full --json
+ravi specs get channels/messages --mode rules --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/operations.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/operations.md
@@ -1,0 +1,31 @@
+# Slack Operations
+
+Use esta referencia para operacoes nativas de workspace/canal: listar canais,
+criar canal, renomear, convidar usuarios, listar membros e listar files.
+
+## Comandos
+
+```bash
+ravi slack channels-list --json
+ravi slack channels-info <channel> --json
+ravi slack members-list <channel> --json
+ravi slack files-list --json
+
+ravi slack channels-create "nome-canal" --execute --json
+ravi slack channels-rename <channel> "novo-nome" --execute --json
+ravi slack channels-invite <channel> <userIds> --execute --json
+```
+
+## Regras
+
+- Mutacoes devem ser dry-run por padrao e so executar com `--execute`.
+- Antes de mutacoes, confirme scopes com `ravi slack permissions-list --json`
+  quando houver erro de permissao ou app recem reinstalado.
+- Prefira IDs Slack explicitos (`C...`, `U...`) quando a operacao for sensivel.
+- Nao use Omni para operacoes Slack novas.
+
+## Specs
+
+```bash
+ravi specs get channels/slack/operations --mode full --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/presence.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/presence.md
@@ -1,0 +1,30 @@
+# Slack Presence And Runtime Status
+
+Use esta referencia para status nativo do Slack, assistant status, typing,
+presenca visivel e problemas de status preso/atrasado.
+
+## Regras
+
+- Runtime status e delivery state sao conceitos separados.
+- Slack assistant status deve usar o Slack thread timestamp estavel, nao uma
+  mensagem outbound movel como `thread_ts`.
+- Status deve ser escopado por sessao + chat/thread.
+- Cada sessao deve ter no maximo um status ativo por chat/thread.
+- Ao terminar o turno, status deve limpar ou chegar a estado terminal.
+- Fallback por reaction nao deve substituir o status nativo quando a capability
+  nativa existe.
+
+## Diagnostico
+
+```bash
+ravi sessions trace <session>
+ravi slack messages-inspect <channel> <ts> --json
+ravi slack topology --json
+```
+
+## Specs
+
+```bash
+ravi specs get channels/presence --mode full --json
+ravi specs get channels/slack/presence --mode full --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/runner-delivery.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/runner-delivery.md
@@ -1,0 +1,31 @@
+# Slack Runner And Delivery
+
+Use esta referencia para problemas de envio, delivery, outbound job, idempotencia
+ou runner Slack.
+
+## Regras
+
+- Runtime response destinada a Slack deve virar delivery job duravel antes do
+  send na plataforma.
+- O runner Slack consome jobs e chama o adapter nativo.
+- Delivery job deve ter idempotency key estavel.
+- Infraestrutura `CHANNEL_OUTBOUND` deve ser criada/verificada uma vez por
+  processo e reutilizada depois de sucesso.
+- Runner so deve ackar job depois de estado terminal ou delivery persistido.
+- Ambiguous timeout nao deve gerar retry cego se a plataforma pode ter aceitado
+  o send sem garantia de idempotencia.
+
+## Diagnostico
+
+```bash
+ravi channels status --json
+ravi channels probe --json
+ravi sessions trace <session>
+```
+
+## Specs
+
+```bash
+ravi specs get channels/delivery --mode full --json
+ravi specs get channels/runner --mode full --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/threads-routing.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/threads-routing.md
@@ -1,0 +1,35 @@
+# Slack Threads And Session Forks
+
+Use esta referencia quando uma Slack thread deve criar ou retomar uma sessao
+separada da conversa principal.
+
+## Regras
+
+- Uma resposta em Slack thread deve resolver `source.threadId` como o `thread_ts`
+  inbound.
+- Thread com `route.session` deve gerar fork a partir da sessao forçada.
+- Se a sessao pai forçada ainda nao existir, a thread ainda deve usar chave
+  derivada da sessao forçada, nao a chave computada do agent default.
+- O child session deve herdar o contexto/permissoes adequados do parent, mas
+  manter estado runtime separado.
+- Outbound da child session deve voltar para a mesma Slack thread.
+
+## Diagnostico
+
+```bash
+ravi slack topology --json
+ravi sessions trace <child-session>
+ravi routes list --json
+```
+
+## Testes Relacionados
+
+```bash
+bun test src/router/resolver.test.ts src/channels/slack/socket-mode.test.ts src/runtime/runtime-session-continuity.test.ts
+```
+
+## Specs
+
+```bash
+ravi specs get channels/slack/threads --mode full --json
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/topology.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/topology.md
@@ -1,0 +1,36 @@
+# Slack Topology
+
+Use esta referencia quando a tarefa envolver ownership, rotas, sessoes,
+diagnostico de canal, ou "qual agent responde neste canal/thread".
+
+## Comandos
+
+```bash
+ravi slack topology --json
+ravi routes list --json
+ravi sessions list --json
+ravi sessions trace <session>
+```
+
+## O Que Topology Deve Explicar
+
+- Slack channel/DM/thread visivel ao bot.
+- Ravi route explicita quando existir.
+- Sessao ligada ao chat/thread.
+- Agent que responde por default quando nao ha rota explicita.
+- Inbound policy gates.
+
+## Regras
+
+- `chat` e container do canal; `session` e estado runtime do agent.
+- Um chat pode alimentar varias sessoes; uma sessao pode estar inscrita em
+  varios chats.
+- Nao corrija roteamento criando outra route por cima de chat ja atachado em
+  sessao errada. Primeiro entenda a subscription/session binding.
+
+## Specs
+
+```bash
+ravi specs get channels/slack/topology --mode full --json
+ravi specs get channels/model --mode rules --json
+```

--- a/src/skills/manager.test.ts
+++ b/src/skills/manager.test.ts
@@ -89,10 +89,14 @@ describe("skills manager", () => {
     const home = join(root, "home");
     const catalogSkills = listCatalogSkills();
     const imageSkill = catalogSkills.find((skill) => skill.name === "image");
+    const slackSkill = catalogSkills.find((skill) => skill.name === "slack");
 
     expect(imageSkill).toBeDefined();
     expect(imageSkill?.source).toBe("catalog:ravi-system/image");
     expect(imageSkill?.files?.map((file) => file.path)).toContain("SKILL.md");
+    expect(slackSkill).toBeDefined();
+    expect(slackSkill?.source).toBe("catalog:ravi-system/slack");
+    expect(slackSkill?.files?.map((file) => file.path)).toContain("references/canvas.md");
 
     const [installed] = installSkills([imageSkill!], { homeDir: home });
 


### PR DESCRIPTION
## Objective

Add an official Ravi Slack skill so future agent sessions can discover how to operate the native Slack integration and its capability-specific flows. This gives Slack the same first-class skill entry point as other Ravi system surfaces instead of relying on the generic channels skill.

## Problem

- Agents had no dedicated Slack skill to learn native Slack operations, Canvas behavior, presence semantics, routing, credentials, or replay/debug workflows.
- The existing channels skill still framed channel management around the legacy Omni surface and did not clearly route Slack work to the native Slack CLI and specs.

## Solution

- Added `ravi-system/slack` with progressive-disclosure instructions and references per Slack capability.
- Added references for Canvas, credentials, messages/replay, operations, presence, runner/delivery, threads/routing, and topology.
- Updated the channels skill to point Slack work to the native Slack skill and `ravi slack` surfaces.
- Added a catalog test to pin the Slack skill and bundled reference files.

## Practical impact

- Other sessions can call `ravi skills show slack --json` and get actionable Slack-native instructions.
- Slack Canvas and channel-management work now has a durable skill entry point instead of depending on chat context.

## What does NOT change

- No Slack runtime behavior changes in this PR.
- No credentials, scopes, or channel routes are modified.
- WhatsApp and legacy Omni compatibility behavior are unchanged.

## Validation

- `bun src/cli/index.ts skills show slack --json`
- `bun scripts/gen-plugins.ts && bin/ravi skills show slack --json`
- `bun test src/skills/manager.test.ts`
- `bun run typecheck`
- Full pre-push checks passed, including build, typecheck, CLI tests, Slack CLI tests, SDK drift checks, and SDK tests.

## Risks

- The new skill may need more capability references as new native Slack commands ship.
- Some references intentionally describe current product limits, especially Canvas bidirectional sync, to avoid overclaiming.

## Rollback

- Revert the Slack skill files, the channels skill update, and the catalog test. Runtime behavior is unaffected because this is skill/catalog documentation only.

## Follow-ups

- Expand the Slack skill as additional native Slack capabilities become available.
- Consider smaller capability-specific child skills if the Slack surface grows beyond one skill plus references.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->