### PR TITLE
fix(runtime): bound provider recovery and cleanup

### DIFF
--- a/docs/runtime-provider-contract.md
+++ b/docs/runtime-provider-contract.md
@@ -37,6 +37,7 @@ Providers own:
 
 - translating `RuntimeStartRequest` into the provider transport
 - normalizing native transport output into `RuntimeEvent`
+- releasing provider-owned transports and subprocesses through the runtime session handle
 - declaring capability support through `RuntimeCapabilities`
 - exposing optional controls such as interrupt, model switch, or thread controls
 
@@ -97,6 +98,13 @@ Message edits require current-session rebase: replace the edited prompt atom, pr
 - `remoteSpawn`
 
 Unsupported fields are omitted before calling the provider based on capabilities.
+
+## Session Handle Lifecycle
+
+`RuntimeSessionHandle` owns the live provider resources for one Ravi runtime session. Providers that open
+subprocesses, sockets, SDK queries, or other external transports must implement idempotent `close()` cleanup.
+The host calls `close()` and closes the event iterator before releasing the session slot or starting recovery.
+Provider cleanup must not depend exclusively on natural exhaustion of the event iterator.
 
 ## Request Assembly Boundary
 

--- a/src/runtime/claude-provider.test.ts
+++ b/src/runtime/claude-provider.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeEvent, RuntimeStartRequest } from "./types.js";
 let nextMessages: any[] = [];
 let queryCalls: Array<{ prompt: unknown; options: Record<string, unknown> }> = [];
 let querySetModelCalls: Array<string | undefined> = [];
+let queryCloseCalls = 0;
 let queryGate: Promise<void> | null = null;
 let releaseQueryGate: (() => void) | null = null;
 
@@ -26,6 +27,10 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       interrupt: async () => {},
       setModel: async (model?: string) => {
         querySetModelCalls.push(model);
+      },
+      close: () => {
+        queryCloseCalls++;
+        releaseQueryGate?.();
       },
       async *[Symbol.asyncIterator]() {
         if (queryGate) {
@@ -94,6 +99,7 @@ describe("createClaudeRuntimeProvider", () => {
     nextMessages = [];
     queryCalls = [];
     querySetModelCalls = [];
+    queryCloseCalls = 0;
     queryGate = null;
     releaseQueryGate = null;
     if (tempDir) {
@@ -122,6 +128,35 @@ describe("createClaudeRuntimeProvider", () => {
 
     const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
     expect(settings.PermissionRequest[0].matcher).toBe("*");
+  });
+
+  it("closes the active Claude SDK query idempotently", async () => {
+    nextMessages = [{ type: "result", subtype: "success", session_id: "claude-session-close" }];
+    queryGate = new Promise<void>((resolve) => {
+      releaseQueryGate = resolve;
+    });
+
+    const provider = createClaudeRuntimeProvider();
+    const session = provider.startSession(
+      makeStartRequest(
+        (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "close" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+        })(),
+      ),
+    );
+
+    const eventsPromise = collectEvents(session.events);
+    await waitFor(() => queryCalls.length === 1);
+    await session.close?.();
+    await session.close?.();
+    await eventsPromise;
+
+    expect(queryCloseCalls).toBe(1);
   });
 
   it("normalizes assistant/tool/result events", async () => {

--- a/src/runtime/claude-provider.ts
+++ b/src/runtime/claude-provider.ts
@@ -119,6 +119,11 @@ export function createClaudeRuntimeProvider(): ClaudeRuntimeProvider {
         interrupt: async () => {
           await activeQuery?.interrupt();
         },
+        close: async () => {
+          const queryResult = activeQuery;
+          activeQuery = null;
+          queryResult?.close();
+        },
         setModel: async (model: string) => {
           currentModel = model;
           if (activeQuery) {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -95,6 +95,27 @@ function findEventsByType<T extends RuntimeEvent["type"]>(
 const CODEX_DYNAMIC_TOOL_DISABLED_TEXT = "No Ravi dynamic tool handler is available for this Codex request.";
 
 describe("createCodexRuntimeProvider", () => {
+  it("exposes explicit transport cleanup on the runtime session handle", async () => {
+    let closeCalls = 0;
+    const provider = createCodexRuntimeProvider({
+      transport: {
+        startTurn() {
+          throw new Error("turn should not start");
+        },
+        close: async () => {
+          closeCalls++;
+        },
+      } as any,
+      defaultModel: "gpt-5",
+    });
+
+    const runtimeSession = provider.startSession(makeStartRequest([]));
+    await runtimeSession.close?.();
+    await runtimeSession.close?.();
+
+    expect(closeCalls).toBe(1);
+  });
+
   it("synchronizes plugin-backed skills during provider bootstrap", () => {
     const synced: Array<{ type: "local"; path: string }> = [];
     const provider = createCodexRuntimeProvider({
@@ -290,6 +311,96 @@ rl.on("line", (line) => {
     expect(threadRequests[0]?.params.dynamicTools).toBeNull();
   });
 
+  it("recovers a resumed multi-agent sub-agent thread into a fresh top-level thread", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-sub-agent-resume-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    const requestsPath = join(cwd, "requests.jsonl");
+
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const requestsPath = ${JSON.stringify(requestsPath)};
+const rl = createInterface({ input: process.stdin });
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") return;
+  if (message.id && message.method === "thread/resume") {
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    send({ id: message.id, result: { thread: { id: message.params.threadId }, model: "gpt-5", modelProvider: "openai" } });
+    return;
+  }
+  if (message.id && message.method === "thread/start") {
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    send({ id: message.id, result: { thread: { id: "thread_top_level" }, model: "gpt-5", modelProvider: "openai" } });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    if (message.params.threadId === "thread_sub_agent") {
+      send({
+        id: message.id,
+        error: { code: -32600, message: "direct app-server input is not allowed for multi-agent v2 sub-agents" },
+      });
+      return;
+    }
+    send({ id: message.id, result: {} });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: "thread_top_level", turn: { id: "turn_recovered", status: "inProgress" } },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "thread_top_level", turn: { id: "turn_recovered", status: "completed" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(
+      makeStartRequest(["recover"], {
+        cwd,
+        resume: "thread_sub_agent",
+      }),
+    );
+
+    const events = await collectEvents(session.events);
+    const requests = readFileSync(requestsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+      "thread/start",
+      "turn/start",
+    ]);
+    expect(requests[1]?.params.threadId).toBe("thread_sub_agent");
+    expect(requests[3]?.params.threadId).toBe("thread_top_level");
+    expect(findEventsByType(events, "turn.complete")).toEqual([
+      expect.objectContaining({ providerSessionId: "thread_top_level" }),
+    ]);
+    expect(
+      findEventsByType(events, "provider.raw").some(
+        (event) => (event.rawEvent as { type?: string })?.type === "thread.resume_recovered",
+      ),
+    ).toBe(true);
+  });
+
   it("passes max/ultra effort as model_reasoning_effort in app-server thread/start and thread/resume", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-effort-appserver-"));
     const command = join(cwd, "fake-codex-app-server.mjs");
@@ -434,36 +545,45 @@ rl.on("line", (line) => {
     const envPath = join(cwd, "env.jsonl");
     writeFileSync(
       command,
-      `#!/usr/bin/env node
+      `#!/usr/bin/env bun
 import { appendFileSync } from "node:fs";
-import { createInterface } from "node:readline";
 
 appendFileSync(${JSON.stringify(envPath)}, JSON.stringify({
   RAVI_CONTEXT_KEY: process.env.RAVI_CONTEXT_KEY,
   RAVI_SESSION_NAME: process.env.RAVI_SESSION_NAME,
 }) + "\\n");
 
-const rl = createInterface({ input: process.stdin });
-const send = (message) => {
-  process.stdout.write(JSON.stringify(message) + "\\n");
-};
-
-rl.on("line", (line) => {
-  const message = JSON.parse(line);
-  if (message.id && message.method === "initialize") {
-    send({ id: message.id, result: {} });
-    return;
-  }
-  if (message.method === "initialized") return;
-  if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
-    send({ id: message.id, result: { thread: { id: "thread_env_refresh" }, model: "gpt-5.4", modelProvider: "openai" } });
-    return;
-  }
-  if (message.id && message.method === "turn/start") {
-    send({ id: message.id, result: {} });
-    send({ jsonrpc: "2.0", method: "turn/started", params: { threadId: "thread_env_refresh", turn: { id: "turn_env_refresh", status: "inProgress" } } });
-    send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: "thread_env_refresh", turn: { id: "turn_env_refresh", status: "completed" } } });
-  }
+const send = (ws, message) => ws.send(JSON.stringify(message));
+const server = Bun.serve({
+  port: 0,
+  fetch(request, server) {
+    if (server.upgrade(request)) return;
+    return new Response("upgrade required", { status: 426 });
+  },
+  websocket: {
+    message(ws, payload) {
+      const message = JSON.parse(String(payload));
+      if (message.id && message.method === "initialize") {
+        send(ws, { id: message.id, result: {} });
+        return;
+      }
+      if (message.method === "initialized") return;
+      if (message.id && (message.method === "thread/start" || message.method === "thread/resume")) {
+        send(ws, { id: message.id, result: { thread: { id: "thread_env_refresh" }, model: "gpt-5.4", modelProvider: "openai" } });
+        return;
+      }
+      if (message.id && message.method === "turn/start") {
+        send(ws, { id: message.id, result: {} });
+        send(ws, { jsonrpc: "2.0", method: "turn/started", params: { threadId: "thread_env_refresh", turn: { id: "turn_env_refresh", status: "inProgress" } } });
+        send(ws, { jsonrpc: "2.0", method: "turn/completed", params: { threadId: "thread_env_refresh", turn: { id: "turn_env_refresh", status: "completed" } } });
+      }
+    },
+  },
+});
+process.stderr.write("listening on: ws://127.0.0.1:" + server.port + "\\n");
+process.on("SIGTERM", () => {
+  server.stop(true);
+  process.exit(0);
 });
 `,
     );
@@ -471,7 +591,7 @@ rl.on("line", (line) => {
 
     const env = {
       PATH: process.env.PATH ?? "",
-      RAVI_CODEX_TRANSPORT: "stdio",
+      RAVI_CODEX_TRANSPORT: "websocket",
       RAVI_CONTEXT_KEY: "rctx_first",
       RAVI_SESSION_NAME: "dev",
     };

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -62,6 +62,7 @@ import { createRuntimeTerminalEventTracker } from "./terminality.js";
 const DEFAULT_CODEX_MODEL = "gpt-5";
 const INTERRUPT_GRACE_MS = 1_500;
 const CODEX_APP_SERVER_SANDBOX = "danger-full-access";
+const CODEX_SUB_AGENT_DIRECT_INPUT_ERROR = "direct app-server input is not allowed for multi-agent v2 sub-agents";
 const RAVI_CODEX_BASH_HOOK_STATUS = "ravi codex bash permission gate";
 const RAVI_CODEX_TOOL_HOOK_STATUS = "ravi codex native tool permission gate";
 const RAVI_CODEX_TOOL_HOOK_MATCHER = buildCodexNativeToolHookMatcher();
@@ -142,6 +143,11 @@ interface CodexCliTransport {
   startTurn(input: CodexCliTurnRequest): CodexCliTurnHandle;
   control?(request: RuntimeControlRequest): Promise<RuntimeControlResult>;
   close?(): Promise<void>;
+}
+
+function isCodexSubAgentDirectInputError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes(CODEX_SUB_AGENT_DIRECT_INPUT_ERROR);
 }
 
 interface CodexSessionState {
@@ -263,6 +269,13 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
     },
     startSession(input) {
       const transport = options.transport ?? createCodexAppServerTransport({ command: options.command });
+      let closePromise: Promise<void> | null = null;
+      const closeTransport = (): Promise<void> => {
+        closePromise ??= (async () => {
+          await transport.close?.();
+        })();
+        return closePromise;
+      };
       const state: CodexSessionState = {
         activeTurn: null,
         interrupted: false,
@@ -279,6 +292,7 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
           defaultModel,
           state,
           skillVisibilityByCwd.get(input.cwd)?.syncedSkillNames ?? [],
+          closeTransport,
         ),
         interrupt: async () => {
           if (!state.activeTurn) {
@@ -287,6 +301,7 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
           state.interrupted = true;
           await state.activeTurn.interrupt();
         },
+        close: closeTransport,
         control: async (request) => {
           if (transport.control) {
             return transport.control(request);
@@ -534,6 +549,7 @@ async function* normalizeCodexEvents(
   defaultModel: string,
   state: CodexSessionState,
   syncedSkillNames: string[],
+  closeTransport: () => Promise<void>,
 ): AsyncGenerator<RuntimeEvent> {
   let previousSessionId = resolveCodexResumeId(input.resumeSession, input.resume, input.cwd);
   const outerAbortSignal = input.abortController.signal;
@@ -858,7 +874,7 @@ async function* normalizeCodexEvents(
       }
     }
   } finally {
-    await transport.close?.();
+    await closeTransport();
   }
 }
 
@@ -894,6 +910,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
   let activeTurn: AppServerTurnState | null = null;
   let activeSpawnEnvSignature: string | null = null;
   let intentionalChildRestart = false;
+  let closePromise: Promise<void> | null = null;
 
   const clearForcedKillTimer = () => {
     if (forcedKillTimer) {
@@ -1554,6 +1571,51 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     }
   }
 
+  async function bootstrapThread(input: CodexCliTurnRequest, resumeThreadId: string | null): Promise<void> {
+    const effort = toCodexRuntimeEffort(input.effort);
+    if (!resumeThreadId) {
+      // Do not let a rejected resumed thread leak into the fresh-thread fallback.
+      currentThreadId = undefined;
+    }
+
+    const threadResponse = resumeThreadId
+      ? await sendRequest("thread/resume", {
+          threadId: resumeThreadId,
+          model: input.model ?? null,
+          modelProvider: null,
+          cwd: input.cwd,
+          approvalPolicy: "never",
+          sandbox: CODEX_APP_SERVER_SANDBOX,
+          config: { model_reasoning_effort: effort },
+          baseInstructions: null,
+          developerInstructions: input.systemPromptAppend || null,
+          dynamicTools: null,
+          personality: null,
+          persistExtendedHistory: false,
+        })
+      : await sendRequest("thread/start", {
+          model: input.model ?? null,
+          modelProvider: null,
+          cwd: input.cwd,
+          approvalPolicy: "never",
+          sandbox: CODEX_APP_SERVER_SANDBOX,
+          config: { model_reasoning_effort: effort },
+          serviceName: null,
+          baseInstructions: null,
+          developerInstructions: input.systemPromptAppend || null,
+          dynamicTools: null,
+          personality: null,
+          ephemeral: false,
+          experimentalRawEvents: false,
+          persistExtendedHistory: false,
+        });
+
+    currentThreadId = firstString(asRecord(threadResponse.thread)?.id, currentThreadId, resumeThreadId ?? undefined);
+    currentInstructionSources = stringArray(threadResponse.instructionSources);
+    resolvedModel = firstString(threadResponse.model, input.model) ?? null;
+    resolvedModelProvider = firstString(threadResponse.modelProvider, resolvedModelProvider) ?? "openai";
+  }
+
   async function ensureClient(input: CodexCliTurnRequest): Promise<void> {
     const nextEnvSignature = buildCodexAppServerEnvSignature(input.env);
     if (!closed && child && !bootstrapPromise && activeSpawnEnvSignature !== nextEnvSignature) {
@@ -1600,44 +1662,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
           params: {},
         });
 
-        const resumeThreadId = currentThreadId ?? input.resume;
-        const effort = toCodexRuntimeEffort(input.effort);
-        const threadResponse = resumeThreadId
-          ? await sendRequest("thread/resume", {
-              threadId: resumeThreadId,
-              model: input.model ?? null,
-              modelProvider: null,
-              cwd: input.cwd,
-              approvalPolicy: "never",
-              sandbox: CODEX_APP_SERVER_SANDBOX,
-              config: { model_reasoning_effort: effort },
-              baseInstructions: null,
-              developerInstructions: input.systemPromptAppend || null,
-              dynamicTools: null,
-              personality: null,
-              persistExtendedHistory: false,
-            })
-          : await sendRequest("thread/start", {
-              model: input.model ?? null,
-              modelProvider: null,
-              cwd: input.cwd,
-              approvalPolicy: "never",
-              sandbox: CODEX_APP_SERVER_SANDBOX,
-              config: { model_reasoning_effort: effort },
-              serviceName: null,
-              baseInstructions: null,
-              developerInstructions: input.systemPromptAppend || null,
-              dynamicTools: null,
-              personality: null,
-              ephemeral: false,
-              experimentalRawEvents: false,
-              persistExtendedHistory: false,
-            });
-
-        currentThreadId = firstString(asRecord(threadResponse.thread)?.id, resumeThreadId);
-        currentInstructionSources = stringArray(threadResponse.instructionSources);
-        resolvedModel = firstString(threadResponse.model, input.model) ?? null;
-        resolvedModelProvider = firstString(threadResponse.modelProvider, resolvedModelProvider) ?? "openai";
+        await bootstrapThread(input, currentThreadId ?? input.resume ?? null);
       } finally {
         bootstrapPromise = null;
       }
@@ -1646,27 +1671,35 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     await bootstrapPromise;
   }
 
-  const close = async () => {
+  const close = (): Promise<void> => {
+    if (closePromise) {
+      return closePromise;
+    }
     if (!child || closed) {
-      return;
+      return Promise.resolve();
     }
     const targetChild = child;
-    targetChild.stdin?.end();
-    signalCodexTransportProcess(targetChild, "SIGTERM");
-    forcedKillTimer = setTimeout(() => {
-      if (child === targetChild && !closed) {
-        signalCodexTransportProcess(targetChild, "SIGKILL");
-      }
-    }, INTERRUPT_GRACE_MS);
-    forcedKillTimer.unref?.();
+    closePromise = (async () => {
+      transport?.closeChannel();
+      signalCodexTransportProcess(targetChild, "SIGTERM");
+      forcedKillTimer = setTimeout(() => {
+        if (child === targetChild && !closed) {
+          signalCodexTransportProcess(targetChild, "SIGKILL");
+        }
+      }, INTERRUPT_GRACE_MS);
+      forcedKillTimer.unref?.();
 
-    await new Promise<void>((resolve) => {
-      if (closed || child !== targetChild) {
-        resolve();
-        return;
-      }
-      targetChild.once("close", () => resolve());
+      await new Promise<void>((resolve) => {
+        if (closed || child !== targetChild) {
+          resolve();
+          return;
+        }
+        targetChild.once("close", () => resolve());
+      });
+    })().finally(() => {
+      closePromise = null;
     });
+    return closePromise;
   };
 
   return {
@@ -1695,29 +1728,55 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
       void (async () => {
         try {
           await ensureClient(input);
-          turn.threadId = currentThreadId ?? input.resume;
-          if (!turn.threadId) {
-            throw new Error("Codex app-server did not initialize a thread");
+          const requestTurnStart = async () => {
+            turn.threadId = currentThreadId ?? input.resume;
+            if (!turn.threadId) {
+              throw new Error("Codex app-server did not initialize a thread");
+            }
+            await sendRequest("turn/start", {
+              threadId: turn.threadId,
+              input: [
+                {
+                  type: "text",
+                  text: input.prompt,
+                  text_elements: [],
+                },
+              ],
+              cwd: null,
+              approvalPolicy: null,
+              sandboxPolicy: null,
+              model: null,
+              effort: input.effort ?? null,
+              summary: null,
+              personality: null,
+              outputSchema: null,
+              collaborationMode: null,
+            });
+          };
+
+          try {
+            await requestTurnStart();
+          } catch (error) {
+            if (!turn.threadId || turn.turnId || !isCodexSubAgentDirectInputError(error)) {
+              throw error;
+            }
+
+            const rejectedThreadId = turn.threadId;
+            log.warn("codex resumed sub-agent thread rejected direct input; starting a fresh top-level thread", {
+              rejectedThreadId,
+            });
+            await bootstrapThread(input, null);
+            if (!currentThreadId || currentThreadId === rejectedThreadId) {
+              throw new Error("Codex app-server did not initialize a fresh top-level thread", { cause: error });
+            }
+            turn.queue.push({
+              type: "thread.resume_recovered",
+              source: "codex.app-server",
+              rejected_thread_id: rejectedThreadId,
+              thread_id: currentThreadId,
+            });
+            await requestTurnStart();
           }
-          await sendRequest("turn/start", {
-            threadId: turn.threadId,
-            input: [
-              {
-                type: "text",
-                text: input.prompt,
-                text_elements: [],
-              },
-            ],
-            cwd: null,
-            approvalPolicy: null,
-            sandboxPolicy: null,
-            model: null,
-            effort: input.effort ?? null,
-            summary: null,
-            personality: null,
-            outputSchema: null,
-            collaborationMode: null,
-          });
         } catch (error) {
           settleTurn(turn, { exitCode: 1, stderr: getStderr().slice(turn.stderrOffset) }, { failQueue: error });
           if (child && !closed) {

--- a/src/runtime/codex-transport.ts
+++ b/src/runtime/codex-transport.ts
@@ -191,6 +191,7 @@ export function createWebsocketTransport(opts: CodexTransportSpawnOptions): Code
   let ws: WebSocket | null = null;
   let resolvedUrl: string | undefined;
   let readySettled = false;
+  let closeRequested = false;
   let transportErrorNotified = false;
   let readyResolve: () => void = () => {};
   let readyReject: (error: Error) => void = () => {};
@@ -261,7 +262,7 @@ export function createWebsocketTransport(opts: CodexTransportSpawnOptions): Code
       notifyTransportError(new Error(`codex websocket error: ${message}`));
     };
     ws.onclose = (event: CloseEvent) => {
-      if (readySettled && spawned.killed) return;
+      if (closeRequested || (readySettled && spawned.killed)) return;
       // Unclean close while child still alive: surface as transport error so
       // the caller can settle the active turn.
       const error = new Error(`codex websocket closed (code=${event.code}, reason=${event.reason || "n/a"})`);
@@ -299,6 +300,7 @@ export function createWebsocketTransport(opts: CodexTransportSpawnOptions): Code
     getStderr: () => state.stderr,
     getStderrOffset: () => state.stderrOffset,
     closeChannel: () => {
+      closeRequested = true;
       clearTimeout(readyTimer);
       try {
         ws?.close();

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -78,6 +78,7 @@ const MAX_TURN_FAILURE_RESPONSE = 320;
 const PROVIDER_INACTIVE_AFTER_TOOL_REASON = "provider_inactive";
 const PROVIDER_TURN_INACTIVITY_REASON = "provider_turn_inactive";
 const IDLE_SESSION_TTL_REASON = "idle_session_ttl";
+const RUNTIME_SESSION_CLOSE_TIMEOUT_MS = 5_000;
 const USER_FACING_LIMIT_SUPPRESSION_DEFAULT_MS = 60 * 60_000;
 const USER_FACING_LIMIT_SUPPRESSION_MAX_MS = 24 * 60 * 60_000;
 const USER_FACING_LIMIT_SUPPRESSION_RESET_GRACE_MS = 60_000;
@@ -1157,6 +1158,61 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
   };
 
   const runtimeEventIterator = runtimeSession.events[Symbol.asyncIterator]();
+  let runtimeSessionClosePromise: Promise<void> | null = null;
+  const closeRuntimeSession = (): Promise<void> => {
+    if (runtimeSessionClosePromise) {
+      return runtimeSessionClosePromise;
+    }
+
+    const closeResources = async () => {
+      await Promise.all([
+        (async () => {
+          try {
+            await runtimeSession.close?.();
+          } catch (error) {
+            log.warn("Failed to close runtime session handle", {
+              runId,
+              sessionName,
+              provider: runtimeSession.provider,
+              error,
+            });
+          }
+        })(),
+        (async () => {
+          try {
+            await runtimeEventIterator.return?.();
+          } catch (error) {
+            log.warn("Failed to close runtime event iterator", {
+              runId,
+              sessionName,
+              provider: runtimeSession.provider,
+              error,
+            });
+          }
+        })(),
+      ]);
+    };
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    runtimeSessionClosePromise = Promise.race([
+      closeResources(),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(() => {
+          log.warn("Timed out closing runtime session resources", {
+            runId,
+            sessionName,
+            provider: runtimeSession.provider,
+            timeoutMs: RUNTIME_SESSION_CLOSE_TIMEOUT_MS,
+          });
+          resolve();
+        }, RUNTIME_SESSION_CLOSE_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]).finally(() => {
+      if (timeout) clearTimeout(timeout);
+    });
+    return runtimeSessionClosePromise;
+  };
   const readNextRuntimeEvent = async (): Promise<IteratorResult<RuntimeEvent>> => {
     const nextEvent = runtimeEventIterator.next();
     let interval: ReturnType<typeof setInterval> | undefined;
@@ -1185,13 +1241,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         if (!streaming.abortController.signal.aborted) {
           streaming.abortController.abort();
         }
-        Promise.resolve(runtimeEventIterator.return?.()).catch((error) => {
-          log.warn("Failed to close inactive provider event iterator", {
-            runId,
-            sessionName,
-            error,
-          });
-        });
+        void closeRuntimeSession();
         resolve({ done: true, value: undefined as never });
       }, PROVIDER_TURN_INACTIVITY_CHECK_MS);
       interval.unref?.();
@@ -2292,6 +2342,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     if (!streaming.abortController.signal.aborted) {
       streaming.abortController.abort();
     }
+    await closeRuntimeSession();
 
     if (streamingSessions.delete(sessionName)) {
       completeRuntimeCredentialAttempt(streaming.currentRuntimeCredential?.attemptId, {

--- a/src/runtime/pi-provider.test.ts
+++ b/src/runtime/pi-provider.test.ts
@@ -25,6 +25,7 @@ class FakePiRpcTransport implements PiRpcTransport {
 
   responseFor?: (command: PiRpcCommand) => PiRpcResponse | Promise<PiRpcResponse> | undefined;
   closed = false;
+  closeCalls = 0;
 
   async start(input: PiRpcStartInput): Promise<void> {
     this.starts.push(input);
@@ -41,6 +42,7 @@ class FakePiRpcTransport implements PiRpcTransport {
 
   async close(): Promise<void> {
     this.closed = true;
+    this.closeCalls++;
   }
 
   pushEvent(event: PiRpcEvent): void {
@@ -76,6 +78,16 @@ describe("Pi runtime provider", () => {
         guarantee: "adapter",
       },
     });
+  });
+
+  it("closes the Pi RPC transport idempotently", async () => {
+    const transport = new FakePiRpcTransport();
+    const handle = createPiRuntimeProvider({ transport }).startSession(createStartRequest("close"));
+
+    await handle.close?.();
+    await handle.close?.();
+
+    expect(transport.closeCalls).toBe(1);
   });
 
   it("normalizes a successful Pi RPC run into canonical runtime events", async () => {

--- a/src/runtime/pi-provider.ts
+++ b/src/runtime/pi-provider.ts
@@ -251,6 +251,11 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
             await safePiCommand(transport, { type: "abort" });
           }
         },
+        close: async () => {
+          const transport = state.transport;
+          state.transport = undefined;
+          await transport?.close();
+        },
         setModel: async (model) => {
           const parsed = parsePiModelSelector(model);
           await sendPiCommand(requireTransport(), {

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -204,6 +204,50 @@ describe("RuntimeSessionDispatcher debounce", () => {
   });
 });
 
+describe("RuntimeSessionDispatcher runtime recovery", () => {
+  it("stops replaying a stashed turn after repeated event-loop closures", async () => {
+    const emitted: Array<{ topic: string; data: Record<string, unknown> }> = [];
+    const dispatcher = new RuntimeSessionDispatcher({
+      instanceId: "test",
+      maxConcurrentSessions: 10,
+      interactiveReservedSessions: 0,
+      safeEmit: async (topic, data) => {
+        emitted.push({ topic, data });
+      },
+      getConfigModel: () => "test-model",
+    });
+    dispatcher.stashedMessages.set("recovery-loop", [
+      createQueuedRuntimeUserMessage({
+        prompt: "retry me",
+        _agentId: "main",
+      }),
+    ]);
+
+    let starts = 0;
+    dispatcher.startStreamingSession = mock(async () => {
+      starts++;
+    });
+    const recovery = dispatcher as unknown as {
+      restartStashedSession(sessionName: string, reason: string): Promise<void>;
+    };
+
+    await recovery.restartStashedSession("recovery-loop", "runtime_event_loop_closed");
+    await recovery.restartStashedSession("recovery-loop", "runtime_event_loop_closed");
+    await recovery.restartStashedSession("recovery-loop", "runtime_event_loop_closed");
+
+    expect(starts).toBe(2);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      topic: "ravi.session.recovery-loop.runtime",
+      data: {
+        type: "dispatch.restart_suppressed",
+        reason: "runtime_event_loop_closed",
+        restartAttempts: 2,
+      },
+    });
+  });
+});
+
 describe("RuntimeSessionDispatcher native runtime steer", () => {
   function createStreamingSession(overrides: Partial<RuntimeHostStreamingSession> = {}): RuntimeHostStreamingSession {
     return {

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -31,7 +31,7 @@ import {
 import { applyDirectRuntimeModelSwitch, resolveRuntimeModelSwitchStrategy } from "./model-switch.js";
 import { DEFAULT_RUNTIME_PROVIDER_ID } from "./provider-registry.js";
 import type { RuntimeProviderId } from "./types.js";
-import type { RuntimeSafeEmit } from "./host-event-loop.js";
+import { formatUserFacingTurnFailure, type RuntimeSafeEmit } from "./host-event-loop.js";
 import { markRuntimeLiveIdle, updateRuntimeLiveState } from "./live-state.js";
 import {
   startRuntimeSession,
@@ -39,6 +39,7 @@ import {
   type PendingRuntimeSessionStart,
 } from "./session-launcher.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { resolveSessionOutputTarget } from "./session-output-target.js";
 import { resolveRuntimeForPrompt, runtimePromptRequiresRestart } from "./task-runtime-context.js";
 import {
   buildRuntimeSessionPoolSnapshot,
@@ -49,6 +50,10 @@ import {
 } from "./session-pool.js";
 
 const log = logger.child("runtime:session-dispatcher");
+const RUNTIME_EVENT_LOOP_CLOSED_REASON = "runtime_event_loop_closed";
+const MAX_RUNTIME_EVENT_LOOP_RESTARTS = 2;
+const RUNTIME_RESTART_EXHAUSTED_ERROR =
+  "Runtime provider stream closed repeatedly. Automatic recovery was stopped; send a new message to retry.";
 const NATIVE_STEER_ACTIVE_TURN_MAX_IDLE_MS = 30_000;
 const IDLE_GAP_RECOVERY_MS = Math.max(1_000, Number(process.env.RAVI_RUNTIME_IDLE_GAP_RECOVERY_MS) || 5_000);
 
@@ -104,6 +109,7 @@ export class RuntimeSessionDispatcher {
   readonly inFlightStartPrompts = new Map<string, RuntimeLaunchPrompt>();
   readonly pendingStartSessions = new Set<string>();
   readonly startingSessions = new Set<string>();
+  private readonly runtimeEventLoopRestartAttempts = new Map<string, number>();
 
   constructor(private readonly options: RuntimeSessionDispatcherOptions) {}
 
@@ -310,6 +316,7 @@ export class RuntimeSessionDispatcher {
       log.info("Clearing session start reservations", { count: this.startReservations.size });
       this.startReservations.clear();
     }
+    this.runtimeEventLoopRestartAttempts.clear();
 
     if (this.streamingSessions.size === 0) {
       return;
@@ -612,6 +619,9 @@ export class RuntimeSessionDispatcher {
   }
 
   async handlePromptImmediate(sessionName: string, prompt: RuntimeLaunchPrompt): Promise<void> {
+    if (!prompt._resumeStashedMessages) {
+      this.runtimeEventLoopRestartAttempts.delete(sessionName);
+    }
     const routerConfig = configStore.getConfig();
     const sessionEntry = getSessionByName(sessionName);
     const existing = this.streamingSessions.get(sessionName);
@@ -1387,6 +1397,79 @@ export class RuntimeSessionDispatcher {
     }
 
     const traceIdentity = this.resolvePendingStartTraceIdentity(sessionName, prompt);
+    const restartAttempt =
+      reason === RUNTIME_EVENT_LOOP_CLOSED_REASON
+        ? (this.runtimeEventLoopRestartAttempts.get(sessionName) ?? 0) + 1
+        : undefined;
+    if (restartAttempt !== undefined && restartAttempt > MAX_RUNTIME_EVENT_LOOP_RESTARTS) {
+      recordRuntimeTraceEvent({
+        sessionKey: traceIdentity.sessionKey,
+        sessionName,
+        agentId: traceIdentity.agentId ?? prompt._agentId,
+        provider: prompt._runtimeProviderId,
+        eventType: "dispatch.restart_suppressed",
+        eventGroup: "dispatch",
+        status: "blocked",
+        source: prompt.source,
+        messageId: prompt.context?.messageId,
+        error: RUNTIME_RESTART_EXHAUSTED_ERROR,
+        payloadJson: {
+          reason,
+          restartAttempts: MAX_RUNTIME_EVENT_LOOP_RESTARTS,
+          stashedQueueSize: stashed.length,
+          resumeStashedMessages: true,
+        },
+      });
+      updateRuntimeLiveState(sessionName, {
+        activity: "blocked",
+        summary: RUNTIME_RESTART_EXHAUSTED_ERROR,
+        agentId: traceIdentity.agentId ?? prompt._agentId,
+        provider: prompt._runtimeProviderId,
+        source: prompt.source,
+      });
+      await this.options
+        .safeEmit(`ravi.session.${sessionName}.runtime`, {
+          type: "dispatch.restart_suppressed",
+          reason,
+          restartAttempts: MAX_RUNTIME_EVENT_LOOP_RESTARTS,
+          stashedQueueSize: stashed.length,
+          error: RUNTIME_RESTART_EXHAUSTED_ERROR,
+          ...(prompt.source ? { _source: prompt.source } : {}),
+          timestamp: new Date().toISOString(),
+        })
+        .catch((error) => {
+          log.warn("Failed to emit suppressed runtime restart event", { sessionName, reason, error });
+        });
+
+      const outputTarget = resolveSessionOutputTarget({
+        sessionKey: traceIdentity.sessionKey,
+        fallback: prompt.source,
+      }).target;
+      if (outputTarget) {
+        const routerConfig = configStore.getConfig();
+        const agentId = traceIdentity.agentId ?? prompt._agentId;
+        const agent = agentId ? routerConfig.agents[agentId] : undefined;
+        if (agent?.mode !== "sentinel") {
+          await nats
+            .emit(`ravi.session.${sessionName}.response`, {
+              response: formatUserFacingTurnFailure(RUNTIME_RESTART_EXHAUSTED_ERROR),
+              target: outputTarget,
+              _emitId: Math.random().toString(36).slice(2, 8),
+              _instanceId: this.options.instanceId,
+              _pid: process.pid,
+              _v: 2,
+            })
+            .catch((error) => {
+              log.warn("Failed to emit exhausted runtime recovery response", { sessionName, reason, error });
+            });
+        }
+      }
+      return;
+    }
+    if (restartAttempt !== undefined) {
+      this.runtimeEventLoopRestartAttempts.set(sessionName, restartAttempt);
+    }
+
     recordRuntimeTraceEvent({
       sessionKey: traceIdentity.sessionKey,
       sessionName,
@@ -1399,6 +1482,12 @@ export class RuntimeSessionDispatcher {
       messageId: prompt.context?.messageId,
       payloadJson: {
         reason,
+        ...(restartAttempt !== undefined
+          ? {
+              restartAttempt,
+              maxRestartAttempts: MAX_RUNTIME_EVENT_LOOP_RESTARTS,
+            }
+          : {}),
         stashedQueueSize: stashed.length,
         resumeStashedMessages: true,
       },

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -152,12 +152,26 @@ function makeRuntimeSession(events: RuntimeEvent[]): RuntimeSessionHandle {
 }
 
 function makeNeverEndingRuntimeSession(): RuntimeSessionHandle {
+  let resolveClose!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClose = resolve;
+  });
   return {
     provider: PROVIDER,
-    events: (async function* () {
-      await new Promise(() => {});
-    })(),
+    events: {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            await closed;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    },
     interrupt: async () => {},
+    close: async () => {
+      resolveClose();
+    },
   };
 }
 
@@ -1173,6 +1187,48 @@ describe("runtime session trace instrumentation", () => {
       autoRecovered: true,
     });
     expect(getSessionTurn("turn-stream-closed-before-tool")?.status).toBe("aborted");
+  });
+
+  it("closes the provider handle and event iterator when the host session is aborted", async () => {
+    let handleCloseCalls = 0;
+    let iteratorReturnCalls = 0;
+    let releaseHandleClose!: () => void;
+    const handleClosed = new Promise<void>((resolve) => {
+      releaseHandleClose = resolve;
+    });
+    const iterator: AsyncIterator<RuntimeEvent> & AsyncIterable<RuntimeEvent> = {
+      next: () => new Promise<IteratorResult<RuntimeEvent>>(() => {}),
+      return: async () => {
+        iteratorReturnCalls++;
+        return { done: true, value: undefined };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const runtimeSession: RuntimeSessionHandle = {
+      provider: PROVIDER,
+      events: iterator,
+      interrupt: async () => {},
+      close: async () => {
+        handleCloseCalls++;
+        await handleClosed;
+      },
+    };
+    const streaming = makeStreamingSession();
+
+    const loop = runTraceLoop(streaming, runtimeSession);
+    await Promise.resolve();
+    streaming.abortController.abort();
+    for (let attempt = 0; attempt < 20 && iteratorReturnCalls === 0; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    expect(iteratorReturnCalls).toBe(1);
+    releaseHandleClose();
+    await loop;
+
+    expect(handleCloseCalls).toBe(1);
   });
 
   it("does not replay an unterminated turn after a tool has started", async () => {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -516,6 +516,8 @@ export interface RuntimeSessionHandle {
    */
   concurrentInputStrategy?: RuntimeConcurrentInputStrategy;
   interrupt(): Promise<void>;
+  /** Release provider-owned transports and subprocesses when the host session ends. */
+  close?(): Promise<void>;
   setModel?(model: string): Promise<void>;
   control?(request: RuntimeControlRequest): Promise<RuntimeControlResult>;
 }


### PR DESCRIPTION
## Objective
Stabilize provider-backed runtime sessions so they recover from invalid stored threads without leaking transports or entering unbounded restart loops.

## Problem
Codex app-server processes accumulated after sessions ended, intentional WebSocket shutdowns looked like failures, and an incompatible resumed sub-agent thread could leave a session permanently silent. Closed event loops could also trigger repeated automatic restarts.

## Solution
Add an explicit idempotent close contract for Codex, Claude, and Pi handles; run handle and iterator cleanup concurrently with a bounded timeout; recover the exact Codex sub-agent resume failure by creating one fresh top-level thread; classify requested WebSocket closes correctly; and cap event-loop recovery before emitting one terminal failure.

## Practical impact
Runtime process counts remain bounded, main and other sessions can recover from stale incompatible Codex thread state, and terminal provider failures no longer replay indefinitely or spam the user.

## What does NOT change
Provider selection, model selection, normal thread resume behavior, user prompts, channel routing, permission policy, and successful turn delivery semantics remain unchanged.

## Validation
The branch passes `bun run test`, `bun run typecheck`, `bun run build`, SDK drift checks, and the complete pre-push quality gate. Live validation confirmed repeated main turns completed after automatic top-level thread recovery and app-server process counts stayed bounded.

## Risks
Recovery intentionally matches the known Codex sub-agent rejection exactly; a future provider wording change would fail closed instead of silently creating a new thread. Cleanup is time-bounded so a broken provider cannot block session shutdown forever.

## Rollback
Revert commit `a56f3a4` to restore the previous provider lifecycle and dispatcher recovery behavior. No database migration or persistent schema rollback is required.

## Automated review
Automated review integrations may append their status badge below this non-required section.