### PR TITLE
Add inherited SDK client for workflows

### DIFF
--- a/packages/ravi-os-sdk/README.md
+++ b/packages/ravi-os-sdk/README.md
@@ -121,6 +121,38 @@ import { RaviClient } from "@ravi-os/sdk/client";
 import { createHttpTransport } from "@ravi-os/sdk/transport/http";
 ```
 
+## Inherit The Calling Ravi Runtime
+
+Handlers launched by Ravi already receive `RAVI_CONTEXT_KEY` plus the local
+gateway env. Use `createInheritedClient` to reuse that runtime context without
+manually wiring transport config:
+
+```ts
+import { createInheritedClient } from "@ravi-os/sdk";
+
+const { client: ravi } = await createInheritedClient();
+await ravi.context.whoami();
+```
+
+Child context mode is available when handing context to another process or
+subsystem. Make inheritance explicit, or pass a narrow `allow` list:
+
+```ts
+const inherited = await createInheritedClient({
+  child: {
+    cliName: "agent-factory",
+    ttl: "5m",
+    inherit: true,
+  },
+});
+
+try {
+  await inherited.client.agents.list({ limit: "10" });
+} finally {
+  await inherited.revoke?.();
+}
+```
+
 ## Examples
 
 ### Read Runtime State

--- a/packages/ravi-os-sdk/package.json
+++ b/packages/ravi-os-sdk/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"
     },
+    "./inherit": {
+      "types": "./dist/inherit.d.ts",
+      "default": "./dist/inherit.js"
+    },
     "./schemas": {
       "types": "./dist/schemas.d.ts",
       "default": "./dist/schemas.js"

--- a/packages/ravi-os-sdk/src/__tests__/inherit.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/inherit.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createInheritedClient,
+  resolveInheritedBaseUrl,
+  resolveInheritedContextKey,
+} from "../inherit.js";
+
+describe("createInheritedClient", () => {
+  it("uses the current runtime context by default", async () => {
+    const seen: Array<{ url: string; auth: string | null; body: unknown }> = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seen.push({
+        url: String(input),
+        auth: headers.get("authorization"),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return jsonResponse({
+        kind: "turn-runtime",
+        agentId: "ravi-workflows",
+        sessionName: "ravi-workflows",
+        capabilitiesCount: 23,
+      });
+    };
+
+    const inherited = await createInheritedClient({
+      env: {
+        RAVI_BASE_URL: "http://ravi.test/",
+        RAVI_CONTEXT_KEY: "rctx_parent",
+      },
+      fetch: fetchImpl,
+    });
+    const me = await inherited.client.context.whoami();
+
+    expect(inherited.mode).toBe("current");
+    expect(inherited.baseUrl).toBe("http://ravi.test");
+    expect(inherited.contextId).toBeUndefined();
+    expect(inherited.revoke).toBeUndefined();
+    expect(me.sessionName).toBe("ravi-workflows");
+    expect(seen).toEqual([
+      {
+        url: "http://ravi.test/api/v1/context/whoami",
+        auth: "Bearer rctx_parent",
+        body: {},
+      },
+    ]);
+  });
+
+  it("can issue, use, and revoke an explicit child context", async () => {
+    const seen: Array<{ path: string; auth: string | null; body: unknown }> = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      seen.push({ path: url.pathname, auth: headers.get("authorization"), body });
+
+      if (url.pathname === "/api/v1/context/issue") {
+        return jsonResponse({
+          contextId: "ctx_child",
+          contextKey: "rctx_child",
+          kind: "cli-runtime",
+          capabilitiesCount: 23,
+        });
+      }
+      if (url.pathname === "/api/v1/context/whoami") {
+        return jsonResponse({
+          kind: "cli-runtime",
+          issuedFor: "sdk-inherit-test",
+          sessionName: "ravi-workflows",
+          capabilitiesCount: 23,
+        });
+      }
+      if (url.pathname === "/api/v1/context/revoke") {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ error: "unexpected" }, 404);
+    };
+
+    const inherited = await createInheritedClient({
+      env: {
+        RAVI_HTTP_HOST: "127.0.0.1",
+        RAVI_HTTP_PORT: "4211",
+        RAVI_CONTEXT_KEY: "rctx_parent",
+      },
+      child: {
+        cliName: "sdk-inherit-test",
+        ttl: "2m",
+        inherit: true,
+      },
+      fetch: fetchImpl,
+    });
+    const me = await inherited.client.context.whoami();
+    await inherited.revoke?.("done");
+
+    expect(inherited.mode).toBe("child");
+    expect(inherited.baseUrl).toBe("http://127.0.0.1:4211");
+    expect(inherited.contextId).toBe("ctx_child");
+    expect(me.issuedFor).toBe("sdk-inherit-test");
+    expect(seen).toEqual([
+      {
+        path: "/api/v1/context/issue",
+        auth: "Bearer rctx_parent",
+        body: { cliName: "sdk-inherit-test", inherit: true, ttl: "2m" },
+      },
+      {
+        path: "/api/v1/context/whoami",
+        auth: "Bearer rctx_child",
+        body: {},
+      },
+      {
+        path: "/api/v1/context/revoke",
+        auth: "Bearer rctx_parent",
+        body: { contextId: "ctx_child", reason: "done" },
+      },
+    ]);
+  });
+
+  it("requires explicit child inheritance or allowed capabilities", async () => {
+    await expect(
+      createInheritedClient({
+        env: {
+          RAVI_BASE_URL: "http://ravi.test",
+          RAVI_CONTEXT_KEY: "rctx_parent",
+        },
+        child: { cliName: "sdk-inherit-test" },
+        fetch: async () => jsonResponse({}),
+      }),
+    ).rejects.toThrow("child mode requires child.inherit === true or a non-empty child.allow");
+  });
+});
+
+describe("inherit env resolution", () => {
+  it("derives base URL and context key from Ravi env", () => {
+    expect(resolveInheritedBaseUrl({ RAVI_HTTP_PORT: "4211" })).toBe("http://127.0.0.1:4211");
+    expect(resolveInheritedBaseUrl({ RAVI_HTTP_HOST: "0.0.0.0", RAVI_HTTP_PORT: "4211" })).toBe(
+      "http://127.0.0.1:4211",
+    );
+    expect(resolveInheritedContextKey({ RAVI_CONTEXT_KEY: " rctx_parent " })).toBe("rctx_parent");
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/ravi-os-sdk/src/index.ts
+++ b/packages/ravi-os-sdk/src/index.ts
@@ -18,6 +18,15 @@ export {
   type HttpTransportConfig,
 } from "./transport/http.js";
 export {
+  createInheritedClient,
+  resolveInheritedBaseUrl,
+  resolveInheritedContextKey,
+  type CreateInheritedClientOptions,
+  type InheritedClientChildOptions,
+  type InheritedClientResult,
+  type RaviInheritedClientEnv,
+} from "./inherit.js";
+export {
   RaviStreamClient,
   createStreamClient,
   parseSse,

--- a/packages/ravi-os-sdk/src/inherit.ts
+++ b/packages/ravi-os-sdk/src/inherit.ts
@@ -1,0 +1,156 @@
+import { RaviClient } from "./client.js";
+import { createHttpTransport, type HttpTransportConfig } from "./transport/http.js";
+import type { ContextIssueInput } from "./types.js";
+
+export type RaviInheritedClientEnv = Record<string, string | undefined>;
+
+export interface InheritedClientChildOptions extends Omit<ContextIssueInput, "cliName"> {
+  cliName: string;
+}
+
+export interface CreateInheritedClientOptions {
+  /** Explicit gateway base URL. Falls back to Ravi runtime env. */
+  baseUrl?: string;
+  /** Explicit context key. Falls back to `RAVI_CONTEXT_KEY`. */
+  contextKey?: string;
+  /** Optional env override for tests or custom launchers. Defaults to `process.env`. */
+  env?: RaviInheritedClientEnv;
+  /** Optional fetch override passed to `createHttpTransport`. */
+  fetch?: typeof fetch;
+  /** Request timeout in ms. `0` = no timeout. */
+  timeoutMs?: number;
+  /** Extra headers merged into every SDK request. */
+  headers?: Record<string, string>;
+  /**
+   * Optional child context mode. Use only when handing context to another
+   * process/subsystem; default mode reuses the current runtime context.
+   */
+  child?: InheritedClientChildOptions;
+}
+
+export interface InheritedClientResult {
+  client: RaviClient;
+  baseUrl: string;
+  mode: "current" | "child";
+  /** Present only in child mode. This is safe to log; the context key is not returned. */
+  contextId?: string;
+  /** Present only in child mode. Revokes the issued child context through the parent context. */
+  revoke?: (reason?: string) => Promise<void>;
+}
+
+export async function createInheritedClient(options: CreateInheritedClientOptions = {}): Promise<InheritedClientResult> {
+  const env = options.env ?? defaultEnv();
+  const baseUrl = resolveInheritedBaseUrl(env, options.baseUrl);
+  const contextKey = resolveInheritedContextKey(env, options.contextKey);
+  const parent = new RaviClient(createHttpTransport(httpConfig(options, baseUrl, contextKey)));
+
+  if (!options.child) {
+    return { client: parent, baseUrl, mode: "current" };
+  }
+
+  const issueInput = buildChildIssueInput(options.child);
+  const issued = await parent.context.issue(issueInput.cliName, {
+    ...(issueInput.allow ? { allow: issueInput.allow } : {}),
+    ...(issueInput.inherit !== undefined ? { inherit: issueInput.inherit } : {}),
+    ...(issueInput.ttl ? { ttl: issueInput.ttl } : {}),
+  });
+  const child = new RaviClient(createHttpTransport(httpConfig(options, baseUrl, issued.contextKey)));
+
+  return {
+    client: child,
+    baseUrl,
+    mode: "child",
+    contextId: issued.contextId,
+    revoke: async (reason = "createInheritedClient child context cleanup") => {
+      await parent.context.revoke(issued.contextId, { reason });
+    },
+  };
+}
+
+export function resolveInheritedBaseUrl(env: RaviInheritedClientEnv = defaultEnv(), explicit?: string): string {
+  const direct = firstNonEmpty(explicit, env.RAVI_BASE_URL, env.RAVI_HTTP_BASE_URL, env.RAVI_GATEWAY_URL);
+  if (direct) return normalizeBaseUrl(direct);
+
+  const port = firstNonEmpty(env.RAVI_HTTP_PORT, env.RAVI_WEBHOOK_PORT);
+  if (port) {
+    const host = normalizeHost(firstNonEmpty(env.RAVI_HTTP_HOST, env.RAVI_WEBHOOK_HOST) ?? "127.0.0.1");
+    return normalizeBaseUrl(`http://${host}:${port}`);
+  }
+
+  throw new Error(
+    "createInheritedClient: missing Ravi gateway URL. Set RAVI_BASE_URL, RAVI_GATEWAY_URL, or RAVI_HTTP_HOST/RAVI_HTTP_PORT.",
+  );
+}
+
+export function resolveInheritedContextKey(env: RaviInheritedClientEnv = defaultEnv(), explicit?: string): string {
+  const contextKey = firstNonEmpty(explicit, env.RAVI_CONTEXT_KEY);
+  if (!contextKey) {
+    throw new Error("createInheritedClient: missing Ravi runtime context. Set RAVI_CONTEXT_KEY or pass contextKey.");
+  }
+  return contextKey;
+}
+
+function buildChildIssueInput(child: InheritedClientChildOptions): ContextIssueInput {
+  const cliName = firstNonEmpty(child.cliName);
+  if (!cliName) {
+    throw new Error("createInheritedClient: child mode requires a non-empty cliName.");
+  }
+
+  const allow = firstNonEmpty(child.allow);
+  const ttl = firstNonEmpty(child.ttl);
+  if (!allow && child.inherit !== true) {
+    throw new Error("createInheritedClient: child mode requires child.inherit === true or a non-empty child.allow.");
+  }
+
+  return {
+    cliName,
+    ...(allow ? { allow } : {}),
+    ...(child.inherit !== undefined ? { inherit: child.inherit } : {}),
+    ...(ttl ? { ttl } : {}),
+  };
+}
+
+function httpConfig(
+  options: Pick<CreateInheritedClientOptions, "fetch" | "headers" | "timeoutMs">,
+  baseUrl: string,
+  contextKey: string,
+): HttpTransportConfig {
+  return {
+    baseUrl,
+    contextKey,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+    ...(options.headers ? { headers: options.headers } : {}),
+    ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+  };
+}
+
+function defaultEnv(): RaviInheritedClientEnv {
+  const runtime = globalThis as typeof globalThis & {
+    process?: { env?: RaviInheritedClientEnv };
+  };
+  return runtime.process?.env ?? {};
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  try {
+    return new URL(trimmed).toString().replace(/\/+$/, "");
+  } catch {
+    throw new Error(`createInheritedClient: invalid Ravi gateway URL: ${value}`);
+  }
+}
+
+function normalizeHost(value: string): string {
+  const host = value.trim();
+  if (host === "0.0.0.0" || host === "::") return "127.0.0.1";
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
+  return host;
+}

--- a/src/plugins/internal/ravi-system/skills/slack/references/block-kit-workflows.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/block-kit-workflows.md
@@ -9,10 +9,12 @@ regra de negocio dentro do core do canal.
 O core do Ravi deve fornecer primitives genericas:
 
 - enviar e atualizar Block Kit;
+- enviar Block Kit ephemeral para um usuario no canal origem via
+  `ravi slack blocks-send <channel> <json> --ephemeral-user <user>`;
 - receber `ravi.inbound.interaction`;
 - resolver credenciais Slack via broker;
 - executar triggers shell;
-- criar rotas, canais, sessoes e artifacts por CLI/API local.
+- criar rotas, canais, sessoes e artifacts por SDK/API local.
 
 O workflow de negocio deve ficar fora do core, por exemplo em
 `.ravi/workflows/<nome>/handler.ts`, com state local e idempotencia.
@@ -25,17 +27,19 @@ O workflow de negocio deve ficar fora do core, por exemplo em
    `actionId`.
 4. Executar handler shell versionado no workspace.
 5. Ler `RAVI_TRIGGER_EVENT_FILE`.
-6. Resolver state local por chave de dominio.
-7. Executar mutacoes nativas: Slack, routes, artifacts, tasks ou bash externo.
-8. Atualizar a mensagem de origem ou publicar follow-up.
-9. Marcar state como processado antes de aceitar novo clique equivalente.
-10. Notificar uma sessao apenas em erro operacional.
+6. Resolver contexto runtime para o handler.
+7. Resolver state local por chave de dominio.
+8. Executar mutacoes nativas: Slack, routes, artifacts, tasks ou bash externo.
+9. Atualizar a mensagem de origem ou publicar follow-up.
+10. Marcar state como processado antes de aceitar novo clique equivalente.
+11. Notificar uma sessao apenas em erro operacional.
 
 ## Fronteira Core vs Workflow
 
 Fica no core:
 
 - `ravi slack blocks-send`;
+- `ravi slack blocks-send --ephemeral-user`;
 - `ravi slack blocks-update`;
 - `ravi slack interactions-respond`;
 - evento `ravi.inbound.interaction`;
@@ -52,8 +56,68 @@ Fica no workflow:
 - arquivo SQLite/JSON de state;
 - mapping `messageTs -> domain id`;
 - regra de negocio;
+- emissao de contexto curto para a interacao quando o trigger shell nao herdar
+  `RAVI_CONTEXT_KEY`;
 - scripts de bash deterministico;
 - decisoes de quando chamar ou nao um agent.
+
+## Contexto Runtime Para Handlers
+
+Handlers TypeScript chamados por trigger shell devem preferir o SDK em vez de
+abrir varios subprocessos `ravi ...`:
+
+```ts
+import { createInheritedClient } from "@ravi-os/sdk";
+
+const { client: ravi } = await createInheritedClient();
+```
+
+Quando o trigger herdar `RAVI_CONTEXT_KEY`, `createInheritedClient()` reutiliza
+o contexto do runtime chamador. Alguns triggers shell, porem, podem executar sem
+`RAVI_CONTEXT_KEY`. Nesse caso, o handler deve emitir um contexto curto para a
+interacao atual, usando o usuario Slack que clicou/submeteu como metadata:
+
+```ts
+import { createInheritedClient } from "@ravi-os/sdk";
+import { createRuntimeContext, snapshotAgentCapabilities } from "<ravi>/src/runtime/context-registry";
+
+const interactionContext = createRuntimeContext({
+  kind: "interaction-runtime",
+  agentId: "ravi-workflows",
+  sessionName: "ravi-workflows",
+  source: {
+    channel: "slack",
+    accountId: "hana-slack",
+    chatId: data.channelId,
+  },
+  capabilities: snapshotAgentCapabilities("ravi-workflows"),
+  metadata: {
+    issuedFor: "agent-factory",
+    actorType: "slack_user",
+    slackUserId: data.userId,
+    sourceMessageTs: data.messageTs,
+    issuanceMode: "slack-interaction",
+  },
+  ttlMs: 10 * 60 * 1000,
+});
+
+const { client: ravi } = await createInheritedClient({
+  contextKey: interactionContext.contextKey,
+});
+```
+
+Regras:
+
+- Nao use admin/default credentials como fallback para interacoes humanas.
+- Nao sintetize `RAVI_AGENT_ID`, `RAVI_SESSION_KEY` ou identidade de usuario por
+  env solto; o contexto emitido deve carregar source e metadata auditavel.
+- TTL deve ser curto; evite revogar sincronicamente em handlers one-shot se a
+  revogacao for mais lenta que o proprio workflow.
+- Nunca logue `contextKey` ou retorno bruto de `context.issue`.
+- Reuse um unico client SDK por execucao do handler.
+- Se o SDK gerado ainda nao expuser uma option nova do CLI, use o transport do
+  SDK para chamar a command path com body explicito e anote o drift para o
+  proximo `ravi sdk client generate`.
 
 ## Response URL E Ephemeral
 
@@ -301,3 +365,63 @@ Faz sentido quando:
   para ephemeral.
 - Erro notifica sessao operacional via `--on-error`.
 - Sucesso deterministico nao chama agent.
+
+## Padrao: Factory De Canais
+
+Quando um canal factory cria um canal novo, nao deixe a confirmacao principal
+apenas no canal recem-criado. Publique uma ephemeral no canal factory para o
+usuario solicitante:
+
+```bash
+ravi slack blocks-send <factory-channel-id> ./channel-created.json \
+  --ephemeral-user <requester-user-id> \
+  --execute --json
+```
+
+O card deve ter:
+
+- resumo curto: canal, agent, sessao e route, quando existirem;
+- botao URL `Abrir canal` usando
+  `https://slack.com/app_redirect?channel=<new-channel-id>`;
+- botao interativo `Configurar permissoes` com
+  `block_id: ravi_channel_created_actions` e
+  `action_id: ravi_channel_configure_permissions`;
+- `value` contendo um identificador estavel do canal/sessao, nunca tokens ou
+  contexto sensivel.
+
+Exemplo minimo:
+
+```json
+{
+  "text": "Canal criado",
+  "blocks": [
+    {
+      "type": "section",
+      "block_id": "ravi_channel_created_summary",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Canal criado:* <#CNEW>\n*Agent:* agente\n*Sessao:* sessao\n*Route:* group:CNEW"
+      }
+    },
+    {
+      "type": "actions",
+      "block_id": "ravi_channel_created_actions",
+      "elements": [
+        {
+          "type": "button",
+          "action_id": "ravi_channel_open",
+          "text": { "type": "plain_text", "text": "Abrir canal" },
+          "url": "https://slack.com/app_redirect?channel=CNEW",
+          "value": "CNEW"
+        },
+        {
+          "type": "button",
+          "action_id": "ravi_channel_configure_permissions",
+          "text": { "type": "plain_text", "text": "Configurar permissoes" },
+          "value": "CNEW"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/src/plugins/internal/ravi-system/skills/slack/references/block-kit.md
+++ b/src/plugins/internal/ravi-system/skills/slack/references/block-kit.md
@@ -20,6 +20,12 @@ Enviar:
 ravi slack blocks-send C123 ./message.json --execute --json
 ```
 
+Enviar privado/ephemeral para um usuario no canal:
+
+```bash
+ravi slack blocks-send C123 ./message.json --ephemeral-user U123 --execute --json
+```
+
 Atualizar:
 
 ```bash
@@ -118,6 +124,10 @@ O shell recebe `RAVI_TRIGGER_EVENT_FILE` com o payload canonico e pode atualizar
 a mensagem via `ravi slack blocks-update` ou cliente Slack nativo. Nao use
 prompt de agent para fluxo que e puro estado + mutacao.
 Use conexao explicita apenas fora de um contexto Slack resolvivel.
+Para handlers TypeScript que chamam o SDK, prefira `createInheritedClient()`.
+Se o trigger shell nao trouxer `RAVI_CONTEXT_KEY`, emita um contexto curto
+`interaction-runtime` com source Slack e `slackUserId` em metadata; nao use
+admin/default credentials para representar uma acao humana.
 
 Para fluxos multi-etapa com state local, idempotencia, filtros em paralelo e
 exemplos de tickets/aprovacoes/deploy, leia `references/block-kit-workflows.md`.
@@ -132,5 +142,8 @@ tratado como input de usuario.
 - Nao exponha token Slack nem `response_url`.
 - Use `responseUrlId` quando precisar substituir/apagar a mensagem interativa
   original sem vazar `response_url`.
+- Para feedback privado em canal factory/origem, use
+  `blocks-send --ephemeral-user <userId>` em vez de publicar uma mensagem
+  normal no canal novo.
 - Use `action_id` e `block_id` estaveis para automacoes.
 - Prefira `blocks-update` para atualizar estado visual de uma mensagem existente.


### PR DESCRIPTION
## Objective
Add a reusable SDK inheritance helper so Slack workflow handlers can connect to the Ravi runtime that invoked them, and document the pattern in the Block Kit workflow skill.

## Problem
Handlers triggered from Slack interactions can run without `RAVI_CONTEXT_KEY`, which made SDK-based workflow mutations fail or fall back toward the wrong runtime identity. The Agent Factory migration exposed that the Block Kit guidance did not describe how to issue a short lived interaction context for the Slack user who clicked the action.

## Solution
This PR adds `createInheritedClient()` to `@ravi-os/sdk`, with support for using the current runtime context or an explicit child context key. It exports the helper from the package root and `@ravi-os/sdk/inherit`, adds focused unit coverage, documents the API in the SDK README, and updates the Block Kit references with the `interaction-runtime` pattern, Slack source metadata, and ephemeral feedback guidance.

## Practical impact
Workflow handlers can now make Ravi and Slack mutations through the SDK using the same effective runtime identity as the invoking Ravi session. Agent Factory style flows can create agents, channels, routes, sessions, and confirmation messages without depending on admin defaults or manually synthesized runtime environment variables.

## What does NOT change
This does not change generated SDK command artifacts, Slack routing semantics, permission policy, or the gateway authorization model. Existing SDK clients continue to work, and workflow handlers still need an authorized Ravi context for privileged mutations.

## Validation
Ran `bun test packages/ravi-os-sdk/src/__tests__`, `(cd packages/ravi-os-sdk && bun run build)`, and `bun run sdk:check`. The branch also passed the repository pre-push checks before publishing, including the SDK drift check.

## Risks
The main risk is handlers creating overly broad or long-lived child contexts if they copy the pattern without preserving the documented TTL and source metadata constraints. The new docs call out that handlers should not log context keys, should not rely on default credentials for human interactions, and should reuse a single inherited client per execution.

## Rollback
Revert commit `274844ca2a90d416e63e4b6caaa12ece411f0761` to remove the SDK helper, tests, package exports, README changes, and Block Kit documentation updates. Existing generated SDK behavior remains unchanged, so rollback is a normal source revert.
