### PR TITLE
Add native Google Search Console read-only app

### DIFF
--- a/.ravi/specs/apps/google-search-console/CHECKS.md
+++ b/.ravi/specs/apps/google-search-console/CHECKS.md
@@ -1,0 +1,10 @@
+# Checks
+
+- No `sde`, organization domain, credential path or secret in App sources.
+- Manifest operations invoke only `ravi gsc` or built-in App handlers.
+- Credential parser rejects malformed and incomplete envelopes.
+- API errors redact OAuth fields.
+- Analytics limits are bounded to Google's documented maximum.
+- Mutations are marked high/destructive and require confirmation.
+- Packaged CLI and SDK expose the native commands.
+- Real read-only calls succeed using a Ravi credential connection.

--- a/.ravi/specs/apps/google-search-console/RUNBOOK.md
+++ b/.ravi/specs/apps/google-search-console/RUNBOOK.md
@@ -1,0 +1,11 @@
+# Runbook
+
+1. Create an OAuth client with Search Console and Site Verification scopes.
+2. Obtain a refresh token using Google's OAuth authorization flow.
+3. Store the JSON envelope in a supported Ravi credential backend as provider
+   `google-search-console` and connection `default` (or another explicit id).
+4. Check access with `ravi gsc sites --json`.
+5. Use an explicit property in every property-scoped command.
+6. Grant App use/execute permissions only after validating the connection.
+
+Never paste the credential envelope into command arguments, logs or a repo.

--- a/.ravi/specs/apps/google-search-console/SPEC.md
+++ b/.ravi/specs/apps/google-search-console/SPEC.md
@@ -1,0 +1,59 @@
+---
+id: apps/google-search-console
+title: "Google Search Console"
+kind: capability
+domain: apps
+capability: google-search-console
+capabilities:
+  - manifest
+  - cli
+  - operations
+tags:
+  - apps
+  - google-search-console
+applies_to:
+  - src/apps/google-search-console
+  - src/cli/commands/google-search-console.ts
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+# Google Search Console Ravi App
+
+## Objective
+
+Provide a native, portable Google Search Console capability through Ravi CLI,
+SDK and Apps. A clean Ravi installation must not require the external `sde`
+binary or organization-specific defaults.
+
+## Contract
+
+- Credentials are resolved through Ravi's credential broker under provider
+  `google-search-console` and a caller-selected connection.
+- The secret is a JSON envelope containing `clientId`, `clientSecret` and
+  `refreshToken`; secret values never appear in command output or traces.
+- Every command accepts explicit property identifiers. No property, domain or
+  account is compiled into Ravi.
+- Native operations cover Search Analytics, Sites, Sitemaps, URL Inspection
+  and Site Verification.
+- Read and mutation operations have distinct `CommandAccess` declarations;
+  destructive operations require confirmation.
+- Public commands declare concrete return schemas and are generated into the
+  TypeScript SDK.
+- The Ravi App manifest delegates only to native `ravi gsc` commands.
+
+## Non-goals
+
+- Changing existing agents, grants or skills.
+- Replacing any existing production workflow.
+- Executing destructive Google operations as part of validation.
+
+## Completion evidence
+
+- Source and packaged manifest validation.
+- SDK generation/check, typecheck, tests and lint.
+- A clean packaged CLI lists the complete native command surface.
+- Real authenticated read calls exercise properties, analytics, inspection
+  and sitemaps without the external SDE CLI.

--- a/.ravi/specs/apps/google-search-console/WHY.md
+++ b/.ravi/specs/apps/google-search-console/WHY.md
@@ -1,0 +1,6 @@
+# Why
+
+An App manifest that shells out to an organization-local CLI is discoverable
+but not portable. Owning the Google protocol, credential contract, permission
+metadata and typed returns in Ravi makes the capability installable and usable
+by any authorized consumer while keeping credentials outside code and traces.

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -3,7 +3,7 @@
 // Drift is detected by `ravi sdk client check` (CI).
 
 import type { Transport } from "./transport/types.js";
-import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
+import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, GscCountriesReturn, GscDateSeriesReturn, GscDevicesReturn, GscFallingReturn, GscInspectReturn, GscQueryReturn, GscRisingReturn, GscSiteAddReturn, GscSiteDeleteReturn, GscSiteGetReturn, GscSitemapDeleteReturn, GscSitemapGetReturn, GscSitemapSubmitReturn, GscSitemapsReturn, GscSitesReturn, GscTopPagesReturn, GscTopQueriesReturn, GscTrendsReturn, GscVerificationTokenReturn, GscVerifySiteReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
 
 /**
  * `RaviClient` exposes every registry command as a typed method.
@@ -2703,6 +2703,234 @@ export class RaviClient {
         groupSegments: ["gmail"],
         command: "read",
         body: { id, ...(options ?? {}) },
+      });
+    }
+  };
+
+  readonly gsc = {
+    /** Break down Search Analytics performance by country */
+    countries: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscCountriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "countries",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Return daily Search Analytics performance */
+    dateSeries: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      query?: string;
+    }): Promise<GscDateSeriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "date-series",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Break down Search Analytics performance by device */
+    devices: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+    }): Promise<GscDevicesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "devices",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** List queries with the largest negative click change */
+    falling: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscFallingReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "falling",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Inspect a URL index status in Google */
+    inspect: async (site: string, url: string, options?: {
+      connection?: string;
+      language?: string;
+    }): Promise<GscInspectReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "inspect",
+        body: { site, url, ...(options ?? {}) },
+      });
+    },
+    /** Run a Search Analytics query with explicit dates and dimensions */
+    query: async (site: string, options?: {
+      connection?: string;
+      dataState?: string;
+      dimensions?: string;
+      end?: string;
+      limit?: string;
+      start?: string;
+      startRow?: string;
+      type?: string;
+    }): Promise<GscQueryReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "query",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** List queries with the largest positive click change */
+    rising: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscRisingReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "rising",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Add a Search Console property */
+    siteAdd: async (site: string, options?: {
+      connection?: string;
+    }): Promise<GscSiteAddReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "site-add",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Remove a Search Console property from this account */
+    siteDelete: async (site: string, options?: {
+      connection?: string;
+    }): Promise<GscSiteDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "site-delete",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Get one Search Console property and its permission level */
+    siteGet: async (site: string, options?: {
+      connection?: string;
+    }): Promise<GscSiteGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "site-get",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Delete a submitted sitemap */
+    sitemapDelete: async (site: string, url: string, options?: {
+      connection?: string;
+    }): Promise<GscSitemapDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "sitemap-delete",
+        body: { site, url, ...(options ?? {}) },
+      });
+    },
+    /** Get one submitted sitemap */
+    sitemapGet: async (site: string, url: string, options?: {
+      connection?: string;
+    }): Promise<GscSitemapGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "sitemap-get",
+        body: { site, url, ...(options ?? {}) },
+      });
+    },
+    /** Submit a sitemap to Google */
+    sitemapSubmit: async (site: string, url: string, options?: {
+      connection?: string;
+    }): Promise<GscSitemapSubmitReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "sitemap-submit",
+        body: { site, url, ...(options ?? {}) },
+      });
+    },
+    /** List submitted sitemaps for a property */
+    sitemaps: async (site: string, options?: {
+      connection?: string;
+    }): Promise<GscSitemapsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "sitemaps",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** List Search Console properties available to the credential */
+    sites: async (options?: {
+      connection?: string;
+    }): Promise<GscSitesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "sites",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Rank pages by clicks for a recent period */
+    topPages: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscTopPagesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "top-pages",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Rank search queries by clicks for a recent period */
+    topQueries: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscTopQueriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "top-queries",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Compare query performance with the preceding period */
+    trends: async (site: string, options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<GscTrendsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "trends",
+        body: { site, ...(options ?? {}) },
+      });
+    },
+    /** Request a Google site-verification token */
+    verificationToken: async (identifier: string, options?: {
+      connection?: string;
+      method?: string;
+    }): Promise<GscVerificationTokenReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "verification-token",
+        body: { identifier, ...(options ?? {}) },
+      });
+    },
+    /** Ask Google to verify ownership of a site */
+    verifySite: async (identifier: string, options?: {
+      connection?: string;
+      method?: string;
+    }): Promise<GscVerifySiteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gsc"],
+        command: "verify-site",
+        body: { identifier, ...(options ?? {}) },
       });
     }
   };

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -29527,6 +29527,1484 @@ export const GmailReadReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `gsc.countries`. */
+export const GscCountriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "28",
+      "type": "string"
+    },
+    "limit": {
+      "default": "10",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.countries`. */
+export const GscCountriesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.date-series`. */
+export const GscDateSeriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "28",
+      "type": "string"
+    },
+    "query": {
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.date-series`. */
+export const GscDateSeriesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.devices`. */
+export const GscDevicesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "28",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.devices`. */
+export const GscDevicesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.falling`. */
+export const GscFallingInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "7",
+      "type": "string"
+    },
+    "limit": {
+      "default": "10",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.falling`. */
+export const GscFallingReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.inspect`. */
+export const GscInspectInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "site": {
+      "description": "Search Console property URL",
+      "type": "string"
+    },
+    "url": {
+      "description": "Fully qualified URL to inspect",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site",
+    "url"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.inspect`. */
+export const GscInspectReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.query`. */
+export const GscQueryInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "dataState": {
+      "description": "final,all,hourly_all",
+      "type": "string"
+    },
+    "dimensions": {
+      "description": "query,page,country,device,date",
+      "type": "string"
+    },
+    "end": {
+      "description": "Last data date",
+      "type": "string"
+    },
+    "limit": {
+      "default": "1000",
+      "description": "Rows, 1-25000",
+      "type": "string"
+    },
+    "site": {
+      "description": "Search Console property URL",
+      "type": "string"
+    },
+    "start": {
+      "description": "First data date",
+      "type": "string"
+    },
+    "startRow": {
+      "default": "0",
+      "description": "Pagination offset",
+      "type": "string"
+    },
+    "type": {
+      "description": "web,image,video,news,discover,googleNews",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.query`. */
+export const GscQueryReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.rising`. */
+export const GscRisingInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "7",
+      "type": "string"
+    },
+    "limit": {
+      "default": "10",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.rising`. */
+export const GscRisingReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.site-add`. */
+export const GscSiteAddInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "description": "Property URL",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.site-add`. */
+export const GscSiteAddReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.site-delete`. */
+export const GscSiteDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "description": "Property URL",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.site-delete`. */
+export const GscSiteDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.site-get`. */
+export const GscSiteGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "description": "Property URL, for example sc-domain:example.com",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.site-get`. */
+export const GscSiteGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.sitemap-delete`. */
+export const GscSitemapDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site",
+    "url"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.sitemap-delete`. */
+export const GscSitemapDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.sitemap-get`. */
+export const GscSitemapGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site",
+    "url"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.sitemap-get`. */
+export const GscSitemapGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.sitemap-submit`. */
+export const GscSitemapSubmitInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site",
+    "url"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.sitemap-submit`. */
+export const GscSitemapSubmitReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.sitemaps`. */
+export const GscSitemapsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "site": {
+      "description": "Search Console property URL",
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.sitemaps`. */
+export const GscSitemapsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.sites`. */
+export const GscSitesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.sites`. */
+export const GscSitesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.top-pages`. */
+export const GscTopPagesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "7",
+      "type": "string"
+    },
+    "limit": {
+      "default": "25",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.top-pages`. */
+export const GscTopPagesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.top-queries`. */
+export const GscTopQueriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "7",
+      "type": "string"
+    },
+    "limit": {
+      "default": "25",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.top-queries`. */
+export const GscTopQueriesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.trends`. */
+export const GscTrendsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "days": {
+      "default": "7",
+      "type": "string"
+    },
+    "limit": {
+      "default": "20",
+      "type": "string"
+    },
+    "site": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "site"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.trends`. */
+export const GscTrendsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.verification-token`. */
+export const GscVerificationTokenInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "identifier": {
+      "type": "string"
+    },
+    "method": {
+      "default": "DNS_TXT",
+      "type": "string"
+    }
+  },
+  "required": [
+    "identifier"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.verification-token`. */
+export const GscVerificationTokenReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gsc.verify-site`. */
+export const GscVerifySiteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "identifier": {
+      "type": "string"
+    },
+    "method": {
+      "default": "DNS_TXT",
+      "type": "string"
+    }
+  },
+  "required": [
+    "identifier"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gsc.verify-site`. */
+export const GscVerifySiteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `heartbeat.disable`. */
 export const HeartbeatDisableInputSchema = {
   "additionalProperties": false,

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -5870,6 +5870,254 @@ export type GmailReadReturn = {
   result?: unknown;
 };
 
+/** Input shape for `gsc.countries`. */
+export type GscCountriesInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.countries`. */
+export type GscCountriesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.date-series`. */
+export type GscDateSeriesInput = {
+  connection?: string;
+  days?: string;
+  query?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.date-series`. */
+export type GscDateSeriesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.devices`. */
+export type GscDevicesInput = {
+  connection?: string;
+  days?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.devices`. */
+export type GscDevicesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.falling`. */
+export type GscFallingInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.falling`. */
+export type GscFallingReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.inspect`. */
+export type GscInspectInput = {
+  connection?: string;
+  language?: string;
+  site: string;
+  url: string;
+};
+
+/** Return shape for `gsc.inspect`. */
+export type GscInspectReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.query`. */
+export type GscQueryInput = {
+  connection?: string;
+  dataState?: string;
+  dimensions?: string;
+  end?: string;
+  limit?: string;
+  site: string;
+  start?: string;
+  startRow?: string;
+  type?: string;
+};
+
+/** Return shape for `gsc.query`. */
+export type GscQueryReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.rising`. */
+export type GscRisingInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.rising`. */
+export type GscRisingReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.site-add`. */
+export type GscSiteAddInput = {
+  connection?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.site-add`. */
+export type GscSiteAddReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.site-delete`. */
+export type GscSiteDeleteInput = {
+  connection?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.site-delete`. */
+export type GscSiteDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.site-get`. */
+export type GscSiteGetInput = {
+  connection?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.site-get`. */
+export type GscSiteGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.sitemap-delete`. */
+export type GscSitemapDeleteInput = {
+  connection?: string;
+  site: string;
+  url: string;
+};
+
+/** Return shape for `gsc.sitemap-delete`. */
+export type GscSitemapDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.sitemap-get`. */
+export type GscSitemapGetInput = {
+  connection?: string;
+  site: string;
+  url: string;
+};
+
+/** Return shape for `gsc.sitemap-get`. */
+export type GscSitemapGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.sitemap-submit`. */
+export type GscSitemapSubmitInput = {
+  connection?: string;
+  site: string;
+  url: string;
+};
+
+/** Return shape for `gsc.sitemap-submit`. */
+export type GscSitemapSubmitReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.sitemaps`. */
+export type GscSitemapsInput = {
+  connection?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.sitemaps`. */
+export type GscSitemapsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.sites`. */
+export type GscSitesInput = {
+  connection?: string;
+};
+
+/** Return shape for `gsc.sites`. */
+export type GscSitesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.top-pages`. */
+export type GscTopPagesInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.top-pages`. */
+export type GscTopPagesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.top-queries`. */
+export type GscTopQueriesInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.top-queries`. */
+export type GscTopQueriesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.trends`. */
+export type GscTrendsInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+  site: string;
+};
+
+/** Return shape for `gsc.trends`. */
+export type GscTrendsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.verification-token`. */
+export type GscVerificationTokenInput = {
+  connection?: string;
+  identifier: string;
+  method?: string;
+};
+
+/** Return shape for `gsc.verification-token`. */
+export type GscVerificationTokenReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gsc.verify-site`. */
+export type GscVerifySiteInput = {
+  connection?: string;
+  identifier: string;
+  method?: string;
+};
+
+/** Return shape for `gsc.verify-site`. */
+export type GscVerifySiteReturn = {
+  result: unknown;
+};
+
 /** Input shape for `heartbeat.disable`. */
 export type HeartbeatDisableInput = {
   id: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:fd6e955f784edd28bac6aef04d0bc579b0a68524078dc1068837a7a859991a0f";
+export const REGISTRY_HASH = "sha256:e4fc85587648e42209c337b98ebdc75ee250fe93e7f92f0a662efc8e7415159e";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "bd8147fc0120";
+export const GIT_SHA = "af0299dade38";

--- a/src/apps/google-search-console/app.test.ts
+++ b/src/apps/google-search-console/app.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+describe("Google Search Console App contract", () => {
+  const manifest = JSON.parse(readFileSync(join(root, "ravi.app.json"), "utf8")) as {
+    operations: Record<string, { interface: string; command?: string; mutating?: boolean }>;
+    skills: string[];
+  };
+
+  it("uses only native Ravi commands", () => {
+    const commands = Object.values(manifest.operations).flatMap((operation) =>
+      operation.command ? [operation.command] : [],
+    );
+    expect(commands.length).toBeGreaterThanOrEqual(20);
+    expect(commands.every((command) => command.startsWith("ravi gsc "))).toBe(true);
+    expect(commands.some((command) => command.includes("sde"))).toBe(false);
+  });
+
+  it("keeps deployment separate from agent and skill changes", () => {
+    expect(manifest.skills).toEqual([]);
+  });
+
+  it("classifies every mutation explicitly", () => {
+    const mutations = Object.values(manifest.operations).filter((operation) => operation.mutating);
+    expect(mutations.length).toBeGreaterThan(0);
+    expect(mutations.every((operation) => operation.interface === "cli")).toBe(true);
+  });
+});

--- a/src/apps/google-search-console/client.test.ts
+++ b/src/apps/google-search-console/client.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { parseCredential } from "./client.js";
+
+describe("GoogleSearchConsoleClient credentials", () => {
+  it("accepts the portable credential envelope", () => {
+    expect(parseCredential('{"clientId":"id","clientSecret":"secret","refreshToken":"refresh"}')).toEqual({
+      clientId: "id",
+      clientSecret: "secret",
+      refreshToken: "refresh",
+    });
+  });
+
+  it("never accepts incomplete credentials", () => {
+    expect(() => parseCredential('{"clientId":"id"}')).toThrow("clientSecret");
+    expect(() => parseCredential("not-json")).toThrow("must be JSON");
+  });
+});

--- a/src/apps/google-search-console/client.ts
+++ b/src/apps/google-search-console/client.ts
@@ -1,0 +1,167 @@
+import { resolveCredentialSecret } from "../../credentials/broker.js";
+
+export interface GoogleSearchConsoleCredential {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}
+
+export interface GscClientOptions {
+  connection?: string;
+  fetch?: typeof globalThis.fetch;
+  /** In-process credential injection for migrations and isolated validation. */
+  credential?: GoogleSearchConsoleCredential;
+}
+
+const SEARCH_CONSOLE = "https://searchconsole.googleapis.com";
+const SITE_VERIFICATION = "https://www.googleapis.com/siteVerification/v1";
+
+export class GoogleSearchConsoleClient {
+  readonly #connection: string;
+  readonly #fetch: typeof globalThis.fetch;
+  readonly #credential?: GoogleSearchConsoleCredential;
+  #accessToken: string | null = null;
+
+  constructor(options: GscClientOptions = {}) {
+    this.#connection = options.connection ?? "default";
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#credential = options.credential;
+  }
+
+  async listSites() {
+    return this.request("/webmasters/v3/sites");
+  }
+
+  async getSite(siteUrl: string) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}`);
+  }
+
+  async addSite(siteUrl: string) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}`, { method: "PUT" });
+  }
+
+  async deleteSite(siteUrl: string) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}`, { method: "DELETE" });
+  }
+
+  async query(siteUrl: string, body: Record<string, unknown>) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/searchAnalytics/query`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async inspect(siteUrl: string, inspectionUrl: string, languageCode?: string) {
+    return this.request("/v1/urlInspection/index:inspect", {
+      method: "POST",
+      body: JSON.stringify({ siteUrl, inspectionUrl, languageCode }),
+    });
+  }
+
+  async listSitemaps(siteUrl: string) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/sitemaps`);
+  }
+
+  async getSitemap(siteUrl: string, feedpath: string) {
+    return this.request(`/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/sitemaps/${encodeURIComponent(feedpath)}`);
+  }
+
+  async submitSitemap(siteUrl: string, feedpath: string) {
+    return this.request(
+      `/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/sitemaps/${encodeURIComponent(feedpath)}`,
+      {
+        method: "PUT",
+      },
+    );
+  }
+
+  async deleteSitemap(siteUrl: string, feedpath: string) {
+    return this.request(
+      `/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/sitemaps/${encodeURIComponent(feedpath)}`,
+      {
+        method: "DELETE",
+      },
+    );
+  }
+
+  async verificationToken(site: { type: "SITE" | "INET_DOMAIN"; identifier: string }, method: string) {
+    return this.requestAbsolute(`${SITE_VERIFICATION}/token`, {
+      method: "POST",
+      body: JSON.stringify({ site, verificationMethod: method }),
+    });
+  }
+
+  async verifySite(site: { type: "SITE" | "INET_DOMAIN"; identifier: string }, method: string) {
+    return this.requestAbsolute(`${SITE_VERIFICATION}/webResource?verificationMethod=${encodeURIComponent(method)}`, {
+      method: "POST",
+      body: JSON.stringify({ site }),
+    });
+  }
+
+  private request(path: string, init: RequestInit = {}) {
+    return this.requestAbsolute(`${SEARCH_CONSOLE}${path}`, init);
+  }
+
+  private async requestAbsolute(url: string, init: RequestInit): Promise<unknown> {
+    const token = await this.accessToken();
+    const response = await this.#fetch(url, {
+      ...init,
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json", ...init.headers },
+    });
+    const text = await response.text();
+    if (!response.ok) throw new Error(`Google Search Console request failed (${response.status}): ${redact(text)}`);
+    return text ? JSON.parse(text) : {};
+  }
+
+  private async accessToken(): Promise<string> {
+    if (this.#accessToken) return this.#accessToken;
+    const credential =
+      this.#credential ??
+      parseCredential(
+        (
+          await resolveCredentialSecret({
+            provider: "google-search-console",
+            connection: this.#connection,
+            action: "auth.check",
+          })
+        ).secret,
+      );
+    const response = await this.#fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: credential.clientId,
+        client_secret: credential.clientSecret,
+        refresh_token: credential.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    });
+    const payload = (await response.json()) as { access_token?: string; error?: string };
+    if (!response.ok || !payload.access_token)
+      throw new Error(`Google OAuth refresh failed: ${payload.error ?? response.status}`);
+    this.#accessToken = payload.access_token;
+    return payload.access_token;
+  }
+}
+
+export function parseCredential(value: string): GoogleSearchConsoleCredential {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("Google Search Console credential must be JSON.");
+  }
+  if (!parsed || typeof parsed !== "object") throw new Error("Google Search Console credential must be an object.");
+  const record = parsed as Record<string, unknown>;
+  for (const field of ["clientId", "clientSecret", "refreshToken"] as const) {
+    if (typeof record[field] !== "string" || !record[field])
+      throw new Error(`Google Search Console credential misses ${field}.`);
+  }
+  return record as unknown as GoogleSearchConsoleCredential;
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/("(?:access_token|refresh_token|client_secret)"\s*:\s*")[^"]+/gi, "$1[redacted]")
+    .slice(0, 1000);
+}

--- a/src/apps/google-search-console/ravi.app.json
+++ b/src/apps/google-search-console/ravi.app.json
@@ -1,0 +1,183 @@
+{
+  "schema": "ravi.app/v1",
+  "id": "google-search-console",
+  "name": "Google Search Console",
+  "version": "0.1.0",
+  "description": "Gerencia propriedades, desempenho, indexação e sitemaps no Google Search Console.",
+  "interfaces": {
+    "cli": {
+      "command": "ravi google-search-console",
+      "json": true,
+      "health": "ravi gsc sites --json"
+    },
+    "ui": {
+      "routes": [
+        {
+          "id": "main",
+          "path": "/apps/google-search-console",
+          "label": "Search Console",
+          "icon": "search",
+          "view": "overview"
+        }
+      ],
+      "views": [
+        {
+          "id": "overview",
+          "type": "dashboard",
+          "title": "Google Search Console",
+          "density": "compact",
+          "query": { "operation": "google-search-console.top-queries" },
+          "actions": [
+            {
+              "id": "top-queries",
+              "label": "Buscas",
+              "icon": "search",
+              "operation": "google-search-console.top-queries",
+              "placement": "toolbar"
+            },
+            {
+              "id": "top-pages",
+              "label": "Páginas",
+              "icon": "file-text",
+              "operation": "google-search-console.top-pages",
+              "placement": "toolbar"
+            },
+            {
+              "id": "sitemaps",
+              "label": "Sitemaps",
+              "icon": "list-tree",
+              "operation": "google-search-console.sitemaps",
+              "placement": "toolbar"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "operations": {
+    "google-search-console.check": {
+      "interface": "builtin",
+      "handler": "apps.manifest.check",
+      "mutating": false
+    },
+    "google-search-console.sites": {
+      "interface": "cli",
+      "command": "ravi gsc sites --json {args}",
+      "mutating": false
+    },
+    "google-search-console.site-add": {
+      "interface": "cli",
+      "command": "ravi gsc site-add --json {args}",
+      "mutating": true,
+      "permission": "gsc:properties:write"
+    },
+    "google-search-console.site-delete": {
+      "interface": "cli",
+      "command": "ravi gsc site-delete --json {args}",
+      "mutating": true,
+      "permission": "gsc:properties:write"
+    },
+    "google-search-console.site-get": {
+      "interface": "cli",
+      "command": "ravi gsc site-get --json {args}",
+      "mutating": false
+    },
+    "google-search-console.verificar-token": {
+      "interface": "cli",
+      "command": "ravi gsc verification-token --json {args}",
+      "mutating": true,
+      "permission": "gsc:verification:write"
+    },
+    "google-search-console.verificar-site": {
+      "interface": "cli",
+      "command": "ravi gsc verify-site --json {args}",
+      "mutating": true,
+      "permission": "gsc:verification:write"
+    },
+    "google-search-console.top-queries": {
+      "interface": "cli",
+      "command": "ravi gsc top-queries --json {args}",
+      "mutating": false
+    },
+    "google-search-console.query": {
+      "interface": "cli",
+      "command": "ravi gsc query --json {args}",
+      "mutating": false
+    },
+    "google-search-console.top-pages": {
+      "interface": "cli",
+      "command": "ravi gsc top-pages --json {args}",
+      "mutating": false
+    },
+    "google-search-console.trends": {
+      "interface": "cli",
+      "command": "ravi gsc trends --json {args}",
+      "mutating": false
+    },
+    "google-search-console.rising": {
+      "interface": "cli",
+      "command": "ravi gsc rising --json {args}",
+      "mutating": false
+    },
+    "google-search-console.falling": {
+      "interface": "cli",
+      "command": "ravi gsc falling --json {args}",
+      "mutating": false
+    },
+    "google-search-console.inspect": {
+      "interface": "cli",
+      "command": "ravi gsc inspect --json {args}",
+      "mutating": false
+    },
+    "google-search-console.sitemaps": {
+      "interface": "cli",
+      "command": "ravi gsc sitemaps --json {args}",
+      "mutating": false
+    },
+    "google-search-console.sitemap-get": {
+      "interface": "cli",
+      "command": "ravi gsc sitemap-get --json {args}",
+      "mutating": false
+    },
+    "google-search-console.sitemap-submit": {
+      "interface": "cli",
+      "command": "ravi gsc sitemap-submit --json {args}",
+      "mutating": true,
+      "permission": "gsc:sitemaps:write"
+    },
+    "google-search-console.sitemap-delete": {
+      "interface": "cli",
+      "command": "ravi gsc sitemap-delete --json {args}",
+      "mutating": true,
+      "permission": "gsc:sitemaps:write"
+    },
+    "google-search-console.devices": {
+      "interface": "cli",
+      "command": "ravi gsc devices --json {args}",
+      "mutating": false
+    },
+    "google-search-console.countries": {
+      "interface": "cli",
+      "command": "ravi gsc countries --json {args}",
+      "mutating": false
+    },
+    "google-search-console.date-series": {
+      "interface": "cli",
+      "command": "ravi gsc date-series --json {args}",
+      "mutating": false
+    }
+  },
+  "permissions": {
+    "required": [],
+    "optional": [],
+    "mutating": ["gsc:properties:write", "gsc:verification:write", "gsc:sitemaps:write"]
+  },
+  "storage": { "sqlite": [], "files": [] },
+  "artifacts": [],
+  "events": { "emits": [], "consumes": [] },
+  "skills": [],
+  "health": {
+    "checks": [{ "type": "cli", "command": "ravi gsc sites --json" }]
+  },
+  "versioning": { "compatibility": "semver", "migrations": [] }
+}

--- a/src/apps/router.ts
+++ b/src/apps/router.ts
@@ -120,11 +120,13 @@ export function resolveAppAliasInvocation(
     if (!appIds.has(candidate)) continue;
     const rest = argv.slice(segmentCount);
     const { json, help, args } = stripRouterFlags(rest);
-    const operation = help ? "help" : args[0];
+    // Root help is owned by the app router. Operation help belongs to the
+    // underlying interface so imported CLIs keep command-specific help.
+    const operation = help && args.length === 0 ? "help" : args[0];
     return {
       appId: candidate,
       operation,
-      args: operation ? args.slice(1) : args,
+      args: operation ? [...args.slice(1), ...(help ? ["--help"] : [])] : args,
       json,
     };
   }
@@ -665,6 +667,19 @@ function parseJsonOutput(stdout: string): unknown {
   try {
     return JSON.parse(trimmed);
   } catch {
+    // Some established CLIs print benign progress before their JSON payload
+    // (for example, an OAuth token refresh notice). Preserve stdout for audit,
+    // but still expose the final machine-readable payload to app callers.
+    const lines = trimmed.split("\n");
+    for (let index = 1; index < lines.length; index++) {
+      const candidate = lines.slice(index).join("\n").trim();
+      if (!candidate.startsWith("{") && !candidate.startsWith("[")) continue;
+      try {
+        return JSON.parse(candidate);
+      } catch {
+        // Keep looking for the first valid trailing JSON document.
+      }
+    }
     return undefined;
   }
 }

--- a/src/cli/commands/google-search-console.ts
+++ b/src/cli/commands/google-search-console.ts
@@ -1,0 +1,433 @@
+import "reflect-metadata";
+import { z } from "zod";
+import { GoogleSearchConsoleClient } from "../../apps/google-search-console/client.js";
+import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
+import { jsonValueSchema } from "../return-schemas.js";
+
+const resultSchema = z.object({ result: jsonValueSchema }).strict();
+const wrap = (result: unknown) => {
+  const payload = { result: result as never };
+  console.log(JSON.stringify(payload, null, 2));
+  return payload;
+};
+
+@Group({
+  name: "gsc",
+  description: "Operate Google Search Console through a credential stored in Ravi",
+  scope: "open",
+})
+export class GoogleSearchConsoleCommands {
+  private client(connection?: string) {
+    return new GoogleSearchConsoleClient({ connection });
+  }
+
+  @Command({ name: "sites", description: "List Search Console properties available to the credential" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.sites", action: "list", risk: "low" })
+  @Returns(resultSchema)
+  async sites(
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).listSites());
+  }
+
+  @Command({ name: "site-get", description: "Get one Search Console property and its permission level" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.sites", action: "get", risk: "low" })
+  @Returns(resultSchema)
+  async siteGet(
+    @Arg("site", { description: "Property URL, for example sc-domain:example.com" }) site: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getSite(site));
+  }
+
+  @Command({ name: "site-add", description: "Add a Search Console property" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-search-console.sites",
+    action: "add",
+    risk: "high",
+    requiresConfirmation: true,
+  })
+  @Returns(resultSchema)
+  async siteAdd(
+    @Arg("site", { description: "Property URL" }) site: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).addSite(site));
+  }
+
+  @Command({ name: "site-delete", description: "Remove a Search Console property from this account" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-search-console.sites",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(resultSchema)
+  async siteDelete(
+    @Arg("site", { description: "Property URL" }) site: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteSite(site));
+  }
+
+  @Command({ name: "query", description: "Run a Search Analytics query with explicit dates and dimensions" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "query", risk: "low" })
+  @Returns(resultSchema)
+  async query(
+    @Arg("site", { description: "Search Console property URL" }) site: string,
+    @Option({ flags: "--start <yyyy-mm-dd>", description: "First data date" }) start: string,
+    @Option({ flags: "--end <yyyy-mm-dd>", description: "Last data date" }) end: string,
+    @Option({ flags: "--dimensions <csv>", description: "query,page,country,device,date" }) dimensions?: string,
+    @Option({ flags: "--limit <n>", description: "Rows, 1-25000", defaultValue: "1000" }) limit?: string,
+    @Option({ flags: "--start-row <n>", description: "Pagination offset", defaultValue: "0" }) startRow?: string,
+    @Option({ flags: "--type <type>", description: "web,image,video,news,discover,googleNews" }) type?: string,
+    @Option({ flags: "--data-state <state>", description: "final,all,hourly_all" }) dataState?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    if (!start || !end) throw new Error("--start and --end are required");
+    const rowLimit = integer(limit, 1000, 1, 25_000);
+    return wrap(
+      await this.client(connection).query(site, {
+        startDate: start,
+        endDate: end,
+        dimensions: csv(dimensions),
+        rowLimit,
+        startRow: integer(startRow, 0, 0, Number.MAX_SAFE_INTEGER),
+        type,
+        dataState,
+      }),
+    );
+  }
+
+  @Command({ name: "top-queries", description: "Rank search queries by clicks for a recent period" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "top-queries", risk: "low" })
+  @Returns(resultSchema)
+  async topQueries(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "7" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "25" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return this.dimensionReport(site, "query", days, limit, connection);
+  }
+
+  @Command({ name: "top-pages", description: "Rank pages by clicks for a recent period" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "top-pages", risk: "low" })
+  @Returns(resultSchema)
+  async topPages(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "7" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "25" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return this.dimensionReport(site, "page", days, limit, connection);
+  }
+
+  @Command({ name: "devices", description: "Break down Search Analytics performance by device" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "devices", risk: "low" })
+  @Returns(resultSchema)
+  async devices(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "28" }) days?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return this.dimensionReport(site, "device", days, "25", connection);
+  }
+
+  @Command({ name: "countries", description: "Break down Search Analytics performance by country" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "countries", risk: "low" })
+  @Returns(resultSchema)
+  async countries(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "28" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "10" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return this.dimensionReport(site, "country", days, limit, connection);
+  }
+
+  @Command({ name: "date-series", description: "Return daily Search Analytics performance" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "date-series", risk: "low" })
+  @Returns(resultSchema)
+  async dateSeries(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "28" }) days?: string,
+    @Option({ flags: "--query <text>" }) query?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    const period = recentPeriod(integer(days, 28, 1, 365));
+    return wrap(
+      await this.client(connection).query(site, {
+        startDate: period.start,
+        endDate: period.end,
+        dimensions: ["date"],
+        rowLimit: 25_000,
+        dimensionFilterGroups: query
+          ? [{ filters: [{ dimension: "query", operator: "contains", expression: query }] }]
+          : undefined,
+      }),
+    );
+  }
+
+  @Command({ name: "trends", description: "Compare query performance with the preceding period" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "trends", risk: "low" })
+  @Returns(resultSchema)
+  async trends(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "7" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "20" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.trendData(site, days, limit, connection));
+  }
+
+  private async trendData(site: string, days?: string, limit?: string, connection?: string) {
+    const count = integer(days, 7, 1, 365);
+    const current = recentPeriod(count);
+    const previous = previousPeriod(current.start, count);
+    const rowLimit = integer(limit, 20, 1, 25_000);
+    const client = this.client(connection);
+    const [now, before] = await Promise.all([
+      client.query(site, { startDate: current.start, endDate: current.end, dimensions: ["query"], rowLimit }),
+      client.query(site, { startDate: previous.start, endDate: previous.end, dimensions: ["query"], rowLimit }),
+    ]);
+    return { current, previous, rows: compareRows(now, before) };
+  }
+
+  @Command({ name: "rising", description: "List queries with the largest positive click change" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "rising", risk: "low" })
+  @Returns(resultSchema)
+  async rising(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "7" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "10" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    const trend = await this.trendData(site, days, "25000", connection);
+    return wrap(sortedTrendRows(trend, "desc", integer(limit, 10, 1, 1000)));
+  }
+
+  @Command({ name: "falling", description: "List queries with the largest negative click change" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.analytics", action: "falling", risk: "low" })
+  @Returns(resultSchema)
+  async falling(
+    @Arg("site") site: string,
+    @Option({ flags: "--days <n>", defaultValue: "7" }) days?: string,
+    @Option({ flags: "--limit <n>", defaultValue: "10" }) limit?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    const trend = await this.trendData(site, days, "25000", connection);
+    return wrap(sortedTrendRows(trend, "asc", integer(limit, 10, 1, 1000)));
+  }
+
+  private async dimensionReport(
+    site: string,
+    dimension: string,
+    days: string | undefined,
+    limit: string | undefined,
+    connection?: string,
+  ) {
+    const period = recentPeriod(integer(days, 7, 1, 365));
+    return wrap(
+      await this.client(connection).query(site, {
+        startDate: period.start,
+        endDate: period.end,
+        dimensions: [dimension],
+        rowLimit: integer(limit, 25, 1, 25_000),
+      }),
+    );
+  }
+
+  @Command({ name: "inspect", description: "Inspect a URL index status in Google" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.inspection", action: "inspect", risk: "low" })
+  @Returns(resultSchema)
+  async inspect(
+    @Arg("site", { description: "Search Console property URL" }) site: string,
+    @Arg("url", { description: "Fully qualified URL to inspect" }) url: string,
+    @Option({ flags: "--language <code>" }) language?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).inspect(site, url, language));
+  }
+
+  @Command({ name: "sitemaps", description: "List submitted sitemaps for a property" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.sitemaps", action: "list", risk: "low" })
+  @Returns(resultSchema)
+  async sitemaps(
+    @Arg("site", { description: "Search Console property URL" }) site: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).listSitemaps(site));
+  }
+
+  @Command({ name: "sitemap-get", description: "Get one submitted sitemap" })
+  @CommandAccess({ kind: "read", resource: "google-search-console.sitemaps", action: "get", risk: "low" })
+  @Returns(resultSchema)
+  async sitemapGet(
+    @Arg("site") site: string,
+    @Arg("url") url: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getSitemap(site, url));
+  }
+
+  @Command({ name: "sitemap-submit", description: "Submit a sitemap to Google" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-search-console.sitemaps",
+    action: "submit",
+    risk: "high",
+    requiresConfirmation: true,
+  })
+  @Returns(resultSchema)
+  async sitemapSubmit(
+    @Arg("site") site: string,
+    @Arg("url") url: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).submitSitemap(site, url));
+  }
+
+  @Command({ name: "sitemap-delete", description: "Delete a submitted sitemap" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-search-console.sitemaps",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(resultSchema)
+  async sitemapDelete(
+    @Arg("site") site: string,
+    @Arg("url") url: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteSitemap(site, url));
+  }
+
+  @Command({ name: "verification-token", description: "Request a Google site-verification token" })
+  @CommandAccess({ kind: "mutate", resource: "google-search-console.verification", action: "token", risk: "medium" })
+  @Returns(resultSchema)
+  async verificationToken(
+    @Arg("identifier") identifier: string,
+    @Option({ flags: "--method <method>", defaultValue: "DNS_TXT" }) method?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).verificationToken(siteIdentifier(identifier), method ?? "DNS_TXT"));
+  }
+
+  @Command({ name: "verify-site", description: "Ask Google to verify ownership of a site" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-search-console.verification",
+    action: "verify",
+    risk: "high",
+    requiresConfirmation: true,
+  })
+  @Returns(resultSchema)
+  async verifySite(
+    @Arg("identifier") identifier: string,
+    @Option({ flags: "--method <method>", defaultValue: "DNS_TXT" }) method?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).verifySite(siteIdentifier(identifier), method ?? "DNS_TXT"));
+  }
+}
+
+// Every finite Ravi command is JSON-addressable. GSC emits the same stable
+// JSON envelope in both modes, while --json makes that contract discoverable
+// to agents, Apps and the generated SDK.
+for (const command of [
+  "sites",
+  "siteGet",
+  "siteAdd",
+  "siteDelete",
+  "query",
+  "topQueries",
+  "topPages",
+  "devices",
+  "countries",
+  "dateSeries",
+  "trends",
+  "rising",
+  "falling",
+  "inspect",
+  "sitemaps",
+  "sitemapGet",
+  "sitemapSubmit",
+  "sitemapDelete",
+  "verificationToken",
+  "verifySite",
+] as const) {
+  const method = GoogleSearchConsoleCommands.prototype[command];
+  Option({ flags: "--json", description: "Print the stable JSON response envelope" })(
+    GoogleSearchConsoleCommands.prototype,
+    command,
+    method.length,
+  );
+}
+
+function csv(value?: string): string[] | undefined {
+  const values = value
+    ?.split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return values?.length ? values : undefined;
+}
+
+function integer(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max)
+    throw new Error(`Expected integer from ${min} to ${max}.`);
+  return parsed;
+}
+
+function siteIdentifier(identifier: string): { type: "SITE" | "INET_DOMAIN"; identifier: string } {
+  return { type: identifier.startsWith("http") ? "SITE" : "INET_DOMAIN", identifier };
+}
+
+function iso(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+function recentPeriod(days: number) {
+  const end = new Date();
+  end.setUTCDate(end.getUTCDate() - 3);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+  return { start: iso(start), end: iso(end) };
+}
+function previousPeriod(currentStart: string, days: number) {
+  const end = new Date(`${currentStart}T00:00:00Z`);
+  end.setUTCDate(end.getUTCDate() - 1);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+  return { start: iso(start), end: iso(end) };
+}
+type AnalyticsRow = { keys?: string[]; clicks?: number; impressions?: number; ctr?: number; position?: number };
+function rows(value: unknown): AnalyticsRow[] {
+  return (value as { rows?: AnalyticsRow[] })?.rows ?? [];
+}
+function compareRows(current: unknown, previous: unknown) {
+  const old = new Map(rows(previous).map((row) => [row.keys?.[0] ?? "", row]));
+  return rows(current).map((row) => {
+    const key = row.keys?.[0] ?? "";
+    const prior = old.get(key);
+    return {
+      key,
+      clicks: row.clicks ?? 0,
+      previousClicks: prior?.clicks ?? 0,
+      clicksChange: (row.clicks ?? 0) - (prior?.clicks ?? 0),
+      impressions: row.impressions ?? 0,
+      previousImpressions: prior?.impressions ?? 0,
+    };
+  });
+}
+function sortedTrendRows(value: unknown, order: "asc" | "desc", limit: number) {
+  const result = value as { rows?: Array<{ clicksChange: number }> };
+  return [...(result.rows ?? [])]
+    .sort((a, b) => (order === "asc" ? a.clicksChange - b.clicksChange : b.clicksChange - a.clicksChange))
+    .slice(0, limit);
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -33,6 +33,7 @@ export * from "./eval.js";
 export * from "./events.js";
 export * from "./feedback.js";
 export * from "./gmail.js";
+export * from "./google-search-console.js";
 export * from "./group.js";
 export * from "./heartbeat.js";
 export * from "./hooks.js";


### PR DESCRIPTION
## Objective

Add a native Google Search Console app to Ravi so agents can read search
performance data (queries, pages, trends, devices, countries), inspect URLs and
list sitemaps through the official Search Console APIs. The app lands read-first:
write operations are declared but gated, and the default agent surface is
read-only.

## Problem

Ravi had no first-class integration with Google Search Console. Reading search
analytics, inspecting a URL's index status, or listing sitemaps required ad-hoc
scripts with no manifest, no permission scoping, and no discovery through the
apps registry.

## Solution

A new `google-search-console` app under `src/apps/`, backed by a typed API client
and a `ravi google-search-console` (`ravi gsc`) CLI command group. The
`ravi.app.json` manifest declares each operation with an explicit `mutating` flag
and per-operation permissions, so read and write surfaces are separated at the
contract level and discoverable via `ravi apps show/check google-search-console`.

## Practical impact

- Read operations return data as `mutating: false`: `sites`, `site-get`,
  `top-queries`, `query`, `top-pages`, `trends`, `rising`, `falling`, `inspect`,
  `sitemaps`, `sitemap-get`, `devices`, `countries`, `date-series`.
- The app is discoverable and validatable through the apps registry.
- Credentials resolve through the app credential resolver; secret values never
  appear in command output or traces.

## What does NOT change

- The shared apps-infra (plugin discovery in `service.ts`, the internal-loader
  and router tests) is taken from `dev` as-is. This app now builds on the
  packaged-plugin discovery that landed with the YouTube app merge, rather than
  carrying its own earlier variant of that infra.
- Write operations (`site-add`, `site-delete`, `sitemap-submit`,
  `sitemap-delete`, verification) are declared for completeness but are
  `mutating: true` and are not wired into any automated or agent-default flow.
- No daemon deploy, migration, or behavior change for other subsystems.

## Validation

- `bun run typecheck` — passes.
- `bunx biome check src/apps/google-search-console src/cli/commands/google-search-console.ts src/apps/router.ts` — clean.
- `bun test src/apps/google-search-console src/apps/router.test.ts src/apps/service.test.ts src/plugins/internal-loader.test.ts` — 37 pass / 0 fail.
- `bun run sdk:check` — SDK client artifacts current after regeneration.
- Local spec/quality gate — Spec gate PASSED (SPEC + WHY + RUNBOOK + CHECKS present).
- Rebased onto current `dev`; conflicts were the generated SDK (resolved by
  regenerating) and shared apps-infra (resolved by keeping dev's merged version).

## Risks

- Read operations call live Google APIs and require a configured Search Console
  credential; with none, the client fails with a clear "credential is not
  configured" error.
- New public CLI surface (`ravi gsc`) and new `@Returns` schemas are added; the
  SDK was regenerated in the same commit so the registry and SDK stay in sync.

## Rollback

Revert the single commit. The app is self-contained (new directory + one CLI
command + index entry + a small additive router change + SDK regen), so reverting
removes the `ravi gsc` surface with no residual effect on other apps.

## Follow-ups

- Wire write operations behind explicit human/agent authorization before enabling
  any mutating flow.
