### PR TITLE
Fix Slack routing ownership fallback

### DIFF
--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -1,5 +1,6 @@
 import { closeAllRaviDbs } from "../db/close-all.js";
 import { closeNats, connectNats } from "../nats.js";
+import { configStore } from "../config-store.js";
 import { logger } from "../utils/logger.js";
 import type { NativePresenceDelivery, NativeTextDelivery } from "./native/types.js";
 import { ChannelOutboundConsumer } from "./outbound-consumer.js";
@@ -68,6 +69,7 @@ export class ChannelRunner {
       explicit: true,
       retry: true,
     });
+    await configStore.startRefresh();
     await ensureChannelOutboundInfrastructure();
 
     this.outboundInfrastructureReady = true;
@@ -114,6 +116,7 @@ export class ChannelRunner {
     this.slackRuntimes = [];
     this.deliveries = [];
     this.presenceDeliveries = [];
+    configStore.stop();
     closeAllRaviDbs();
     await closeNats({ drainTimeoutMs: 2_000 });
     log.info("Channel runner stopped", { pid: process.pid });

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { ensureContactFromInbound } from "../../contacts.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
-import { getOrCreateSession, getSessionByName, listSessionSubscriptions } from "../../router/index.js";
-import { dbFindChatMessage, dbGetChat, getDb } from "../../router/router-db.js";
+import {
+  attachChatToSession,
+  getOrCreateSession,
+  getSessionByName,
+  listSessionSubscriptions,
+} from "../../router/index.js";
+import { dbFindChatMessage, dbGetChat, dbUpsertChat, getDb } from "../../router/router-db.js";
 import type { RouterConfig } from "../../router/types.js";
 import {
   SlackAssistantThreadPresence,
@@ -191,6 +196,105 @@ describe("Slack Socket Mode routing", () => {
     expect(listSessionSubscriptions(session!.sessionKey)).toEqual([
       expect.objectContaining({
         chatId: canonicalChatId,
+        role: "primary",
+        speechMode: "speak",
+      }),
+    ]);
+  });
+
+  it("routes Slack inbound to an existing chat subscription before account-agent fallback", async () => {
+    seedAgent("route-agent", "/tmp/route-agent");
+    seedAgent("owner-agent", "/tmp/owner-agent");
+    const chat = dbUpsertChat({
+      channel: "slack",
+      instanceId: "ravi-rbbt-slack",
+      platformChatId: "C123",
+      chatType: "group",
+      title: "C123",
+      rawProvenance: { source: "test" },
+      seenAt: 1_713_000_000_000,
+    });
+    const ownerSession = getOrCreateSession(
+      "agent:owner-agent:slack:ravi-rbbt-slack:group:C123",
+      "owner-agent",
+      "/tmp/owner-agent",
+      {
+        name: "owner-agent",
+        channel: "slack",
+        accountId: "ravi-rbbt-slack",
+        groupId: "C123",
+        lastChannel: "slack",
+        lastTo: "C123",
+        lastAccountId: "ravi-rbbt-slack",
+      },
+    );
+    attachChatToSession({
+      sessionKey: ownerSession.sessionKey,
+      chatId: chat.id,
+      role: "primary",
+      attachedByType: "system",
+      attachedReason: "test-owner",
+      speechMode: "speak",
+      setOutputTarget: true,
+    });
+
+    const config: RouterConfig = {
+      agents: {
+        "route-agent": {
+          id: "route-agent",
+          cwd: "/tmp/route-agent",
+          dmScope: "per-peer",
+        },
+        "owner-agent": {
+          id: "owner-agent",
+          cwd: "/tmp/owner-agent",
+          dmScope: "per-peer",
+        },
+      },
+      routes: [],
+      defaultAgent: "route-agent",
+      defaultDmScope: "per-peer",
+      accountAgents: { "ravi-rbbt-slack": "route-agent" },
+      instanceToAccount: { "ravi-rbbt-slack": "ravi-rbbt-slack" },
+      instances: {},
+    };
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "ravi-rbbt-slack",
+      getRouterConfig: () => config,
+      publishPrompt: async (sessionName, payload) => {
+        published.push({ sessionName, payload });
+      },
+      webClient: {} as never,
+    });
+
+    await service.handleEnvelope({
+      envelope_id: "env-subscription-owner-1",
+      payload: {
+        team_id: "T1",
+        event_id: "Ev1",
+        event_time: 1_713_000_001,
+        event: {
+          type: "message",
+          channel: "C123",
+          channel_type: "channel",
+          user: "U123",
+          text: "still here?",
+          ts: "1713000001.000100",
+        },
+      },
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.sessionName).toBe("owner-agent");
+    expect(getSessionByName("route-agent")).toBeNull();
+    expect(listSessionSubscriptions(ownerSession.sessionKey)).toEqual([
+      expect.objectContaining({
+        chatId: chat.id,
         role: "primary",
         speechMode: "speak",
       }),

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -202,7 +202,7 @@ describe("Slack Socket Mode routing", () => {
     ]);
   });
 
-  it("routes Slack inbound to an existing chat subscription before account-agent fallback", async () => {
+  it("routes Slack inbound to an existing chat subscription when no route matches", async () => {
     seedAgent("route-agent", "/tmp/route-agent");
     seedAgent("owner-agent", "/tmp/owner-agent");
     const chat = dbUpsertChat({
@@ -254,7 +254,7 @@ describe("Slack Socket Mode routing", () => {
       routes: [],
       defaultAgent: "route-agent",
       defaultDmScope: "per-peer",
-      accountAgents: { "ravi-rbbt-slack": "route-agent" },
+      accountAgents: {},
       instanceToAccount: { "ravi-rbbt-slack": "ravi-rbbt-slack" },
       instances: {},
     };

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -584,24 +584,7 @@ export class SlackSocketModeService {
     const peerKind = slackPeerKindForChannelType(message.channelType);
     const isGroup = peerKind !== "dm";
     const routeThreadId = message.thread.routeThreadTs;
-    let matched = matchRoute(routerConfig, {
-      phone: message.channelId,
-      channel: "slack",
-      accountId: this.options.routeAccountId,
-      isGroup,
-      groupId: isGroup ? message.channelId : undefined,
-      peerKind,
-      threadId: routeThreadId,
-    });
-    if (!matched) {
-      log.info("Slack inbound skipped: no route matched", {
-        accountId: this.options.accountId,
-        channelId: message.channelId,
-        threadId: routeThreadId,
-      });
-      return;
-    }
-
+    const routeAccountId = this.options.routeAccountId ?? this.options.accountId;
     const instanceId = this.options.instanceId ?? this.options.accountId;
     const canonicalChat = dbUpsertChat({
       channel: "slack",
@@ -619,9 +602,18 @@ export class SlackSocketModeService {
       },
       seenAt: message.eventTimeMs,
     });
+    let matched = matchRoute(routerConfig, {
+      phone: message.channelId,
+      channel: "slack",
+      accountId: routeAccountId,
+      isGroup,
+      groupId: isGroup ? message.channelId : undefined,
+      peerKind,
+      threadId: routeThreadId,
+    });
 
     const existingSubscription = findSessionByAttachedChat(canonicalChat.id);
-    if (existingSubscription && existingSubscription.sessionKey !== matched.sessionKey) {
+    if (existingSubscription && (!matched || existingSubscription.sessionKey !== matched.sessionKey)) {
       const ownerSession = getSession(existingSubscription.sessionKey);
       const ownerAgent = ownerSession ? routerConfig.agents[ownerSession.agentId] : undefined;
       const sameInstance = subscriptionAllowsCrossInstance(canonicalChat.id, existingSubscription.sessionKey);
@@ -629,20 +621,20 @@ export class SlackSocketModeService {
         log.warn("Slack subscription override would jump instances - ignoring subscription, using route resolution", {
           chatId: canonicalChat.id,
           subscriptionSessionKey: existingSubscription.sessionKey,
-          routeSessionKey: matched.sessionKey,
+          routeSessionKey: matched?.sessionKey,
         });
       } else if (ownerSession && ownerAgent) {
         log.info("Slack inbound rerouted by session subscription", {
           chatId: canonicalChat.id,
-          fromSessionKey: matched.sessionKey,
+          fromSessionKey: matched?.sessionKey,
           toSessionKey: existingSubscription.sessionKey,
         });
         matched = {
           agentId: ownerSession.agentId,
           agent: ownerAgent,
           sessionKey: existingSubscription.sessionKey,
-          dmScope: matched.dmScope,
-          route: matched.route,
+          dmScope: matched?.dmScope ?? ownerAgent.dmScope ?? routerConfig.defaultDmScope,
+          route: matched?.route,
         } satisfies MatchedRoute;
       } else {
         log.warn("Slack subscription points to a missing session or agent - falling back to route resolution", {
@@ -652,6 +644,14 @@ export class SlackSocketModeService {
           hasAgent: !!ownerAgent,
         });
       }
+    }
+    if (!matched) {
+      log.info("Slack inbound skipped: no route matched", {
+        accountId: routeAccountId,
+        channelId: message.channelId,
+        threadId: routeThreadId,
+      });
+      return;
     }
 
     const resolved = commitMatchedRoute(matched, {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -2,7 +2,15 @@ import { configStore } from "../../config-store.js";
 import { resolvePlatformIdentity } from "../../contacts.js";
 import { publish } from "../../nats.js";
 import { publishSessionPrompt } from "../../omni/session-stream.js";
-import { attachChatToSession, commitMatchedRoute, listSessionSubscriptions, matchRoute } from "../../router/index.js";
+import {
+  attachChatToSession,
+  commitMatchedRoute,
+  findSessionByAttachedChat,
+  getSession,
+  listSessionSubscriptions,
+  matchRoute,
+  subscriptionAllowsCrossInstance,
+} from "../../router/index.js";
 import {
   dbBindSessionToChat,
   dbListChatParticipants,
@@ -11,7 +19,7 @@ import {
   dbUpsertChatParticipant,
   type ChannelConfig,
 } from "../../router/router-db.js";
-import type { RouterConfig } from "../../router/types.js";
+import type { MatchedRoute, RouterConfig } from "../../router/types.js";
 import type { MessageActorMetadata, MessageContext, MessageTarget } from "../../runtime/message-types.js";
 import { transcribeAudio } from "../../transcribe/openai.js";
 import { logger } from "../../utils/logger.js";
@@ -576,7 +584,7 @@ export class SlackSocketModeService {
     const peerKind = slackPeerKindForChannelType(message.channelType);
     const isGroup = peerKind !== "dm";
     const routeThreadId = message.thread.routeThreadTs;
-    const matched = matchRoute(routerConfig, {
+    let matched = matchRoute(routerConfig, {
       phone: message.channelId,
       channel: "slack",
       accountId: this.options.routeAccountId,
@@ -594,14 +602,6 @@ export class SlackSocketModeService {
       return;
     }
 
-    const resolved = commitMatchedRoute(matched, {
-      phone: message.channelId,
-      isGroup,
-      groupId: isGroup ? message.channelId : undefined,
-      peerKind,
-      threadId: routeThreadId,
-    });
-    const sessionName = resolved.sessionName ?? resolved.sessionKey;
     const instanceId = this.options.instanceId ?? this.options.accountId;
     const canonicalChat = dbUpsertChat({
       channel: "slack",
@@ -619,6 +619,49 @@ export class SlackSocketModeService {
       },
       seenAt: message.eventTimeMs,
     });
+
+    const existingSubscription = findSessionByAttachedChat(canonicalChat.id);
+    if (existingSubscription && existingSubscription.sessionKey !== matched.sessionKey) {
+      const ownerSession = getSession(existingSubscription.sessionKey);
+      const ownerAgent = ownerSession ? routerConfig.agents[ownerSession.agentId] : undefined;
+      const sameInstance = subscriptionAllowsCrossInstance(canonicalChat.id, existingSubscription.sessionKey);
+      if (!sameInstance) {
+        log.warn("Slack subscription override would jump instances - ignoring subscription, using route resolution", {
+          chatId: canonicalChat.id,
+          subscriptionSessionKey: existingSubscription.sessionKey,
+          routeSessionKey: matched.sessionKey,
+        });
+      } else if (ownerSession && ownerAgent) {
+        log.info("Slack inbound rerouted by session subscription", {
+          chatId: canonicalChat.id,
+          fromSessionKey: matched.sessionKey,
+          toSessionKey: existingSubscription.sessionKey,
+        });
+        matched = {
+          agentId: ownerSession.agentId,
+          agent: ownerAgent,
+          sessionKey: existingSubscription.sessionKey,
+          dmScope: matched.dmScope,
+          route: matched.route,
+        } satisfies MatchedRoute;
+      } else {
+        log.warn("Slack subscription points to a missing session or agent - falling back to route resolution", {
+          chatId: canonicalChat.id,
+          subscriptionSessionKey: existingSubscription.sessionKey,
+          hasSession: !!ownerSession,
+          hasAgent: !!ownerAgent,
+        });
+      }
+    }
+
+    const resolved = commitMatchedRoute(matched, {
+      phone: message.channelId,
+      isGroup,
+      groupId: isGroup ? message.channelId : undefined,
+      peerKind,
+      threadId: routeThreadId,
+    });
+    const sessionName = resolved.sessionName ?? resolved.sessionKey;
 
     dbBindSessionToChat({
       sessionKey: resolved.sessionKey,


### PR DESCRIPTION
## Objective

Keep Slack native inbound messages attached to the session that already owns the Slack chat, even when the live route/config path is stale or falls back.

## Problem

Workflow-created Slack channels such as `ravi-workflows` and `gh-discussions` could drift into `hana-slack` fallback sessions. Replay used fresh routing and worked, but live Socket Mode could commit a fallback before honoring the existing chat subscription.

## Solution

Start config-store refresh in the standalone channel runner, and change Slack Socket Mode to upsert the canonical chat before final routing. The handler now checks `findSessionByAttachedChat` before accepting a route skip/fallback, lets the valid subscription owner override the route, and falls back from `routeAccountId` to `accountId`.

## Practical impact

Slack messages and uploads in channels that are already attached to dedicated agents stay in their intended sessions. Operators no longer need to manually delete fallback `hana-slack` sessions after route drift.

## What does NOT change

Explicit Slack routes still create sessions normally for new chats without an existing owner. Cross-instance subscription jumps remain blocked, and Slack delivery/presence behavior is unchanged.

## Validation

- `bun test src/channels/slack/socket-mode.test.ts`
- `bun run build`
- pre-push hook passed: SDK drift check, build, typecheck, full test suite, and SDK check
- live smoke verified in Slack for `gh-discussions` and `ravi-workflows` after restarting `ravi` and `ravi-channels`

## Risks

The change relies on the existing session subscription table as the ownership source for Slack chats. A stale or incorrect subscription can still route a chat to that owner, but the existing cross-instance guard prevents jumps across channel instances.

## Rollback

Revert commits `2a8b560` and `c0d5112`, rebuild the bundle, and restart `ravi` plus `ravi-channels`. If needed, delete any fallback sessions created while the reverted code was live.
