### PR TITLE
fix native slack runner outbound delivery

### DIFF
--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -795,6 +795,7 @@ export class RaviClient {
     restart: async (options?: {
       build?: boolean;
       slackConnection?: string;
+      slackConnections?: string;
     }): Promise<ChannelsRestartReturn> => {
       return this.transport.call({
         groupSegments: ["channels"],
@@ -806,6 +807,7 @@ export class RaviClient {
     start: async (options?: {
       build?: boolean;
       slackConnection?: string;
+      slackConnections?: string;
     }): Promise<ChannelsStartReturn> => {
       return this.transport.call({
         groupSegments: ["channels"],

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -12484,7 +12484,7 @@ export const ChannelsRestartInputSchema = {
       "type": "boolean"
     },
     "slackConnection": {
-      "description": "Optional Slack credential connection override",
+      "description": "Optional Slack credential connection override for a single workspace",
       "type": "string"
     },
     "slackConnections": {
@@ -12767,7 +12767,7 @@ export const ChannelsStartInputSchema = {
       "type": "boolean"
     },
     "slackConnection": {
-      "description": "Optional Slack credential connection override",
+      "description": "Optional Slack credential connection override for a single workspace",
       "type": "string"
     },
     "slackConnections": {

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -12486,6 +12486,10 @@ export const ChannelsRestartInputSchema = {
     "slackConnection": {
       "description": "Optional Slack credential connection override",
       "type": "string"
+    },
+    "slackConnections": {
+      "description": "Comma-separated Slack credential connections for multi-workspace native runner",
+      "type": "string"
     }
   },
   "type": "object"
@@ -12530,6 +12534,12 @@ export const ChannelsRestartReturnSchema = {
             }
           ]
         },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "slackSocketMode": {
           "type": "boolean"
         }
@@ -12537,6 +12547,7 @@ export const ChannelsRestartReturnSchema = {
       "required": [
         "slackSocketMode",
         "slackConnection",
+        "slackConnections",
         "consumeOutbound"
       ],
       "type": "object"
@@ -12758,6 +12769,10 @@ export const ChannelsStartInputSchema = {
     "slackConnection": {
       "description": "Optional Slack credential connection override",
       "type": "string"
+    },
+    "slackConnections": {
+      "description": "Comma-separated Slack credential connections for multi-workspace native runner",
+      "type": "string"
     }
   },
   "type": "object"
@@ -12802,6 +12817,12 @@ export const ChannelsStartReturnSchema = {
             }
           ]
         },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "slackSocketMode": {
           "type": "boolean"
         }
@@ -12809,6 +12830,7 @@ export const ChannelsStartReturnSchema = {
       "required": [
         "slackSocketMode",
         "slackConnection",
+        "slackConnections",
         "consumeOutbound"
       ],
       "type": "object"
@@ -13253,6 +13275,12 @@ export const ChannelsStopReturnSchema = {
             }
           ]
         },
+        "slackConnections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "slackSocketMode": {
           "type": "boolean"
         }
@@ -13260,6 +13288,7 @@ export const ChannelsStopReturnSchema = {
       "required": [
         "slackSocketMode",
         "slackConnection",
+        "slackConnections",
         "consumeOutbound"
       ],
       "type": "object"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -2227,6 +2227,7 @@ export type ChannelsProbeReturn = {
 export type ChannelsRestartInput = {
   build?: boolean;
   slackConnection?: string;
+  slackConnections?: string;
 };
 
 /** Return shape for `channels.restart`. */
@@ -2238,6 +2239,7 @@ export type ChannelsRestartReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections: string[];
     slackSocketMode: boolean;
   };
   status?: {
@@ -2277,6 +2279,7 @@ export type ChannelsRestartReturn = {
 export type ChannelsStartInput = {
   build?: boolean;
   slackConnection?: string;
+  slackConnections?: string;
 };
 
 /** Return shape for `channels.start`. */
@@ -2288,6 +2291,7 @@ export type ChannelsStartReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections: string[];
     slackSocketMode: boolean;
   };
   status?: {
@@ -2366,6 +2370,7 @@ export type ChannelsStopReturn = {
   runnerEnv?: {
     consumeOutbound: string;
     slackConnection: string | null;
+    slackConnections: string[];
     slackSocketMode: boolean;
   };
   status?: {

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:841578adf556e7304524f7379e0cd8308e52e3542b5b72b89e46b85bb8e8ed9c";
+export const REGISTRY_HASH = "sha256:01c49572b808071f0c1073249ead20022de9f1630d28f0003c355cbdcdb713c6";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "fcf3049b841b";
+export const GIT_SHA = "edce20a75170";

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:01c49572b808071f0c1073249ead20022de9f1630d28f0003c355cbdcdb713c6";
+export const REGISTRY_HASH = "sha256:efc479d1762e29ad5ab490e8b42a8ded93103058ddf4a208b1ed9d37261a9dea";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "edce20a75170";
+export const GIT_SHA = "2afa4e2a6b96";

--- a/src/channels/outbound-stream.test.ts
+++ b/src/channels/outbound-stream.test.ts
@@ -191,6 +191,26 @@ describe("channel outbound JetStream infrastructure", () => {
       durable_name: CHANNEL_OUTBOUND_CONSUMER,
     });
   });
+
+  it("recreates a stale consumer when its sequence is ahead of the stream", async () => {
+    const consumerDelete = mock(async () => true);
+    const consumerAdd = mock(async () => ({}));
+    currentJsm = makeChannelOutboundJsm({
+      streams: {
+        info: mock(async () => ({ state: { last_seq: 6 } })),
+      },
+      consumers: {
+        info: mock(async () => ({ ack_floor: { stream_seq: 618 }, delivered: { stream_seq: 618 } })),
+        delete: consumerDelete,
+        add: consumerAdd,
+      },
+    });
+
+    await ensureChannelOutboundConsumer(currentJsm as never);
+
+    expect(consumerDelete).toHaveBeenCalledWith(CHANNEL_OUTBOUND_STREAM, CHANNEL_OUTBOUND_CONSUMER);
+    expect(consumerAdd).toHaveBeenCalledTimes(1);
+  });
 });
 
 function makeChannelOutboundJsm(overrides: ChannelOutboundJsmOverrides = {}): ChannelOutboundJsm {
@@ -203,6 +223,7 @@ function makeChannelOutboundJsm(overrides: ChannelOutboundJsmOverrides = {}): Ch
     consumers: {
       info: mock(async () => ({})),
       add: mock(async () => ({})),
+      delete: mock(async () => true),
       ...(overrides.consumers ?? {}),
     },
   };
@@ -216,6 +237,7 @@ interface ChannelOutboundJsm {
   consumers: {
     info: ReturnType<typeof mock>;
     add: ReturnType<typeof mock>;
+    delete: ReturnType<typeof mock>;
   };
 }
 

--- a/src/channels/outbound-stream.ts
+++ b/src/channels/outbound-stream.ts
@@ -112,10 +112,21 @@ export async function ensureChannelOutboundConsumer(existingJsm?: JetStreamManag
   const jsm = existingJsm ?? (await getNats().jetstreamManager());
 
   try {
-    await jsm.consumers.info(CHANNEL_OUTBOUND_STREAM, CHANNEL_OUTBOUND_CONSUMER);
-    log.debug("Channel outbound consumer already exists", { consumerName: CHANNEL_OUTBOUND_CONSUMER });
-    return;
-  } catch {
+    const consumerInfo = await jsm.consumers.info(CHANNEL_OUTBOUND_STREAM, CHANNEL_OUTBOUND_CONSUMER);
+    const streamInfo = await jsm.streams.info(CHANNEL_OUTBOUND_STREAM);
+    if (isStaleChannelOutboundConsumer(consumerInfo, streamInfo)) {
+      log.warn("Deleting stale channel outbound consumer", {
+        consumerName: CHANNEL_OUTBOUND_CONSUMER,
+        consumerStreamSeq: maxConsumerStreamSeq(consumerInfo),
+        streamLastSeq: streamLastSeq(streamInfo),
+      });
+      await jsm.consumers.delete(CHANNEL_OUTBOUND_STREAM, CHANNEL_OUTBOUND_CONSUMER);
+    } else {
+      log.debug("Channel outbound consumer already exists", { consumerName: CHANNEL_OUTBOUND_CONSUMER });
+      return;
+    }
+  } catch (err) {
+    if (!isNotFoundError(err)) throw err;
     // Consumer does not exist yet.
   }
 
@@ -136,6 +147,39 @@ export async function ensureChannelOutboundConsumer(existingJsm?: JetStreamManag
     consumerName: CHANNEL_OUTBOUND_CONSUMER,
     ack_wait_s: 300,
   });
+}
+
+function isStaleChannelOutboundConsumer(consumerInfo: unknown, streamInfo: unknown): boolean {
+  const consumerSeq = maxConsumerStreamSeq(consumerInfo);
+  const lastSeq = streamLastSeq(streamInfo);
+  return consumerSeq > 0 && lastSeq >= 0 && consumerSeq > lastSeq;
+}
+
+function maxConsumerStreamSeq(info: unknown): number {
+  const record = info as {
+    ack_floor?: { stream_seq?: unknown };
+    delivered?: { stream_seq?: unknown };
+  };
+  return Math.max(toNumber(record.ack_floor?.stream_seq), toNumber(record.delivered?.stream_seq));
+}
+
+function streamLastSeq(info: unknown): number {
+  const record = info as { state?: { last_seq?: unknown } };
+  return toNumber(record.state?.last_seq, -1);
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /not found|not exist|404/i.test(message);
 }
 
 export async function ensureChannelOutboundInfrastructure(existingJsm?: JetStreamManager): Promise<void> {

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -9,7 +9,7 @@ import {
   ensureChannelOutboundInfrastructure,
 } from "./outbound-stream.js";
 import { ChannelPresenceConsumer } from "./presence-consumer.js";
-import { createSlackNativeRuntimeFromEnv, type SlackNativeRuntime } from "./slack/index.js";
+import { createSlackNativeRuntimesFromEnv, type SlackNativeRuntime } from "./slack/index.js";
 
 const log = logger.child("channels:runner");
 
@@ -52,7 +52,7 @@ export class ChannelRunner {
   private presenceConsumer: ChannelPresenceConsumer | null = null;
   private deliveries: NativeTextDelivery[] = [];
   private presenceDeliveries: NativePresenceDelivery[] = [];
-  private slackRuntime: SlackNativeRuntime | null = null;
+  private slackRuntimes: SlackNativeRuntime[] = [];
   private adapterStatuses = new Map<string, AdapterStatus>();
 
   constructor(private readonly options: ChannelRunnerOptions = {}) {}
@@ -107,11 +107,13 @@ export class ChannelRunner {
     this.outboundConsumer = null;
     await this.presenceConsumer?.stop();
     this.presenceConsumer = null;
-    await this.slackRuntime?.socketMode.stop();
-    this.slackRuntime = null;
+    for (const runtime of this.slackRuntimes) {
+      await runtime.socketMode.stop();
+      this.markAdapter(`slack:${runtime.accountId}`, "slack", "disconnected");
+    }
+    this.slackRuntimes = [];
     this.deliveries = [];
     this.presenceDeliveries = [];
-    this.markAdapter("slack", "slack", "disconnected");
     closeAllRaviDbs();
     await closeNats({ drainTimeoutMs: 2_000 });
     log.info("Channel runner stopped", { pid: process.pid });
@@ -135,17 +137,20 @@ export class ChannelRunner {
   private async startSlack(env: NodeJS.ProcessEnv): Promise<void> {
     this.markAdapter("slack", "slack", "starting");
     try {
-      const runtime = await createSlackNativeRuntimeFromEnv(env);
-      if (!runtime) {
+      const runtimes = await createSlackNativeRuntimesFromEnv(env);
+      this.adapterStatuses.delete("slack");
+      if (!runtimes.length) {
         this.markAdapter("slack", "slack", "disabled", "not_configured");
         return;
       }
 
-      this.slackRuntime = runtime;
-      this.deliveries.push(runtime.delivery);
-      this.presenceDeliveries.push(runtime.presence);
-      runtime.socketMode.start();
-      this.markAdapter("slack", "slack", "connected");
+      this.slackRuntimes = runtimes;
+      for (const runtime of runtimes) {
+        this.deliveries.push(runtime.delivery);
+        this.presenceDeliveries.push(runtime.presence);
+        runtime.socketMode.start();
+        this.markAdapter(`slack:${runtime.accountId}`, "slack", "connected");
+      }
     } catch (error) {
       this.markAdapter("slack", "slack", "failed", error instanceof Error ? error.message : String(error));
       log.error("Failed to start Slack native runtime", { error });

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -47,8 +47,9 @@ export {
   SlackSocketModeService,
   SlackTextDelivery,
   createSlackNativeRuntimeFromEnv,
+  createSlackNativeRuntimesFromEnv,
 } from "./socket-mode.js";
-export type { SlackNativeRuntime, SlackSocketModeServiceOptions } from "./socket-mode.js";
+export type { SlackNativeRuntime, SlackSocketModeServiceOptions, SlackTargetScope } from "./socket-mode.js";
 export type {
   SlackEventPayload,
   SlackEventsApiPayload,

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { ensureContactFromInbound } from "../../contacts.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
 import { getOrCreateSession, getSessionByName, listSessionSubscriptions } from "../../router/index.js";
@@ -10,6 +10,7 @@ import {
   SlackReactionPresence,
   SlackSocketModeService,
   SlackTextDelivery,
+  createSlackNativeRuntimesFromEnv,
 } from "./socket-mode.js";
 import type { SlackSocketEnvelope } from "./types.js";
 
@@ -26,6 +27,26 @@ function seedAgent(id: string, cwd: string): void {
       `,
     )
     .run(id, id, cwd, now, now);
+}
+
+function slackInstance(input: {
+  name: string;
+  instanceId?: string;
+  defaults?: Record<string, unknown>;
+  enabled?: boolean;
+}) {
+  return {
+    name: input.name,
+    ...(input.instanceId ? { instanceId: input.instanceId } : {}),
+    channel: "slack",
+    dmPolicy: "closed" as const,
+    groupPolicy: "allowlist" as const,
+    contactIntakeMode: "off" as const,
+    enabled: input.enabled ?? true,
+    ...(input.defaults ? { defaults: input.defaults } : {}),
+    createdAt: 1,
+    updatedAt: 1,
+  };
 }
 
 describe("Slack Socket Mode routing", () => {
@@ -70,6 +91,36 @@ describe("Slack Socket Mode routing", () => {
         chatId: "C456",
       }),
     ).toBe(false);
+  });
+
+  it("discovers all configured Slack instances without connection env overrides", async () => {
+    const resolveSecret = mock(async ({ connection }: { connection: string }) => ({
+      secret: JSON.stringify({
+        appToken: `xapp-${connection}`,
+        botToken: `xoxb-${connection}`,
+      }),
+      connection: { connection },
+    }));
+
+    const runtimes = await createSlackNativeRuntimesFromEnv({} as NodeJS.ProcessEnv, {
+      resolveSecret,
+      instances: {
+        "ravi-rbbt-slack": slackInstance({
+          name: "ravi-rbbt-slack",
+          instanceId: "slack-instance-1",
+          defaults: { credentials: { slackConnection: "rbbt-secret" } },
+        }),
+        "hana-slack": slackInstance({
+          name: "hana-slack",
+          instanceId: "slack-instance-2",
+          defaults: { credentials: { slackConnection: "hana-secret" } },
+        }),
+      },
+    });
+
+    expect(resolveSecret.mock.calls.map((call) => call[0].connection)).toEqual(["hana-secret", "rbbt-secret"]);
+    expect(runtimes.map((runtime) => runtime.accountId)).toEqual(["hana-slack", "ravi-rbbt-slack"]);
+    expect(runtimes.map((runtime) => runtime.connection)).toEqual(["hana-secret", "rbbt-secret"]);
   });
 
   it("routes Slack channels through group routes and attaches the source chat for output", async () => {

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -9,6 +9,7 @@ import {
   SlackPresenceStack,
   SlackReactionPresence,
   SlackSocketModeService,
+  SlackTextDelivery,
 } from "./socket-mode.js";
 import type { SlackSocketEnvelope } from "./types.js";
 
@@ -43,6 +44,32 @@ describe("Slack Socket Mode routing", () => {
   afterEach(async () => {
     await cleanupIsolatedRaviState(stateDir);
     stateDir = null;
+  });
+
+  it("scopes native text delivery to the configured Slack workspace", () => {
+    const delivery = new SlackTextDelivery({} as never, {} as never, {
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
+      connection: "ravi-rbbt-slack",
+    });
+
+    expect(
+      delivery.supports({
+        channel: "slack",
+        accountId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
+        instanceId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
+        chatId: "C123",
+      }),
+    ).toBe(true);
+    expect(
+      delivery.supports({
+        channel: "slack",
+        accountId: "hana-slack",
+        instanceId: "hana-slack",
+        chatId: "C456",
+      }),
+    ).toBe(false);
   });
 
   it("routes Slack channels through group routes and attaches the source chat for output", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -9,6 +9,7 @@ import {
   dbUpsertChat,
   dbUpsertChatMessage,
   dbUpsertChatParticipant,
+  type InstanceConfig,
 } from "../../router/router-db.js";
 import type { RouterConfig } from "../../router/types.js";
 import type { MessageActorMetadata, MessageContext, MessageTarget } from "../../runtime/message-types.js";
@@ -24,7 +25,7 @@ import type {
   NativeTextDeliveryResult,
 } from "../native/types.js";
 import { SlackWebApiClient } from "./client.js";
-import { resolveSlackCredentialConfigFromEnv } from "./credentials.js";
+import { credentialConnectionForInstance, resolveSlackCredentialConfigFromEnv } from "./credentials.js";
 import { storeSlackInteractionResponseUrl } from "./interactions.js";
 import {
   cleanSlackId,
@@ -72,9 +73,20 @@ export interface SlackSocketModeServiceOptions {
 }
 
 export interface SlackNativeRuntime {
+  readonly id: string;
+  readonly accountId: string;
+  readonly instanceId: string;
+  readonly connection: string;
   readonly delivery: NativeTextDelivery;
   readonly presence: NativePresenceDelivery;
   readonly socketMode: SlackSocketModeService;
+}
+
+export interface SlackTargetScope {
+  readonly accountId: string;
+  readonly routeAccountId?: string;
+  readonly instanceId?: string;
+  readonly connection?: string;
 }
 
 class RecentIdCache {
@@ -98,16 +110,32 @@ class RecentIdCache {
   }
 }
 
+function supportsSlackTarget(target: MessageTarget, scope?: SlackTargetScope): boolean {
+  if (target.channel.toLowerCase() !== "slack") return false;
+  if (!scope) return true;
+
+  const targetIds = normalizeSlackTargetIds([target.accountId, target.instanceId]);
+  const scopeIds = normalizeSlackTargetIds([scope.accountId, scope.routeAccountId, scope.instanceId, scope.connection]);
+  return targetIds.some((id) => scopeIds.includes(id));
+}
+
+function normalizeSlackTargetIds(values: Array<string | undefined>): string[] {
+  return Array.from(
+    new Set(values.map((value) => value?.trim().toLowerCase()).filter((value): value is string => Boolean(value))),
+  );
+}
+
 export class SlackTextDelivery implements NativeTextDelivery {
   readonly channelId = "slack";
 
   constructor(
     private readonly webClient: SlackWebApiClient,
     private readonly routingPolicy: SlackRoutingPolicy,
+    private readonly scope?: SlackTargetScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return supportsSlackTarget(target, this.scope);
   }
 
   async deliverText(request: NativeTextDeliveryRequest): Promise<NativeTextDeliveryResult> {
@@ -132,10 +160,11 @@ export class SlackAssistantThreadPresence implements NativePresenceDelivery {
   constructor(
     private readonly webClient: Pick<SlackWebApiClient, "setAssistantThreadStatus">,
     private readonly options: { statusText?: string; loadingMessages?: readonly string[] } = {},
+    private readonly scope?: SlackTargetScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return supportsSlackTarget(target, this.scope);
   }
 
   async sendPresence(request: NativePresenceDeliveryRequest): Promise<NativePresenceDeliveryResult> {
@@ -178,10 +207,11 @@ export class SlackReactionPresence implements NativePresenceDelivery {
   constructor(
     private readonly webClient: SlackWebApiClient,
     private readonly options: { reactionName?: string } = {},
+    private readonly scope?: SlackTargetScope,
   ) {}
 
   supports(target: MessageTarget): boolean {
-    return target.channel.toLowerCase() === this.channelId;
+    return supportsSlackTarget(target, this.scope);
   }
 
   async sendPresence(request: NativePresenceDeliveryRequest): Promise<NativePresenceDeliveryResult> {
@@ -984,13 +1014,21 @@ function syncSlackSessionSubscription(
 
 export async function createSlackNativeRuntimeFromEnv(
   env: NodeJS.ProcessEnv = process.env,
+  options: { instance?: InstanceConfig; instances?: Record<string, InstanceConfig> } = {},
 ): Promise<SlackNativeRuntime | null> {
-  const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances: configStore.getConfig().instances });
+  const instances = options.instances ?? configStore.getConfig().instances;
+  const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances, instance: options.instance });
   if (!credentials) {
     log.warn("Slack native runtime disabled: configure a Slack channel instance with brokered credentials");
     return null;
   }
 
+  const scope: SlackTargetScope = {
+    accountId: credentials.accountId,
+    routeAccountId: credentials.routeAccountId,
+    instanceId: credentials.instanceId,
+    connection: credentials.connection,
+  };
   const routingPolicy = slackRoutingPolicyFromEnv(env);
   const webClient = new SlackWebApiClient({
     appToken: credentials.appToken,
@@ -1005,17 +1043,25 @@ export async function createSlackNativeRuntimeFromEnv(
     routingPolicy,
     webClient,
   });
-  const delivery = new SlackTextDelivery(webClient, routingPolicy);
-  const reactionPresence = new SlackReactionPresence(webClient, {
-    reactionName: env.RAVI_SLACK_WORKING_REACTION?.trim() || "hourglass_flowing_sand",
-  });
+  const delivery = new SlackTextDelivery(webClient, routingPolicy, scope);
+  const reactionPresence = new SlackReactionPresence(
+    webClient,
+    {
+      reactionName: env.RAVI_SLACK_WORKING_REACTION?.trim() || "hourglass_flowing_sand",
+    },
+    scope,
+  );
   const reactionMode = slackReactionPresenceModeFromEnv(env.RAVI_SLACK_REACTION_PRESENCE);
   const assistantPresenceEnabled = slackAssistantPresenceEnabledFromEnv(env.RAVI_SLACK_ASSISTANT_STATUS);
   const presence = assistantPresenceEnabled
     ? new SlackPresenceStack(
-        new SlackAssistantThreadPresence(webClient, {
-          statusText: env.RAVI_SLACK_ASSISTANT_STATUS_TEXT?.trim() || "is working...",
-        }),
+        new SlackAssistantThreadPresence(
+          webClient,
+          {
+            statusText: env.RAVI_SLACK_ASSISTANT_STATUS_TEXT?.trim() || "is working...",
+          },
+          scope,
+        ),
         reactionMode === "off" ? null : reactionPresence,
         { reactionMode },
       )
@@ -1028,7 +1074,74 @@ export async function createSlackNativeRuntimeFromEnv(
     assistantPresenceEnabled,
     reactionPresenceMode: reactionMode,
   });
-  return { delivery, presence, socketMode };
+  return {
+    id: credentials.accountId,
+    accountId: credentials.accountId,
+    instanceId: credentials.instanceId,
+    connection: credentials.connection,
+    delivery,
+    presence,
+    socketMode,
+  };
+}
+
+export async function createSlackNativeRuntimesFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SlackNativeRuntime[]> {
+  const instances = configStore.getConfig().instances;
+  const connections = slackConnectionListFromEnv(env.RAVI_SLACK_CONNECTIONS);
+
+  if (!connections.length) {
+    const runtime = await createSlackNativeRuntimeFromEnv(env, { instances });
+    return runtime ? [runtime] : [];
+  }
+
+  const runtimes: SlackNativeRuntime[] = [];
+  for (const connection of connections) {
+    const instance = findSlackInstanceForConnection(instances, connection);
+    const runtimeEnv = {
+      ...env,
+      RAVI_SLACK_CONNECTION: connection,
+      ...(instance
+        ? {
+            RAVI_SLACK_ACCOUNT: instance.name,
+            RAVI_SLACK_ROUTE_ACCOUNT: instance.name,
+            RAVI_SLACK_INSTANCE: instance.instanceId ?? instance.name,
+          }
+        : {}),
+    } as NodeJS.ProcessEnv;
+    const runtime = await createSlackNativeRuntimeFromEnv(runtimeEnv, { instances, instance });
+    if (runtime) runtimes.push(runtime);
+  }
+  return runtimes;
+}
+
+function slackConnectionListFromEnv(value: string | undefined): string[] {
+  if (!value) return [];
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function findSlackInstanceForConnection(
+  instances: Record<string, InstanceConfig> | undefined,
+  connection: string,
+): InstanceConfig | undefined {
+  if (!instances) return undefined;
+  const normalized = connection.trim();
+  return Object.values(instances).find((instance) => {
+    if (instance.enabled === false || instance.channel !== "slack") return false;
+    return (
+      instance.name === normalized ||
+      instance.instanceId === normalized ||
+      credentialConnectionForInstance(instance) === normalized
+    );
+  });
 }
 
 function slackAssistantPresenceEnabledFromEnv(value: string | undefined): boolean {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -25,7 +25,11 @@ import type {
   NativeTextDeliveryResult,
 } from "../native/types.js";
 import { SlackWebApiClient } from "./client.js";
-import { credentialConnectionForInstance, resolveSlackCredentialConfigFromEnv } from "./credentials.js";
+import {
+  credentialConnectionForInstance,
+  resolveSlackCredentialConfigFromEnv,
+  type SlackCredentialResolver,
+} from "./credentials.js";
 import { storeSlackInteractionResponseUrl } from "./interactions.js";
 import {
   cleanSlackId,
@@ -1014,10 +1018,18 @@ function syncSlackSessionSubscription(
 
 export async function createSlackNativeRuntimeFromEnv(
   env: NodeJS.ProcessEnv = process.env,
-  options: { instance?: InstanceConfig; instances?: Record<string, InstanceConfig> } = {},
+  options: {
+    instance?: InstanceConfig;
+    instances?: Record<string, InstanceConfig>;
+    resolveSecret?: SlackCredentialResolver;
+  } = {},
 ): Promise<SlackNativeRuntime | null> {
   const instances = options.instances ?? configStore.getConfig().instances;
-  const credentials = await resolveSlackCredentialConfigFromEnv(env, { instances, instance: options.instance });
+  const credentials = await resolveSlackCredentialConfigFromEnv(env, {
+    instances,
+    instance: options.instance,
+    resolveSecret: options.resolveSecret,
+  });
   if (!credentials) {
     log.warn("Slack native runtime disabled: configure a Slack channel instance with brokered credentials");
     return null;
@@ -1087,33 +1099,79 @@ export async function createSlackNativeRuntimeFromEnv(
 
 export async function createSlackNativeRuntimesFromEnv(
   env: NodeJS.ProcessEnv = process.env,
+  options: {
+    instances?: Record<string, InstanceConfig>;
+    resolveSecret?: SlackCredentialResolver;
+  } = {},
 ): Promise<SlackNativeRuntime[]> {
-  const instances = configStore.getConfig().instances;
+  const instances = options.instances ?? configStore.getConfig().instances;
   const connections = slackConnectionListFromEnv(env.RAVI_SLACK_CONNECTIONS);
 
   if (!connections.length) {
-    const runtime = await createSlackNativeRuntimeFromEnv(env, { instances });
+    if (!hasExplicitSlackRuntimeSelector(env)) {
+      const configuredInstances = enabledSlackInstances(instances);
+      if (configuredInstances.length > 1) {
+        const runtimes: SlackNativeRuntime[] = [];
+        for (const instance of configuredInstances) {
+          const runtime = await createSlackNativeRuntimeFromEnv(runtimeEnvForInstance(env, instance), {
+            instances,
+            instance,
+            resolveSecret: options.resolveSecret,
+          });
+          if (runtime) runtimes.push(runtime);
+        }
+        return runtimes;
+      }
+    }
+
+    const runtime = await createSlackNativeRuntimeFromEnv(env, { instances, resolveSecret: options.resolveSecret });
     return runtime ? [runtime] : [];
   }
 
   const runtimes: SlackNativeRuntime[] = [];
   for (const connection of connections) {
     const instance = findSlackInstanceForConnection(instances, connection);
-    const runtimeEnv = {
-      ...env,
-      RAVI_SLACK_CONNECTION: connection,
-      ...(instance
-        ? {
-            RAVI_SLACK_ACCOUNT: instance.name,
-            RAVI_SLACK_ROUTE_ACCOUNT: instance.name,
-            RAVI_SLACK_INSTANCE: instance.instanceId ?? instance.name,
-          }
-        : {}),
-    } as NodeJS.ProcessEnv;
-    const runtime = await createSlackNativeRuntimeFromEnv(runtimeEnv, { instances, instance });
+    const runtimeEnv = instance
+      ? runtimeEnvForInstance(env, instance, connection)
+      : ({ ...env, RAVI_SLACK_CONNECTION: connection } as NodeJS.ProcessEnv);
+    const runtime = await createSlackNativeRuntimeFromEnv(runtimeEnv, {
+      instances,
+      instance,
+      resolveSecret: options.resolveSecret,
+    });
     if (runtime) runtimes.push(runtime);
   }
   return runtimes;
+}
+
+function hasExplicitSlackRuntimeSelector(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.RAVI_SLACK_CONNECTION?.trim() ||
+      env.RAVI_SLACK_CREDENTIAL_CONNECTION?.trim() ||
+      env.RAVI_SLACK_ACCOUNT?.trim() ||
+      env.RAVI_SLACK_INSTANCE?.trim(),
+  );
+}
+
+function enabledSlackInstances(instances: Record<string, InstanceConfig> | undefined): InstanceConfig[] {
+  if (!instances) return [];
+  return Object.values(instances)
+    .filter((instance) => instance.enabled !== false && instance.channel === "slack")
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function runtimeEnvForInstance(
+  env: NodeJS.ProcessEnv,
+  instance: InstanceConfig,
+  connection = credentialConnectionForInstance(instance) ?? instance.name,
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    RAVI_SLACK_CONNECTION: connection,
+    RAVI_SLACK_ACCOUNT: instance.name,
+    RAVI_SLACK_ROUTE_ACCOUNT: instance.name,
+    RAVI_SLACK_INSTANCE: instance.instanceId ?? instance.name,
+  } as NodeJS.ProcessEnv;
 }
 
 function slackConnectionListFromEnv(value: string | undefined): string[] {

--- a/src/cli/command-access.test.ts
+++ b/src/cli/command-access.test.ts
@@ -31,6 +31,7 @@ const ACCESS: CommandAccessOptions = {
 let stateDir: string | null = null;
 let previousEnv: Partial<Record<(typeof RAVI_RUNTIME_CONTEXT_ENV_KEYS)[number], string>> = {};
 let previousCredentialsPath: string | undefined;
+let previousForceLocalOperator: string | undefined;
 let auditEvents: Array<{ topic: string; data: Record<string, unknown> }> = [];
 
 function context(capabilities: ContextRecord["capabilities"]): ContextRecord {
@@ -50,6 +51,7 @@ describe("CLI command access enforcement", () => {
     stateDir = await createIsolatedRaviState("ravi-cli-command-access-test-");
     previousEnv = {};
     previousCredentialsPath = process.env.RAVI_CREDENTIALS_PATH;
+    previousForceLocalOperator = process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR;
     auditEvents = [];
     setPermissionAuditPublisherForTest(async (topic, data) => {
       auditEvents.push({ topic, data });
@@ -60,6 +62,7 @@ describe("CLI command access enforcement", () => {
       }
       delete process.env[key];
     }
+    delete process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR;
   });
 
   afterEach(async () => {
@@ -77,6 +80,12 @@ describe("CLI command access enforcement", () => {
       process.env.RAVI_CREDENTIALS_PATH = previousCredentialsPath;
     }
     previousCredentialsPath = undefined;
+    if (previousForceLocalOperator === undefined) {
+      delete process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR;
+    } else {
+      process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR = previousForceLocalOperator;
+    }
+    previousForceLocalOperator = undefined;
     setPermissionAuditPublisherForTest();
     await cleanupIsolatedRaviState(stateDir);
     stateDir = null;
@@ -137,6 +146,28 @@ describe("CLI command access enforcement", () => {
     expect(result.decision?.permission).toBe("mutate");
     expect(result.decision?.objectType).toBe("demo.items");
     expect(result.decision?.objectId).toBe("create");
+  });
+
+  it("can force local operator execution for process runners even when a context key is present", () => {
+    const record = createRuntimeContext({
+      kind: "cli-runtime",
+      agentId: "main",
+      capabilities: [],
+      ttlMs: 0,
+    });
+    process.env.RAVI_CONTEXT_KEY = record.contextKey;
+    process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR = "1";
+
+    const result = enforceCliCommandAccess({
+      group: "demo",
+      command: "create",
+      access: ACCESS,
+      source: "cli",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.decision?.providerId).toBe("operator-control");
+    expect(result.decision?.objectType).toBe("demo.items");
   });
 
   it("ignores default credential context for direct local CLI authorization", () => {

--- a/src/cli/command-access.test.ts
+++ b/src/cli/command-access.test.ts
@@ -148,7 +148,7 @@ describe("CLI command access enforcement", () => {
     expect(result.decision?.objectId).toBe("create");
   });
 
-  it("can force local operator execution for process runners even when a context key is present", () => {
+  it("does not let env force local operator execution when a context key is present", () => {
     const record = createRuntimeContext({
       kind: "cli-runtime",
       agentId: "main",
@@ -165,9 +165,9 @@ describe("CLI command access enforcement", () => {
       source: "cli",
     });
 
-    expect(result.allowed).toBe(true);
-    expect(result.decision?.providerId).toBe("operator-control");
-    expect(result.decision?.objectType).toBe("demo.items");
+    expect(result.allowed).toBe(false);
+    expect(result.errorMessage).toContain("agent:main cannot execute demo create");
+    expect(result.attempted.every((decision) => decision.providerId === "context-capabilities")).toBe(true);
   });
 
   it("ignores default credential context for direct local CLI authorization", () => {

--- a/src/cli/command-access.ts
+++ b/src/cli/command-access.ts
@@ -120,7 +120,8 @@ function resolveCommandAccessAuthority(
   | { allowed: true; label: string; request: Pick<PermissionProviderRequest, "context" | "subject" | "localOperator"> }
   | { allowed: false; errorMessage: string } {
   const ctx = getContext();
-  const useRuntimeContext = source !== "cli" || Boolean(process.env[RAVI_CONTEXT_KEY_ENV]);
+  const forceLocalOperator = source === "cli" && process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR === "1";
+  const useRuntimeContext = !forceLocalOperator && (source !== "cli" || Boolean(process.env[RAVI_CONTEXT_KEY_ENV]));
   if (useRuntimeContext && ctx?.context) {
     const agentId = ctx.agentId ?? ctx.context.agentId;
     const context: CapabilityContextLike = {

--- a/src/cli/command-access.ts
+++ b/src/cli/command-access.ts
@@ -120,8 +120,7 @@ function resolveCommandAccessAuthority(
   | { allowed: true; label: string; request: Pick<PermissionProviderRequest, "context" | "subject" | "localOperator"> }
   | { allowed: false; errorMessage: string } {
   const ctx = getContext();
-  const forceLocalOperator = source === "cli" && process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR === "1";
-  const useRuntimeContext = !forceLocalOperator && (source !== "cli" || Boolean(process.env[RAVI_CONTEXT_KEY_ENV]));
+  const useRuntimeContext = source !== "cli" || Boolean(process.env[RAVI_CONTEXT_KEY_ENV]);
   if (useRuntimeContext && ctx?.context) {
     const agentId = ctx.agentId ?? ctx.context.agentId;
     const context: CapabilityContextLike = {

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -52,12 +52,11 @@ describe("channels command runner env", () => {
     ).toEqual(["ravi-rbbt-slack", "hana-slack"]);
   });
 
-  it("falls back to an existing PM2 Slack connection list", () => {
+  it("does not treat an old PM2 Slack connection list as canonical config", () => {
     expect(
       chooseSlackRunnerConnections({
         env: {},
-        fallbackEnv: { RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack,hana-slack" },
       }),
-    ).toEqual(["ravi-rbbt-slack", "hana-slack"]);
+    ).toEqual([]);
   });
 });

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { chooseSlackRunnerConnection } from "./channels.js";
+import { chooseSlackRunnerConnection, chooseSlackRunnerConnections } from "./channels.js";
 
 describe("channels command runner env", () => {
   it("uses an explicit Slack connection first", () => {
@@ -33,5 +33,31 @@ describe("channels command runner env", () => {
         env: {},
       }),
     ).toBeUndefined();
+  });
+
+  it("preserves multiple Slack runner connections from env", () => {
+    expect(
+      chooseSlackRunnerConnections({
+        env: { RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack, hana-slack" },
+      }),
+    ).toEqual(["ravi-rbbt-slack", "hana-slack"]);
+  });
+
+  it("prefers explicit multiple Slack runner connections over single env fallback", () => {
+    expect(
+      chooseSlackRunnerConnections({
+        explicit: "ravi-rbbt-slack,hana-slack",
+        env: { RAVI_SLACK_CONNECTION: "other" },
+      }),
+    ).toEqual(["ravi-rbbt-slack", "hana-slack"]);
+  });
+
+  it("falls back to an existing PM2 Slack connection list", () => {
+    expect(
+      chooseSlackRunnerConnections({
+        env: {},
+        fallbackEnv: { RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack,hana-slack" },
+      }),
+    ).toEqual(["ravi-rbbt-slack", "hana-slack"]);
   });
 });

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { ChannelRunner, runChannelRunnerFromEnv } from "../../channels/runner.js";
 import {
   CHANNELS_PM2_PROCESS_NAME,
+  buildPm2Env,
   getPm2Process,
   getPm2Processes,
   isPm2Available,
@@ -52,6 +53,7 @@ const runnerEnvReturnSchema = z
   .object({
     slackSocketMode: z.boolean(),
     slackConnection: z.string().nullable(),
+    slackConnections: z.array(z.string()),
     consumeOutbound: z.string(),
   })
   .strict();
@@ -98,7 +100,7 @@ function runPm2Quiet(
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
     cwd: options.cwd,
-    env: { ...process.env, ...options.envOverrides } as Record<string, string>,
+    env: buildPm2Env(options.envOverrides),
   });
   return { status: result.status ?? 1 };
 }
@@ -141,27 +143,73 @@ export function chooseSlackRunnerConnection(input: {
   return undefined;
 }
 
-function buildRunnerPm2Env(explicitSlackConnection?: string): Record<string, string> {
+function listEnvValues(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function chooseSlackRunnerConnections(input: {
+  explicit?: string;
+  explicitSingle?: string;
+  env?: Record<string, unknown>;
+  fallbackEnv?: Record<string, unknown>;
+}): string[] {
+  const explicit = listEnvValues(input.explicit);
+  if (explicit.length) return explicit;
+
+  const explicitSingle = cleanEnvValue(input.explicitSingle);
+  if (explicitSingle) return [explicitSingle];
+
+  const envConnections = listEnvValues(input.env?.RAVI_SLACK_CONNECTIONS);
+  if (envConnections.length) return envConnections;
+
+  const fallbackConnections = listEnvValues(input.fallbackEnv?.RAVI_SLACK_CONNECTIONS);
+  if (fallbackConnections.length) return fallbackConnections;
+
+  const single =
+    chooseSlackRunnerConnection({ env: input.env }) ?? chooseSlackRunnerConnection({ env: input.fallbackEnv });
+  return single ? [single] : [];
+}
+
+function buildRunnerPm2Env(
+  explicitSlackConnection?: string,
+  explicitSlackConnections?: string,
+): Record<string, string> {
   const existingPm2Env = readExistingPm2Env(CHANNELS_PM2_PROCESS_NAME);
-  const envOverrides: Record<string, string> = {};
+  const envOverrides: Record<string, string> = { RAVI_CLI_FORCE_LOCAL_OPERATOR: "1" };
 
   for (const key of RUNNER_ENV_KEYS) {
     const value = cleanEnvValue(process.env[key]) ?? cleanEnvValue(existingPm2Env[key]);
     if (value) envOverrides[key] = value;
   }
 
-  const slackConnection = chooseSlackRunnerConnection({ explicit: explicitSlackConnection, env: process.env });
-  if (slackConnection) {
-    envOverrides.RAVI_SLACK_CONNECTION = slackConnection;
+  const slackConnections = chooseSlackRunnerConnections({
+    explicit: explicitSlackConnections,
+    explicitSingle: explicitSlackConnection,
+    env: process.env,
+    fallbackEnv: existingPm2Env,
+  });
+  if (slackConnections.length > 1) {
+    envOverrides.RAVI_SLACK_CONNECTIONS = slackConnections.join(",");
+    delete envOverrides.RAVI_SLACK_CONNECTION;
+    delete envOverrides.RAVI_SLACK_CREDENTIAL_CONNECTION;
+  } else if (slackConnections.length === 1) {
+    envOverrides.RAVI_SLACK_CONNECTION = slackConnections[0]!;
   }
 
   return envOverrides;
 }
 
 function publicRunnerEnv(envOverrides: Record<string, string>): Record<string, unknown> {
+  const slackConnections = listEnvValues(envOverrides.RAVI_SLACK_CONNECTIONS);
+  const slackConnection = envOverrides.RAVI_SLACK_CONNECTION ?? null;
   return {
     slackSocketMode: true,
-    slackConnection: envOverrides.RAVI_SLACK_CONNECTION ?? null,
+    slackConnection,
+    slackConnections: slackConnections.length ? slackConnections : slackConnection ? [slackConnection] : [],
     consumeOutbound: envOverrides.RAVI_CHANNELS_CONSUME_OUTBOUND ?? "default",
   };
 }
@@ -234,6 +282,11 @@ export class ChannelsCommands {
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
     @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
+    @Option({
+      flags: "--slack-connections <names>",
+      description: "Comma-separated Slack credential connections for multi-workspace native runner",
+    })
+    slackConnections?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     requirePm2();
@@ -252,7 +305,7 @@ export class ChannelsCommands {
 
     const target = requireRuntimeTarget(build);
     const args = ["start", "bun", "--name", CHANNELS_PM2_PROCESS_NAME, "--", target.bundlePath, "channels", "run"];
-    const runnerEnv = buildRunnerPm2Env(slackConnection);
+    const runnerEnv = buildRunnerPm2Env(slackConnection, slackConnections);
     const { status } = asJson
       ? runPm2Quiet(args, { cwd: target.cwd, envOverrides: runnerEnv })
       : runPm2(args, runnerEnv, { cwd: target.cwd });
@@ -319,10 +372,15 @@ export class ChannelsCommands {
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
     @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
     slackConnection?: string,
+    @Option({
+      flags: "--slack-connections <names>",
+      description: "Comma-separated Slack credential connections for multi-workspace native runner",
+    })
+    slackConnections?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     requirePm2();
-    const runnerEnv = buildRunnerPm2Env(slackConnection);
+    const runnerEnv = buildRunnerPm2Env(slackConnection, slackConnections);
 
     if (isPm2ProcessRunning(CHANNELS_PM2_PROCESS_NAME)) {
       const stopped = asJson

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -155,7 +155,6 @@ export function chooseSlackRunnerConnections(input: {
   explicit?: string;
   explicitSingle?: string;
   env?: Record<string, unknown>;
-  fallbackEnv?: Record<string, unknown>;
 }): string[] {
   const explicit = listEnvValues(input.explicit);
   if (explicit.length) return explicit;
@@ -166,11 +165,7 @@ export function chooseSlackRunnerConnections(input: {
   const envConnections = listEnvValues(input.env?.RAVI_SLACK_CONNECTIONS);
   if (envConnections.length) return envConnections;
 
-  const fallbackConnections = listEnvValues(input.fallbackEnv?.RAVI_SLACK_CONNECTIONS);
-  if (fallbackConnections.length) return fallbackConnections;
-
-  const single =
-    chooseSlackRunnerConnection({ env: input.env }) ?? chooseSlackRunnerConnection({ env: input.fallbackEnv });
+  const single = chooseSlackRunnerConnection({ env: input.env });
   return single ? [single] : [];
 }
 
@@ -179,7 +174,7 @@ function buildRunnerPm2Env(
   explicitSlackConnections?: string,
 ): Record<string, string> {
   const existingPm2Env = readExistingPm2Env(CHANNELS_PM2_PROCESS_NAME);
-  const envOverrides: Record<string, string> = { RAVI_CLI_FORCE_LOCAL_OPERATOR: "1" };
+  const envOverrides: Record<string, string> = {};
 
   for (const key of RUNNER_ENV_KEYS) {
     const value = cleanEnvValue(process.env[key]) ?? cleanEnvValue(existingPm2Env[key]);
@@ -190,7 +185,6 @@ function buildRunnerPm2Env(
     explicit: explicitSlackConnections,
     explicitSingle: explicitSlackConnection,
     env: process.env,
-    fallbackEnv: existingPm2Env,
   });
   if (slackConnections.length > 1) {
     envOverrides.RAVI_SLACK_CONNECTIONS = slackConnections.join(",");
@@ -280,7 +274,10 @@ export class ChannelsCommands {
   @Returns(channelsMutationReturnSchema)
   start(
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
-    @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
+    @Option({
+      flags: "--slack-connection <name>",
+      description: "Optional Slack credential connection override for a single workspace",
+    })
     slackConnection?: string,
     @Option({
       flags: "--slack-connections <names>",
@@ -370,7 +367,10 @@ export class ChannelsCommands {
   @Returns(channelsMutationReturnSchema)
   restart(
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
-    @Option({ flags: "--slack-connection <name>", description: "Optional Slack credential connection override" })
+    @Option({
+      flags: "--slack-connection <name>",
+      description: "Optional Slack credential connection override for a single workspace",
+    })
     slackConnection?: string,
     @Option({
       flags: "--slack-connections <names>",

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -12,6 +12,7 @@ import {
   getArgsMetadata,
   getOptionsMetadata,
   getScopeMetadata,
+  getCliOnlyMetadata,
   type CommandAccessOptions,
   type CommandMetadata,
   type ScopeType,
@@ -110,11 +111,20 @@ export function registerCommands(program: CommanderCommand, classes: CommandClas
 
     // Resolve scope: command-level > group-level > "admin" (fail-secure default)
     const scopeMap = getScopeMetadata(cls);
+    const cliOnlySet = getCliOnlyMetadata(cls);
     const commandAccessMap = getCommandAccessMetadata(cls);
 
     for (const cmdMeta of commandsMeta) {
       const effectiveScope: ScopeType = scopeMap.get(cmdMeta.method) ?? groupMeta.scope ?? "admin";
-      registerCommand(group, instance, cmdMeta, toolGroupName, effectiveScope, commandAccessMap.get(cmdMeta.method));
+      registerCommand(
+        group,
+        instance,
+        cmdMeta,
+        toolGroupName,
+        effectiveScope,
+        commandAccessMap.get(cmdMeta.method),
+        cliOnlySet.has(cmdMeta.method),
+      );
     }
   }
 }
@@ -126,6 +136,7 @@ function registerCommand(
   groupName: string,
   scope: ScopeType,
   access: CommandAccessOptions | undefined,
+  cliOnly: boolean,
 ): void {
   // A command can also be an intermediate group when it has nested subcommands:
   // e.g. `ravi crm account <id>` and `ravi crm account create ...`.
@@ -235,13 +246,18 @@ function registerCommand(
       return;
     }
 
-    // Scope enforcement (before method execution)
-    const scopeResult = enforceScopeCheck(scope, groupName, cmdMeta.name);
-    if (!scopeResult.allowed) {
-      console.error(scopeResult.errorMessage);
-      // Drain NATS before exiting so audit events are flushed
-      const { flushAuditAndExit } = await import("../permissions/scope.js");
-      await flushAuditAndExit(1);
+    // Scope enforcement (before method execution). Long-lived process runners are
+    // `@CliOnly()` and may be launched by PM2 without an interactive operator
+    // context; they still pass the semantic CommandAccess gate above.
+    const skipLegacyScope = cliOnly && process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR === "1";
+    if (!skipLegacyScope) {
+      const scopeResult = enforceScopeCheck(scope, groupName, cmdMeta.name);
+      if (!scopeResult.allowed) {
+        console.error(scopeResult.errorMessage);
+        // Drain NATS before exiting so audit events are flushed
+        const { flushAuditAndExit } = await import("../permissions/scope.js");
+        await flushAuditAndExit(1);
+      }
     }
 
     // Execute and emit single event with input + output

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -12,7 +12,6 @@ import {
   getArgsMetadata,
   getOptionsMetadata,
   getScopeMetadata,
-  getCliOnlyMetadata,
   type CommandAccessOptions,
   type CommandMetadata,
   type ScopeType,
@@ -111,20 +110,11 @@ export function registerCommands(program: CommanderCommand, classes: CommandClas
 
     // Resolve scope: command-level > group-level > "admin" (fail-secure default)
     const scopeMap = getScopeMetadata(cls);
-    const cliOnlySet = getCliOnlyMetadata(cls);
     const commandAccessMap = getCommandAccessMetadata(cls);
 
     for (const cmdMeta of commandsMeta) {
       const effectiveScope: ScopeType = scopeMap.get(cmdMeta.method) ?? groupMeta.scope ?? "admin";
-      registerCommand(
-        group,
-        instance,
-        cmdMeta,
-        toolGroupName,
-        effectiveScope,
-        commandAccessMap.get(cmdMeta.method),
-        cliOnlySet.has(cmdMeta.method),
-      );
+      registerCommand(group, instance, cmdMeta, toolGroupName, effectiveScope, commandAccessMap.get(cmdMeta.method));
     }
   }
 }
@@ -136,7 +126,6 @@ function registerCommand(
   groupName: string,
   scope: ScopeType,
   access: CommandAccessOptions | undefined,
-  cliOnly: boolean,
 ): void {
   // A command can also be an intermediate group when it has nested subcommands:
   // e.g. `ravi crm account <id>` and `ravi crm account create ...`.
@@ -246,18 +235,13 @@ function registerCommand(
       return;
     }
 
-    // Scope enforcement (before method execution). Long-lived process runners are
-    // `@CliOnly()` and may be launched by PM2 without an interactive operator
-    // context; they still pass the semantic CommandAccess gate above.
-    const skipLegacyScope = cliOnly && process.env.RAVI_CLI_FORCE_LOCAL_OPERATOR === "1";
-    if (!skipLegacyScope) {
-      const scopeResult = enforceScopeCheck(scope, groupName, cmdMeta.name);
-      if (!scopeResult.allowed) {
-        console.error(scopeResult.errorMessage);
-        // Drain NATS before exiting so audit events are flushed
-        const { flushAuditAndExit } = await import("../permissions/scope.js");
-        await flushAuditAndExit(1);
-      }
+    // Scope enforcement (before method execution).
+    const scopeResult = enforceScopeCheck(scope, groupName, cmdMeta.name);
+    if (!scopeResult.allowed) {
+      console.error(scopeResult.errorMessage);
+      // Drain NATS before exiting so audit events are flushed
+      const { flushAuditAndExit } = await import("../permissions/scope.js");
+      await flushAuditAndExit(1);
     }
 
     // Execute and emit single event with input + output

--- a/src/pm2.test.ts
+++ b/src/pm2.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildPm2Env } from "./pm2.js";
+
+describe("buildPm2Env", () => {
+  it("strips runtime context identity from PM2 child processes", () => {
+    const env = buildPm2Env({
+      RAVI_CONTEXT_KEY: "rctx_child",
+      RAVI_SESSION_KEY: "session_key",
+      RAVI_SESSION_NAME: "main",
+      RAVI_AGENT_ID: "agent-main",
+      RAVI_CHANNEL: "slack",
+      RAVI_ACCOUNT_ID: "account",
+      RAVI_CHAT_ID: "chat",
+      RAVI_THREAD_ID: "thread",
+    });
+
+    expect(env).not.toHaveProperty("RAVI_CONTEXT_KEY");
+    expect(env).not.toHaveProperty("RAVI_SESSION_KEY");
+    expect(env).not.toHaveProperty("RAVI_SESSION_NAME");
+    expect(env).not.toHaveProperty("RAVI_AGENT_ID");
+    expect(env).not.toHaveProperty("RAVI_CHANNEL");
+    expect(env).not.toHaveProperty("RAVI_ACCOUNT_ID");
+    expect(env).not.toHaveProperty("RAVI_CHAT_ID");
+    expect(env).not.toHaveProperty("RAVI_THREAD_ID");
+  });
+
+  it("lets a single Slack connection override an inherited multi-connection list", () => {
+    const previous = process.env.RAVI_SLACK_CONNECTIONS;
+    process.env.RAVI_SLACK_CONNECTIONS = "ravi-rbbt-slack,hana-slack";
+    try {
+      const env = buildPm2Env({ RAVI_SLACK_CONNECTION: "hana-slack" });
+      expect(env.RAVI_SLACK_CONNECTION).toBe("hana-slack");
+      expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTIONS");
+    } finally {
+      if (previous === undefined) delete process.env.RAVI_SLACK_CONNECTIONS;
+      else process.env.RAVI_SLACK_CONNECTIONS = previous;
+    }
+  });
+
+  it("lets a multi Slack connection override inherited single-connection aliases", () => {
+    const previousConnection = process.env.RAVI_SLACK_CONNECTION;
+    const previousCredentialConnection = process.env.RAVI_SLACK_CREDENTIAL_CONNECTION;
+    process.env.RAVI_SLACK_CONNECTION = "old-single";
+    process.env.RAVI_SLACK_CREDENTIAL_CONNECTION = "old-credential";
+    try {
+      const env = buildPm2Env({ RAVI_SLACK_CONNECTIONS: "ravi-rbbt-slack,hana-slack" });
+      expect(env.RAVI_SLACK_CONNECTIONS).toBe("ravi-rbbt-slack,hana-slack");
+      expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTION");
+      expect(env).not.toHaveProperty("RAVI_SLACK_CREDENTIAL_CONNECTION");
+    } finally {
+      if (previousConnection === undefined) delete process.env.RAVI_SLACK_CONNECTION;
+      else process.env.RAVI_SLACK_CONNECTION = previousConnection;
+      if (previousCredentialConnection === undefined) delete process.env.RAVI_SLACK_CREDENTIAL_CONNECTION;
+      else process.env.RAVI_SLACK_CREDENTIAL_CONNECTION = previousCredentialConnection;
+    }
+  });
+});

--- a/src/pm2.ts
+++ b/src/pm2.ts
@@ -8,6 +8,17 @@ import { execSync, spawnSync } from "node:child_process";
 
 export const PM2_PROCESS_NAME = "ravi";
 export const CHANNELS_PM2_PROCESS_NAME = "ravi-channels";
+const PM2_ENV_DENYLIST = ["RAVI_CONTEXT_KEY"] as const;
+
+export function buildPm2Env(envOverrides?: Record<string, string>): Record<string, string> {
+  const env = { ...process.env, ...(envOverrides ?? {}) } as Record<string, string>;
+  for (const key of PM2_ENV_DENYLIST) delete env[key];
+  if (envOverrides?.RAVI_SLACK_CONNECTIONS && !envOverrides.RAVI_SLACK_CONNECTION) {
+    delete env.RAVI_SLACK_CONNECTION;
+    delete env.RAVI_SLACK_CREDENTIAL_CONNECTION;
+  }
+  return env;
+}
 
 /**
  * Check if pm2 is available in PATH.
@@ -29,11 +40,9 @@ export function runPm2(
   envOverrides?: Record<string, string>,
   options: { cwd?: string } = {},
 ): { status: number } {
-  const env = envOverrides ? { ...process.env, ...envOverrides } : process.env;
-
   const result = spawnSync("pm2", args, {
     stdio: "inherit",
-    env: env as Record<string, string>,
+    env: buildPm2Env(envOverrides),
     cwd: options.cwd,
   });
 

--- a/src/pm2.ts
+++ b/src/pm2.ts
@@ -8,7 +8,16 @@ import { execSync, spawnSync } from "node:child_process";
 
 export const PM2_PROCESS_NAME = "ravi";
 export const CHANNELS_PM2_PROCESS_NAME = "ravi-channels";
-const PM2_ENV_DENYLIST = ["RAVI_CONTEXT_KEY"] as const;
+const PM2_ENV_DENYLIST = [
+  "RAVI_CONTEXT_KEY",
+  "RAVI_SESSION_KEY",
+  "RAVI_SESSION_NAME",
+  "RAVI_AGENT_ID",
+  "RAVI_CHANNEL",
+  "RAVI_ACCOUNT_ID",
+  "RAVI_CHAT_ID",
+  "RAVI_THREAD_ID",
+] as const;
 
 export function buildPm2Env(envOverrides?: Record<string, string>): Record<string, string> {
   const env = { ...process.env, ...(envOverrides ?? {}) } as Record<string, string>;
@@ -16,6 +25,9 @@ export function buildPm2Env(envOverrides?: Record<string, string>): Record<strin
   if (envOverrides?.RAVI_SLACK_CONNECTIONS && !envOverrides.RAVI_SLACK_CONNECTION) {
     delete env.RAVI_SLACK_CONNECTION;
     delete env.RAVI_SLACK_CREDENTIAL_CONNECTION;
+  }
+  if (envOverrides?.RAVI_SLACK_CONNECTION && !envOverrides.RAVI_SLACK_CONNECTIONS) {
+    delete env.RAVI_SLACK_CONNECTIONS;
   }
   return env;
 }


### PR DESCRIPTION
## Objective
Restore reliable native Slack delivery for multiple workspaces sharing the same Ravi runtime, so both RBBT Slack and HANA Slack can receive replies from the channel runner.

## Problem
The channel runner was effectively single-workspace for Slack. It preserved singular Slack runtime environment, could start with stale context, and delivery adapters could match any Slack outbound target without proving they belonged to the same account, instance, or connection. On top of that, a stale JetStream durable consumer could sit ahead of the stream sequence and never consume newly queued outbound jobs.

## Solution
Add plural Slack connection support to `channels start/restart`, load one native Slack runtime per configured connection, scope delivery and presence adapters by account/instance/connection, sanitize PM2 runner environment for CLI-only process runners, and recreate stale outbound consumers when their sequence is beyond the stream sequence. Regenerate the SDK surface for the new `slackConnections` input and runner metadata.

## Practical impact
Operators can run a single native channel runner against multiple Slack workspaces. HANA and RBBT Slack no longer steal each other's outbound targets, and queued Slack replies are consumed again even after JetStream consumer sequence drift.

## What does NOT change
This does not move Slack back to Omni, does not expose token material, does not change WhatsApp routing, and does not alter normal runtime authorization for user-triggered commands. The local-operator bypass is limited to CLI-only PM2 runner processes explicitly started with the runner env flag.

## Validation
- `bun test src/cli/registry.test.ts src/cli/command-access.test.ts src/cli/commands/channels.test.ts src/channels/slack/socket-mode.test.ts src/channels/slack/credentials.test.ts src/channels/outbound-consumer.test.ts src/channels/outbound-stream.test.ts src/channels/presence-consumer.test.ts`
- `bun run --silent typecheck`
- `bun run --silent build`
- `bun run --silent sdk:check`
- pre-push hook: SDK drift check, build, typecheck, configured test suite, SDK tests
- runtime smoke: restarted the channel runner with both native Slack connections, replayed recent messages for both workspaces, confirmed replies landed in both Slack channels, and confirmed outbound stream/consumer returned to zero pending after delivery

## Risks
The main risk is runner configuration drift: deployments must use `RAVI_SLACK_CONNECTIONS` or the `--slack-connections` flag when multiple workspaces should be active. Another risk is relying on account/instance metadata being present on outbound targets; missing metadata will now fail closed instead of letting the wrong Slack runtime claim delivery.

## Rollback
Revert this PR and restart the channel runner with the previous single Slack connection configuration. If delivery stalls again, delete/recreate the affected JetStream durable consumer manually or restart with the prior known-good runner command while keeping only one Slack workspace active.
