### PR TITLE
fix: authorize SDK gateway by command capability

### DIFF
--- a/extensions/whatsapp-overlay/background.js
+++ b/extensions/whatsapp-overlay/background.js
@@ -197,6 +197,15 @@ function toErrorResponse(error) {
   };
 }
 
+function fallbackUnlessAuth(error, fallback) {
+  if (isAuthOrPermissionError(error)) throw error;
+  return fallback;
+}
+
+function isAuthOrPermissionError(error) {
+  return error?.status === 401 || error?.status === 403;
+}
+
 async function fetchSessionWorkspace(payload = {}) {
   const session = clean(payload.session);
   if (!session) return { ok: false, error: "Missing session" };
@@ -754,7 +763,7 @@ async function postAgentTtsSettings(payload = {}) {
   if (!agentId) return { ok: false, status: 400, code: "missing_agent", error: "Missing agentId" };
   const settings = payload.settings && typeof payload.settings === "object" ? payload.settings : {};
   const { client } = await getClient();
-  const agentsResult = await client.agents.list({}).catch(() => ({ agents: [] }));
+  const agentsResult = await client.agents.list({}).catch((error) => fallbackUnlessAuth(error, { agents: [] }));
   const agents = Array.isArray(agentsResult?.agents) ? agentsResult.agents : [];
   const agent = agents.find((item) => clean(item?.id ?? item?.agentId ?? item?.name) === agentId) ?? null;
   const currentDefaults =

--- a/extensions/whatsapp-overlay/background.js
+++ b/extensions/whatsapp-overlay/background.js
@@ -754,10 +754,7 @@ async function postAgentTtsSettings(payload = {}) {
   if (!agentId) return { ok: false, status: 400, code: "missing_agent", error: "Missing agentId" };
   const settings = payload.settings && typeof payload.settings === "object" ? payload.settings : {};
   const { client } = await getClient();
-  const agentsResult = await client.agents.list({}).catch((error) => {
-    if (error?.status === 401 || error?.status === 403) throw error;
-    return { agents: [] };
-  });
+  const agentsResult = await client.agents.list({}).catch(() => ({ agents: [] }));
   const agents = Array.isArray(agentsResult?.agents) ? agentsResult.agents : [];
   const agent = agents.find((item) => clean(item?.id ?? item?.agentId ?? item?.name) === agentId) ?? null;
   const currentDefaults =

--- a/extensions/whatsapp-overlay/lib/compositions.js
+++ b/extensions/whatsapp-overlay/lib/compositions.js
@@ -573,7 +573,7 @@ function normalizeSessions(result) {
 
 function listAgents(client) {
   return client?.agents?.list
-    ? client.agents.list({}).catch(() => ({ agents: [] }))
+    ? client.agents.list({}).catch((error) => fallbackUnlessAuth(error, { agents: [] }))
     : Promise.resolve({ agents: [] });
 }
 

--- a/extensions/whatsapp-overlay/lib/compositions.js
+++ b/extensions/whatsapp-overlay/lib/compositions.js
@@ -573,7 +573,7 @@ function normalizeSessions(result) {
 
 function listAgents(client) {
   return client?.agents?.list
-    ? client.agents.list({}).catch((error) => fallbackUnlessAuth(error, { agents: [] }))
+    ? client.agents.list({}).catch(() => ({ agents: [] }))
     : Promise.resolve({ agents: [] });
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -40,7 +40,6 @@ import { resolveOmniConnection } from "./omni-config.js";
 import { ensureSessionPromptsStream, publishSessionPrompt } from "./omni/session-stream.js";
 import { ensureRaviEventsStream } from "./events/audit-stream.js";
 import { startWebhookHttpServerFromEnv, type WebhookHttpServerHandle } from "./webhooks/http-server.js";
-import { hasLiveAdminContext } from "./runtime/context-registry.js";
 import type { MessageTarget } from "./runtime/message-types.js";
 import { dbHasActiveAssignedTaskForSession } from "./tasks/task-db.js";
 import { startWorkObjectNatsService, type WorkObjectNatsServiceHandle } from "./work-objects/index.js";
@@ -412,11 +411,6 @@ export async function startDaemon() {
   webhookHttpServer = startWebhookHttpServerFromEnv();
   if (webhookHttpServer) {
     log.info("Webhook HTTP server ready", { url: webhookHttpServer.url });
-    if (!hasLiveAdminContext()) {
-      log.warn(
-        "No admin runtime context exists — gateway will reject all non-open requests until you run `ravi daemon init-admin-key`.",
-      );
-    }
   } else {
     log.info("Webhook HTTP server disabled (set RAVI_HTTP_PORT to enable)");
   }

--- a/src/permissions/denials.test.ts
+++ b/src/permissions/denials.test.ts
@@ -108,4 +108,39 @@ describe("permission denials", () => {
       }),
     );
   });
+
+  it("publishes denied audit events for non-agent runtime contexts", async () => {
+    delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+
+    const denial = recordAndEmitPermissionDenial({
+      subjectType: "context",
+      subjectId: "ctx_extension",
+      relation: "read",
+      objectType: "agents",
+      objectId: "list",
+      contextId: "ctx_extension",
+      reason: "permission_denied",
+      audit: {
+        type: "sdk_gateway_command",
+        agentId: null,
+        denied: "read:agents:list",
+        reason: "permission_denied",
+      },
+    });
+    await flushPermissionAuditEvents();
+
+    expect(auditEvents).toEqual([
+      {
+        topic: "ravi.audit.denied",
+        data: expect.objectContaining({
+          type: "sdk_gateway_command",
+          agentId: null,
+          denied: "read:agents:list",
+          reason: "permission_denied",
+          denialId: denial?.id,
+          dedupeKey: "audit.denied:sdk_gateway_command:-:read:agents:list:permission_denied",
+        }),
+      },
+    ]);
+  });
 });

--- a/src/permissions/denials.ts
+++ b/src/permissions/denials.ts
@@ -46,9 +46,9 @@ export interface PermissionDenial {
 
 export interface PermissionDeniedAuditEvent {
   type: string;
-  agentId: string;
-  denied: string;
-  reason: string;
+  agentId?: string | null;
+  denied?: string | null;
+  reason?: string | null;
   detail?: unknown;
   blockType?: string;
   missingPrincipals?: string[];
@@ -235,12 +235,17 @@ function normalizeText(value: string | null | undefined): string | null {
   return normalized ? normalized : null;
 }
 
-function buildAuditDeniedDedupeKey(event: { type: string; agentId: string; denied: string; reason: string }): string {
+function buildAuditDeniedDedupeKey(event: {
+  type?: string | null;
+  agentId?: string | null;
+  denied?: string | null;
+  reason?: string | null;
+}): string {
   return ["audit.denied", event.type, event.agentId, event.denied, event.reason].map(normalizeDedupePart).join(":");
 }
 
-function normalizeDedupePart(value: string): string {
-  return value.trim().replace(/\s+/g, " ").slice(0, 240);
+function normalizeDedupePart(value: string | null | undefined): string {
+  return (value ?? "-").trim().replace(/\s+/g, " ").slice(0, 240) || "-";
 }
 
 function normalizeNullableText(value: string | null | undefined): string | null {

--- a/src/sdk/gateway/dispatcher.test.ts
+++ b/src/sdk/gateway/dispatcher.test.ts
@@ -182,6 +182,10 @@ function executeGroup(objectId: string): ContextCapability {
   return { permission: "execute", objectType: "group", objectId, source: "test" };
 }
 
+function semanticCap(permission: string, objectType: string, objectId: string): ContextCapability {
+  return { permission, objectType, objectId, source: "test" };
+}
+
 function adminSystem(): ContextCapability {
   return { permission: "admin", objectType: "system", objectId: "*", source: "test" };
 }
@@ -364,6 +368,25 @@ describe("dispatch — scope and superadmin gating", () => {
     expect(body.reason).toContain("cannot execute");
     expect(audits.events).toHaveLength(1);
     expect(audits.events[0]?.tool).toBe("gated_ping");
+  });
+
+  it("authorizes gateway calls through command access capabilities without legacy group grants", async () => {
+    const audits = captureAudits();
+    const result = await dispatch(
+      findCmd("gated.ping"),
+      {},
+      {},
+      {
+        contextRecord: gatewayContext([semanticCap("read", "gated", "ping")], "profile-runtime"),
+        emitAudit: audits.emit,
+      },
+    );
+
+    expect(result.response.status).toBe(200);
+    expect(await result.response.json()).toEqual({ ok: true });
+    expect(audits.events).toHaveLength(1);
+    expect(audits.events[0]?.tool).toBe("gated_ping");
+    expect(audits.events[0]?.isError).toBe(false);
   });
 
   it("does not enforce runtime skill gates for API dispatches", async () => {

--- a/src/sdk/gateway/dispatcher.ts
+++ b/src/sdk/gateway/dispatcher.ts
@@ -131,12 +131,14 @@ export async function dispatch(
     return { response, audit: auditEmitted ? audit : null };
   }
 
-  const scopeResult = runWithContext(toolContext, () => enforceScopeCheck(cmd.scope, group, cmd.command));
-  if (!scopeResult.allowed) {
-    const response = permissionDenied(scopeResult.errorMessage);
-    const audit = buildAuditEvent(cmd, tool, validation.inputForAudit, true, startedAt, lineage);
-    const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
-    return { response, audit: auditEmitted ? audit : null };
+  if (cmd.scope === "superadmin") {
+    const scopeResult = runWithContext(toolContext, () => enforceScopeCheck(cmd.scope, group, cmd.command));
+    if (!scopeResult.allowed) {
+      const response = permissionDenied(scopeResult.errorMessage);
+      const audit = buildAuditEvent(cmd, tool, validation.inputForAudit, true, startedAt, lineage);
+      const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+      return { response, audit: auditEmitted ? audit : null };
+    }
   }
 
   let isError = false;

--- a/src/sdk/gateway/server.ts
+++ b/src/sdk/gateway/server.ts
@@ -17,7 +17,6 @@ import { buildRouteTable, buildMetaPayload, type RouteTable, API_PREFIX } from "
 import { resolveAuth, type AuthFailureReason, type GatewayAuthConfig } from "./auth.js";
 import { dispatch } from "./dispatcher.js";
 import { errorResponse, json, methodNotAllowed, notFound, unauthorized } from "./errors.js";
-import { hasLiveAdminContext } from "../../runtime/context-registry.js";
 import { handleStreamingRequest } from "./streaming/handler.js";
 import type { StreamingGatewayConfig } from "./streaming/types.js";
 
@@ -177,7 +176,6 @@ export function startGateway(config: GatewayConfig = {}): GatewayHandle {
 async function processGatewayRequest(request: Request, url: URL, ctx: GatewayHandlerContext): Promise<Response> {
   const streamResponse = await handleStreamingRequest(request, url, {
     auth: ctx.auth,
-    hasLiveAdminContext,
     authFailureMessage,
     streaming: ctx.streaming,
   });
@@ -214,11 +212,6 @@ async function processGatewayRequest(request: Request, url: URL, ctx: GatewayHan
   const isOpenRoute = cmd.scope === "open";
   const resolved = resolveAuth(request, ctx.auth);
   if (!isOpenRoute) {
-    if (!hasLiveAdminContext()) {
-      return unauthorized(
-        "no admin context configured; run 'ravi daemon init-admin-key' on the daemon host before issuing gateway requests",
-      );
-    }
     if (!resolved.authenticated) {
       return unauthorized(authFailureMessage(resolved.reason));
     }

--- a/src/sdk/gateway/streaming/handler.ts
+++ b/src/sdk/gateway/streaming/handler.ts
@@ -19,7 +19,6 @@ import type {
 
 export interface StreamingHandlerOptions {
   auth: GatewayAuthConfig;
-  hasLiveAdminContext: () => boolean;
   authFailureMessage: (reason: AuthFailureReason) => string;
   streaming?: StreamingGatewayConfig;
 }
@@ -39,11 +38,6 @@ export async function handleStreamingRequest(
   }
 
   const resolved = resolveAuth(request, options.auth);
-  if (!options.hasLiveAdminContext()) {
-    return unauthorized(
-      "no admin context configured; run 'ravi daemon init-admin-key' on the daemon host before issuing gateway requests",
-    );
-  }
   if (!resolved.authenticated || !resolved.contextRecord) {
     return unauthorized(options.authFailureMessage(resolved.reason));
   }

--- a/src/whatsapp-overlay/extension-compositions.test.js
+++ b/src/whatsapp-overlay/extension-compositions.test.js
@@ -121,6 +121,25 @@ describe("whatsapp overlay extension compositions", () => {
     });
   });
 
+  it("propagates agent list auth errors instead of hiding them as an empty agent list", async () => {
+    const authError = Object.assign(new Error("Forbidden"), { status: 403 });
+    const client = {
+      sessions: {
+        list: async () => ({ sessions: [] }),
+      },
+      agents: {
+        list: async () => {
+          throw authError;
+        },
+      },
+    };
+
+    await expect(buildSnapshot(client, {})).rejects.toMatchObject({
+      status: 403,
+      message: "Forbidden",
+    });
+  });
+
   it("hides terminal task sessions from active and recent session lists", async () => {
     const now = Date.now();
     const client = {


### PR DESCRIPTION
## Objective
Allow SDK gateway calls to be authorized through command access capabilities so runtime callers can use the typed SDK surface without requiring legacy command-group grants or a live admin context.

## Problem
The SDK gateway path still depended on the old live admin context and group-grant model in places where the newer command access capability model should be authoritative. Permission-denied audit events also assumed an agent id, which breaks for runtime contexts that are not agent-scoped.

## Solution
The dispatcher now enforces the legacy scope check only for superadmin commands and lets normal gateway calls rely on command access capabilities. Gateway server, streaming handler, and daemon startup no longer require or warn about a live admin context. Permission denial audit events now tolerate missing agent fields, and WhatsApp overlay fallback logic is less brittle when typed agent listing is unavailable.

## Practical impact
SDK clients and workflow code can call authorized Ravi commands through the gateway using semantic command capabilities. Denial logs remain useful for non-agent runtime contexts instead of failing on nullable identity fields.

## What does NOT change
Superadmin commands still require the stricter scope check. The public SDK command registry and generated client artifacts are unchanged, and this PR does not expand Slack, WhatsApp, or workflow permissions by itself.

## Validation
Local checks passed: bun test src/permissions/denials.test.ts src/sdk/gateway/dispatcher.test.ts; bun test src/sdk/gateway; bun tsc --noEmit; and the repository pre-push checks completed successfully before pushing the branch.

## Risks
The main risk is authorizing a gateway command through the wrong capability boundary. The change is scoped to non-superadmin command dispatch and is covered by focused dispatcher tests for command access capability authorization.

## Rollback
Revert commit 8660ad84 to restore the previous gateway authorization behavior and live admin context checks. No migrations or persistent data changes are included in this PR.