### PR TITLE
Backfill Slack channel configs from legacy instances

### DIFF
--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -2488,6 +2488,7 @@ function getDb(): Database {
   ensureColumn(db, "channels", "credential_connection", "TEXT");
   ensureColumn(db, "channels", "defaults", "TEXT");
   ensureColumn(db, "channels", "deleted_at", "INTEGER");
+  backfillLegacySlackInstancesToChannels(db);
 
   const contextColumns = db.prepare("PRAGMA table_info(contexts)").all() as Array<{ name: string }>;
   if (contextColumns.length > 0 && !contextColumns.some((c) => c.name === "context_id")) {
@@ -2680,6 +2681,81 @@ function ensureColumn(database: Database, table: string, column: string, definit
       throw error;
     }
   }
+}
+
+function backfillLegacySlackInstancesToChannels(database: Database): void {
+  const legacyInstances = database
+    .prepare(
+      `SELECT name, enabled, defaults, created_at, updated_at
+       FROM instances
+       WHERE LOWER(TRIM(channel)) = 'slack'
+         AND deleted_at IS NULL
+       ORDER BY name`,
+    )
+    .all() as Array<{
+    name: string;
+    enabled: number | null;
+    defaults: string | null;
+    created_at: number;
+    updated_at: number;
+  }>;
+
+  if (legacyInstances.length === 0) return;
+
+  const insertChannel = database.prepare(
+    `INSERT OR IGNORE INTO channels (
+       name, provider, enabled, credential_connection, defaults,
+       created_at, updated_at, deleted_at
+     )
+     VALUES (?, 'slack', ?, ?, NULL, ?, ?, NULL)`,
+  );
+
+  let migrated = 0;
+  database.transaction(() => {
+    for (const instance of legacyInstances) {
+      migrated += insertChannel.run(
+        instance.name,
+        instance.enabled === 0 ? 0 : 1,
+        legacySlackCredentialConnection(instance.name, instance.defaults),
+        instance.created_at,
+        instance.updated_at,
+      ).changes;
+    }
+  })();
+
+  if (migrated > 0) {
+    log.info("Backfilled Slack channel configs from legacy instances", { count: migrated });
+  }
+}
+
+function legacySlackCredentialConnection(instanceName: string, defaultsJson: string | null): string {
+  if (!defaultsJson) return instanceName;
+
+  try {
+    const parsed = JSON.parse(defaultsJson) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return instanceName;
+    const defaults = parsed as Record<string, unknown>;
+    const credentials = asStringRecord(defaults.credentials);
+    return (
+      firstNonEmptyString(defaults, "slackCredentialConnection", "credentialConnection") ??
+      firstNonEmptyString(credentials, "slackConnection", "slackCredentialConnection", "connection") ??
+      instanceName
+    );
+  } catch {
+    return instanceName;
+  }
+}
+
+function asStringRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function firstNonEmptyString(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
 }
 
 function isDuplicateColumnRace(error: unknown): boolean {

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -3,13 +3,18 @@ import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-
 import {
   dbCreateAgent,
   dbCreateContext,
+  dbDeleteChannel,
+  dbDeleteInstance,
   dbGetAgent,
   dbGetChannel,
+  dbListChannels,
   dbListContexts,
   dbPruneContexts,
   dbUpdateAgent,
   dbUpdateChannel,
   dbUpsertChannel,
+  dbUpsertInstance,
+  closeRouterDb,
   getDb,
 } from "./router-db.js";
 import { getOrCreateSession } from "./sessions.js";
@@ -172,6 +177,65 @@ describe("router context queries", () => {
     const cleared = dbUpdateChannel("ravi-rbbt-slack", { credentialConnection: null });
     expect(cleared.credentialConnection).toBeUndefined();
     expect(dbGetChannel("ravi-rbbt-slack")?.provider).toBe("slack");
+  });
+
+  it("backfills legacy Slack instances into channel configs without overwriting explicit channels", () => {
+    dbUpsertInstance({ name: "legacy-slack", channel: "slack" });
+    dbUpsertInstance({
+      name: "legacy-slack-disabled",
+      channel: "slack",
+      enabled: false,
+      defaults: { credentials: { slackConnection: "legacy-slack-secret" } },
+    });
+    dbUpsertInstance({ name: "legacy-whatsapp", channel: "whatsapp" });
+    dbUpsertInstance({ name: "legacy-slack-deleted", channel: "slack" });
+    dbDeleteInstance("legacy-slack-deleted");
+    dbUpsertInstance({ name: "deleted-channel-slack", channel: "slack" });
+    dbUpsertChannel({
+      name: "deleted-channel-slack",
+      provider: "slack",
+      credentialConnection: "deleted-channel-secret",
+    });
+    dbDeleteChannel("deleted-channel-slack");
+
+    dbUpsertInstance({
+      name: "configured-slack",
+      channel: "slack",
+      defaults: { slackCredentialConnection: "legacy-connection" },
+    });
+    const configured = dbUpsertChannel({
+      name: "configured-slack",
+      provider: "slack",
+      enabled: false,
+      credentialConnection: "explicit-connection",
+      defaults: { subscriptionScope: "chat_and_thread" },
+    });
+
+    closeRouterDb();
+    getDb();
+
+    expect(dbGetChannel("legacy-slack")).toMatchObject({
+      name: "legacy-slack",
+      provider: "slack",
+      enabled: true,
+      credentialConnection: "legacy-slack",
+    });
+    expect(dbGetChannel("legacy-slack")?.defaults).toBeUndefined();
+    expect(dbGetChannel("legacy-slack-disabled")).toMatchObject({
+      name: "legacy-slack-disabled",
+      provider: "slack",
+      enabled: false,
+      credentialConnection: "legacy-slack-secret",
+    });
+    expect(dbGetChannel("legacy-whatsapp")).toBeNull();
+    expect(dbGetChannel("legacy-slack-deleted")).toBeNull();
+    expect(dbGetChannel("deleted-channel-slack")).toBeNull();
+    expect(dbGetChannel("configured-slack")).toEqual(configured);
+
+    const firstPass = dbListChannels();
+    closeRouterDb();
+    getDb();
+    expect(dbListChannels()).toEqual(firstPass);
   });
 });
 


### PR DESCRIPTION
## Objective

Restore automatic Slack startup for existing Ravi installations after the native channel credential refactor.

## Problem

The runtime moved Slack discovery from legacy `instances` records to `channels`, but installed databases were left without matching channel rows. After restart, PM2 stayed online while the Slack adapter was disabled as `not_configured`.

## Solution

Run an idempotent SQLite bootstrap backfill for every non-deleted Slack instance. The migration preserves enabled state, reproduces the legacy credential-connection precedence, and inserts with conflict protection so explicit or soft-deleted channels are never overwritten or resurrected.

## Practical impact

Existing installations automatically recover their Slack channel configuration on the next database bootstrap and channel-runner restart. Partial migrations are healed safely without manual channel creation.

## What does NOT change

The credential broker remains authoritative, raw Slack tokens are not moved, routing and session ownership are unchanged, and existing channel configurations continue to take precedence.

## Validation

The full pre-push suite passed. Typecheck and build passed, along with 31 focused router, Slack credentials, Socket Mode, and channels CLI tests. Both changed files pass Biome checks.

## Risks

A malformed legacy defaults payload falls back to the instance name, matching the previous runtime behavior. The migration only inserts missing rows and does not validate whether the referenced broker connection is currently active.

## Rollback

Revert commit `3fc32cc` to stop future backfills. Rows already created can be soft-deleted through the channels CLI; existing explicit and soft-deleted rows are never modified by this migration.
