### PR TITLE
Add Slack SDK connection alias

### DIFF
--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -5830,6 +5830,7 @@ export class RaviClient {
   readonly slack = {
     /** Send a Slack Block Kit message; dry-run unless --execute is set */
     blocksSend: async (channel: string, file: string, options?: {
+      connection?: string;
       ephemeralUser?: string;
       execute?: boolean;
       text?: string;
@@ -6056,6 +6057,7 @@ export class RaviClient {
     },
     /** Invite Slack users to a channel; dry-run unless --execute is set */
     channelsInvite: async (channel: string, users: string, options?: {
+      connection?: string;
       execute?: boolean;
     }): Promise<SlackChannelsInviteReturn> => {
       return this.transport.call({

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -55274,6 +55274,10 @@ export const SlackBlocksSendInputSchema = {
       "description": "Slack channel/conversation ID",
       "type": "string"
     },
+    "connection": {
+      "description": "Ravi channel config; SDK-safe alias for --channel",
+      "type": "string"
+    },
     "ephemeralUser": {
       "description": "Send as an ephemeral message visible only to this Slack user",
       "type": "string"
@@ -57505,6 +57509,10 @@ export const SlackChannelsInviteInputSchema = {
   "properties": {
     "channel": {
       "description": "Slack channel/conversation ID",
+      "type": "string"
+    },
+    "connection": {
+      "description": "Ravi channel config; SDK-safe alias for --channel",
       "type": "string"
     },
     "execute": {

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -11468,6 +11468,7 @@ export type SkillsWhoReturn = {
 /** Input shape for `slack.blocks-send`. */
 export type SlackBlocksSendInput = {
   channel: string;
+  connection?: string;
   ephemeralUser?: string;
   execute?: boolean;
   file: string;
@@ -11856,6 +11857,7 @@ export type SlackChannelsInfoReturn = {
 /** Input shape for `slack.channels-invite`. */
 export type SlackChannelsInviteInput = {
   channel: string;
+  connection?: string;
   execute?: boolean;
   users: string;
 };

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:7721e66e1e3bc768498614b8432124d2d149ded10fdb69083a9f5bb20b180677";
+export const REGISTRY_HASH = "sha256:6a4189690cce5588eb848b6452cea0cdc630d778de773b226629dcf8835b3b32";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "6f540e07599d";
+export const GIT_SHA = "4a491f72b79c";

--- a/src/cli/commands/slack.ts
+++ b/src/cli/commands/slack.ts
@@ -1228,6 +1228,8 @@ export class SlackCommands {
     @Arg("channel", { description: "Slack channel/conversation ID" }) channel: string,
     @Arg("file", { description: "Path to a Block Kit message JSON file" }) file: string,
     @Option({ flags: "--channel <name>", description: "Ravi channel config" }) raviChannel?: string,
+    @Option({ flags: "--connection <name>", description: "Ravi channel config; SDK-safe alias for --channel" })
+    connection?: string,
     @Option({ flags: "--text <text>", description: "Top-level fallback text for notifications/accessibility" })
     text?: string,
     @Option({ flags: "--thread-ts <ts>", description: "Send inside a Slack thread" }) threadTs?: string,
@@ -1249,7 +1251,7 @@ export class SlackCommands {
       ...(threadTs ? { threadTs } : {}),
       ...(ephemeralUser ? { ephemeralUser } : {}),
     };
-    const { client, config } = await createSlackOpsContext(raviChannel, method);
+    const { client, config } = await createSlackOpsContext(connection || raviChannel, method);
     if (!execute) return this.printMutationDryRun(config, method, request, asJson);
     const raw = ephemeralUser
       ? await client.postEphemeral({
@@ -1812,11 +1814,13 @@ export class SlackCommands {
     @Arg("channel", { description: "Slack channel/conversation ID" }) channel: string,
     @Arg("users", { description: "Comma-separated Slack user IDs" }) usersValue: string,
     @Option({ flags: "--channel <name>", description: "Ravi channel config" }) raviChannel?: string,
+    @Option({ flags: "--connection <name>", description: "Ravi channel config; SDK-safe alias for --channel" })
+    connection?: string,
     @Option({ flags: "--execute", description: "Perform the mutation; default is dry-run" }) execute?: boolean,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     const request = { channel, userIds: parseRequiredCsvOption(usersValue, "Slack user ids") };
-    const { client, config } = await createSlackOpsContext(raviChannel, "conversations.invite");
+    const { client, config } = await createSlackOpsContext(connection || raviChannel, "conversations.invite");
     if (!execute) return this.printMutationDryRun(config, "conversations.invite", request, asJson);
     const raw = await client.conversationsInvite(request);
     const payload = this.mutationPayload(config, false, "conversations.invite", request, raw.channel, raw);


### PR DESCRIPTION
## Summary

Adds `--connection` as an SDK-safe alias for the Slack channel config option on `slack blocks-send` and `slack channels-invite`.

This fixes workflow handlers that call the generated SDK with a positional Slack conversation `channel` plus a separate Ravi Slack connection. Without the alias, the SDK option name collides with the positional `channel` argument and cannot express the connection cleanly.

The generated SDK client, schemas, types, and registry fingerprint were regenerated from the updated CLI registry.

## Validation

- `bun run sdk:check`
- `bun run typecheck`
- `bun test src/cli/commands/slack.test.ts`
- `git diff --check`
- dry-run: `bun src/cli/index.ts slack blocks-send C0BGVKNEPG9 .ravi/workflows/slack-ticket-demo/entry-card.json --connection hana-slack --json`
- dry-run: `bun src/cli/index.ts slack channels-invite C0BGVKNEPG9 U0BF9CB6Q5V --connection hana-slack --json`
- pre-push hook: SDK drift, build, typecheck, full test suite, SDK tests
