### PR TITLE
[codex] Fix runtime performance hot paths

### DIFF
--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -269,6 +269,32 @@ describe("runCoverageGate", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("passes when the session stream focused test is in the diff", () => {
+    const cwd = makeWorkspace();
+
+    const result = runCoverageGate(["src/omni/session-stream.ts", "src/omni/session-stream.test.ts"], cwd);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/omni/"]);
+  });
+
+  it("passes when runtime transport focused tests are in the diff", () => {
+    const cwd = makeWorkspace();
+
+    const result = runCoverageGate(
+      [
+        "src/runtime/codex-transport.ts",
+        "src/runtime/codex-transport.test.ts",
+        "src/runtime/prompt-subscription.ts",
+        "src/runtime/prompt-subscription.test.ts",
+      ],
+      cwd,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
+  });
+
   it("fails for runtime change without focused test", () => {
     const cwd = makeWorkspace();
 

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -19,7 +19,11 @@ const REQUIRED_COMPANIONS = ["WHY.md", "RUNBOOK.md", "CHECKS.md"] as const;
  * Each prefix maps to a list of known test file glob patterns.
  */
 export const RUNTIME_PATH_MAP: Record<string, string[]> = {
-  "src/omni/": ["src/omni/consumer-context.test.ts", "src/omni/consumer-policy.test.ts"],
+  "src/omni/": [
+    "src/omni/consumer-context.test.ts",
+    "src/omni/consumer-policy.test.ts",
+    "src/omni/session-stream.test.ts",
+  ],
   "src/router/": [
     "src/router/router.test.ts",
     "src/router/sessions.test.ts",
@@ -33,6 +37,8 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/runtime/session-goals.test.ts",
     "src/runtime/session-trace.test.ts",
     "src/runtime/compaction-announcement.test.ts",
+    "src/runtime/codex-transport.test.ts",
+    "src/runtime/prompt-subscription.test.ts",
   ],
   "src/session-trace/": ["src/session-trace/session-trace.test.ts"],
   "src/triggers/": ["src/triggers/triggers.test.ts"],

--- a/src/omni/session-stream.test.ts
+++ b/src/omni/session-stream.test.ts
@@ -2,15 +2,19 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let currentJsm: PromptJsm;
 
-const { ensureSessionConsumer, ensureSessionPromptInfrastructure, ensureSessionPromptsStream } = await import(
-  "./session-stream.js"
-);
+const {
+  ensureSessionConsumer,
+  ensureSessionPromptInfrastructure,
+  ensureSessionPromptsStream,
+  resetSessionPromptInfrastructureCacheForTests,
+} = await import("./session-stream.js");
 
 afterAll(() => {
   mock.restore();
 });
 
 beforeEach(() => {
+  resetSessionPromptInfrastructureCacheForTests();
   currentJsm = makePromptJsm();
 });
 
@@ -59,6 +63,36 @@ describe("session prompt JetStream infrastructure", () => {
 
     expect(calls.streamAdds).toBe(1);
     expect(calls.consumerAdds).toBe(1);
+  });
+
+  it("caches successful infrastructure validation off the publish hot path", async () => {
+    const streamInfo = mock(async () => ({}));
+    const consumerInfo = mock(async () => ({}));
+    currentJsm = makePromptJsm({
+      streams: { info: streamInfo },
+      consumers: { info: consumerInfo },
+    });
+
+    await ensureSessionPromptInfrastructure(currentJsm as never);
+    await ensureSessionPromptInfrastructure(currentJsm as never);
+
+    expect(streamInfo).toHaveBeenCalledTimes(1);
+    expect(consumerInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("force revalidates cached infrastructure for health checks and recovery", async () => {
+    const streamInfo = mock(async () => ({}));
+    const consumerInfo = mock(async () => ({}));
+    currentJsm = makePromptJsm({
+      streams: { info: streamInfo },
+      consumers: { info: consumerInfo },
+    });
+
+    await ensureSessionPromptInfrastructure(currentJsm as never);
+    await ensureSessionPromptInfrastructure(currentJsm as never, { force: true });
+
+    expect(streamInfo).toHaveBeenCalledTimes(2);
+    expect(consumerInfo).toHaveBeenCalledTimes(2);
   });
 
   it("treats stream add conflicts as success when the stream now exists", async () => {

--- a/src/omni/session-stream.ts
+++ b/src/omni/session-stream.ts
@@ -31,6 +31,11 @@ const CONSUMER_NAME = "ravi-prompts";
 let legacyConsumerCleanupComplete = false;
 let legacyConsumerCleanupInFlight: Promise<void> | null = null;
 let sessionPromptInfrastructureInFlight: Promise<void> | null = null;
+let sessionPromptInfrastructureReady = false;
+
+export interface EnsureSessionPromptInfrastructureOptions {
+  force?: boolean;
+}
 
 export function getConsumerName(): string {
   return CONSUMER_NAME;
@@ -164,13 +169,34 @@ export async function ensureSessionConsumer(jsm: JetStreamManager): Promise<void
  * the daemon process stays alive; re-ensuring both pieces lets the pull loop
  * recover without requiring a full daemon restart.
  */
-export async function ensureSessionPromptInfrastructure(existingJsm?: JetStreamManager): Promise<void> {
+export async function ensureSessionPromptInfrastructure(
+  existingJsm?: JetStreamManager,
+  options: EnsureSessionPromptInfrastructureOptions = {},
+): Promise<void> {
+  if (sessionPromptInfrastructureReady && !options.force) return;
   if (sessionPromptInfrastructureInFlight) return sessionPromptInfrastructureInFlight;
 
-  sessionPromptInfrastructureInFlight = ensureSessionPromptInfrastructureOnce(existingJsm).finally(() => {
-    sessionPromptInfrastructureInFlight = null;
-  });
+  sessionPromptInfrastructureInFlight = ensureSessionPromptInfrastructureOnce(existingJsm)
+    .then(() => {
+      sessionPromptInfrastructureReady = true;
+    })
+    .catch((err) => {
+      if (options.force) {
+        sessionPromptInfrastructureReady = false;
+      }
+      throw err;
+    })
+    .finally(() => {
+      sessionPromptInfrastructureInFlight = null;
+    });
   return sessionPromptInfrastructureInFlight;
+}
+
+export function resetSessionPromptInfrastructureCacheForTests(): void {
+  legacyConsumerCleanupComplete = false;
+  legacyConsumerCleanupInFlight = null;
+  sessionPromptInfrastructureInFlight = null;
+  sessionPromptInfrastructureReady = false;
 }
 
 async function ensureSessionPromptInfrastructureOnce(existingJsm?: JetStreamManager): Promise<void> {
@@ -203,7 +229,20 @@ export async function publishSessionPrompt(sessionName: string, payload: Record<
     deliveryBarrier,
     deliveryBarrierSource,
   };
-  await js.publish(`ravi.session.${sessionName}.prompt`, sc.encode(JSON.stringify(enrichedPayload)));
+  try {
+    await js.publish(`ravi.session.${sessionName}.prompt`, sc.encode(JSON.stringify(enrichedPayload)));
+  } catch (error) {
+    if (!isPromptPublishInfrastructureError(error)) {
+      throw error;
+    }
+    sessionPromptInfrastructureReady = false;
+    log.warn("SESSION_PROMPTS publish failed after cached infrastructure; revalidating once", {
+      sessionName,
+      error,
+    });
+    await ensureSessionPromptInfrastructure(undefined, { force: true });
+    await js.publish(`ravi.session.${sessionName}.prompt`, sc.encode(JSON.stringify(enrichedPayload)));
+  }
   try {
     recordPromptPublishedTrace({ sessionName, payload: enrichedPayload });
   } catch (error) {
@@ -236,4 +275,15 @@ async function ensureConsumerExistsAfterRace(jsm: JetStreamManager, originalErro
 function isNotFoundError(err: unknown): boolean {
   const message = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
   return message.includes("not found") || message.includes("deleted");
+}
+
+function isPromptPublishInfrastructureError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  return (
+    message.includes("stream not found") ||
+    message.includes("consumer not found") ||
+    message.includes("not found") ||
+    message.includes("deleted") ||
+    message.includes("no responders")
+  );
 }

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -10,6 +10,7 @@ import { logger } from "../utils/logger.js";
 import {
   createCodexTransport,
   resolveCodexTransportKind,
+  signalCodexTransportProcess,
   type CodexTransport,
   type CodexTransportKind,
 } from "./codex-transport.js";
@@ -997,18 +998,14 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
           if (activeTurn) {
             settleTurn(activeTurn, { exitCode: 1, stderr: getStderr() }, { failQueue: error });
           }
-          newTransport.child.kill("SIGKILL");
+          signalCodexTransportProcess(newTransport.child, "SIGKILL");
         }
       },
       onTransportError: (error) => {
         if (activeTurn) {
           settleTurn(activeTurn, { exitCode: 1, stderr: getStderr() }, { failQueue: error });
         }
-        try {
-          newTransport.child.kill("SIGKILL");
-        } catch {
-          // child already gone
-        }
+        signalCodexTransportProcess(newTransport.child, "SIGKILL");
       },
     });
 
@@ -1161,10 +1158,10 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
       if (!child || closed) {
         return;
       }
-      child.kill("SIGINT");
+      signalCodexTransportProcess(child, "SIGINT");
       forcedKillTimer = setTimeout(() => {
         if (!closed && child) {
-          child.kill("SIGKILL");
+          signalCodexTransportProcess(child, "SIGKILL");
         }
       }, INTERRUPT_GRACE_MS);
       forcedKillTimer.unref?.();
@@ -1655,10 +1652,10 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     }
     const targetChild = child;
     targetChild.stdin?.end();
-    targetChild.kill("SIGTERM");
+    signalCodexTransportProcess(targetChild, "SIGTERM");
     forcedKillTimer = setTimeout(() => {
       if (child === targetChild && !closed) {
-        targetChild.kill("SIGKILL");
+        signalCodexTransportProcess(targetChild, "SIGKILL");
       }
     }, INTERRUPT_GRACE_MS);
     forcedKillTimer.unref?.();
@@ -1724,7 +1721,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         } catch (error) {
           settleTurn(turn, { exitCode: 1, stderr: getStderr().slice(turn.stderrOffset) }, { failQueue: error });
           if (child && !closed) {
-            child.kill("SIGKILL");
+            signalCodexTransportProcess(child, "SIGKILL");
           }
         }
       })();
@@ -1769,6 +1766,7 @@ function _createCodexCliTransport(options: { command?: string } = {}): CodexCliT
       const args = buildExecArgs(input.resume, input.model, toCodexRuntimeEffort(input.effort));
       const child = spawn(command, args, {
         cwd: input.cwd,
+        detached: true,
         env: input.env,
         stdio: ["pipe", "pipe", "pipe"],
       });
@@ -1838,10 +1836,10 @@ function _createCodexCliTransport(options: { command?: string } = {}): CodexCliT
             return;
           }
 
-          child.kill("SIGINT");
+          signalCodexTransportProcess(child, "SIGINT");
           forcedKillTimer = setTimeout(() => {
             if (!closed) {
-              child.kill("SIGKILL");
+              signalCodexTransportProcess(child, "SIGKILL");
             }
           }, INTERRUPT_GRACE_MS);
           forcedKillTimer.unref?.();

--- a/src/runtime/codex-transport.test.ts
+++ b/src/runtime/codex-transport.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 
-import { shouldSuppressCodexStderrLine } from "./codex-transport.js";
+import { shouldSuppressCodexStderrLine, signalCodexTransportProcess } from "./codex-transport.js";
 
 describe("codex transport stderr filtering", () => {
   it("suppresses known benign Codex skill icon warnings", () => {
@@ -32,5 +32,41 @@ describe("codex transport stderr filtering", () => {
         "2026-05-31T16:42:42.751501Z  WARN codex_rmcp_client::stdio_server_launcher: Failed to kill MCP process group 25383: No such process (os error 3)",
       ),
     ).toBe(true);
+  });
+});
+
+describe("codex transport process signaling", () => {
+  it("signals the app-server process group when a pid is available", () => {
+    const childKill = mock(() => true);
+    const processKill = mock(() => true);
+
+    signalCodexTransportProcess({ pid: 1234, kill: childKill }, "SIGTERM", processKill);
+
+    expect(processKill).toHaveBeenCalledWith(-1234, "SIGTERM");
+    expect(childKill).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct child signaling when process-group signaling fails", () => {
+    const childKill = mock(() => true);
+    const processKill = mock(() => {
+      throw Object.assign(new Error("not permitted"), { code: "EPERM" });
+    });
+
+    signalCodexTransportProcess({ pid: 1234, kill: childKill }, "SIGKILL", processKill);
+
+    expect(processKill).toHaveBeenCalledWith(-1234, "SIGKILL");
+    expect(childKill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("does not fall back when the process group is already gone", () => {
+    const childKill = mock(() => true);
+    const processKill = mock(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+
+    signalCodexTransportProcess({ pid: 1234, kill: childKill }, "SIGKILL", processKill);
+
+    expect(processKill).toHaveBeenCalledWith(-1234, "SIGKILL");
+    expect(childKill).not.toHaveBeenCalled();
   });
 });

--- a/src/runtime/codex-transport.ts
+++ b/src/runtime/codex-transport.ts
@@ -50,6 +50,33 @@ export interface CodexTransport {
   closeChannel(): void;
 }
 
+export type CodexTransportProcess = Pick<ChildProcess, "pid" | "kill">;
+export type CodexProcessSignaler = (pid: number, signal?: NodeJS.Signals | number) => boolean;
+
+export function signalCodexTransportProcess(
+  child: CodexTransportProcess,
+  signal: NodeJS.Signals,
+  killProcess: CodexProcessSignaler = process.kill,
+): void {
+  const pid = child.pid;
+  if (typeof pid === "number" && Number.isFinite(pid) && pid > 0) {
+    try {
+      killProcess(-pid, signal);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+        return;
+      }
+    }
+  }
+
+  try {
+    child.kill(signal);
+  } catch {
+    // already gone
+  }
+}
+
 export function shouldSuppressCodexStderrLine(line: string): boolean {
   if (line.includes(BENIGN_CODEX_SKILL_ICON_WARNING) && line.includes("icon path must not contain '..'")) {
     return true;
@@ -91,6 +118,7 @@ function attachStderrStreaming(
 export function createStdioTransport(opts: CodexTransportSpawnOptions): CodexTransport {
   const spawned = spawn(opts.command, [...opts.baseArgs, "app-server"], {
     cwd: opts.cwd,
+    detached: true,
     env: opts.env,
     stdio: ["pipe", "pipe", "pipe"],
   });
@@ -154,6 +182,7 @@ export function createStdioTransport(opts: CodexTransportSpawnOptions): CodexTra
 export function createWebsocketTransport(opts: CodexTransportSpawnOptions): CodexTransport {
   const spawned = spawn(opts.command, [...opts.baseArgs, "app-server", "--listen", "ws://127.0.0.1:0"], {
     cwd: opts.cwd,
+    detached: true,
     env: opts.env,
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/src/runtime/prompt-subscription.test.ts
+++ b/src/runtime/prompt-subscription.test.ts
@@ -70,7 +70,7 @@ describe("RuntimePromptSubscription", () => {
 
     await waitUntil(() => consumeCalls.length === 1 && !subscription.active);
 
-    expect(ensureInfrastructureMock).toHaveBeenCalled();
+    expect(ensureInfrastructureMock).toHaveBeenCalledWith({ force: true });
     expect(fakeJetStream.consumers.get).toHaveBeenCalledWith("SESSION_PROMPTS", "ravi-prompts");
     expect(consumeCalls[0]).toMatchObject({
       expires: 2000,

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -1,6 +1,11 @@
 import { StringCodec } from "nats";
 import { getNats, nats } from "../nats.js";
-import { SESSION_STREAM, ensureSessionPromptInfrastructure, getConsumerName } from "../omni/session-stream.js";
+import {
+  SESSION_STREAM,
+  ensureSessionPromptInfrastructure,
+  getConsumerName,
+  type EnsureSessionPromptInfrastructureOptions,
+} from "../omni/session-stream.js";
 import { logger } from "../utils/logger.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
@@ -11,7 +16,7 @@ export interface RuntimePromptSubscriptionOptions {
   isRunning(): boolean;
   getStreamingSessionCount(): number;
   getRuntimeSessionPoolSnapshot?(): RuntimeSessionPoolSnapshot;
-  ensurePromptInfrastructure?(): Promise<void>;
+  ensurePromptInfrastructure?(options?: EnsureSessionPromptInfrastructureOptions): Promise<void>;
   markConsumerReady(): void;
   handlePrompt(sessionName: string, prompt: RuntimeLaunchPrompt): Promise<void>;
 }
@@ -81,7 +86,7 @@ export class RuntimePromptSubscription {
       const js = nc.jetstream();
 
       const consumerName = getConsumerName();
-      await this.ensurePromptInfrastructure();
+      await this.ensurePromptInfrastructure({ force: true });
 
       while (this.options.isRunning()) {
         try {
@@ -160,7 +165,7 @@ export class RuntimePromptSubscription {
 
           if (isPromptBootstrapError(err)) {
             log.warn("Prompt pull unavailable during bootstrap, re-ensuring stream/consumer", { error: err });
-            await this.ensurePromptInfrastructure();
+            await this.ensurePromptInfrastructure({ force: true });
           } else {
             log.error("Prompt subscription error - will reconnect pull", {
               error: err,
@@ -199,7 +204,7 @@ export class RuntimePromptSubscription {
   private ensurePromptInfrastructureForHealthCheck(): void {
     if (this.healthProbeInFlight) return;
     this.healthProbeInFlight = true;
-    this.ensurePromptInfrastructure()
+    this.ensurePromptInfrastructure({ force: true })
       .catch((error) => {
         log.warn("Subscriber health check: failed to verify prompt infrastructure", { error });
       })
@@ -208,8 +213,8 @@ export class RuntimePromptSubscription {
       });
   }
 
-  private ensurePromptInfrastructure(): Promise<void> {
-    return this.options.ensurePromptInfrastructure?.() ?? ensureSessionPromptInfrastructure();
+  private ensurePromptInfrastructure(options?: EnsureSessionPromptInfrastructureOptions): Promise<void> {
+    return this.options.ensurePromptInfrastructure?.(options) ?? ensureSessionPromptInfrastructure(undefined, options);
   }
 }
 


### PR DESCRIPTION
## Objective

Reduce Ravi runtime latency after the recent slowdown by removing unnecessary hot-path work and ensuring Codex transport processes are cleaned up reliably.

## Problem

Message delivery was paying repeated SESSION_PROMPTS stream and consumer validation costs during normal prompt publishing. Recent Codex app-server runs could also leave native app-server children alive after the Ravi wrapper process exited, increasing local resource pressure.

## Solution

Cache successful SESSION_PROMPTS infrastructure validation away from the publish hot path, force revalidation only for health and recovery flows, and signal Codex app-server process groups with a direct-child fallback when cleanup requires compatibility.

## Practical impact

Normal prompt publishing does less repeated NATS setup work, session trace and response handling stay responsive, and Codex app-server children are less likely to accumulate after restarts or interrupts.

## What does NOT change

This does not change user-facing routing, provider selection, authorization policy, prompt contents, or the external channel contract. It only changes runtime infrastructure caching and Codex subprocess lifecycle cleanup.

## Validation

- `git diff --check`
- `bun test src/runtime/codex-transport.test.ts src/omni/session-stream.test.ts src/runtime/prompt-subscription.test.ts`
- `bun run build`
- pre-push full suite: SDK check, build, typecheck, main test suites, SDK tests/check

## Risks

The main risk is stale prompt-stream infrastructure cache state after NATS stream changes. The implementation keeps explicit force-revalidation paths for subscription recovery and health checks to avoid keeping a bad cache entry alive.

## Rollback

Revert commit `1d9da70` from branch `codex/runtime-performance-hotpath-fixes` to restore the previous prompt infrastructure validation and Codex process signaling behavior.
