### PR TITLE
fix(runtime): honor full-access for Pi provider preflight

### DIFF
--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -15,7 +15,13 @@ import { nats } from "../nats.js";
 import { authorizeRuntimeContext, requestPollAnswer, type ApprovalTarget } from "../approval/service.js";
 import { buildAuditContextProvenance } from "../permissions/audit-provenance.js";
 import { emitPermissionDeniedAudit, recordAndEmitPermissionDenial } from "../permissions/denials.js";
-import { agentCan, canWithCapabilityContext, isDelegatedAuthorityContext } from "../permissions/provider-runtime.js";
+import {
+  agentCan,
+  canWithCapabilities,
+  canWithCapabilityContext,
+  isDelegatedAuthorityContext,
+  materializeSubjectCapabilities,
+} from "../permissions/provider-runtime.js";
 import type { ContextRecord } from "../router/index.js";
 import type {
   RuntimeApprovalResult,
@@ -51,27 +57,61 @@ export interface RuntimeHostServicesOptions {
   onSkillGatePersisted?: (skillVisibility: RuntimeSkillVisibilitySnapshot) => void;
 }
 
+function agentHasMaterializedCapability(
+  agentId: string,
+  permission: string,
+  objectType: string,
+  objectId: string,
+): boolean {
+  return canWithCapabilities(materializeSubjectCapabilities("agent", agentId), permission, objectType, objectId);
+}
+
+function capabilitySnapshotHasUnrestrictedToolExecution(capabilities: ContextRecord["capabilities"]): boolean {
+  return (
+    canWithCapabilities(capabilities, "admin", "system", "*") ||
+    (canWithCapabilities(capabilities, "use", "tool", "*") &&
+      canWithCapabilities(capabilities, "execute", "executable", "*"))
+  );
+}
+
+function capabilitySnapshotHasUnrestrictedToolSurface(capabilities: ContextRecord["capabilities"]): boolean {
+  return (
+    canWithCapabilities(capabilities, "admin", "system", "*") || canWithCapabilities(capabilities, "use", "tool", "*")
+  );
+}
+
 function hasUnrestrictedToolExecution(agentId: string): boolean {
   return (
     agentCan(agentId, "admin", "system", "*") ||
-    (agentCan(agentId, "use", "tool", "*") && agentCan(agentId, "execute", "executable", "*"))
+    agentHasMaterializedCapability(agentId, "admin", "system", "*") ||
+    ((agentCan(agentId, "use", "tool", "*") || agentHasMaterializedCapability(agentId, "use", "tool", "*")) &&
+      (agentCan(agentId, "execute", "executable", "*") ||
+        agentHasMaterializedCapability(agentId, "execute", "executable", "*")))
   );
 }
 
 function hasUnrestrictedToolSurface(agentId: string): boolean {
-  return agentCan(agentId, "admin", "system", "*") || agentCan(agentId, "use", "tool", "*");
+  return (
+    agentCan(agentId, "admin", "system", "*") ||
+    agentHasMaterializedCapability(agentId, "admin", "system", "*") ||
+    agentCan(agentId, "use", "tool", "*") ||
+    agentHasMaterializedCapability(agentId, "use", "tool", "*")
+  );
 }
 
 export function getRuntimeToolAccessMode(
   capabilities: RuntimeCapabilities,
   agentId: string,
-  context?: Pick<ContextRecord, "kind" | "metadata">,
+  context?: Pick<ContextRecord, "kind" | "metadata" | "capabilities">,
 ): RuntimeToolAccessMode {
+  const accessRequirement = capabilities.tools?.accessRequirement ?? capabilities.toolAccessRequirement;
   if (context && isDelegatedAuthorityContext(context)) {
-    return "restricted";
+    if (accessRequirement === "tool_surface") {
+      return capabilitySnapshotHasUnrestrictedToolSurface(context.capabilities) ? "unrestricted" : "restricted";
+    }
+    return capabilitySnapshotHasUnrestrictedToolExecution(context.capabilities) ? "unrestricted" : "restricted";
   }
 
-  const accessRequirement = capabilities.tools?.accessRequirement ?? capabilities.toolAccessRequirement;
   if (accessRequirement === "tool_surface") {
     return hasUnrestrictedToolSurface(agentId) ? "unrestricted" : "restricted";
   }

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -41,6 +41,25 @@ describe("runtime request context authority", () => {
     stateDir = null;
   });
 
+  it("treats agent runtime full-access defaults as unrestricted tool access", () => {
+    dbCreateAgent({ id: "pi-agent", cwd: "/tmp/pi-agent" });
+    dbUpdateAgent("pi-agent", { defaults: { runtimePermissions: { profile: "full-access" } } });
+
+    expect(getRuntimeToolAccessMode({} as Parameters<typeof getRuntimeToolAccessMode>[0], "pi-agent")).toBe(
+      "unrestricted",
+    );
+  });
+
+  it("treats full-access agent identity turn contexts as unrestricted tool access", () => {
+    expect(
+      getRuntimeToolAccessMode({} as Parameters<typeof getRuntimeToolAccessMode>[0], "pi-agent", {
+        kind: "turn-runtime",
+        capabilities: [{ permission: "admin", objectType: "system", objectId: "*" }],
+        metadata: { authorityMode: "agent-identity" },
+      }),
+    ).toBe("unrestricted");
+  });
+
   it("uses agent identity authority by default when the env var is unset", () => {
     const previous = process.env.RAVI_TURN_SCOPED_AUTHORITY;
     delete process.env.RAVI_TURN_SCOPED_AUTHORITY;

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -21,7 +21,6 @@ import {
   type RuntimeUserMessage,
 } from "./host-session.js";
 import type { ChannelContext, RuntimeLaunchPrompt } from "./message-types.js";
-import { shouldUseTurnScopedAuthorityForPrompt } from "./runtime-request-context.js";
 import { buildRuntimeStartRequest, resolveRuntimePromptSource } from "./runtime-request-builder.js";
 import { resolveRuntimeSession } from "./session-resolver.js";
 import { markRuntimeTaskAcceptedForPrompt, resolveRuntimeForPrompt } from "./task-runtime-context.js";
@@ -236,9 +235,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     assertRuntimeCompatibility(runtimeProvider, {
       requiresMcpServers: !!agent.specMode,
       requiresRemoteSpawn: !!agent.remote,
-      toolAccessMode: shouldUseTurnScopedAuthorityForPrompt(prompt, resolvedSource)
-        ? "restricted"
-        : getRuntimeToolAccessMode(runtimeCapabilities, agent.id),
+      toolAccessMode: getRuntimeToolAccessMode(runtimeCapabilities, agent.id),
     });
 
     const resumableProviderSessionId = canResumeStoredSession ? storedProviderSessionId : undefined;


### PR DESCRIPTION
## Summary
- honor materialized agent runtime defaults when deciding runtime tool access
- allow full-access agent-identity turn contexts to satisfy provider-native runtime preflight
- stop forcing Pi provider compatibility checks to restricted before consulting agent permissions

## Why
Pi provider owns tools in the RPC MVP and must reject restricted tool access. Agents configured with `ravi agents permissions <id> full-access` were still blocked because the launcher forced the compatibility check into restricted mode before consulting the agent permissions.

## Tests
- `bun test src/runtime/runtime-request-context.test.ts --test-name-pattern "full-access"`
- `bun test src/runtime/runtime-request-context.test.ts src/runtime/index.test.ts src/runtime/pi-provider.test.ts src/runtime/provider-contract.test.ts src/permissions/provider-runtime.test.ts src/permissions/capability-context.test.ts`
- `bun run typecheck`

## Runtime smoke
- SDE `antigravity-pi` isolated session reached Pi adapter and completed with `antigravity-ok`.

## Note
- Full local pre-push suite was blocked by unrelated task/project profile catalog failures in the SDE environment (`default` task profile missing from system profile list). The runtime/Pi focused suites above passed.
