### PR TITLE
Report session overrides after agent config changes

### DIFF
--- a/.ravi/specs/agents/CHECKS.md
+++ b/.ravi/specs/agents/CHECKS.md
@@ -21,6 +21,15 @@
 - Assigning a missing or disabled preset MUST fail and MUST NOT fall back to the
   global default silently.
 
+## Agent Set Session Override Checks
+
+- `agents set --json` MUST return a typed `sessionOverrides` array on both
+  changed and idempotent mutations.
+- Every entry MUST use the canonical session name and MUST include only active
+  `model`, `effort`, and `thinking` override fields.
+- Human output MUST list all active overrides and MUST avoid raw channel ids.
+- A mutation with no active session overrides MUST NOT print a warning.
+
 ## Commands
 
 - `bun test src/cli/commands/agents.test.ts`

--- a/.ravi/specs/agents/SPEC.md
+++ b/.ravi/specs/agents/SPEC.md
@@ -50,6 +50,13 @@ An agent is not a human user, contact, chat, route, or permission profile.
   command is direct local operator CLI with no resolved principal.
 - Agent list/show/picker/route-selection surfaces MUST filter by agent
   visibility.
+- Every successful `ravi agents set` response MUST include `sessionOverrides`
+  for all sessions owned by the agent that have active runtime overrides. Each
+  entry MUST use the canonical session name and expose only active `model`,
+  `effort`, and `thinking` fields. Human output MUST warn concisely when the
+  array is non-empty and MUST NOT present raw channel ids as session identity.
+- Idempotent `ravi agents set` mutations MAY return `changed=false`, but MUST
+  still report the current `sessionOverrides` state.
 - Hidden agents SHOULD appear missing on direct lookup.
 - Routes that point to hidden agents MUST NOT disclose hidden agent metadata to
   principals that lack `view agent:<id>`.
@@ -76,6 +83,9 @@ tool execution.
   that lacks `view agent:<id>`.
 - `ravi agents set <id> effort <level>` persists a canonical effort default,
   and `clear` removes it.
+- `ravi agents set <id> <key> <value> --json` returns every active session
+  runtime override using canonical session names, including on idempotent
+  `changed=false` mutations.
 - A superadmin executor invoked by an untrusted contact does not expose hidden
   agents solely because the executor has broad grants.
 

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -119,7 +119,7 @@ export class RaviClient {
         body: { id },
       });
     },
-    /** Set agent property */
+    /** Set agent property and report active session runtime overrides */
     set: async (id: string, key: string, value: string): Promise<AgentsSetReturn> => {
       return this.transport.call({
         groupSegments: ["agents"],

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -1395,6 +1395,45 @@ export const AgentsSetReturnSchema = {
     "key": {
       "type": "string"
     },
+    "sessionOverrides": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "effort": {
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              "ultra"
+            ],
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "sessionName": {
+            "type": "string"
+          },
+          "thinking": {
+            "enum": [
+              "off",
+              "normal",
+              "verbose"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionName"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "value": {}
   },
   "required": [
@@ -1402,7 +1441,8 @@ export const AgentsSetReturnSchema = {
     "changed",
     "agentId",
     "key",
-    "value"
+    "value",
+    "sessionOverrides"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -298,6 +298,12 @@ export type AgentsSetReturn = {
   agentId: string;
   changed: boolean;
   key: string;
+  sessionOverrides: Array<{
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
+    model?: string;
+    sessionName: string;
+    thinking?: "off" | "normal" | "verbose";
+  }>;
   value: unknown;
   [k: string]: unknown;
 };

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:0c806c7abaf3d71018d51ab2673e472825eaa63e3a942e61b1a8858f633a39b6";
+export const REGISTRY_HASH = "sha256:83d642f13e3ceeb48feab0d2d97d1d24c0d2df41a9b73a4abb3dc6a3e0e2de14";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "fc65fd6ff377";
+export const GIT_SHA = "d336ec24d4f3";

--- a/src/cli/commands/agents.test.ts
+++ b/src/cli/commands/agents.test.ts
@@ -25,6 +25,9 @@ type SessionLike = {
   providerSessionId?: string | null;
   sdkSessionId?: string | null;
   runtimeProvider?: string | null;
+  modelOverride?: string | null;
+  effortOverride?: string | null;
+  thinkingLevel?: "off" | "normal" | "verbose" | null;
   lastChannel?: string | null;
   lastTo?: string | null;
   inputTokens?: number | null;
@@ -217,6 +220,7 @@ mock.module("../../runtime/model-preset-store.js", () => ({
 }));
 
 const { AgentsCommands } = await import("./agents.js");
+const { agentSetReturnSchema } = await import("./operational-return-schemas.js");
 
 describe("AgentsCommands set model validation", () => {
   beforeEach(() => {
@@ -339,6 +343,190 @@ describe("AgentsCommands set model validation", () => {
     );
 
     expect(createAgentCalls).toHaveLength(0);
+  });
+});
+
+describe("AgentsCommands set session override reporting", () => {
+  beforeEach(() => {
+    currentAgent = { id: "dev", cwd: "/tmp/dev", provider: "codex", model: "gpt-5.5" };
+    allAgents = [];
+    createAgentCalls = [];
+    updateAgentCalls = [];
+    sessionsByAgent = [];
+  });
+
+  it("returns every active session override by canonical session name in JSON", async () => {
+    sessionsByAgent = [
+      {
+        sessionKey: "agent:dev:raw-channel-829a",
+        name: "zeta-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: "gpt-5.6",
+        effortOverride: "high",
+        thinkingLevel: "verbose",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        sessionKey: "agent:dev:another-raw-channel",
+        name: "alpha-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: null,
+        effortOverride: "max",
+        thinkingLevel: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        sessionKey: "agent:dev:no-overrides",
+        name: "idle-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: null,
+        effortOverride: null,
+        thinkingLevel: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const commands = new AgentsCommands();
+    const logCalls: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logCalls.push(args.map(String).join(" "));
+
+    try {
+      const payload = await commands.set("dev", "model", "gpt-5.6", true);
+
+      expect(payload).toMatchObject({
+        changed: true,
+        sessionOverrides: [
+          { sessionName: "alpha-session", effort: "max" },
+          {
+            sessionName: "zeta-session",
+            model: "gpt-5.6",
+            effort: "high",
+            thinking: "verbose",
+          },
+        ],
+      });
+      expect(Object.keys(payload?.sessionOverrides[0] ?? {})).toEqual(["sessionName", "effort"]);
+      expect(agentSetReturnSchema.safeParse(payload).success).toBe(true);
+      expect(logCalls.join("\n")).not.toContain("raw-channel");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("reports changed=false while preserving current session overrides for an idempotent set", async () => {
+    sessionsByAgent = [
+      {
+        sessionKey: "agent:dev:main",
+        name: "dev-main",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        thinkingLevel: "off",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const commands = new AgentsCommands();
+    const originalLog = console.log;
+    console.log = () => {};
+
+    try {
+      const payload = await commands.set("dev", "model", "gpt-5.5", true);
+
+      expect(payload).toMatchObject({
+        changed: false,
+        sessionOverrides: [{ sessionName: "dev-main", thinking: "off" }],
+      });
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("prints a concise human warning with all active fields across sessions", async () => {
+    sessionsByAgent = [
+      {
+        sessionKey: "agent:dev:raw-bravo",
+        name: "bravo-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: "gpt-5.5",
+        thinkingLevel: "verbose",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        sessionKey: "agent:dev:raw-alpha",
+        name: "alpha-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        effortOverride: "max",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        sessionKey: "agent:dev:raw-idle",
+        name: "idle-session",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: null,
+        effortOverride: null,
+        thinkingLevel: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const commands = new AgentsCommands();
+    const logCalls: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logCalls.push(args.map(String).join(" "));
+
+    try {
+      await commands.set("dev", "model", "gpt-5.6", false);
+
+      expect(logCalls).toEqual([
+        "\u2713 model set: dev -> gpt-5.6",
+        "Warning: 2 sessions have runtime overrides:",
+        "  - alpha-session: effort=max",
+        "  - bravo-session: model=gpt-5.5, thinking=verbose",
+      ]);
+      expect(logCalls.join("\n")).not.toContain("raw-");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("confirms the absence of overrides without a warning on an idempotent human mutation", async () => {
+    sessionsByAgent = [
+      {
+        sessionKey: "agent:dev:main",
+        name: "dev-main",
+        agentId: "dev",
+        agentCwd: "/tmp/dev",
+        modelOverride: null,
+        effortOverride: null,
+        thinkingLevel: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const commands = new AgentsCommands();
+    const logCalls: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logCalls.push(args.map(String).join(" "));
+
+    try {
+      await commands.set("dev", "model", "gpt-5.5", false);
+
+      expect(logCalls).toEqual(["\u2713 model unchanged: dev -> gpt-5.5", "  Session overrides: none"]);
+      expect(logCalls.some((line) => line.startsWith("Warning:"))).toBe(false);
+    } finally {
+      console.log = originalLog;
+    }
   });
 });
 

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -5,6 +5,7 @@
 import "reflect-metadata";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { isDeepStrictEqual } from "node:util";
 import { Group, Command, CommandAccess, Arg, Option } from "../decorators.js";
 import { fail } from "../context.js";
 import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
@@ -58,7 +59,7 @@ import {
   type AgentInstructionState,
 } from "../../runtime/agent-instructions.js";
 import { formatCliRuntimeTarget, getCliRuntimeMismatchMessage, inspectCliRuntimeTarget } from "../runtime-target.js";
-import type { AgentConfig, AgentUpdateInput } from "../../router/types.js";
+import type { AgentConfig, AgentUpdateInput, SessionEntry } from "../../router/types.js";
 import { filterItemsByCanonicalTag } from "../../tags/helpers.js";
 import { searchTagBindingsForSelector } from "../../tags/service.js";
 import type { TagBinding } from "../../tags/types.js";
@@ -131,6 +132,23 @@ interface AgentInstructionSyncSummary {
   changed: boolean;
 }
 
+interface AgentSessionOverrideSummary {
+  sessionName: string;
+  model?: string;
+  effort?: NonNullable<SessionEntry["effortOverride"]>;
+  thinking?: NonNullable<SessionEntry["thinkingLevel"]>;
+}
+
+interface AgentSetMutationPayload {
+  action: "set";
+  changed: boolean;
+  agentId: string;
+  key: string;
+  value: unknown;
+  agent?: AgentConfig;
+  sessionOverrides: AgentSessionOverrideSummary[];
+}
+
 type AgentJsonSummary = Omit<AgentConfig, "modelPresetId"> & {
   isDefault: boolean;
   effectiveProvider: string;
@@ -143,6 +161,64 @@ type AgentJsonSummary = Omit<AgentConfig, "modelPresetId"> & {
 
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
+}
+
+function listActiveAgentSessionOverrides(agentId: string): AgentSessionOverrideSummary[] {
+  return getSessionsByAgent(agentId)
+    .flatMap((session) => {
+      const summary: AgentSessionOverrideSummary = {
+        sessionName: session.name?.trim() || "(canonical name unavailable)",
+      };
+
+      if (typeof session.modelOverride === "string" && session.modelOverride.length > 0) {
+        summary.model = session.modelOverride;
+      }
+      if (session.effortOverride !== null && session.effortOverride !== undefined) {
+        summary.effort = session.effortOverride;
+      }
+      if (session.thinkingLevel !== null && session.thinkingLevel !== undefined) {
+        summary.thinking = session.thinkingLevel;
+      }
+
+      return summary.model !== undefined || summary.effort !== undefined || summary.thinking !== undefined
+        ? [summary]
+        : [];
+    })
+    .sort((left, right) => left.sessionName.localeCompare(right.sessionName));
+}
+
+function buildAgentSetMutationPayload(input: {
+  before: AgentConfig;
+  agentId: string;
+  key: string;
+  value: unknown;
+}): AgentSetMutationPayload {
+  const updatedAgent = getAgent(input.agentId) ?? undefined;
+  return {
+    action: "set",
+    changed: !isDeepStrictEqual(input.before, updatedAgent),
+    agentId: input.agentId,
+    key: input.key,
+    value: input.value ?? null,
+    agent: updatedAgent,
+    sessionOverrides: listActiveAgentSessionOverrides(input.agentId),
+  };
+}
+
+function printAgentSessionOverrideSummary(sessionOverrides: AgentSessionOverrideSummary[]): void {
+  if (sessionOverrides.length === 0) {
+    console.log("  Session overrides: none");
+    return;
+  }
+
+  const subject = sessionOverrides.length === 1 ? "session has" : "sessions have";
+  console.log(`Warning: ${sessionOverrides.length} ${subject} runtime overrides:`);
+  for (const session of sessionOverrides) {
+    const fields = (["model", "effort", "thinking"] as const)
+      .flatMap((field) => (session[field] === undefined ? [] : [`${field}=${session[field]}`]))
+      .join(", ");
+    console.log(`  - ${session.sessionName}: ${fields}`);
+  }
 }
 
 function formatTagSlugs(tags: TagBinding[]): string {
@@ -771,7 +847,7 @@ export class AgentsCommands {
     }
   }
 
-  @Command({ name: "set", description: "Set agent property" })
+  @Command({ name: "set", description: "Set agent property and report active session runtime overrides" })
   @CommandAccess({
     kind: "mutate",
     resource: "agents",
@@ -841,18 +917,25 @@ export class AgentsCommands {
           fail(`Error: ${err instanceof Error ? err.message : err}`);
         }
       }
-      const presetPayload = {
-        action: "set" as const,
-        changed: true as const,
+      const presetPayload = buildAgentSetMutationPayload({
+        before: agent,
         agentId: id,
         key,
         value: cleared ? null : value,
-        agent: getAgent(id),
-      };
+      });
       if (asJson) {
         printJson(presetPayload);
       } else {
-        console.log(cleared ? `\u2713 modelPreset cleared: ${id}` : `\u2713 modelPreset set: ${id} -> ${value}`);
+        console.log(
+          presetPayload.changed
+            ? cleared
+              ? `\u2713 modelPreset cleared: ${id}`
+              : `\u2713 modelPreset set: ${id} -> ${value}`
+            : cleared
+              ? `\u2713 modelPreset already clear: ${id}`
+              : `\u2713 modelPreset unchanged: ${id} -> ${value}`,
+        );
+        printAgentSessionOverrideSummary(presetPayload.sessionOverrides);
       }
       emitConfigChanged();
       return presetPayload;
@@ -866,22 +949,25 @@ export class AgentsCommands {
       }
       try {
         updateAgent(id, { groupDebounceMs: parsed === 0 ? undefined : parsed });
-        const debouncePayload = {
-          action: "set" as const,
-          changed: true as const,
+        const debouncePayload = buildAgentSetMutationPayload({
+          before: agent,
           agentId: id,
           key,
           value: parsed === 0 ? null : parsed,
-          agent: getAgent(id),
-        };
+        });
         if (asJson) {
           printJson(debouncePayload);
         } else {
           console.log(
-            parsed === 0
-              ? `\u2713 groupDebounceMs disabled: ${id}`
-              : `\u2713 groupDebounceMs set: ${id} -> ${parsed}ms`,
+            debouncePayload.changed
+              ? parsed === 0
+                ? `\u2713 groupDebounceMs disabled: ${id}`
+                : `\u2713 groupDebounceMs set: ${id} -> ${parsed}ms`
+              : parsed === 0
+                ? `\u2713 groupDebounceMs already disabled: ${id}`
+                : `\u2713 groupDebounceMs unchanged: ${id} -> ${parsed}ms`,
           );
+          printAgentSessionOverrideSummary(debouncePayload.sessionOverrides);
         }
         emitConfigChanged();
         return debouncePayload;
@@ -1006,20 +1092,21 @@ export class AgentsCommands {
       if (key === "cwd" || key === "provider") {
         ensureAgentDirs(loadRouterConfig());
       }
-      const payload = {
-        action: "set" as const,
-        changed: true as const,
+      const payload = buildAgentSetMutationPayload({
+        before: agent,
         agentId: id,
         key,
         value: parsedValue,
-        agent: getAgent(id),
-      };
+      });
       if (asJson) {
         printJson(payload);
       } else {
         console.log(
-          `\u2713 ${key} set: ${id} -> ${typeof parsedValue === "string" ? parsedValue : JSON.stringify(parsedValue)}`,
+          `\u2713 ${key} ${payload.changed ? "set" : "unchanged"}: ${id} -> ${
+            typeof parsedValue === "string" ? parsedValue : JSON.stringify(parsedValue)
+          }`,
         );
+        printAgentSessionOverrideSummary(payload.sessionOverrides);
       }
       emitConfigChanged();
       return payload;

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ZodTypeAny } from "zod";
 import { Returns } from "../decorators.js";
 import { jsonObjectSchema, jsonValueSchema } from "../return-schemas.js";
+import { RUNTIME_EFFORT_LEVELS } from "../../runtime/effort.js";
 
 export const looseObjectSchema = z.object({}).passthrough();
 export const looseObjectOrNullSchema = looseObjectSchema.nullable();
@@ -1869,6 +1870,16 @@ export const agentSetReturnSchema = z
     key: z.string(),
     value: z.unknown(),
     agent: agentRecordReturnSchema.optional(),
+    sessionOverrides: z.array(
+      z
+        .object({
+          sessionName: z.string(),
+          model: z.string().optional(),
+          effort: z.enum(RUNTIME_EFFORT_LEVELS).optional(),
+          thinking: z.enum(["off", "normal", "verbose"]).optional(),
+        })
+        .strict(),
+    ),
   })
   .passthrough();
 


### PR DESCRIPTION
## Objective

Make every successful `ravi agents set` response expose session-level runtime overrides that can shadow the updated agent configuration.

## Problem

Agent defaults for model and effort can be overridden by existing sessions. The command previously reported only the agent mutation, so operators could incorrectly assume the new configuration applied to every session.

## Solution

Add a typed `sessionOverrides` array containing each canonical session name and its active `model`, `effort`, and `thinking` overrides. Human output now prints a concise warning when overrides exist and a non-warning confirmation when none exist.

## Practical impact

Operators immediately see which sessions still diverge after changing an agent. SDK consumers receive the same information through the generated typed return contract.

## What does NOT change

This change does not modify session override values, routing, providers, permissions, channel transport, or running session history. It only reports existing session state after the agent mutation.

## Validation

- `bun test src/cli/commands/agents.test.ts`
- `bun test src/cli/commands/sdk-returns.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run sdk:check`
- full pre-push test suite
- `git diff --check`

## Risks

The public return shape gains a required typed array, and idempotent writes may now report `changed=false`. Focused tests cover changed and unchanged mutations, empty overrides, multiple sessions, and multiple override fields.

## Rollback

Revert commit `0723bb9` and regenerate the SDK artifacts. No database migration or runtime state repair is required.