### PR TITLE
fix(runtime): preserve terminal presence cleanup

### DIFF
--- a/src/gateway-session-trace.test.ts
+++ b/src/gateway-session-trace.test.ts
@@ -1123,7 +1123,7 @@ describe("Gateway session trace instrumentation", () => {
     );
   });
 
-  it("stops active presence from idle runtime status", async () => {
+  it("keeps active presence through idle runtime status", async () => {
     const { sessionName } = seedSession();
     const sendTyping = mock(async () => {});
     const renewActiveTarget = mock(async () => true);
@@ -1139,9 +1139,84 @@ describe("Gateway session trace instrumentation", () => {
       },
     );
 
+    await handleRuntimePresence(gateway, sessionName, { type: "assistant.message", _source: target });
+    renewActiveTarget.mockClear();
+    sendTyping.mockClear();
     await handleRuntimePresence(gateway, sessionName, { type: "status", status: "idle", _source: target });
 
     expect(renewActiveTarget).not.toHaveBeenCalled();
+    expect(clearActiveTarget).not.toHaveBeenCalled();
+    expect(sendTyping).not.toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "5511999999999@s.whatsapp.net",
+      false,
+    );
+  });
+
+  it("ignores raw provider terminal native events until canonical turn completion", async () => {
+    const { sessionName } = seedSession();
+    const sendTyping = mock(async () => {});
+    const renewActiveTarget = mock(async () => true);
+    const clearActiveTarget = mock(async () => {});
+    const target = makeResponse().target!;
+    const gateway = makeGateway(
+      mock(async () => ({ messageId: "outbound-1" })),
+      {
+        sendTyping,
+        getActiveTarget: () => target,
+        renewActiveTarget,
+        clearActiveTarget,
+      },
+    );
+
+    await handleRuntimePresence(gateway, sessionName, { type: "assistant.message", _source: target });
+    renewActiveTarget.mockClear();
+    sendTyping.mockClear();
+    await handleRuntimePresence(gateway, sessionName, {
+      type: "provider.raw",
+      nativeEvent: "turn.completed",
+      _source: target,
+    });
+
+    expect(renewActiveTarget).not.toHaveBeenCalled();
+    expect(clearActiveTarget).not.toHaveBeenCalled();
+    expect(sendTyping).not.toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "5511999999999@s.whatsapp.net",
+      false,
+    );
+
+    await handleRuntimePresence(gateway, sessionName, { type: "turn.complete", _source: target });
+
+    expect(clearActiveTarget).toHaveBeenCalledTimes(1);
+    expect(sendTyping).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "5511999999999@s.whatsapp.net",
+      false,
+    );
+  });
+
+  it("does not repeat terminal presence stop for duplicate terminal events", async () => {
+    const { sessionName } = seedSession();
+    const sendTyping = mock(async () => {});
+    const target = makeResponse().target!;
+    let activeTarget: typeof target | undefined = target;
+    const clearActiveTarget = mock(async () => {
+      activeTarget = undefined;
+    });
+    const gateway = makeGateway(
+      mock(async () => ({ messageId: "outbound-1" })),
+      {
+        sendTyping,
+        getActiveTarget: () => activeTarget,
+        clearActiveTarget,
+      },
+    );
+
+    await handleRuntimePresence(gateway, sessionName, { type: "turn.complete", _source: target });
+    sendTyping.mockClear();
+    await handleRuntimePresence(gateway, sessionName, { type: "turn.completed", _source: target });
+
     expect(clearActiveTarget).toHaveBeenCalledTimes(1);
     expect(sendTyping).not.toHaveBeenCalled();
   });
@@ -1417,7 +1492,12 @@ describe("Gateway session trace instrumentation", () => {
     });
 
     expect(clearActiveTarget).toHaveBeenCalledTimes(1);
-    expect(sendTyping).not.toHaveBeenCalled();
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    expect(sendTyping).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "5511999999999@s.whatsapp.net",
+      false,
+    );
   });
 
   it("stops presence immediately when the response is silent", async () => {

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -30,7 +30,6 @@ import { logger } from "./utils/logger.js";
 import type { OmniSender } from "./omni/sender.js";
 import type { OmniConsumer } from "./omni/consumer.js";
 import { getAgentPlatformIdentity, recordOutbound } from "./contacts.js";
-import { SessionTypingTracker } from "./gateway-typing.js";
 import { assertChannelSupportsStickers } from "./channels/capabilities.js";
 import { buildChannelOutboundJobFromResponse, publishChannelOutboundJob } from "./channels/outbound-stream.js";
 import { subjectForChannelPresence } from "./channels/presence-consumer.js";
@@ -198,7 +197,6 @@ export class Gateway {
   private omniConsumer: OmniConsumer;
   private emitEvent: typeof nats.emit;
   private activeSubscriptions = new Set<string>();
-  private typingTracker = new SessionTypingTracker();
   private presenceRenewedAt = new Map<string, number>();
   private activeRuntimeSessions = new Set<string>();
   private runtimeActivitySequences = new Map<string, number>();
@@ -206,6 +204,7 @@ export class Gateway {
   private nativePresenceTargets = new Map<string, PresenceTarget>();
   private nativeStatusAnchors = new Map<string, PresenceTarget>();
   private nativePresenceTurns = new Map<string, NativePresenceTurnState>();
+  private terminalPresenceStopped = new Set<string>();
   private postDeliveryRenewals = new Map<string, ReturnType<typeof setTimeout>>();
   private interruptedPresenceStops = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -240,7 +239,6 @@ export class Gateway {
   async stop(): Promise<void> {
     log.info("Stopping gateway...");
     this.running = false;
-    this.typingTracker = new SessionTypingTracker();
     this.presenceRenewedAt.clear();
     this.activeRuntimeSessions.clear();
     this.runtimeActivitySequences.clear();
@@ -248,20 +246,10 @@ export class Gateway {
     this.nativePresenceTargets.clear();
     this.nativeStatusAnchors.clear();
     this.nativePresenceTurns.clear();
+    this.terminalPresenceStopped.clear();
     this.clearPostDeliveryRenewals();
     this.clearInterruptedPresenceStops();
     log.info("Gateway stopped");
-  }
-
-  private async sendTypingIfChanged(
-    sessionName: string,
-    target: PresenceTarget,
-    active: boolean,
-    reason = "state-change",
-  ): Promise<void> {
-    if (active && this.isPresenceSuppressed(target)) return;
-    if (!this.typingTracker.shouldEmit(sessionName, active)) return;
-    await this.sendTyping(target, active, { sessionName, reason });
   }
 
   private async sendTyping(
@@ -685,6 +673,7 @@ export class Gateway {
   }
 
   private async stopPresenceForSession(sessionName: string, target?: PresenceTarget): Promise<void> {
+    const alreadyStopped = this.terminalPresenceStopped.has(sessionName);
     this.activeRuntimeSessions.delete(sessionName);
     this.terminalRuntimeSessions.add(sessionName);
     this.presenceRenewedAt.delete(sessionName);
@@ -700,6 +689,8 @@ export class Gateway {
       turnState.terminal = true;
     }
     const localTarget = this.omniConsumer.getActiveTarget(sessionName) as PresenceTarget | undefined;
+    if (alreadyStopped && !localTarget) return;
+
     if (localTarget) {
       const localStopTarget = this.shouldUseNativePresence(localTarget)
         ? (this.runtimePresenceTarget(sessionName, localTarget) ?? localTarget)
@@ -707,26 +698,25 @@ export class Gateway {
       if (this.shouldUseNativePresence(localStopTarget)) {
         await this.sendTyping(localStopTarget, false, { sessionName, reason: "terminal-clear-active-target" });
       } else {
-        await this.emitPresenceDiagnostic(sessionName, {
-          active: false,
-          status: "inactive",
-          reason: "terminal-clear-active-target",
-          target: localStopTarget,
-        });
+        await this.sendTyping(localStopTarget, false, { sessionName, reason: "terminal-clear-active-target" });
       }
       await this.omniConsumer.clearActiveTarget(sessionName);
+      this.terminalPresenceStopped.add(sessionName);
       if (preferredTarget && !this.targetsMatch(localStopTarget, preferredTarget)) {
         await this.sendTyping(preferredTarget, false, { sessionName, reason: "terminal-fallback-stop" });
       }
       return;
     }
 
+    if (alreadyStopped) return;
+
     if (preferredTarget) {
       if (this.shouldUseNativePresence(preferredTarget)) {
         await this.sendTyping(preferredTarget, false, { sessionName, reason: "terminal-stop" });
       } else {
-        await this.sendTypingIfChanged(sessionName, preferredTarget, false, "terminal-stop");
+        await this.sendTyping(preferredTarget, false, { sessionName, reason: "terminal-stop" });
       }
+      this.terminalPresenceStopped.add(sessionName);
     }
   }
 
@@ -788,7 +778,8 @@ export class Gateway {
     this.schedulePostDeliveryPresenceRenewal(sessionName, outboundTarget, "native-delivery-renew");
   }
 
-  private isTerminalRuntimeEvent(type: string | undefined, status?: string, nativeEvent?: string): boolean {
+  private isTerminalRuntimeEvent(type: string | undefined, _status?: string, nativeEvent?: string): boolean {
+    if (type === "provider.raw" || type === "status") return false;
     return (
       type === "result" ||
       type === "silent" ||
@@ -796,12 +787,12 @@ export class Gateway {
       type === "turn.completed" ||
       type === "turn.failed" ||
       type === "session.timeout" ||
-      (type === "status" && status === "idle") ||
-      nativeEvent === "turn.complete" ||
-      nativeEvent === "turn.completed" ||
-      nativeEvent === "turn.failed" ||
-      nativeEvent === "turn/completed" ||
-      nativeEvent === "turn/failed"
+      (!type &&
+        (nativeEvent === "turn.complete" ||
+          nativeEvent === "turn.completed" ||
+          nativeEvent === "turn.failed" ||
+          nativeEvent === "turn/completed" ||
+          nativeEvent === "turn/failed"))
     );
   }
 
@@ -1240,6 +1231,7 @@ export class Gateway {
     if (this.terminalRuntimeSessions.has(sessionName)) {
       if (!this.isPresenceStartEvent(data.type, data.nativeEvent)) return;
       this.terminalRuntimeSessions.delete(sessionName);
+      this.terminalPresenceStopped.delete(sessionName);
     }
 
     if (data._source && this.isPresenceStartEvent(data.type, data.nativeEvent)) {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -1329,10 +1329,11 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           });
         }
 
+        const liveActivity = status === "idle" ? "idle" : streaming.compacting ? "compacting" : "thinking";
         patchLiveState(
           {
-            activity: streaming.compacting ? "compacting" : "thinking",
-            summary: streaming.compacting ? "compacting" : "runtime active",
+            activity: liveActivity,
+            summary: status === "idle" ? "runtime idle" : streaming.compacting ? "compacting" : "runtime active",
             agentId: agent.id,
             runId,
             provider: runtimeSession.provider,

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -795,6 +795,29 @@ describe("runtime session trace instrumentation", () => {
     expect(streaming.turnActive).toBe(false);
   });
 
+  it("clears live busy state when the provider emits idle status", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming);
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        {
+          type: "status",
+          status: "idle",
+        },
+      ]),
+    );
+
+    const live = getRuntimeLiveStateForSession(makeSession());
+    expect(live).toMatchObject({
+      activity: "idle",
+      summary: "runtime idle",
+    });
+    expect(live?.busySince).toBeUndefined();
+    expect(live?.toolName).toBeUndefined();
+  });
+
   it("clears compaction at terminal boundaries even without an idle status", async () => {
     const streaming = makeStreamingSession();
     seedAdapterTrace(streaming);


### PR DESCRIPTION
## Objective

Preserve the useful terminal presence cleanup behavior from the dirty runtime worktree as a focused change on top of current `dev`. The PR keeps channel presence alive during non-terminal provider noise and clears it only when the runtime emits a canonical terminal boundary.

## Problem

The local runtime branch mixed three unrelated areas: NATS topic registry, Meet profile/runtime work, and terminal presence cleanup. NATS is already present in current `dev`, the Meet commit conflicts with the newer native meeting foundation, and only the terminal presence behavior still made sense to salvage.

## Solution

Port the terminal presence semantics into the current gateway/runtime code: provider `status` and `provider.raw` events no longer terminate presence, canonical terminal events stop presence once, duplicate terminal stops are ignored, and a new turn clears the stopped marker. Provider idle status now updates live runtime state to `runtime idle` instead of leaving stale busy state.

## Practical impact

Slack/native presence should stop being cleared by raw provider events that merely look terminal. Operators should see idle runtime state when the provider says idle, while actual turn completion still clears active typing/presence promptly.

## What does NOT change

This PR does not reintroduce the older Meet resolved-profile commit or change the current native meeting foundation in `dev`. It also does not add the NATS topic registry because that work is already merged in `dev` as `c7d9c45`.

## Validation

- `bunx biome check src/gateway.ts src/gateway-session-trace.test.ts src/runtime/host-event-loop.ts src/runtime/session-trace.test.ts`
- `bun run typecheck`
- `bun test src/gateway-session-trace.test.ts src/runtime/session-trace.test.ts`
- pre-push checks passed: SDK drift, build, typecheck, configured test suite, and SDK check

## Risks

The main risk is presence staying active if a provider emits only raw terminal-looking events and never emits the canonical terminal event. The change is intentionally biased toward avoiding premature presence cleanup because raw provider/status events were not reliable terminal boundaries.

## Rollback

Revert this PR to restore the previous gateway/runtime terminal presence behavior. Operationally, presence can also be cleared by the next canonical terminal event or by restarting the affected runtime session if an edge case leaves stale presence active.

## Follow-ups

Keep the Meet work out of this PR and re-evaluate it separately against the current native meeting channel foundation. If needed, add a separate migration/spec for meeting profiles instead of replaying the old conflicted commit.