### PR TITLE
Fix native Slack multi-runner

### DIFF
--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -795,6 +795,7 @@ export class RaviClient {
     restart: async (options?: {
       build?: boolean;
       slackConnection?: string;
+      slackConnections?: string;
     }): Promise<ChannelsRestartReturn> => {
       return this.transport.call({
         groupSegments: ["channels"],
@@ -806,6 +807,7 @@ export class RaviClient {
     start: async (options?: {
       build?: boolean;
       slackConnection?: string;
+      slackConnections?: string;
     }): Promise<ChannelsStartReturn> => {
       return this.transport.call({
         groupSegments: ["channels"],

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -12486,6 +12486,10 @@ export const ChannelsRestartInputSchema = {
     "slackConnection": {
       "description": "Optional Slack credential connection override",
       "type": "string"
+    },
+    "slackConnections": {
+      "description": "Comma-separated Slack credential connections to run in one native runner",
+      "type": "string"
     }
   },
   "type": "object"
@@ -12529,6 +12533,12 @@ export const ChannelsRestartReturnSchema = {
               "type": "null"
             }
           ]
+        },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "slackSocketMode": {
           "type": "boolean"
@@ -12758,6 +12768,10 @@ export const ChannelsStartInputSchema = {
     "slackConnection": {
       "description": "Optional Slack credential connection override",
       "type": "string"
+    },
+    "slackConnections": {
+      "description": "Comma-separated Slack credential connections to run in one native runner",
+      "type": "string"
     }
   },
   "type": "object"
@@ -12801,6 +12815,12 @@ export const ChannelsStartReturnSchema = {
               "type": "null"
             }
           ]
+        },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "slackSocketMode": {
           "type": "boolean"
@@ -13252,6 +13272,12 @@ export const ChannelsStopReturnSchema = {
               "type": "null"
             }
           ]
+        },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "slackSocketMode": {
           "type": "boolean"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -2227,6 +2227,7 @@ export type ChannelsProbeReturn = {
 export type ChannelsRestartInput = {
   build?: boolean;
   slackConnection?: string;
+  slackConnections?: string;
 };
 
 /** Return shape for `channels.restart`. */
@@ -2238,6 +2239,7 @@ export type ChannelsRestartReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections?: string[];
     slackSocketMode: boolean;
   };
   status?: {
@@ -2277,6 +2279,7 @@ export type ChannelsRestartReturn = {
 export type ChannelsStartInput = {
   build?: boolean;
   slackConnection?: string;
+  slackConnections?: string;
 };
 
 /** Return shape for `channels.start`. */
@@ -2288,6 +2291,7 @@ export type ChannelsStartReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections?: string[];
     slackSocketMode: boolean;
   };
   status?: {
@@ -2366,6 +2370,7 @@ export type ChannelsStopReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections?: string[];
     slackSocketMode: boolean;
   };
   status?: {

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:6ca452ad82b3f4290a6de938d721ada0b3c19c3edf41facd520773893624f7b8";
+export const REGISTRY_HASH = "sha256:53347f7b4acac4117cf707c6629b3e8610bf2584612d4c53d52e8003918d3011";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "27a97d4bc291";
+export const GIT_SHA = "e9e82a1693f9";

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -9,7 +9,7 @@ import {
   ensureChannelOutboundInfrastructure,
 } from "./outbound-stream.js";
 import { ChannelPresenceConsumer } from "./presence-consumer.js";
-import { createSlackNativeRuntimeFromEnv, type SlackNativeRuntime } from "./slack/index.js";
+import { createSlackNativeRuntimesFromEnv, type SlackNativeRuntime } from "./slack/index.js";
 
 const log = logger.child("channels:runner");
 
@@ -52,7 +52,7 @@ export class ChannelRunner {
   private presenceConsumer: ChannelPresenceConsumer | null = null;
   private deliveries: NativeTextDelivery[] = [];
   private presenceDeliveries: NativePresenceDelivery[] = [];
-  private slackRuntime: SlackNativeRuntime | null = null;
+  private slackRuntimes: SlackNativeRuntime[] = [];
   private adapterStatuses = new Map<string, AdapterStatus>();
 
   constructor(private readonly options: ChannelRunnerOptions = {}) {}
@@ -107,8 +107,8 @@ export class ChannelRunner {
     this.outboundConsumer = null;
     await this.presenceConsumer?.stop();
     this.presenceConsumer = null;
-    await this.slackRuntime?.socketMode.stop();
-    this.slackRuntime = null;
+    await Promise.all(this.slackRuntimes.map((runtime) => runtime.socketMode.stop()));
+    this.slackRuntimes = [];
     this.deliveries = [];
     this.presenceDeliveries = [];
     this.markAdapter("slack", "slack", "disconnected");
@@ -135,16 +135,18 @@ export class ChannelRunner {
   private async startSlack(env: NodeJS.ProcessEnv): Promise<void> {
     this.markAdapter("slack", "slack", "starting");
     try {
-      const runtime = await createSlackNativeRuntimeFromEnv(env);
-      if (!runtime) {
+      const runtimes = await createSlackNativeRuntimesFromEnv(env);
+      if (runtimes.length === 0) {
         this.markAdapter("slack", "slack", "disabled", "not_configured");
         return;
       }
 
-      this.slackRuntime = runtime;
-      this.deliveries.push(runtime.delivery);
-      this.presenceDeliveries.push(runtime.presence);
-      runtime.socketMode.start();
+      this.slackRuntimes = runtimes;
+      for (const runtime of runtimes) {
+        this.deliveries.push(runtime.delivery);
+        this.presenceDeliveries.push(runtime.presence);
+        runtime.socketMode.start();
+      }
       this.markAdapter("slack", "slack", "connected");
     } catch (error) {
       this.markAdapter("slack", "slack", "failed", error instanceof Error ? error.message : String(error));

--- a/src/channels/slack/client.ts
+++ b/src/channels/slack/client.ts
@@ -89,6 +89,10 @@ export interface SlackConversationHistoryInput {
   readonly inclusive?: boolean;
 }
 
+export interface SlackConversationRepliesInput extends SlackConversationHistoryInput {
+  readonly ts: string;
+}
+
 export interface SlackConversationMembersInput {
   readonly channel: string;
   readonly limit?: number;
@@ -217,6 +221,8 @@ export interface SlackConversationHistoryResponse extends SlackApiResponse {
   readonly has_more?: boolean;
   readonly response_metadata?: SlackCursorPaging;
 }
+
+export interface SlackConversationRepliesResponse extends SlackConversationHistoryResponse {}
 
 export interface SlackConversationMembersResponse extends SlackApiResponse {
   readonly members?: string[];
@@ -421,6 +427,22 @@ export class SlackWebApiClient {
       this.botToken,
       compactBody({
         channel: input.channel,
+        limit: input.limit,
+        cursor: input.cursor,
+        latest: input.latest,
+        oldest: input.oldest,
+        inclusive: input.inclusive,
+      }),
+    );
+  }
+
+  async conversationsReplies(input: SlackConversationRepliesInput): Promise<SlackConversationRepliesResponse> {
+    return this.apiRequest<SlackConversationRepliesResponse>(
+      "conversations.replies",
+      this.botToken,
+      compactBody({
+        channel: input.channel,
+        ts: input.ts,
         limit: input.limit,
         cursor: input.cursor,
         latest: input.latest,

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -47,6 +47,7 @@ export {
   SlackSocketModeService,
   SlackTextDelivery,
   createSlackNativeRuntimeFromEnv,
+  createSlackNativeRuntimesFromEnv,
 } from "./socket-mode.js";
 export type { SlackNativeRuntime, SlackSocketModeServiceOptions } from "./socket-mode.js";
 export type {

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -331,6 +331,112 @@ describe("Slack Socket Mode routing", () => {
     ]);
   });
 
+  it("routes Slack message_replied updates by fetching the latest thread reply", async () => {
+    getOrCreateSession("ravi-hil", "ravi-hil", "/tmp/ravi-hil", { name: "ravi-hil" });
+    const config: RouterConfig = {
+      agents: {
+        "ravi-hil": {
+          id: "ravi-hil",
+          cwd: "/tmp/ravi-hil",
+          dmScope: "per-peer",
+        },
+      },
+      routes: [
+        {
+          pattern: "group:C123",
+          accountId: "ravi-rbbt-slack",
+          agent: "ravi-hil",
+          session: "ravi-hil",
+          priority: 100,
+          policy: "open",
+          channel: "slack",
+        },
+      ],
+      defaultAgent: "ravi-hil",
+      defaultDmScope: "per-peer",
+      accountAgents: { "ravi-rbbt-slack": "ravi-hil" },
+      instanceToAccount: {},
+      instances: {},
+    };
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "slack-instance-1",
+      getRouterConfig: () => config,
+      publishPrompt: async (sessionName, payload) => {
+        published.push({ sessionName, payload });
+      },
+      webClient: {
+        conversationsReplies: async (input: Record<string, unknown>) => {
+          expect(input).toMatchObject({
+            channel: "C123",
+            ts: "1713000000.000100",
+            oldest: "1713000040.000300",
+            latest: "1713000040.000300",
+            inclusive: true,
+          });
+          return {
+            ok: true,
+            messages: [
+              {
+                type: "message",
+                user: "U999",
+                text: "root",
+                ts: "1713000000.000100",
+                thread_ts: "1713000000.000100",
+              },
+              {
+                type: "message",
+                user: "U123",
+                text: "responde esse fio",
+                ts: "1713000040.000300",
+                thread_ts: "1713000000.000100",
+              },
+            ],
+          };
+        },
+      } as never,
+    });
+
+    await service.handleEnvelope({
+      envelope_id: "env-message-replied-1",
+      payload: {
+        team_id: "T1",
+        event_id: "EvReplyUpdate1",
+        event_time: 1_713_000_040,
+        event: {
+          type: "message",
+          subtype: "message_replied",
+          channel: "C123",
+          channel_type: "channel",
+          ts: "1713000040.000400",
+          message: {
+            type: "message",
+            user: "U999",
+            text: "root",
+            ts: "1713000000.000100",
+            thread_ts: "1713000000.000100",
+            latest_reply: "1713000040.000300",
+            replies: [{ user: "U123", ts: "1713000040.000300" }],
+          },
+        },
+      },
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.sessionName).toBe("ravi-hil-t-1713000000000100");
+    expect(String(published[0]?.payload.prompt)).toContain("responde esse fio");
+    expect(published[0]?.payload.source).toMatchObject({
+      channel: "slack",
+      chatId: "C123",
+      threadId: "1713000000.000100",
+      sourceMessageId: "1713000040.000300",
+    });
+  });
+
   it("uses a temporary Slack reaction as the native working presence indicator", async () => {
     const calls: Array<{ method: string; input: Record<string, unknown> }> = [];
     const presence = new SlackReactionPresence(

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -36,7 +36,13 @@ import {
   slackRoutingPolicyFromEnv,
   slackTsToMs,
 } from "./routing.js";
-import type { SlackNormalizedFile, SlackNormalizedMessage, SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
+import type {
+  SlackEventPayload,
+  SlackNormalizedFile,
+  SlackNormalizedMessage,
+  SlackRoutingPolicy,
+  SlackSocketEnvelope,
+} from "./types.js";
 
 const log = logger.child("channels:slack");
 
@@ -415,7 +421,7 @@ export class SlackSocketModeService {
       return "processed";
     }
 
-    const normalized = this.normalizeEnvelope(envelope);
+    const normalized = await this.normalizeEnvelope(envelope);
     if (!normalized) return "ignored";
 
     await this.routeMessage(normalized);
@@ -467,8 +473,8 @@ export class SlackSocketModeService {
     });
   }
 
-  private normalizeEnvelope(envelope: SlackSocketEnvelope): SlackNormalizedMessage | null {
-    const event = envelopeEvent(envelope);
+  private async normalizeEnvelope(envelope: SlackSocketEnvelope): Promise<SlackNormalizedMessage | null> {
+    const event = await this.resolveMessageEvent(envelopeEvent(envelope));
     if (!event || shouldIgnoreSlackMessageEvent(event)) return null;
 
     const channelId = cleanSlackId(event.channel);
@@ -498,6 +504,47 @@ export class SlackSocketModeService {
       eventTimeMs,
       rawEnvelope: envelope,
     };
+  }
+
+  private async resolveMessageEvent(event: SlackEventPayload | undefined): Promise<SlackEventPayload | undefined> {
+    if (!event || event.type !== "message" || event.subtype !== "message_replied") return event;
+
+    const channel = cleanSlackId(event.channel);
+    const parent = recordField(event, "message");
+    const threadTs = stringField(parent, "thread_ts") ?? stringField(parent, "ts") ?? cleanSlackId(event.thread_ts);
+    const latestReplyTs =
+      stringField(event, "latest_reply") ?? stringField(parent, "latest_reply") ?? latestReplyTsFromParent(parent);
+    if (!channel || !threadTs || !latestReplyTs) return undefined;
+
+    try {
+      const replies = await this.webClient.conversationsReplies({
+        channel,
+        ts: threadTs,
+        oldest: latestReplyTs,
+        latest: latestReplyTs,
+        inclusive: true,
+        limit: 10,
+      });
+      const reply = selectSlackThreadReply(replies.messages, threadTs, latestReplyTs);
+      if (!reply) return undefined;
+      return {
+        ...reply,
+        type: stringField(reply, "type") ?? "message",
+        channel,
+        channel_type: cleanSlackId(event.channel_type) ?? stringField(parent, "channel_type") ?? "channel",
+        thread_ts: stringField(reply, "thread_ts") ?? threadTs,
+        team: stringField(reply, "team") ?? cleanSlackId(event.team),
+      };
+    } catch (error) {
+      log.warn("Failed to fetch Slack thread reply", {
+        accountId: this.options.accountId,
+        channel,
+        threadTs,
+        latestReplyTs,
+        error,
+      });
+      return undefined;
+    }
   }
 
   private normalizeInteractionEnvelope(envelope: SlackSocketEnvelope): Record<string, unknown> | null {
@@ -931,6 +978,32 @@ function slackInteractionResponseUrl(record: Record<string, unknown>): string | 
 function firstRecord(value: unknown): Record<string, unknown> | undefined {
   if (!Array.isArray(value)) return undefined;
   return asRecord(value[0]);
+}
+
+function latestReplyTsFromParent(parent: Record<string, unknown> | undefined): string | undefined {
+  const replies = Array.isArray(parent?.replies) ? parent.replies : [];
+  for (let index = replies.length - 1; index >= 0; index -= 1) {
+    const ts = stringField(replies[index], "ts");
+    if (ts) return ts;
+  }
+  return undefined;
+}
+
+function selectSlackThreadReply(
+  messages: readonly unknown[] | undefined,
+  threadTs: string,
+  latestReplyTs: string,
+): Record<string, unknown> | undefined {
+  const records = (messages ?? [])
+    .map(asRecord)
+    .filter((message): message is Record<string, unknown> => Boolean(message));
+  return (
+    records.find((message) => stringField(message, "ts") === latestReplyTs) ??
+    records
+      .slice()
+      .reverse()
+      .find((message) => stringField(message, "thread_ts") === threadTs && stringField(message, "ts") !== threadTs)
+  );
 }
 
 function recordField(record: unknown, key: string): Record<string, unknown> | undefined {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -10,6 +10,7 @@ import {
   dbUpsertChatMessage,
   dbUpsertChatParticipant,
 } from "../../router/router-db.js";
+import type { InstanceConfig } from "../../router/router-db.js";
 import type { RouterConfig } from "../../router/types.js";
 import type { MessageActorMetadata, MessageContext, MessageTarget } from "../../runtime/message-types.js";
 import { transcribeAudio } from "../../transcribe/openai.js";
@@ -24,7 +25,7 @@ import type {
   NativeTextDeliveryResult,
 } from "../native/types.js";
 import { SlackWebApiClient } from "./client.js";
-import { resolveSlackCredentialConfigFromEnv } from "./credentials.js";
+import { credentialConnectionForInstance, resolveSlackCredentialConfigFromEnv } from "./credentials.js";
 import { storeSlackInteractionResponseUrl } from "./interactions.js";
 import {
   cleanSlackId,
@@ -77,6 +78,24 @@ export interface SlackNativeRuntime {
   readonly socketMode: SlackSocketModeService;
 }
 
+interface SlackDeliveryScope {
+  readonly accountId: string;
+  readonly routeAccountId?: string;
+  readonly instanceId?: string;
+  readonly connection?: string;
+}
+
+function slackTargetMatchesScope(scope: SlackDeliveryScope | undefined, target: MessageTarget): boolean {
+  if (target.channel.toLowerCase() !== "slack") return false;
+  if (!scope) return true;
+  const ids = new Set(
+    [scope.accountId, scope.routeAccountId, scope.instanceId, scope.connection]
+      .map((item) => item?.trim())
+      .filter((item): item is string => Boolean(item)),
+  );
+  return Boolean((target.instanceId && ids.has(target.instanceId)) || (target.accountId && ids.has(target.accountId)));
+}
+
 class RecentIdCache {
   private readonly ids = new Set<string>();
   private readonly order: string[] = [];
@@ -104,10 +123,11 @@ export class SlackTextDelivery implements NativeTextDelivery {
   constructor(
     private readonly webClient: SlackWebApiClient,
     private readonly routingPolicy: SlackRoutingPolicy,
+    private readonly scope?: SlackDeliveryScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return slackTargetMatchesScope(this.scope, target);
   }
 
   async deliverText(request: NativeTextDeliveryRequest): Promise<NativeTextDeliveryResult> {
@@ -132,10 +152,11 @@ export class SlackAssistantThreadPresence implements NativePresenceDelivery {
   constructor(
     private readonly webClient: Pick<SlackWebApiClient, "setAssistantThreadStatus">,
     private readonly options: { statusText?: string; loadingMessages?: readonly string[] } = {},
+    private readonly scope?: SlackDeliveryScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return slackTargetMatchesScope(this.scope, target);
   }
 
   async sendPresence(request: NativePresenceDeliveryRequest): Promise<NativePresenceDeliveryResult> {
@@ -178,10 +199,11 @@ export class SlackReactionPresence implements NativePresenceDelivery {
   constructor(
     private readonly webClient: SlackWebApiClient,
     private readonly options: { reactionName?: string } = {},
+    private readonly scope?: SlackDeliveryScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return slackTargetMatchesScope(this.scope, target);
   }
 
   async sendPresence(request: NativePresenceDeliveryRequest): Promise<NativePresenceDeliveryResult> {
@@ -984,8 +1006,12 @@ function syncSlackSessionSubscription(
 
 export async function createSlackNativeRuntimeFromEnv(
   env: NodeJS.ProcessEnv = process.env,
+  options: { instance?: InstanceConfig } = {},
 ): Promise<SlackNativeRuntime | null> {
-  const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances: configStore.getConfig().instances });
+  const credentials = await resolveSlackCredentialConfigFromEnv(env, {
+    instances: configStore.getConfig().instances,
+    instance: options.instance,
+  });
   if (!credentials) {
     log.warn("Slack native runtime disabled: configure a Slack channel instance with brokered credentials");
     return null;
@@ -1005,17 +1031,26 @@ export async function createSlackNativeRuntimeFromEnv(
     routingPolicy,
     webClient,
   });
-  const delivery = new SlackTextDelivery(webClient, routingPolicy);
-  const reactionPresence = new SlackReactionPresence(webClient, {
-    reactionName: env.RAVI_SLACK_WORKING_REACTION?.trim() || "hourglass_flowing_sand",
-  });
+  const scope = slackDeliveryScopeFromCredentials(credentials);
+  const delivery = new SlackTextDelivery(webClient, routingPolicy, scope);
+  const reactionPresence = new SlackReactionPresence(
+    webClient,
+    {
+      reactionName: env.RAVI_SLACK_WORKING_REACTION?.trim() || "hourglass_flowing_sand",
+    },
+    scope,
+  );
   const reactionMode = slackReactionPresenceModeFromEnv(env.RAVI_SLACK_REACTION_PRESENCE);
   const assistantPresenceEnabled = slackAssistantPresenceEnabledFromEnv(env.RAVI_SLACK_ASSISTANT_STATUS);
   const presence = assistantPresenceEnabled
     ? new SlackPresenceStack(
-        new SlackAssistantThreadPresence(webClient, {
-          statusText: env.RAVI_SLACK_ASSISTANT_STATUS_TEXT?.trim() || "is working...",
-        }),
+        new SlackAssistantThreadPresence(
+          webClient,
+          {
+            statusText: env.RAVI_SLACK_ASSISTANT_STATUS_TEXT?.trim() || "is working...",
+          },
+          scope,
+        ),
         reactionMode === "off" ? null : reactionPresence,
         { reactionMode },
       )
@@ -1029,6 +1064,65 @@ export async function createSlackNativeRuntimeFromEnv(
     reactionPresenceMode: reactionMode,
   });
   return { delivery, presence, socketMode };
+}
+
+export async function createSlackNativeRuntimesFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SlackNativeRuntime[]> {
+  const explicitConnections = parseSlackConnectionList(env.RAVI_SLACK_CONNECTIONS);
+  if (explicitConnections.length === 0) {
+    const runtime = await createSlackNativeRuntimeFromEnv(env);
+    return runtime ? [runtime] : [];
+  }
+
+  const instances = configStore.getConfig().instances;
+  const runtimes: SlackNativeRuntime[] = [];
+  for (const connection of explicitConnections) {
+    const instance = findSlackInstanceForConnection(instances, connection);
+    const runtime = await createSlackNativeRuntimeFromEnv({ ...env, RAVI_SLACK_CONNECTION: connection }, { instance });
+    if (runtime) runtimes.push(runtime);
+  }
+  return runtimes;
+}
+
+function parseSlackConnectionList(value: string | undefined): string[] {
+  if (!value?.trim()) return [];
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function findSlackInstanceForConnection(
+  instances: Record<string, InstanceConfig> | undefined,
+  connection: string,
+): InstanceConfig | undefined {
+  return Object.values(instances ?? {}).find((instance) => {
+    if (instance.enabled === false || instance.channel !== "slack") return false;
+    return (
+      instance.name === connection ||
+      instance.instanceId === connection ||
+      credentialConnectionForInstance(instance) === connection
+    );
+  });
+}
+
+function slackDeliveryScopeFromCredentials(credentials: {
+  accountId: string;
+  routeAccountId?: string;
+  instanceId?: string;
+  connection?: string;
+}): SlackDeliveryScope {
+  return {
+    accountId: credentials.accountId,
+    routeAccountId: credentials.routeAccountId,
+    instanceId: credentials.instanceId,
+    connection: credentials.connection,
+  };
 }
 
 function slackAssistantPresenceEnabledFromEnv(value: string | undefined): boolean {

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { chooseSlackRunnerConnection } from "./channels.js";
+import { buildRunnerPm2ProcessEnv, chooseSlackRunnerConnection } from "./channels.js";
 
 describe("channels command runner env", () => {
   it("uses an explicit Slack connection first", () => {
@@ -33,5 +33,35 @@ describe("channels command runner env", () => {
         env: {},
       }),
     ).toBeUndefined();
+  });
+
+  it("strips runtime context and Slack token env from the persistent PM2 runner", () => {
+    const env = buildRunnerPm2ProcessEnv({
+      baseEnv: {
+        NATS_URL: "nats://127.0.0.1:4222",
+        PATH: "/usr/bin",
+        RAVI_AGENT_ID: "main",
+        RAVI_CHANNEL: "whatsapp-baileys",
+        RAVI_CONTEXT_KEY: "rctx_secret",
+        RAVI_SESSION_KEY: "agent:main:main",
+        RAVI_SLACK_BOT_TOKEN: "xoxb-secret",
+        RAVI_WEBHOOK_PUBLIC_BASE_URL: "https://example.test",
+      },
+      envOverrides: {
+        RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack,hana-slack",
+      },
+    });
+
+    expect(env).toMatchObject({
+      NATS_URL: "nats://127.0.0.1:4222",
+      PATH: "/usr/bin",
+      RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack,hana-slack",
+      RAVI_WEBHOOK_PUBLIC_BASE_URL: "https://example.test",
+    });
+    expect(env.RAVI_CONTEXT_KEY).toBeUndefined();
+    expect(env.RAVI_SESSION_KEY).toBeUndefined();
+    expect(env.RAVI_AGENT_ID).toBeUndefined();
+    expect(env.RAVI_CHANNEL).toBeUndefined();
+    expect(env.RAVI_SLACK_BOT_TOKEN).toBeUndefined();
   });
 });

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -52,6 +52,7 @@ const runnerEnvReturnSchema = z
   .object({
     slackSocketMode: z.boolean(),
     slackConnection: z.string().nullable(),
+    slackConnections: z.array(z.string()).optional(),
     consumeOutbound: z.string(),
   })
   .strict();
@@ -84,23 +85,88 @@ function printJson(payload: unknown): void {
 
 const RUNNER_ENV_KEYS = [
   "RAVI_CHANNELS_CONSUME_OUTBOUND",
+  "RAVI_SLACK_CONNECTIONS",
   "RAVI_SLACK_SUBSCRIPTION_SCOPE",
   "RAVI_SLACK_THREAD_REPLY_MODE",
   "RAVI_SLACK_ROOT_REPLY_MODE",
   "RAVI_SLACK_WORKING_REACTION",
 ] as const;
 
+const RUNNER_TRANSIENT_ENV_KEYS = new Set([
+  "RAVI_ACCOUNT_ID",
+  "RAVI_ACTOR_TYPE",
+  "RAVI_AGENT_ID",
+  "RAVI_CANONICAL_CHAT_ID",
+  "RAVI_CHANNEL",
+  "RAVI_CHAT_ID",
+  "RAVI_CONTACT_ID",
+  "RAVI_CONTEXT_ID",
+  "RAVI_CONTEXT_KEY",
+  "RAVI_INSTANCE_ID",
+  "RAVI_MODEL",
+  "RAVI_NORMALIZED_SENDER_ID",
+  "RAVI_PARENT_CONTEXT_ID",
+  "RAVI_PLATFORM_IDENTITY_ID",
+  "RAVI_RAW_SENDER_ID",
+  "RAVI_SENDER_ID",
+  "RAVI_SENDER_NAME",
+  "RAVI_SENDER_PHONE",
+  "RAVI_SESSION_KEY",
+  "RAVI_SESSION_NAME",
+  "RAVI_TURN_ID",
+  "RAVI_TURN_KEY",
+]);
+
+const RUNNER_SECRET_ENV_KEYS = new Set([
+  "RAVI_SLACK_APP_TOKEN",
+  "RAVI_SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+  "SLACK_BOT_TOKEN",
+]);
+
+function isTransientRunnerEnvKey(key: string): boolean {
+  return RUNNER_TRANSIENT_ENV_KEYS.has(key) || key.startsWith("RAVI_SOURCE_") || key.startsWith("RAVI_TURN_");
+}
+
+export function buildRunnerPm2ProcessEnv(input: {
+  baseEnv?: Record<string, string | undefined>;
+  envOverrides?: Record<string, string>;
+}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input.baseEnv ?? process.env)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  for (const [key, value] of Object.entries(input.envOverrides ?? {})) {
+    env[key] = value;
+  }
+
+  for (const key of Object.keys(env)) {
+    if (isTransientRunnerEnvKey(key) || RUNNER_SECRET_ENV_KEYS.has(key)) {
+      delete env[key];
+    }
+  }
+
+  return env;
+}
+
+function runPm2Detached(
+  args: string[],
+  options: { cwd?: string; envOverrides?: Record<string, string>; quiet?: boolean } = {},
+): { status: number } {
+  const result = spawnSync("pm2", args, {
+    stdio: options.quiet ? ["ignore", "pipe", "pipe"] : "inherit",
+    encoding: options.quiet ? "utf-8" : undefined,
+    cwd: options.cwd,
+    env: buildRunnerPm2ProcessEnv({ envOverrides: options.envOverrides }),
+  });
+  return { status: result.status ?? 1 };
+}
+
 function runPm2Quiet(
   args: string[],
   options: { cwd?: string; envOverrides?: Record<string, string> } = {},
 ): { status: number } {
-  const result = spawnSync("pm2", args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
-    cwd: options.cwd,
-    env: { ...process.env, ...options.envOverrides } as Record<string, string>,
-  });
-  return { status: result.status ?? 1 };
+  return runPm2Detached(args, { ...options, quiet: true });
 }
 
 function cleanEnvValue(value: unknown): string | undefined {
@@ -141,13 +207,35 @@ export function chooseSlackRunnerConnection(input: {
   return undefined;
 }
 
-function buildRunnerPm2Env(explicitSlackConnection?: string): Record<string, string> {
+function collectCsv(value: string | undefined): string[] {
+  if (!value) return [];
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function buildRunnerPm2Env(
+  explicitSlackConnection?: string,
+  explicitSlackConnections?: string,
+): Record<string, string> {
   const existingPm2Env = readExistingPm2Env(CHANNELS_PM2_PROCESS_NAME);
   const envOverrides: Record<string, string> = {};
 
   for (const key of RUNNER_ENV_KEYS) {
     const value = cleanEnvValue(process.env[key]) ?? cleanEnvValue(existingPm2Env[key]);
     if (value) envOverrides[key] = value;
+  }
+
+  const slackConnections = cleanEnvValue(explicitSlackConnections);
+  if (slackConnections) {
+    envOverrides.RAVI_SLACK_CONNECTIONS = slackConnections;
+    delete envOverrides.RAVI_SLACK_CONNECTION;
+    return envOverrides;
   }
 
   const slackConnection = chooseSlackRunnerConnection({ explicit: explicitSlackConnection, env: process.env });
@@ -162,6 +250,7 @@ function publicRunnerEnv(envOverrides: Record<string, string>): Record<string, u
   return {
     slackSocketMode: true,
     slackConnection: envOverrides.RAVI_SLACK_CONNECTION ?? null,
+    slackConnections: collectCsv(envOverrides.RAVI_SLACK_CONNECTIONS),
     consumeOutbound: envOverrides.RAVI_CHANNELS_CONSUME_OUTBOUND ?? "default",
   };
 }
@@ -234,6 +323,11 @@ export class ChannelsCommands {
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
     @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
+    @Option({
+      flags: "--slack-connections <csv>",
+      description: "Comma-separated Slack credential connections to run in one native runner",
+    })
+    slackConnections?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     requirePm2();
@@ -252,10 +346,10 @@ export class ChannelsCommands {
 
     const target = requireRuntimeTarget(build);
     const args = ["start", "bun", "--name", CHANNELS_PM2_PROCESS_NAME, "--", target.bundlePath, "channels", "run"];
-    const runnerEnv = buildRunnerPm2Env(slackConnection);
+    const runnerEnv = buildRunnerPm2Env(slackConnection, slackConnections);
     const { status } = asJson
       ? runPm2Quiet(args, { cwd: target.cwd, envOverrides: runnerEnv })
-      : runPm2(args, runnerEnv, { cwd: target.cwd });
+      : runPm2Detached(args, { cwd: target.cwd, envOverrides: runnerEnv });
     const payload = {
       action: "start" as const,
       changed: status === 0,
@@ -319,10 +413,15 @@ export class ChannelsCommands {
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
     @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
+    @Option({
+      flags: "--slack-connections <csv>",
+      description: "Comma-separated Slack credential connections to run in one native runner",
+    })
+    slackConnections?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     requirePm2();
-    const runnerEnv = buildRunnerPm2Env(slackConnection);
+    const runnerEnv = buildRunnerPm2Env(slackConnection, slackConnections);
 
     if (isPm2ProcessRunning(CHANNELS_PM2_PROCESS_NAME)) {
       const stopped = asJson
@@ -335,7 +434,7 @@ export class ChannelsCommands {
     const args = ["start", "bun", "--name", CHANNELS_PM2_PROCESS_NAME, "--", target.bundlePath, "channels", "run"];
     const { status } = asJson
       ? runPm2Quiet(args, { cwd: target.cwd, envOverrides: runnerEnv })
-      : runPm2(args, runnerEnv, { cwd: target.cwd });
+      : runPm2Detached(args, { cwd: target.cwd, envOverrides: runnerEnv });
     const payload = {
       action: "restart" as const,
       changed: status === 0,


### PR DESCRIPTION
## Summary

- run multiple native Slack credential connections inside one `ravi-channels` process
- scope outbound Slack delivery/presence by account/instance/connection so workspaces do not steal each other's messages
- sanitize the long-lived PM2 runner env so it does not inherit turn/session context or raw Slack token env
- regenerate the SDK surface for the new channels runner env shape

## Root Cause

`ravi-channels` was not running the native Slack sockets for both workspaces. When restarted from an active Ravi turn, PM2 inherited `RAVI_CONTEXT_KEY` and session identity, so `channels run` was evaluated as the wrong runtime principal and hit the command access guard before connecting. The old single-runtime Slack path also could not safely run HANA and RBBT together because both would share the same outbound durable consumer without scoped delivery.

## Validation

- `bun test src/cli/commands/channels.test.ts src/channels/slack/credentials.test.ts src/channels/slack/socket-mode.test.ts`
- `bun run typecheck`
- pre-push full build, typecheck, test suite, and SDK check
- live `ravi-channels` restarted with `RAVI_SLACK_CONNECTIONS=ravi-rbbt-slack,hana-slack`
- foreground probe reported Slack adapter connected
- Slack API permission probes returned ok for both RBBT and HANA connections
