### PR TITLE
[codex] fix slack credential instance resolution

### DIFF
--- a/.ravi/specs/channels/CHECKS.md
+++ b/.ravi/specs/channels/CHECKS.md
@@ -1,0 +1,13 @@
+# Channels Checks
+
+- [ ] Native adapters MUST route inbound events only when a Ravi channel
+      instance/account is explicit.
+- [ ] Missing route account MUST NOT fall back to cross-account route matching.
+- [ ] Provider ids MUST be stored as provenance and MUST NOT replace Ravi chat,
+      thread, actor, route or session ids in product-facing contracts.
+- [ ] Channel credentials MUST be resolved through the credential broker/manager
+      unless an explicit local smoke-test fallback is enabled.
+- [ ] Env vars MUST NOT introduce persistent channel identity, connection
+      identity or instance ownership.
+- [ ] Feature code SHOULD depend on normalized Ravi channel concepts before raw
+      provider payloads.

--- a/.ravi/specs/channels/RUNBOOK.md
+++ b/.ravi/specs/channels/RUNBOOK.md
@@ -1,0 +1,27 @@
+# Channels Runbook
+
+## Diagnosticar Inbound
+
+1. Identifique a instância de canal que recebeu o evento.
+2. Confirme que o evento carrega conta/instância explícita antes de rotear.
+3. Verifique chat, thread, ator e mensagem normalizados.
+4. Confirme que a sessão foi escolhida por route/subscription, não por id cru
+   de provedor.
+5. Preserve ids crus apenas como provenance/debug.
+
+## Diagnosticar Outbound
+
+1. Comece pelo intent do Ravi: sessão, chat/thread alvo, actor e policy.
+2. Confirme a capability do canal e da instância antes de renderizar.
+3. Resolva credenciais pelo broker/manager quando o adapter precisar falar com
+   o provedor.
+4. Envie pelo adapter de transporte.
+5. Registre delivery state e erros sem imprimir segredo.
+
+## Migração De Adapter
+
+1. Modele o comportamento no spec de `channels` ou sub-spec aplicável.
+2. Mantenha compatibilidade com Omni como bridge quando necessário.
+3. Não promova env vars a fonte de identidade permanente.
+4. Adicione teste focado para a fronteira alterada.
+5. Rode o quality gate antes de abrir PR.

--- a/.ravi/specs/channels/SPEC.md
+++ b/.ravi/specs/channels/SPEC.md
@@ -35,6 +35,9 @@ Ravi MUST abstract Omni as a transport/gateway adapter. Product and agent-facing
 - Channel-specific behavior SHOULD be exposed to Ravi through typed capabilities and normalized events when a feature needs it, not through provider conditionals spread across features.
 - A dedicated channel capability registry MAY be deferred until a concrete feature needs it. The source of capability facts SHOULD be Omni.
 - Agent-executed channel CLIs MUST default to the current runtime source account when it is available. Falling back to the first configured account is only valid outside a sourced runtime context.
+- Native channel adapters MUST bind inbound routing to an explicit Ravi account/channel instance. A missing route account MUST NOT cause cross-account route matching.
+- Native channel adapters MUST resolve provider secrets through the credential broker/manager using the channel instance as the authority. Provider tokens in env are allowed only as explicit local smoke-test fallback.
+- Environment variables such as `RAVI_SLACK_CONNECTION` MUST NOT introduce channel identity, connection identity, or instance ownership. If a temporary env fallback exists, it is a dev-only transport bootstrap, not Ravi semantics.
 
 ## Boundary
 

--- a/.ravi/specs/channels/WHY.md
+++ b/.ravi/specs/channels/WHY.md
@@ -1,0 +1,19 @@
+# Por Que Channels Existe
+
+Channels define a fronteira semântica entre o Ravi e os transportes externos.
+
+O Ravi precisa ser dono de conceitos como chat, thread, mensagem, ator, rota,
+policy, presença, delivery e credenciais. WhatsApp, Slack, Omni e futuros
+adapters devem fornecer transporte, rendering e capacidades específicas, mas
+não devem decidir identidade operacional ou estado de sessão.
+
+Sem esse domínio raiz, cada adapter tende a recriar semântica própria. Isso
+faz feature code depender de ids crus de provedor, vaza detalhes de transporte
+para agents e torna migrações como Omni para canais nativos difíceis de
+auditar.
+
+O spec raiz existe para manter invariantes comuns. Sub-specs como
+`channels/credentials`, `channels/messages`, `channels/presence` e
+`channels/runner` detalham contratos específicos, mas não podem contrariar a
+fronteira principal: canal entrega eventos e payloads; Ravi decide semântica e
+runtime.

--- a/.ravi/specs/channels/adapters/slack/RUNBOOK.md
+++ b/.ravi/specs/channels/adapters/slack/RUNBOOK.md
@@ -3,16 +3,17 @@
 ## Local Smoke
 
 1. Add a Slack connection through `ravi credentials`.
-2. Set `RAVI_SLACK_SOCKET_MODE=1`.
-3. Set `RAVI_SLACK_CONNECTION=<connection>`.
-4. Start `ravi channels run` or `ravi channels start`.
+2. Register or update the Slack channel instance in Ravi.
+   - Preferred: credential connection id equals the instance name.
+   - Alternative: set instance defaults with `{"slackCredentialConnection":"<connection>"}`.
+3. Set `RAVI_SLACK_SOCKET_MODE=1` only while the daemon compatibility path owns Socket Mode.
+4. Start `ravi channels run` / `ravi channels start` when the native runner owns adapters, or restart the compatibility daemon while that path exists.
 5. Send a DM or channel message to the Slack app.
 6. Confirm the Ravi session responds in Slack.
 
 ## Debug
 
-- No connection: check `ravi credentials connections show`.
+- No connection: check the Slack instance and `ravi credentials connections show`.
 - No inbound: check Socket Mode logs and Slack app event subscriptions.
 - Wrong thread: check `RAVI_SLACK_SUBSCRIPTION_SCOPE`, `RAVI_SLACK_THREAD_REPLY_MODE`, `RAVI_SLACK_ROOT_REPLY_MODE`.
 - Duplicate response: check duplicate runner processes and Socket Mode lock.
-

--- a/.ravi/specs/channels/adapters/slack/RUNBOOK.md
+++ b/.ravi/specs/channels/adapters/slack/RUNBOOK.md
@@ -6,10 +6,10 @@
 2. Register or update the Slack channel instance in Ravi.
    - Preferred: credential connection id equals the instance name.
    - Alternative: set instance defaults with `{"slackCredentialConnection":"<connection>"}`.
-3. Set `RAVI_SLACK_SOCKET_MODE=1` only while the daemon compatibility path owns Socket Mode.
-4. Start `ravi channels run` / `ravi channels start` when the native runner owns adapters, or restart the compatibility daemon while that path exists.
-5. Send a DM or channel message to the Slack app.
-6. Confirm the Ravi session responds in Slack.
+3. Start `ravi channels run` / `ravi channels start` when the native runner owns adapters, or restart the compatibility daemon while that path exists.
+   Slack native uses Socket Mode by definition; there is no separate mode flag.
+4. Send a DM or channel message to the Slack app.
+5. Confirm the Ravi session responds in Slack.
 
 ## Debug
 

--- a/.ravi/specs/channels/credentials/SPEC.md
+++ b/.ravi/specs/channels/credentials/SPEC.md
@@ -27,6 +27,10 @@ normative: true
    - `execute:<provider>:<action>`
 8. The broker MUST support local Keychain and production Vault-compatible refs.
 9. Env credentials MAY be used only as explicit local smoke-test fallback.
+10. Channel instances are the authority for selecting channel credentials.
+    The default credential connection id SHOULD match the Ravi instance name.
+    Instance defaults MAY override this with `slackCredentialConnection` or
+    `credentials.slackConnection`.
 
 ## Slack Secret Shape
 
@@ -47,4 +51,3 @@ SLACK_BOT_TOKEN=xoxb-...
 ```
 
 The raw value MUST never be printed.
-

--- a/.ravi/specs/channels/roadmap/RUNBOOK.md
+++ b/.ravi/specs/channels/roadmap/RUNBOOK.md
@@ -19,7 +19,6 @@ Se Slack nativo falhar no piloto:
 
 - parar `ravi channels`;
 - manter `ravi daemon` rodando;
-- desabilitar `RAVI_SLACK_SOCKET_MODE`;
+- desabilitar ou remover a instância Slack nativa;
 - remover/disable a connection Slack se o erro for credencial;
 - manter Omni/WhatsApp intactos.
-

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -12484,7 +12484,7 @@ export const ChannelsRestartInputSchema = {
       "type": "boolean"
     },
     "slackConnection": {
-      "description": "Slack credential connection for Socket Mode",
+      "description": "Optional Slack credential connection override",
       "type": "string"
     }
   },
@@ -12756,7 +12756,7 @@ export const ChannelsStartInputSchema = {
       "type": "boolean"
     },
     "slackConnection": {
-      "description": "Slack credential connection for Socket Mode",
+      "description": "Optional Slack credential connection override",
       "type": "string"
     }
   },

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:8424af65b2939c147d15e065f86699a860db23bbec51c2be30818b03aa0cb009";
+export const REGISTRY_HASH = "sha256:5a15185af3b8cf80cc72c8561d10ba4cfb2ff9571b046c3abb1209b4d61561a3";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "def3351c8306";
+export const GIT_SHA = "c0732ebdc6f5";

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:5a15185af3b8cf80cc72c8561d10ba4cfb2ff9571b046c3abb1209b4d61561a3";
+export const REGISTRY_HASH = "sha256:baca7c8d22d772f83d9b3821803b660bfa9a3cfefdc6cd0ce8343a0b9ed4269b";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "c0732ebdc6f5";
+export const GIT_SHA = "bcd005635b3d";

--- a/src/channels/slack/credentials.test.ts
+++ b/src/channels/slack/credentials.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, mock } from "bun:test";
-import { parseSlackSecretPayload, resolveSlackCredentialConfigFromEnv } from "./credentials.js";
+import {
+  credentialConnectionForInstance,
+  parseSlackSecretPayload,
+  resolveSlackCredentialConfigFromEnv,
+} from "./credentials.js";
 
 describe("Slack credential config", () => {
   it("parses JSON broker secrets", () => {
@@ -35,7 +39,103 @@ describe("Slack credential config", () => {
     });
   });
 
-  it("resolves broker credentials when a Slack connection is configured", async () => {
+  it("resolves broker credentials from the enabled Slack instance", async () => {
+    const resolveSecret = mock(async () => ({
+      secret: JSON.stringify({
+        appToken: "xapp-broker",
+        botToken: "xoxb-broker",
+        accountId: "T1",
+      }),
+      connection: { connection: "ravi-rbbt-slack" },
+    }));
+
+    const config = await resolveSlackCredentialConfigFromEnv(
+      {},
+      {
+        resolveSecret,
+        instances: {
+          "ravi-rbbt-slack": slackInstance({
+            name: "ravi-rbbt-slack",
+            instanceId: "slack-instance-1",
+          }),
+        },
+      },
+    );
+
+    expect(resolveSecret).toHaveBeenCalledWith({
+      provider: "slack",
+      connection: "ravi-rbbt-slack",
+      action: "socket_mode.connect",
+    });
+    expect(config).toMatchObject({
+      appToken: "xapp-broker",
+      botToken: "xoxb-broker",
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "slack-instance-1",
+      connection: "ravi-rbbt-slack",
+      source: "broker",
+    });
+  });
+
+  it("uses the instance credential connection default when configured", async () => {
+    const resolveSecret = mock(async () => ({
+      secret: JSON.stringify({
+        appToken: "xapp-broker",
+        botToken: "xoxb-broker",
+      }),
+      connection: { connection: "rbbt-secret" },
+    }));
+
+    const config = await resolveSlackCredentialConfigFromEnv(
+      {},
+      {
+        resolveSecret,
+        instances: {
+          "ravi-rbbt-slack": slackInstance({
+            name: "ravi-rbbt-slack",
+            instanceId: "slack-instance-1",
+            defaults: { slackCredentialConnection: "rbbt-secret" },
+          }),
+        },
+      },
+    );
+
+    expect(resolveSecret).toHaveBeenCalledWith({
+      provider: "slack",
+      connection: "rbbt-secret",
+      action: "socket_mode.connect",
+    });
+    expect(config).toMatchObject({
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "slack-instance-1",
+      connection: "rbbt-secret",
+      source: "broker",
+    });
+  });
+
+  it("does not guess a broker connection when multiple Slack instances are enabled", async () => {
+    const resolveSecret = mock(async () => ({
+      secret: JSON.stringify({ appToken: "xapp-broker", botToken: "xoxb-broker" }),
+    }));
+
+    const config = await resolveSlackCredentialConfigFromEnv(
+      {},
+      {
+        resolveSecret,
+        instances: {
+          "ravi-rbbt-slack": slackInstance({ name: "ravi-rbbt-slack" }),
+          "ravi-slack-dev": slackInstance({ name: "ravi-slack-dev" }),
+        },
+      },
+    );
+
+    expect(config).toBeNull();
+    expect(resolveSecret).not.toHaveBeenCalled();
+  });
+
+  it("resolves broker credentials when an explicit dev connection override is configured", async () => {
     const resolveSecret = mock(async () => ({
       secret: JSON.stringify({
         appToken: "xapp-broker",
@@ -63,6 +163,7 @@ describe("Slack credential config", () => {
       botToken: "xoxb-broker",
       accountId: "T1",
       instanceId: "slack-main",
+      connection: "main",
       source: "broker",
     });
   });
@@ -84,7 +185,40 @@ describe("Slack credential config", () => {
     ).toMatchObject({
       appToken: "xapp-env",
       botToken: "xoxb-env",
+      connection: "slack",
       source: "env",
     });
   });
+
+  it("maps Slack instances to broker connection ids", () => {
+    expect(
+      credentialConnectionForInstance(
+        slackInstance({
+          name: "ravi-rbbt-slack",
+          defaults: { credentials: { slackConnection: "rbbt-secret" } },
+        }),
+      ),
+    ).toBe("rbbt-secret");
+    expect(credentialConnectionForInstance(slackInstance({ name: "ravi-rbbt-slack" }))).toBe("ravi-rbbt-slack");
+  });
 });
+
+function slackInstance(input: {
+  name: string;
+  instanceId?: string;
+  defaults?: Record<string, unknown>;
+  enabled?: boolean;
+}) {
+  return {
+    name: input.name,
+    ...(input.instanceId ? { instanceId: input.instanceId } : {}),
+    channel: "slack",
+    dmPolicy: "closed" as const,
+    groupPolicy: "allowlist" as const,
+    contactIntakeMode: "off" as const,
+    enabled: input.enabled ?? true,
+    ...(input.defaults ? { defaults: input.defaults } : {}),
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/src/channels/slack/credentials.ts
+++ b/src/channels/slack/credentials.ts
@@ -1,4 +1,5 @@
 import { resolveCredentialSecret } from "../../credentials/index.js";
+import type { InstanceConfig } from "../../router/router-db.js";
 
 export interface SlackCredentialConfig {
   appToken: string;
@@ -6,6 +7,7 @@ export interface SlackCredentialConfig {
   accountId: string;
   routeAccountId?: string;
   instanceId: string;
+  connection: string;
   source: "broker" | "env";
 }
 
@@ -25,9 +27,18 @@ export type SlackCredentialResolver = (input: {
 
 export async function resolveSlackCredentialConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
-  options: { resolveSecret?: SlackCredentialResolver; action?: string } = {},
+  options: {
+    resolveSecret?: SlackCredentialResolver;
+    action?: string;
+    instance?: InstanceConfig;
+    instances?: Record<string, InstanceConfig>;
+  } = {},
 ): Promise<SlackCredentialConfig | null> {
-  const connection = env.RAVI_SLACK_CONNECTION?.trim() || env.RAVI_SLACK_CREDENTIAL_CONNECTION?.trim();
+  const instance = options.instance ?? selectSlackInstance(options.instances, env);
+  const connection =
+    credentialConnectionForInstance(instance) ||
+    env.RAVI_SLACK_CONNECTION?.trim() ||
+    env.RAVI_SLACK_CREDENTIAL_CONNECTION?.trim();
   if (connection) {
     const resolved = await (options.resolveSecret ?? resolveCredentialSecret)({
       provider: "slack",
@@ -35,18 +46,20 @@ export async function resolveSlackCredentialConfigFromEnv(
       action: options.action ?? "socket_mode.connect",
     });
     const payload = parseSlackSecretPayload(resolved.secret);
+    const accountId =
+      instance?.name ||
+      env.RAVI_SLACK_ACCOUNT?.trim() ||
+      payload.accountId ||
+      resolved.connection?.connection ||
+      connection;
     return {
       appToken: payload.appToken,
       botToken: payload.botToken,
-      accountId: env.RAVI_SLACK_ACCOUNT?.trim() || payload.accountId || resolved.connection?.connection || connection,
-      routeAccountId: env.RAVI_SLACK_ROUTE_ACCOUNT?.trim() || payload.routeAccountId,
+      accountId,
+      routeAccountId: instance?.name || env.RAVI_SLACK_ROUTE_ACCOUNT?.trim() || payload.routeAccountId || accountId,
       instanceId:
-        env.RAVI_SLACK_INSTANCE?.trim() ||
-        payload.instanceId ||
-        env.RAVI_SLACK_ACCOUNT?.trim() ||
-        payload.accountId ||
-        resolved.connection?.connection ||
-        connection,
+        instance?.instanceId || instance?.name || env.RAVI_SLACK_INSTANCE?.trim() || payload.instanceId || accountId,
+      connection,
       source: "broker",
     };
   }
@@ -66,8 +79,37 @@ export async function resolveSlackCredentialConfigFromEnv(
     accountId,
     routeAccountId: env.RAVI_SLACK_ROUTE_ACCOUNT?.trim() || undefined,
     instanceId: env.RAVI_SLACK_INSTANCE?.trim() || accountId,
+    connection: env.RAVI_SLACK_CREDENTIAL_CONNECTION?.trim() || env.RAVI_SLACK_CONNECTION?.trim() || accountId,
     source: "env",
   };
+}
+
+export function credentialConnectionForInstance(instance: InstanceConfig | null | undefined): string | undefined {
+  if (!instance || instance.enabled === false || instance.channel !== "slack") return undefined;
+  const defaults = instance.defaults ?? {};
+  const credentials = asRecord(defaults.credentials);
+  return (
+    stringField(defaults, "slackCredentialConnection", "credentialConnection") ||
+    stringField(credentials, "slackConnection", "slackCredentialConnection", "connection") ||
+    instance.name
+  );
+}
+
+function selectSlackInstance(
+  instances: Record<string, InstanceConfig> | undefined,
+  env: NodeJS.ProcessEnv,
+): InstanceConfig | undefined {
+  if (!instances) return undefined;
+  const selector = env.RAVI_SLACK_ACCOUNT?.trim() || env.RAVI_SLACK_INSTANCE?.trim();
+  const candidates = Object.values(instances).filter(
+    (instance) => instance.enabled !== false && instance.channel === "slack",
+  );
+
+  if (selector) {
+    return candidates.find((instance) => instance.name === selector || instance.instanceId === selector);
+  }
+
+  return candidates.length === 1 ? candidates[0] : undefined;
 }
 
 export function parseSlackSecretPayload(secret: string): SlackSecretPayload {
@@ -118,6 +160,10 @@ function stringField(record: Record<string, unknown>, ...keys: string[]): string
     if (typeof value === "string" && value.trim()) return value.trim();
   }
   return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
 function stripQuotes(value: string): string {

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -8,6 +8,7 @@ export type {
   SlackWebApiClientOptions,
 } from "./client.js";
 export {
+  credentialConnectionForInstance,
   parseSlackSecretPayload,
   resolveSlackCredentialConfigFromEnv,
 } from "./credentials.js";

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -835,9 +835,9 @@ export async function createSlackNativeRuntimeFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<SlackNativeRuntime | null> {
   if (env.RAVI_SLACK_SOCKET_MODE !== "1" && env.RAVI_SLACK_SOCKET_MODE !== "true") return null;
-  const credentials = await resolveSlackCredentialConfigFromEnv(env);
+  const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances: configStore.getConfig().instances });
   if (!credentials) {
-    log.warn("Slack native runtime disabled: configure RAVI_SLACK_CONNECTION or opt into env credentials");
+    log.warn("Slack native runtime disabled: configure a Slack channel instance with brokered credentials");
     return null;
   }
 
@@ -873,6 +873,7 @@ export async function createSlackNativeRuntimeFromEnv(
   log.info("Slack native runtime configured", {
     accountId: credentials.accountId,
     instanceId: credentials.instanceId,
+    connection: credentials.connection,
     source: credentials.source,
     assistantPresenceEnabled,
     reactionPresenceMode: reactionMode,

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -834,7 +834,6 @@ function syncSlackSessionSubscription(
 export async function createSlackNativeRuntimeFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<SlackNativeRuntime | null> {
-  if (env.RAVI_SLACK_SOCKET_MODE !== "1" && env.RAVI_SLACK_SOCKET_MODE !== "true") return null;
   const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances: configStore.getConfig().instances });
   if (!credentials) {
     log.warn("Slack native runtime disabled: configure a Slack channel instance with brokered credentials");

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -7,8 +7,6 @@ describe("channels command runner env", () => {
       chooseSlackRunnerConnection({
         explicit: "  ravi-rbbt-slack  ",
         env: { RAVI_SLACK_CONNECTION: "other" },
-        pm2Env: { RAVI_SLACK_CONNECTION: "pm2" },
-        activeCredentialConnections: ["other", "pm2", "ravi-rbbt-slack"],
       }),
     ).toBe("ravi-rbbt-slack");
   });
@@ -17,36 +15,22 @@ describe("channels command runner env", () => {
     expect(
       chooseSlackRunnerConnection({
         env: { RAVI_SLACK_CONNECTION: "ravi-rbbt-slack" },
-        pm2Env: { RAVI_SLACK_CONNECTION: "pm2-slack" },
-        activeCredentialConnections: ["ravi-rbbt-slack", "pm2-slack"],
       }),
     ).toBe("ravi-rbbt-slack");
   });
 
-  it("preserves the previous PM2 Slack connection when the current env is empty", () => {
+  it("supports the legacy Slack credential connection env name", () => {
     expect(
       chooseSlackRunnerConnection({
-        pm2Env: { RAVI_SLACK_CONNECTION: "ravi-rbbt-slack" },
-        activeCredentialConnections: ["ravi-rbbt-slack", "ravi-slack-dev"],
+        env: { RAVI_SLACK_CREDENTIAL_CONNECTION: "ravi-rbbt-slack" },
       }),
     ).toBe("ravi-rbbt-slack");
   });
 
-  it("selects the active Slack credential with configured Slack routes", () => {
+  it("does not synthesize a Slack connection from credentials or routes", () => {
     expect(
       chooseSlackRunnerConnection({
-        activeCredentialConnections: ["ravi-rbbt-slack", "ravi-slack-dev"],
-        enabledSlackInstanceNames: ["ravi-rbbt-slack", "ravi-slack-dev"],
-        routedSlackAccountIds: ["ravi-rbbt-slack", "ravi-rbbt-slack"],
-      }),
-    ).toBe("ravi-rbbt-slack");
-  });
-
-  it("does not guess when multiple active Slack connections are equally plausible", () => {
-    expect(
-      chooseSlackRunnerConnection({
-        activeCredentialConnections: ["ravi-rbbt-slack", "ravi-slack-dev"],
-        enabledSlackInstanceNames: ["ravi-rbbt-slack", "ravi-slack-dev"],
+        env: {},
       }),
     ).toBeUndefined();
   });

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -6,7 +6,6 @@ import "reflect-metadata";
 import { spawnSync } from "node:child_process";
 import { z } from "zod";
 import { ChannelRunner, runChannelRunnerFromEnv } from "../../channels/runner.js";
-import { listCredentialConnections } from "../../credentials/index.js";
 import {
   CHANNELS_PM2_PROCESS_NAME,
   getPm2Process,
@@ -19,7 +18,6 @@ import { CliOnly, Command, CommandAccess, Group, Option, Returns } from "../deco
 import { fail } from "../context.js";
 import { jsonObjectSchema } from "../return-schemas.js";
 import { resolveDaemonRuntimeTarget, type DaemonRuntimeTarget } from "./daemon.js";
-import { loadRouterConfig } from "../../router/config.js";
 
 const pm2ProcessReturnSchema = z
   .object({
@@ -132,10 +130,6 @@ function readExistingPm2Env(processName: string): Record<string, unknown> {
 export function chooseSlackRunnerConnection(input: {
   explicit?: string;
   env?: Record<string, unknown>;
-  pm2Env?: Record<string, unknown>;
-  activeCredentialConnections?: readonly string[];
-  enabledSlackInstanceNames?: readonly string[];
-  routedSlackAccountIds?: readonly string[];
 }): string | undefined {
   const explicit = cleanEnvValue(input.explicit);
   if (explicit) return explicit;
@@ -144,62 +138,7 @@ export function chooseSlackRunnerConnection(input: {
     cleanEnvValue(input.env?.RAVI_SLACK_CONNECTION) ?? cleanEnvValue(input.env?.RAVI_SLACK_CREDENTIAL_CONNECTION);
   if (envConnection) return envConnection;
 
-  const pm2Connection =
-    cleanEnvValue(input.pm2Env?.RAVI_SLACK_CONNECTION) ?? cleanEnvValue(input.pm2Env?.RAVI_SLACK_CREDENTIAL_CONNECTION);
-  if (pm2Connection) return pm2Connection;
-
-  const activeCredentials = Array.from(
-    new Set(
-      (input.activeCredentialConnections ?? []).map(cleanEnvValue).filter((value): value is string => Boolean(value)),
-    ),
-  );
-  const activeSet = new Set(activeCredentials);
-
-  const routedCandidates = Array.from(
-    new Set(
-      (input.routedSlackAccountIds ?? [])
-        .map(cleanEnvValue)
-        .filter((value): value is string => Boolean(value && activeSet.has(value))),
-    ),
-  );
-  if (routedCandidates.length === 1) return routedCandidates[0] ?? undefined;
-
-  const enabledInstanceCandidates = Array.from(
-    new Set(
-      (input.enabledSlackInstanceNames ?? [])
-        .map(cleanEnvValue)
-        .filter((value): value is string => Boolean(value && activeSet.has(value))),
-    ),
-  );
-  if (enabledInstanceCandidates.length === 1) return enabledInstanceCandidates[0] ?? undefined;
-
-  return activeCredentials.length === 1 ? activeCredentials[0] : undefined;
-}
-
-function resolveSlackRunnerConnection(explicit?: string, pm2Env: Record<string, unknown> = {}): string | undefined {
-  const credentialPage = listCredentialConnections({
-    provider: "slack",
-    status: "active",
-    includeDisabled: false,
-    limit: 100,
-    offset: 0,
-  });
-  const config = loadRouterConfig();
-  const enabledSlackInstanceNames = Object.values(config.instances)
-    .filter((instance) => instance.enabled !== false && instance.channel === "slack")
-    .map((instance) => instance.name);
-  const routedSlackAccountIds = config.routes
-    .filter((route) => config.instances[route.accountId]?.channel === "slack")
-    .map((route) => route.accountId);
-
-  return chooseSlackRunnerConnection({
-    explicit,
-    env: process.env,
-    pm2Env,
-    activeCredentialConnections: credentialPage.items.map((connection) => connection.connection),
-    enabledSlackInstanceNames,
-    routedSlackAccountIds,
-  });
+  return undefined;
 }
 
 function buildRunnerPm2Env(explicitSlackConnection?: string): Record<string, string> {
@@ -211,9 +150,8 @@ function buildRunnerPm2Env(explicitSlackConnection?: string): Record<string, str
     if (value) envOverrides[key] = value;
   }
 
-  const slackConnection = resolveSlackRunnerConnection(explicitSlackConnection, existingPm2Env);
+  const slackConnection = chooseSlackRunnerConnection({ explicit: explicitSlackConnection, env: process.env });
   if (slackConnection) {
-    envOverrides.RAVI_SLACK_SOCKET_MODE = "1";
     envOverrides.RAVI_SLACK_CONNECTION = slackConnection;
   }
 
@@ -222,7 +160,7 @@ function buildRunnerPm2Env(explicitSlackConnection?: string): Record<string, str
 
 function publicRunnerEnv(envOverrides: Record<string, string>): Record<string, unknown> {
   return {
-    slackSocketMode: envOverrides.RAVI_SLACK_SOCKET_MODE === "1" || envOverrides.RAVI_SLACK_SOCKET_MODE === "true",
+    slackSocketMode: true,
     slackConnection: envOverrides.RAVI_SLACK_CONNECTION ?? null,
     consumeOutbound: envOverrides.RAVI_CHANNELS_CONSUME_OUTBOUND ?? "default",
   };
@@ -294,7 +232,7 @@ export class ChannelsCommands {
   @Returns(channelsMutationReturnSchema)
   start(
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
-    @Option({ flags: "--slack-connection <name>", description: "Slack credential connection for Socket Mode" })
+    @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
@@ -379,7 +317,7 @@ export class ChannelsCommands {
   @Returns(channelsMutationReturnSchema)
   restart(
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
-    @Option({ flags: "--slack-connection <name>", description: "Slack credential connection for Socket Mode" })
+    @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {


### PR DESCRIPTION
## Objective

Make native Slack use Ravi channel-instance credentials by default and make Socket Mode the built-in Slack runtime path instead of an env-gated mode.

## Problem

The previous native Slack path still had two env-shaped responsibilities:

- `RAVI_SLACK_CONNECTION` could become operational identity for choosing the Slack credential connection.
- `RAVI_SLACK_SOCKET_MODE=1` was required to enable the native Slack Socket Mode runtime, even though native Slack has no other supported runtime mode right now.

That conflicts with the credential manager direction: channel instances should own channel identity, provider secrets should stay behind the broker, and Socket Mode should be adapter behavior rather than an operator opt-in flag.

## Solution

Slack credential config now prefers the enabled Slack `ChannelInstance`, derives the broker connection from the instance name by default, and supports explicit instance defaults such as `slackCredentialConnection` or `credentials.slackConnection`. Multiple enabled Slack instances do not get guessed silently.

The channel runner no longer injects or reads `RAVI_SLACK_SOCKET_MODE`; native Slack always attempts Socket Mode when a Slack instance can resolve brokered credentials. `ravi channels start` also no longer synthesizes `RAVI_SLACK_CONNECTION` from active credentials or routes. That env remains only as an explicit operator/dev connection override, not as the normal setup path.

This PR also adds root `channels` companion specs and updates the Slack runbook/roadmap so the spec gate and docs match the new contract.

## Practical impact

Operators do not need to persist `RAVI_SLACK_CONNECTION=slack` or `RAVI_SLACK_SOCKET_MODE=1` for the normal Slack setup path. A Slack instance in Ravi becomes the authority for the credential connection, and Socket Mode is the native Slack behavior by definition.

## What does NOT change

This does not change Slack message routing semantics, does not expose provider secrets to agents, does not decommission Omni, and does not remove explicit local smoke-test support for raw/env credentials when intentionally enabled.

## Validation

- `bunx biome check --write src/channels/slack/socket-mode.ts src/cli/commands/channels.ts src/cli/commands/channels.test.ts`
- `bun test src/cli/commands/channels.test.ts src/channels/slack/credentials.test.ts src/channels/slack/socket-mode.test.ts src/channels/slack/routing.test.ts`
- `bun run typecheck`
- `bun run sdk:check`
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts`
- `git diff --check`
- Pre-push hook on latest push passed SDK drift check, build, typecheck, full test suite, and SDK tests.

## Risks

The main risk is a deployment that previously depended on hidden env state in PM2 or ambiguous active Slack credentials. The implementation now fails closed unless the Slack instance/defaults identify the credential connection or the operator provides an explicit override.

## Rollback

Revert the PR commits to restore the previous env-gated Socket Mode and `RAVI_SLACK_CONNECTION`-first behavior. No database migration or secret migration is introduced by this change.