### PR TITLE
feat(apps): add native YouTube app

### DIFF
--- a/.ravi/specs/apps/manifest/SPEC.md
+++ b/.ravi/specs/apps/manifest/SPEC.md
@@ -90,6 +90,10 @@ Canonical manifest protocol: `ravi.app/v1`.
 - An app manifest MUST NOT bypass the Permission Provider Runtime, context-key
   authorization, skill gates, runtime provider boundaries, or plugin
   association rules.
+- A CLI operation whose command begins with `ravi` MUST execute the entrypoint
+  of the current Ravi process. It MUST NOT resolve an older or different Ravi
+  installation from `PATH`, because that creates version skew between app
+  discovery and operation execution.
 
 ## Manifest Shape
 

--- a/.ravi/specs/apps/youtube/CHECKS.md
+++ b/.ravi/specs/apps/youtube/CHECKS.md
@@ -1,0 +1,43 @@
+# YouTube Ravi App / CHECKS
+
+## Checks
+
+- Manifest validation MUST pass with exactly one `youtube` app and zero errors or warnings.
+- The focused client, app, and CLI suites MUST pass without network access or a real credential.
+- `yt health --json` MUST pass metadata-only with `authenticated=false` and `externalCheckPerformed=false`.
+- `yt info --json` with isolated empty state MUST fail before any Google request with an actionable missing-credential error.
+- Generated command and SDK artifacts MUST remain current, and typecheck, build, Biome, and diff checks MUST pass.
+- Static preservation checks MUST find no SDE dependency, legacy credential path, monetary scope, or monetary metric in implementation code.
+
+Run from the repository/worktree root:
+
+```bash
+bun run gen:commands
+bun test src/apps/youtube src/cli/commands/youtube.test.ts
+bun src/cli/index.ts apps check youtube --json
+bun src/cli/index.ts yt --help
+bun src/cli/index.ts yt health --json
+bun run sdk:generate
+bun run sdk:check
+bun run typecheck
+bun run build
+bunx biome check src/apps/youtube src/cli/commands/youtube.ts src/cli/commands/youtube.test.ts
+```
+
+Credential-failure regression with no real backend or network:
+
+```bash
+RAVI_STATE_DIR=/tmp/ravi-youtube-empty bun src/cli/index.ts yt info --json
+```
+
+Expected: exit 1 with an actionable `YouTube credential unavailable` message before any Google request. Do not add a token to make this check pass.
+
+Static preservation checks:
+
+```bash
+git diff --name-only origin/dev...HEAD
+rg -n "sde|youtube-token|youtube-credentials" src/apps/youtube src/cli/commands/youtube.ts
+rg -n "yt-analytics-monetary|estimatedRevenue|grossRevenue" src/apps/youtube src/cli/commands/youtube.ts
+```
+
+Expected: no SDE dependency/token path and no monetary scope/metric in implementation code. Mentions in tests/specs may only assert their absence.

--- a/.ravi/specs/apps/youtube/RUNBOOK.md
+++ b/.ravi/specs/apps/youtube/RUNBOOK.md
@@ -1,0 +1,28 @@
+# YouTube Ravi App / RUNBOOK
+
+## Debug Flow
+
+1. Validate discovery without executing app code:
+
+   ```bash
+   bun src/cli/index.ts apps check youtube --json
+   bun src/cli/index.ts apps show youtube --json
+   ```
+
+2. Inspect Phase 1 readiness without resolving a secret:
+
+   ```bash
+   bun src/cli/index.ts yt health --json
+   ```
+
+   `authenticated: false` is expected. `ready: true` means only that an active `youtube:<connection>` metadata record exists.
+
+3. If a command fails with `YouTube credential unavailable`, do not read or import the SDE token. Credential onboarding belongs to a later approved phase.
+
+4. If a fake-fetch unit test fails, inspect the exact official endpoint, method, query and body recorded by the test. The implementation constants are in `src/apps/youtube/client.ts`.
+
+5. If the CLI is absent, run `bun run gen:commands` and verify `src/cli/commands/index.ts` exports `youtube.js`. Do not edit the barrel manually.
+
+6. If SDK checks fail after a CLI contract change, run `bun run sdk:generate`, inspect the generated TypeScript and Swift SDK diffs, then rerun `bun run sdk:check`.
+
+7. Never debug Phase 1 by running reply, update, delete, create, add or remove against Google. Those paths are validated only with fake `fetch` until separately approved.

--- a/.ravi/specs/apps/youtube/SPEC.md
+++ b/.ravi/specs/apps/youtube/SPEC.md
@@ -1,0 +1,62 @@
+---
+id: apps/youtube
+title: "YouTube Ravi App"
+kind: capability
+domain: apps
+capabilities:
+  - youtube
+tags:
+  - ravi-apps
+  - google
+  - youtube
+applies_to:
+  - src/apps/youtube
+  - src/cli/commands/youtube.ts
+owners:
+  - ravi-dev
+status: active
+normative: true
+---
+
+# YouTube Ravi App
+
+## Intent
+
+Define the native, parallel Phase 1 migration of the legacy `sde yt` surface to a Ravi App. The app exposes official YouTube Data API v3 and YouTube Analytics API v2 resources while preserving the SDE implementation as an untouched fallback. Real credential onboarding and authenticated live proof are deliberately outside Phase 1.
+
+## Invariants
+
+- The app MUST use the native app ID `youtube` and the decorated CLI group `ravi yt` (alias `ravi youtube`).
+- The native client MUST call only official Google endpoints under `https://www.googleapis.com/youtube/v3` and `https://youtubeanalytics.googleapis.com/v2`.
+- The native client MUST NOT execute `sde`, import SDE modules, read SDE credential/token files, or alter the legacy SDE code or runtime.
+- Phase 1 MUST NOT implement OAuth consent/callback/token refresh, use a real token, or perform an authenticated live request.
+- Missing credentials MUST fail closed before `fetch`, with an actionable broker configuration error that contains no secret value or secret path.
+- `health` MUST inspect only local credential metadata; it MUST report `authenticated: false` and `externalCheckPerformed: false` until a later authenticated proof phase.
+- Every CLI command MUST declare `@CommandAccess`, a typed `@Returns`, `--json`, and agent-usable help with official-source pointers.
+- Read operations MUST use `youtube:read`; Analytics MUST use `youtube:analytics:read`; captions list/download MUST use `youtube:captions:read` because Google requires an elevated edit-capable scope.
+- Public writes MUST use distinct comment/video/playlist write permissions and `risk: high` with confirmation. Video/playlist deletion and playlist-item removal MUST use distinct delete permissions and `risk: destructive` with confirmation.
+- The app MUST declare no financial operations and MUST NOT request YouTube monetary/revenue Analytics metrics in Phase 1.
+- The app MUST remain stateless: no SQLite schema, file persistence, migrations, or new NATS events.
+- Channel uploads SHOULD be listed through `channels.list` -> uploads playlist -> `playlistItems.list` -> `videos.list`, avoiding the higher-cost legacy `search.list` listing path.
+- Replies MUST use the official top-level comment resource ID (`topLevelComment.id`) as `comments.insert.snippet.parentId`, not the comment-thread ID.
+- Partial video updates MUST preserve every mutable property in each included `part`; the command result MUST be refetched as a complete video representation after `videos.update`.
+- Playlist reads MUST preserve each playlist-item ID independently, including duplicate videos and unavailable video resources, so destructive removal targets the selected occurrence.
+- All tests MUST use injected credentials and fake `fetch`; no test may depend on network access or a real secret.
+
+## Validation
+
+- `bun test src/apps/youtube src/cli/commands/youtube.test.ts`
+- `bun src/cli/index.ts apps check youtube --json`
+- `bun src/cli/index.ts yt health --json`
+- `bun src/cli/index.ts yt info --json` with an isolated empty `RAVI_STATE_DIR` MUST fail before network access.
+- `bun run gen:commands && bun run sdk:generate && bun run sdk:check`
+- `bun run typecheck && bun run build`
+- `bunx biome check src/apps/youtube src/cli/commands/youtube.ts src/cli/commands/youtube.test.ts`
+
+## Known Failure Modes
+
+- Reading `/home/ravi/sde/credentials/*` would silently couple the new app to the legacy deployment and violate credential isolation.
+- Using `commentThread.id` as a reply parent can target the wrong resource; only `topLevelComment.id` is valid for `comments.insert`.
+- Treating captions as generic read can understate the required `youtube.force-ssl`/`youtubepartner` authorization.
+- Adding revenue metrics would introduce a financial permission class and the `yt-analytics-monetary.readonly` scope, which Phase 1 explicitly excludes.
+- Running mutation commands for validation would create public or irreversible effects; only fake-fetch tests are valid in Phase 1.

--- a/.ravi/specs/apps/youtube/WHY.md
+++ b/.ravi/specs/apps/youtube/WHY.md
@@ -1,0 +1,67 @@
+# YouTube Ravi App / WHY
+
+## Rationale
+
+`confirmed_official_contract: yes` on 2026-07-13.
+
+The official Data API reference confirms the v3 resource model and relative endpoints under `https://www.googleapis.com/youtube/v3`. The official Analytics reference confirms `GET https://youtubeanalytics.googleapis.com/v2/reports`, its query parameters, and the required read scopes. This is sufficient to implement a native parallel app without treating SDE as the source of truth.
+
+Official sources:
+
+- Data API reference: <https://developers.google.com/youtube/v3/docs>
+- OAuth scopes: <https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps>
+- Analytics reports.query: <https://developers.google.com/youtube/analytics/reference/reports/query>
+- Analytics channel reports: <https://developers.google.com/youtube/analytics/channel_reports>
+- Captions download: <https://developers.google.com/youtube/v3/docs/captions/download>
+
+The client is native rather than an SDE wrapper because the official REST contract is clear and bounded. It accepts an access-token envelope from the Ravi credential broker but does not implement token acquisition or refresh in Phase 1. This lets the structure, command contract, permissions and failure behavior be tested without a real credential.
+
+## Legacy Gaps Corrected
+
+- `sde yt videos` uses `search.list` for the upload feed. The native app follows Google's implementation guidance and reads the channel uploads playlist, reducing quota cost and preserving pagination.
+- The legacy comment mapping exposes the thread ID as `commentId`. The official reply contract requires the top-level comment ID in `snippet.parentId`; the native app exposes both `threadId` and the correct `commentId`.
+- Legacy `health` authenticates and calls Google. Native Phase 1 `health` checks broker metadata only and explicitly refuses to claim authentication.
+- Legacy `auth-url` and `auth` are intentionally not migrated in this phase.
+
+## Operation Matrix
+
+| operacao_sde | categoria | risco_read_write | endpoint_ou_recurso_oficial | status_decisao | justificativa | fonte_oficial | observacoes_para_ravi_dev |
+|---|---|---|---|---|---|---|---|
+| `info` | channel | read | `GET /channels?mine=true` | migrar | Contract and channel statistics are official | channels.list | `youtube:read` |
+| `videos` | videos | read | `GET /channels` + `GET /playlistItems` + `GET /videos` | migrar | Official uploads-playlist path is cheaper than legacy search | channels.list, playlistItems.list, videos.list | Cursor preserved |
+| `video` | videos | read | `GET /videos?id=...` | migrar | Direct official detail lookup | videos.list | Normalized stable output |
+| `buscar` | videos | read | `GET /search` + `GET /videos` | migrar | Official text/channel search, then enrichment | search.list, videos.list | Native name `search` |
+| `stats` | videos | read | `GET /videos?id=...` + local derivation | migrar | Lifetime counters official; views/day deterministic | videos.list | No persistence |
+| `comentarios` | comments | read | `GET /commentThreads?videoId=...` | migrar | Official thread listing | commentThreads.list | Exposes thread and comment IDs |
+| `sem-resposta` | comments | read | `GET /commentThreads` + local filter | migrar | Reply count is in official thread resource | commentThreads.list | Native name `unanswered` |
+| `responder` | comments | write-high | `POST /comments` | migrar | Official reply method | comments.insert | `youtube:comments:write`, HITL; fake-fetch only |
+| `playlists` | playlists | read | `GET /playlists?mine=true` | migrar | Official owned-playlist list | playlists.list | `youtube:read` |
+| `playlist` | playlists | read | `GET /playlistItems` + `GET /videos` | migrar | Official playlist contents | playlistItems.list, videos.list | Returns playlistItemId |
+| `playlist-criar` | playlists | write-high | `POST /playlists` | migrar | Official create method | playlists.insert | `youtube:playlists:write`, HITL |
+| `playlist-deletar` | playlists | destructive | `DELETE /playlists?id=...` | migrar | Official delete method | playlists.delete | `youtube:playlists:delete`, HITL |
+| `playlist-add` | playlists | write-high | `POST /playlistItems` | migrar | Official item insertion | playlistItems.insert | Non-idempotent, HITL |
+| `playlist-remove` | playlists | destructive | `DELETE /playlistItems?id=...` | migrar | Official item deletion | playlistItems.delete | Requires playlistItemId, HITL |
+| `inscricoes` | subscriptions | read | `GET /subscriptions?mine=true` | migrar | Official outgoing subscription feed | subscriptions.list | Native name `subscriptions` |
+| `legendas` | captions | read-sensitive | `GET /captions?videoId=...` | migrar | Official caption metadata | captions.list | Separate elevated permission |
+| `legenda-baixar` | captions | read-sensitive | `GET /captions/{id}` | migrar | Official binary/text download | captions.download | Separate elevated permission |
+| `categorias-video` | videos | read | `GET /videoCategories?regionCode=...` | migrar | Official assignable categories | videoCategories.list | Native name `video-categories` |
+| `analytics-overview` | analytics | read | `GET /v2/reports` aggregate metrics | migrar | Official targeted query | reports.query, channel reports | No monetary metrics |
+| `analytics-series` | analytics | read | `GET /v2/reports?dimensions=day` | migrar | Official time dimension | reports.query, channel reports | Metric allowlist |
+| `analytics-top` | analytics | read | `GET /v2/reports?dimensions=video` + `GET /videos` | migrar | Official video report plus title enrichment | reports.query, videos.list | Bounded results |
+| `analytics-traffic` | analytics | read | `GET /v2/reports?dimensions=insightTrafficSourceType` | migrar | Official traffic-source report | channel reports | No financial metrics |
+| `analytics-demo` | analytics | read | `GET /v2/reports?dimensions=ageGroup,gender` | migrar | Official demographic report | channel reports | Native name `analytics-demographics` |
+| `analytics-paises` | analytics | read | `GET /v2/reports?dimensions=country` | migrar | Official geography report | channel reports | Native name `analytics-countries` |
+| `analytics-devices` | analytics | read | `GET /v2/reports?dimensions=deviceType` | migrar | Official device report | channel reports | `youtube:analytics:read` |
+| `video-update` | videos | write-high | `GET /videos` + `PUT /videos` | migrar | Preserve unspecified required fields before official update | videos.list, videos.update | `youtube:videos:write`, HITL |
+| `video-delete` | videos | destructive | `DELETE /videos?id=...` | migrar | Official permanent delete | videos.delete | `youtube:videos:delete`, HITL |
+| `health` | setup | local-read | Ravi credential metadata only | adicionar | Phase 1 must not authenticate or call Google | Ravi broker contract | Reports no external proof |
+| `auth-url`, `auth` | authentication | setup-sensitive | OAuth 2.0 flow | aguardar | Real auth/token onboarding is outside Phase 1 | OAuth guide | Not present in app/CLI |
+
+Financial operations: none. Revenue and ad-performance reports are intentionally excluded.
+
+## Rejected Alternatives
+
+- **SDE wrapper:** rejected because it would retain legacy token-file coupling and duplicate-process behavior despite a clear official API.
+- **Credential import from SDE:** rejected because Phase 1 forbids real token use and legacy secret access.
+- **Database/cache:** rejected because all outputs are provider-owned data or deterministic derivations; persistence adds no lineage needed for Phase 1.
+- **NATS events:** rejected because no new cross-system lifecycle is introduced.

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -3,7 +3,7 @@
 // Drift is detected by `ravi sdk client check` (CI).
 
 import type { Transport } from "./transport/types.js";
-import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn } from "./types.js";
+import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
 
 /**
  * `RaviClient` exposes every registry command as a typed method.
@@ -7741,6 +7741,323 @@ export class RaviClient {
           body: { specId },
         });
       }
+    }
+  };
+
+  readonly yt = {
+    /** Break down recent views and watch time by country */
+    analyticsCountries: async (options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<YtAnalyticsCountriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-countries",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Break down viewer percentage by age group and gender */
+    analyticsDemographics: async (options?: {
+      connection?: string;
+      days?: string;
+    }): Promise<YtAnalyticsDemographicsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-demographics",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Break down recent views and watch time by device type */
+    analyticsDevices: async (options?: {
+      connection?: string;
+      days?: string;
+    }): Promise<YtAnalyticsDevicesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-devices",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Return aggregate channel engagement metrics for a recent period */
+    analyticsOverview: async (options?: {
+      connection?: string;
+      days?: string;
+    }): Promise<YtAnalyticsOverviewReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-overview",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Return a daily time series for one approved YouTube Analytics metric */
+    analyticsSeries: async (options?: {
+      connection?: string;
+      days?: string;
+      metric?: "views" | "estimatedMinutesWatched" | "averageViewDuration" | "subscribersGained" | "likes" | "comments" | "shares";
+    }): Promise<YtAnalyticsSeriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-series",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Rank channel videos by views for a recent period */
+    analyticsTop: async (options?: {
+      connection?: string;
+      days?: string;
+      limit?: string;
+    }): Promise<YtAnalyticsTopReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-top",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Break down recent views and watch time by traffic-source type */
+    analyticsTraffic: async (options?: {
+      connection?: string;
+      days?: string;
+    }): Promise<YtAnalyticsTrafficReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "analytics-traffic",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Download one caption track as text */
+    captionDownload: async (captionId: string, options?: {
+      connection?: string;
+      format?: "srt" | "vtt" | "ttml";
+      language?: string;
+    }): Promise<YtCaptionDownloadReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "caption-download",
+        body: { captionId, ...(options ?? {}) },
+      });
+    },
+    /** List caption tracks for one video */
+    captions: async (videoId: string, options?: {
+      connection?: string;
+    }): Promise<YtCaptionsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "captions",
+        body: { videoId, ...(options ?? {}) },
+      });
+    },
+    /** List top-level comment threads for a video */
+    comments: async (videoId: string, options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtCommentsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "comments",
+        body: { videoId, ...(options ?? {}) },
+      });
+    },
+    /** Inspect YouTube credential metadata without resolving a secret or calling Google */
+    health: async (options?: {
+      connection?: string;
+    }): Promise<YtHealthReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "health",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Return metadata and lifetime counters for the authenticated channel */
+    info: async (options?: {
+      connection?: string;
+    }): Promise<YtInfoReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "info",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** List videos and playlist-item IDs from one playlist */
+    playlist: async (playlistId: string, options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtPlaylistReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist",
+        body: { playlistId, ...(options ?? {}) },
+      });
+    },
+    /** Add one video to a YouTube playlist */
+    playlistAdd: async (playlistId: string, videoId: string, options?: {
+      connection?: string;
+    }): Promise<YtPlaylistAddReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-add",
+        body: { playlistId, videoId, ...(options ?? {}) },
+      });
+    },
+    /** Create a YouTube playlist */
+    playlistCreate: async (title: string, options?: {
+      connection?: string;
+      description?: string;
+      privacy?: "public" | "private" | "unlisted";
+    }): Promise<YtPlaylistCreateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-create",
+        body: { title, ...(options ?? {}) },
+      });
+    },
+    /** Permanently delete a YouTube playlist without deleting its videos */
+    playlistDelete: async (playlistId: string, options?: {
+      connection?: string;
+    }): Promise<YtPlaylistDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-delete",
+        body: { playlistId, ...(options ?? {}) },
+      });
+    },
+    /** Remove one playlist item without deleting the video */
+    playlistRemove: async (playlistItemId: string, options?: {
+      connection?: string;
+    }): Promise<YtPlaylistRemoveReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-remove",
+        body: { playlistItemId, ...(options ?? {}) },
+      });
+    },
+    /** List playlists owned by the authenticated channel */
+    playlists: async (options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtPlaylistsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlists",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Publish a reply to a top-level YouTube comment */
+    reply: async (commentId: string, text: string, options?: {
+      connection?: string;
+    }): Promise<YtReplyReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "reply",
+        body: { commentId, text, ...(options ?? {}) },
+      });
+    },
+    /** Search videos in the authenticated channel */
+    search: async (query: string, options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtSearchReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "search",
+        body: { query, ...(options ?? {}) },
+      });
+    },
+    /** Calculate lifetime video counters, age and average views per day */
+    stats: async (id: string, options?: {
+      connection?: string;
+    }): Promise<YtStatsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "stats",
+        body: { id, ...(options ?? {}) },
+      });
+    },
+    /** List channels followed by the authenticated channel */
+    subscriptions: async (options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtSubscriptionsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "subscriptions",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** List recent comment threads with zero replies */
+    unanswered: async (videoId: string, options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtUnansweredReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "unanswered",
+        body: { videoId, ...(options ?? {}) },
+      });
+    },
+    /** Get one video by YouTube video ID */
+    video: async (id: string, options?: {
+      connection?: string;
+    }): Promise<YtVideoReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "video",
+        body: { id, ...(options ?? {}) },
+      });
+    },
+    /** List assignable YouTube video categories for a region */
+    videoCategories: async (options?: {
+      connection?: string;
+      region?: string;
+    }): Promise<YtVideoCategoriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "video-categories",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Permanently delete an owned YouTube video */
+    videoDelete: async (id: string, options?: {
+      connection?: string;
+    }): Promise<YtVideoDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "video-delete",
+        body: { id, ...(options ?? {}) },
+      });
+    },
+    /** Update selected metadata on an owned YouTube video */
+    videoUpdate: async (id: string, options?: {
+      category?: string;
+      connection?: string;
+      description?: string;
+      privacy?: "public" | "private" | "unlisted";
+      tags?: string;
+      title?: string;
+    }): Promise<YtVideoUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "video-update",
+        body: { id, ...(options ?? {}) },
+      });
+    },
+    /** List videos from the authenticated channel uploads playlist */
+    videos: async (options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtVideosReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "videos",
+        body: { ...(options ?? {}) },
+      });
     }
   };
 }

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -69668,3 +69668,2144 @@ export const WorkflowsSpecsShowReturnSchema = {
   "properties": {},
   "type": "object"
 } as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-countries`. */
+export const YtAnalyticsCountriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Rows, 1-200 (default: 10)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-countries`. */
+export const YtAnalyticsCountriesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "countries": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "country": {
+            "type": "string"
+          },
+          "subscribersGained": {
+            "type": "number"
+          },
+          "views": {
+            "type": "number"
+          },
+          "watchTimeMinutes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "country",
+          "views",
+          "watchTimeMinutes",
+          "subscribersGained"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "countries"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-demographics`. */
+export const YtAnalyticsDemographicsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-demographics`. */
+export const YtAnalyticsDemographicsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "demographics": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "ageGroup": {
+            "type": "string"
+          },
+          "gender": {
+            "type": "string"
+          },
+          "viewerPercentage": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "ageGroup",
+          "gender",
+          "viewerPercentage"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "demographics"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-devices`. */
+export const YtAnalyticsDevicesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-devices`. */
+export const YtAnalyticsDevicesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "devices": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "device": {
+            "type": "string"
+          },
+          "views": {
+            "type": "number"
+          },
+          "watchTimeMinutes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "device",
+          "views",
+          "watchTimeMinutes"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "devices"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-overview`. */
+export const YtAnalyticsOverviewInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-overview`. */
+export const YtAnalyticsOverviewReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "overview": {
+      "additionalProperties": false,
+      "properties": {
+        "avgViewDurationSec": {
+          "type": "number"
+        },
+        "comments": {
+          "type": "number"
+        },
+        "dislikes": {
+          "type": "number"
+        },
+        "likes": {
+          "type": "number"
+        },
+        "netSubscribers": {
+          "type": "number"
+        },
+        "shares": {
+          "type": "number"
+        },
+        "subscribersGained": {
+          "type": "number"
+        },
+        "subscribersLost": {
+          "type": "number"
+        },
+        "views": {
+          "type": "number"
+        },
+        "watchTimeMinutes": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "views",
+        "watchTimeMinutes",
+        "avgViewDurationSec",
+        "subscribersGained",
+        "subscribersLost",
+        "netSubscribers",
+        "likes",
+        "dislikes",
+        "comments",
+        "shares"
+      ],
+      "type": "object"
+    },
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "overview"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-series`. */
+export const YtAnalyticsSeriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "metric": {
+      "description": "views|estimatedMinutesWatched|averageViewDuration|subscribersGained|likes|comments|shares (default: views)",
+      "enum": [
+        "views",
+        "estimatedMinutesWatched",
+        "averageViewDuration",
+        "subscribersGained",
+        "likes",
+        "comments",
+        "shares"
+      ],
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-series`. */
+export const YtAnalyticsSeriesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "items": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metric": {
+      "type": "string"
+    },
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "metric",
+    "data"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-top`. */
+export const YtAnalyticsTopInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Rows, 1-200 (default: 10)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-top`. */
+export const YtAnalyticsTopReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "period": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "videos": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "avgViewDurationSec": {
+            "type": "number"
+          },
+          "comments": {
+            "type": "number"
+          },
+          "likes": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "views": {
+            "type": "number"
+          },
+          "watchTimeMinutes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "views",
+          "watchTimeMinutes",
+          "avgViewDurationSec",
+          "likes",
+          "comments"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "videos"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.analytics-traffic`. */
+export const YtAnalyticsTrafficInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "days": {
+      "description": "Recent days, 1-365 (default: 28)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.analytics-traffic`. */
+export const YtAnalyticsTrafficReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "period": {
+      "type": "string"
+    },
+    "sources": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "views": {
+            "type": "number"
+          },
+          "watchTimeMinutes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "source",
+          "views",
+          "watchTimeMinutes"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "period",
+    "sources"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.caption-download`. */
+export const YtCaptionDownloadInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "captionId": {
+      "description": "Caption track ID from `ravi yt captions`",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "format": {
+      "description": "srt|vtt|ttml (default: srt)",
+      "enum": [
+        "srt",
+        "vtt",
+        "ttml"
+      ],
+      "type": "string"
+    },
+    "language": {
+      "description": "Optional ISO 639-1 translation language",
+      "type": "string"
+    }
+  },
+  "required": [
+    "captionId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.caption-download`. */
+export const YtCaptionDownloadReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "captionId": {
+      "type": "string"
+    },
+    "content": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "captionId",
+    "format",
+    "content"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.captions`. */
+export const YtCaptionsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "videoId": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.captions`. */
+export const YtCaptionsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "captions": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "captionId": {
+            "type": "string"
+          },
+          "isAutoSynced": {
+            "type": "boolean"
+          },
+          "isDraft": {
+            "type": "boolean"
+          },
+          "language": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "trackKind": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "captionId",
+          "language",
+          "name",
+          "trackKind",
+          "isAutoSynced",
+          "isDraft",
+          "status",
+          "lastUpdated"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    },
+    "videoId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "videoId",
+    "captions",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.comments`. */
+export const YtCommentsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-100 (default: 20)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    },
+    "videoId": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.comments`. */
+export const YtCommentsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "comments": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "authorChannelUrl": {
+            "type": "string"
+          },
+          "commentId": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "text": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId",
+          "commentId",
+          "author",
+          "authorChannelUrl",
+          "text",
+          "likeCount",
+          "publishedAt",
+          "replyCount"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "nextPageToken": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    },
+    "videoId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "videoId",
+    "comments",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.health`. */
+export const YtHealthInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.health`. */
+export const YtHealthReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "app": {
+      "const": "youtube",
+      "type": "string"
+    },
+    "authenticated": {
+      "const": false,
+      "type": "boolean"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "credentialConfigured": {
+      "type": "boolean"
+    },
+    "credentialStatus": {
+      "type": "string"
+    },
+    "externalCheckPerformed": {
+      "const": false,
+      "type": "boolean"
+    },
+    "message": {
+      "type": "string"
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "app",
+    "connection",
+    "ready",
+    "credentialConfigured",
+    "credentialStatus",
+    "authenticated",
+    "externalCheckPerformed",
+    "message"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.info`. */
+export const YtInfoInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.info`. */
+export const YtInfoReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "channel": {
+      "additionalProperties": false,
+      "properties": {
+        "channelId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "subscriberCount": {
+          "type": "number"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "uploadsPlaylistId": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "videoCount": {
+          "type": "number"
+        },
+        "viewCount": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "channelId",
+        "title",
+        "description",
+        "subscriberCount",
+        "videoCount",
+        "viewCount",
+        "thumbnail",
+        "uploadsPlaylistId",
+        "url"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "channel"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist`. */
+export const YtPlaylistInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 25)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    },
+    "playlistId": {
+      "description": "YouTube playlist ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist`. */
+export const YtPlaylistReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "playlistId": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    },
+    "videos": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "duration",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "success",
+    "playlistId",
+    "videos",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist-add`. */
+export const YtPlaylistAddInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "playlistId": {
+      "description": "Target YouTube playlist ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "videoId": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistId",
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-add`. */
+export const YtPlaylistAddReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "additionalProperties": false,
+      "properties": {
+        "playlistId": {
+          "type": "string"
+        },
+        "playlistItemId": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "videoId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "playlistItemId",
+        "playlistId",
+        "videoId",
+        "title"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "item"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist-create`. */
+export const YtPlaylistCreateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "description": {
+      "description": "Playlist description",
+      "type": "string"
+    },
+    "privacy": {
+      "description": "public|private|unlisted (default: private)",
+      "enum": [
+        "public",
+        "private",
+        "unlisted"
+      ],
+      "type": "string"
+    },
+    "title": {
+      "description": "Playlist title",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "title"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-create`. */
+export const YtPlaylistCreateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "playlist": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "itemCount": {
+          "type": "number"
+        },
+        "playlistId": {
+          "type": "string"
+        },
+        "privacyStatus": {
+          "type": "string"
+        },
+        "publishedAt": {
+          "type": "string"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "playlistId",
+        "title",
+        "description",
+        "thumbnail",
+        "itemCount",
+        "publishedAt",
+        "privacyStatus",
+        "url"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "playlist"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist-delete`. */
+export const YtPlaylistDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "playlistId": {
+      "description": "Owned YouTube playlist ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-delete`. */
+export const YtPlaylistDeleteReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "deleted"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist-remove`. */
+export const YtPlaylistRemoveInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "playlistItemId": {
+      "description": "Playlist item ID, not video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistItemId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-remove`. */
+export const YtPlaylistRemoveReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "removed": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "removed"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlists`. */
+export const YtPlaylistsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 25)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlists`. */
+export const YtPlaylistsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "playlists": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "itemCount": {
+            "type": "number"
+          },
+          "playlistId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "playlistId",
+          "title",
+          "description",
+          "thumbnail",
+          "itemCount",
+          "publishedAt",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "playlists",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.reply`. */
+export const YtReplyInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "description": "Top-level comment ID from `ravi yt comments`",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "text": {
+      "description": "Exact approved reply text",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "commentId",
+    "text"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.reply`. */
+export const YtReplyReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "replyId": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "replyId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.search`. */
+export const YtSearchInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 10)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    },
+    "query": {
+      "description": "Search text",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "query"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.search`. */
+export const YtSearchReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "query": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    },
+    "videos": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "duration",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "success",
+    "videos",
+    "totalResults",
+    "query"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.stats`. */
+export const YtStatsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "id": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.stats`. */
+export const YtStatsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "stats": {
+      "additionalProperties": false,
+      "properties": {
+        "commentCount": {
+          "type": "number"
+        },
+        "daysSincePublish": {
+          "type": "number"
+        },
+        "likeCount": {
+          "type": "number"
+        },
+        "publishedAt": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "videoId": {
+          "type": "string"
+        },
+        "viewCount": {
+          "type": "number"
+        },
+        "viewsPerDay": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "videoId",
+        "title",
+        "viewCount",
+        "likeCount",
+        "commentCount",
+        "publishedAt",
+        "daysSincePublish",
+        "viewsPerDay"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "stats"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.subscriptions`. */
+export const YtSubscriptionsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 25)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.subscriptions`. */
+export const YtSubscriptionsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "subscriptions": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "subscriptionId": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "totalItemCount": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscriptionId",
+          "channelId",
+          "title",
+          "description",
+          "thumbnail",
+          "publishedAt",
+          "totalItemCount",
+          "url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "subscriptions",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.unanswered`. */
+export const YtUnansweredInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Threads inspected, 1-100 (default: 50)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    },
+    "videoId": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.unanswered`. */
+export const YtUnansweredReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "comments": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "authorChannelUrl": {
+            "type": "string"
+          },
+          "commentId": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "text": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId",
+          "commentId",
+          "author",
+          "authorChannelUrl",
+          "text",
+          "likeCount",
+          "publishedAt",
+          "replyCount"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "nextPageToken": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalUnanswered": {
+      "type": "number"
+    },
+    "videoId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "videoId",
+    "comments",
+    "totalUnanswered"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.video`. */
+export const YtVideoInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "id": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.video`. */
+export const YtVideoReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "video": {
+      "additionalProperties": false,
+      "properties": {
+        "commentCount": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "likeCount": {
+          "type": "number"
+        },
+        "playlistItemId": {
+          "type": "string"
+        },
+        "privacyStatus": {
+          "type": "string"
+        },
+        "publishedAt": {
+          "type": "string"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "videoId": {
+          "type": "string"
+        },
+        "viewCount": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "videoId",
+        "title",
+        "description",
+        "publishedAt",
+        "thumbnail",
+        "viewCount",
+        "likeCount",
+        "commentCount",
+        "duration",
+        "privacyStatus",
+        "url"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "success",
+    "video"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.video-categories`. */
+export const YtVideoCategoriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "region": {
+      "description": "ISO 3166-1 alpha-2 region (default: BR)",
+      "pattern": "^[A-Za-z]{2}$",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.video-categories`. */
+export const YtVideoCategoriesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "categories": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "assignable": {
+            "type": "boolean"
+          },
+          "categoryId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "categoryId",
+          "title",
+          "assignable"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "region": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "region",
+    "categories",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.video-delete`. */
+export const YtVideoDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "id": {
+      "description": "Owned YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.video-delete`. */
+export const YtVideoDeleteReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "deleted"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.video-update`. */
+export const YtVideoUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "category": {
+      "description": "Replacement category ID",
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "description": {
+      "description": "Replacement description",
+      "type": "string"
+    },
+    "id": {
+      "description": "Owned YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "privacy": {
+      "description": "public|private|unlisted",
+      "enum": [
+        "public",
+        "private",
+        "unlisted"
+      ],
+      "type": "string"
+    },
+    "tags": {
+      "description": "Replacement comma-separated tag list",
+      "type": "string"
+    },
+    "title": {
+      "description": "Replacement title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.video-update`. */
+export const YtVideoUpdateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "video": {
+      "additionalProperties": false,
+      "properties": {
+        "commentCount": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "likeCount": {
+          "type": "number"
+        },
+        "playlistItemId": {
+          "type": "string"
+        },
+        "privacyStatus": {
+          "type": "string"
+        },
+        "publishedAt": {
+          "type": "string"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "videoId": {
+          "type": "string"
+        },
+        "viewCount": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "videoId",
+        "title",
+        "description",
+        "publishedAt",
+        "thumbnail",
+        "viewCount",
+        "likeCount",
+        "commentCount",
+        "duration",
+        "privacyStatus",
+        "url"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "success",
+    "video"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.videos`. */
+export const YtVideosInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 10)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.videos`. */
+export const YtVideosReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "nextPageToken": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    },
+    "videos": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "duration",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "success",
+    "videos",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -14746,3 +14746,584 @@ export type WorkflowsSpecsShowInput = {
 
 /** Return shape for `workflows.specs.show`. */
 export type WorkflowsSpecsShowReturn = Record<string, unknown>;
+
+/** Input shape for `yt.analytics-countries`. */
+export type YtAnalyticsCountriesInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+};
+
+/** Return shape for `yt.analytics-countries`. */
+export type YtAnalyticsCountriesReturn = {
+  countries: Array<{
+    country: string;
+    subscribersGained: number;
+    views: number;
+    watchTimeMinutes: number;
+  }>;
+  period: string;
+  success: true;
+};
+
+/** Input shape for `yt.analytics-demographics`. */
+export type YtAnalyticsDemographicsInput = {
+  connection?: string;
+  days?: string;
+};
+
+/** Return shape for `yt.analytics-demographics`. */
+export type YtAnalyticsDemographicsReturn = {
+  demographics: Array<{
+    ageGroup: string;
+    gender: string;
+    viewerPercentage: number;
+  }>;
+  period: string;
+  success: true;
+};
+
+/** Input shape for `yt.analytics-devices`. */
+export type YtAnalyticsDevicesInput = {
+  connection?: string;
+  days?: string;
+};
+
+/** Return shape for `yt.analytics-devices`. */
+export type YtAnalyticsDevicesReturn = {
+  devices: Array<{
+    device: string;
+    views: number;
+    watchTimeMinutes: number;
+  }>;
+  period: string;
+  success: true;
+};
+
+/** Input shape for `yt.analytics-overview`. */
+export type YtAnalyticsOverviewInput = {
+  connection?: string;
+  days?: string;
+};
+
+/** Return shape for `yt.analytics-overview`. */
+export type YtAnalyticsOverviewReturn = {
+  overview: {
+    avgViewDurationSec: number;
+    comments: number;
+    dislikes: number;
+    likes: number;
+    netSubscribers: number;
+    shares: number;
+    subscribersGained: number;
+    subscribersLost: number;
+    views: number;
+    watchTimeMinutes: number;
+  };
+  period: string;
+  success: true;
+};
+
+/** Input shape for `yt.analytics-series`. */
+export type YtAnalyticsSeriesInput = {
+  connection?: string;
+  days?: string;
+  metric?: "views" | "estimatedMinutesWatched" | "averageViewDuration" | "subscribersGained" | "likes" | "comments" | "shares";
+};
+
+/** Return shape for `yt.analytics-series`. */
+export type YtAnalyticsSeriesReturn = {
+  data: Array<Record<string, string | number | boolean | null>>;
+  metric: string;
+  period: string;
+  success: true;
+};
+
+/** Input shape for `yt.analytics-top`. */
+export type YtAnalyticsTopInput = {
+  connection?: string;
+  days?: string;
+  limit?: string;
+};
+
+/** Return shape for `yt.analytics-top`. */
+export type YtAnalyticsTopReturn = {
+  period: string;
+  success: true;
+  videos: Array<{
+    avgViewDurationSec: number;
+    comments: number;
+    likes: number;
+    title: string;
+    videoId: string;
+    views: number;
+    watchTimeMinutes: number;
+  }>;
+};
+
+/** Input shape for `yt.analytics-traffic`. */
+export type YtAnalyticsTrafficInput = {
+  connection?: string;
+  days?: string;
+};
+
+/** Return shape for `yt.analytics-traffic`. */
+export type YtAnalyticsTrafficReturn = {
+  period: string;
+  sources: Array<{
+    source: string;
+    views: number;
+    watchTimeMinutes: number;
+  }>;
+  success: true;
+};
+
+/** Input shape for `yt.caption-download`. */
+export type YtCaptionDownloadInput = {
+  captionId: string;
+  connection?: string;
+  format?: "srt" | "vtt" | "ttml";
+  language?: string;
+};
+
+/** Return shape for `yt.caption-download`. */
+export type YtCaptionDownloadReturn = {
+  captionId: string;
+  content: string;
+  format: string;
+  success: true;
+};
+
+/** Input shape for `yt.captions`. */
+export type YtCaptionsInput = {
+  connection?: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.captions`. */
+export type YtCaptionsReturn = {
+  captions: Array<{
+    captionId: string;
+    isAutoSynced: boolean;
+    isDraft: boolean;
+    language: string;
+    lastUpdated: string;
+    name: string;
+    status: string;
+    trackKind: string;
+  }>;
+  success: true;
+  totalResults: number;
+  videoId: string;
+};
+
+/** Input shape for `yt.comments`. */
+export type YtCommentsInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.comments`. */
+export type YtCommentsReturn = {
+  comments: Array<{
+    author: string;
+    authorChannelUrl: string;
+    commentId: string;
+    likeCount: number;
+    publishedAt: string;
+    replyCount: number;
+    text: string;
+    threadId: string;
+  }>;
+  nextPageToken?: string;
+  success: true;
+  totalResults: number;
+  videoId: string;
+};
+
+/** Input shape for `yt.health`. */
+export type YtHealthInput = {
+  connection?: string;
+};
+
+/** Return shape for `yt.health`. */
+export type YtHealthReturn = {
+  app: "youtube";
+  authenticated: false;
+  connection: string;
+  credentialConfigured: boolean;
+  credentialStatus: string;
+  externalCheckPerformed: false;
+  message: string;
+  ready: boolean;
+  success: true;
+};
+
+/** Input shape for `yt.info`. */
+export type YtInfoInput = {
+  connection?: string;
+};
+
+/** Return shape for `yt.info`. */
+export type YtInfoReturn = {
+  channel: {
+    channelId: string;
+    description: string;
+    subscriberCount: number;
+    thumbnail: string;
+    title: string;
+    uploadsPlaylistId: string;
+    url: string;
+    videoCount: number;
+    viewCount: number;
+  };
+  success: true;
+};
+
+/** Input shape for `yt.playlist`. */
+export type YtPlaylistInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+  playlistId: string;
+};
+
+/** Return shape for `yt.playlist`. */
+export type YtPlaylistReturn = {
+  nextPageToken?: string;
+  playlistId: string;
+  success: true;
+  totalResults: number;
+  videos: Array<{
+    commentCount: number;
+    description: string;
+    duration: string;
+    likeCount: number;
+    playlistItemId?: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+    videoId: string;
+    viewCount: number;
+  }>;
+};
+
+/** Input shape for `yt.playlist-add`. */
+export type YtPlaylistAddInput = {
+  connection?: string;
+  playlistId: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.playlist-add`. */
+export type YtPlaylistAddReturn = {
+  item: {
+    playlistId: string;
+    playlistItemId: string;
+    title: string;
+    videoId: string;
+  };
+  success: true;
+};
+
+/** Input shape for `yt.playlist-create`. */
+export type YtPlaylistCreateInput = {
+  connection?: string;
+  description?: string;
+  privacy?: "public" | "private" | "unlisted";
+  title: string;
+};
+
+/** Return shape for `yt.playlist-create`. */
+export type YtPlaylistCreateReturn = {
+  playlist: {
+    description: string;
+    itemCount: number;
+    playlistId: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+  };
+  success: true;
+};
+
+/** Input shape for `yt.playlist-delete`. */
+export type YtPlaylistDeleteInput = {
+  connection?: string;
+  playlistId: string;
+};
+
+/** Return shape for `yt.playlist-delete`. */
+export type YtPlaylistDeleteReturn = {
+  deleted: string;
+  success: true;
+};
+
+/** Input shape for `yt.playlist-remove`. */
+export type YtPlaylistRemoveInput = {
+  connection?: string;
+  playlistItemId: string;
+};
+
+/** Return shape for `yt.playlist-remove`. */
+export type YtPlaylistRemoveReturn = {
+  removed: string;
+  success: true;
+};
+
+/** Input shape for `yt.playlists`. */
+export type YtPlaylistsInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+};
+
+/** Return shape for `yt.playlists`. */
+export type YtPlaylistsReturn = {
+  nextPageToken?: string;
+  playlists: Array<{
+    description: string;
+    itemCount: number;
+    playlistId: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+  }>;
+  success: true;
+  totalResults: number;
+};
+
+/** Input shape for `yt.reply`. */
+export type YtReplyInput = {
+  commentId: string;
+  connection?: string;
+  text: string;
+};
+
+/** Return shape for `yt.reply`. */
+export type YtReplyReturn = {
+  replyId: string;
+  success: true;
+};
+
+/** Input shape for `yt.search`. */
+export type YtSearchInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+  query: string;
+};
+
+/** Return shape for `yt.search`. */
+export type YtSearchReturn = {
+  nextPageToken?: string;
+  query: string;
+  success: true;
+  totalResults: number;
+  videos: Array<{
+    commentCount: number;
+    description: string;
+    duration: string;
+    likeCount: number;
+    playlistItemId?: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+    videoId: string;
+    viewCount: number;
+  }>;
+};
+
+/** Input shape for `yt.stats`. */
+export type YtStatsInput = {
+  connection?: string;
+  id: string;
+};
+
+/** Return shape for `yt.stats`. */
+export type YtStatsReturn = {
+  stats: {
+    commentCount: number;
+    daysSincePublish: number;
+    likeCount: number;
+    publishedAt: string;
+    title: string;
+    videoId: string;
+    viewCount: number;
+    viewsPerDay: number;
+  };
+  success: true;
+};
+
+/** Input shape for `yt.subscriptions`. */
+export type YtSubscriptionsInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+};
+
+/** Return shape for `yt.subscriptions`. */
+export type YtSubscriptionsReturn = {
+  nextPageToken?: string;
+  subscriptions: Array<{
+    channelId: string;
+    description: string;
+    publishedAt: string;
+    subscriptionId: string;
+    thumbnail: string;
+    title: string;
+    totalItemCount: number;
+    url: string;
+  }>;
+  success: true;
+  totalResults: number;
+};
+
+/** Input shape for `yt.unanswered`. */
+export type YtUnansweredInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.unanswered`. */
+export type YtUnansweredReturn = {
+  comments: Array<{
+    author: string;
+    authorChannelUrl: string;
+    commentId: string;
+    likeCount: number;
+    publishedAt: string;
+    replyCount: number;
+    text: string;
+    threadId: string;
+  }>;
+  nextPageToken?: string;
+  success: true;
+  totalUnanswered: number;
+  videoId: string;
+};
+
+/** Input shape for `yt.video`. */
+export type YtVideoInput = {
+  connection?: string;
+  id: string;
+};
+
+/** Return shape for `yt.video`. */
+export type YtVideoReturn = {
+  success: true;
+  video: {
+    commentCount: number;
+    description: string;
+    duration: string;
+    likeCount: number;
+    playlistItemId?: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+    videoId: string;
+    viewCount: number;
+  };
+};
+
+/** Input shape for `yt.video-categories`. */
+export type YtVideoCategoriesInput = {
+  connection?: string;
+  region?: string;
+};
+
+/** Return shape for `yt.video-categories`. */
+export type YtVideoCategoriesReturn = {
+  categories: Array<{
+    assignable: boolean;
+    categoryId: string;
+    title: string;
+  }>;
+  region: string;
+  success: true;
+  totalResults: number;
+};
+
+/** Input shape for `yt.video-delete`. */
+export type YtVideoDeleteInput = {
+  connection?: string;
+  id: string;
+};
+
+/** Return shape for `yt.video-delete`. */
+export type YtVideoDeleteReturn = {
+  deleted: string;
+  success: true;
+};
+
+/** Input shape for `yt.video-update`. */
+export type YtVideoUpdateInput = {
+  category?: string;
+  connection?: string;
+  description?: string;
+  id: string;
+  privacy?: "public" | "private" | "unlisted";
+  tags?: string;
+  title?: string;
+};
+
+/** Return shape for `yt.video-update`. */
+export type YtVideoUpdateReturn = {
+  success: true;
+  video: {
+    commentCount: number;
+    description: string;
+    duration: string;
+    likeCount: number;
+    playlistItemId?: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+    videoId: string;
+    viewCount: number;
+  };
+};
+
+/** Input shape for `yt.videos`. */
+export type YtVideosInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+};
+
+/** Return shape for `yt.videos`. */
+export type YtVideosReturn = {
+  nextPageToken?: string;
+  success: true;
+  totalResults: number;
+  videos: Array<{
+    commentCount: number;
+    description: string;
+    duration: string;
+    likeCount: number;
+    playlistItemId?: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+    videoId: string;
+    viewCount: number;
+  }>;
+};

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:5b8a62b586fb3a5cc40d6d0fefdd194bd5d766c8eb319a171c6aa9d0a832f2fe";
+export const REGISTRY_HASH = "sha256:fd6e955f784edd28bac6aef04d0bc579b0a68524078dc1068837a7a859991a0f";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "610102995b6b";
+export const GIT_SHA = "bd8147fc0120";

--- a/src/apps/router.test.ts
+++ b/src/apps/router.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { runWithContext } from "../cli/context.js";
 import type { ContextCapability, ContextRecord } from "../router/router-db.js";
 import { cleanupIsolatedRaviState } from "../test/ravi-state.js";
-import { maybeRunAppAliasRoute, resolveAppAliasInvocation, runAppOperation } from "./router.js";
+import { maybeRunAppAliasRoute, resolveAppAliasInvocation, resolveRaviCliCommand, runAppOperation } from "./router.js";
 
 const tempRoots: string[] = [];
 const tempStateDirs: string[] = [];
@@ -368,6 +368,27 @@ describe("Ravi app router", () => {
       result: { appRoot: appDir },
     });
     expect(realpathSync((result.result as { cwd: string }).cwd)).toBe(realpathSync(appDir));
+  });
+
+  it("runs Ravi CLI app operations through the current installation", () => {
+    expect(
+      resolveRaviCliCommand("ravi yt health --json", {
+        execPath: "/opt/bun/bin/bun",
+        entrypoint: "/opt/ravi current/dist/bundle/index.js",
+      }),
+    ).toBe("/opt/bun/bin/bun '/opt/ravi current/dist/bundle/index.js' yt health --json");
+    expect(
+      resolveRaviCliCommand("bun local-app.mjs --json", {
+        execPath: "/opt/bun/bin/bun",
+        entrypoint: "/opt/ravi/dist/bundle/index.js",
+      }),
+    ).toBe("bun local-app.mjs --json");
+    expect(
+      resolveRaviCliCommand("ravi yt info --json", {
+        execPath: "/opt/bun/bin/bun",
+        entrypoint: "dist/bundle/index.js",
+      }),
+    ).toBe(`/opt/bun/bin/bun ${join(process.cwd(), "dist/bundle/index.js")} yt info --json`);
   });
 
   it("resolves dotted operation ids from whitespace-separated CLI tokens", async () => {

--- a/src/apps/router.ts
+++ b/src/apps/router.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { discoverAppManifests, getAppManifest, RAVI_APP_BUILTIN_OPERATION_HANDLERS } from "./service.js";
 import type {
   RaviAppAliasInvocation,
@@ -377,8 +377,9 @@ async function runCliOperation(
     operationId: resolved.id,
     args: options.args,
   });
+  const runtimeCommand = resolveRaviCliCommand(command);
   const appRoot = dirname(app.path);
-  const run = await spawnShellCommand(command, {
+  const run = await spawnShellCommand(runtimeCommand, {
     cwd: appRoot,
     env: {
       ...options.env,
@@ -564,6 +565,18 @@ function renderCliCommand(template: string, input: { appId: string; operationId:
   });
   if (usedArgsPlaceholder || input.args.length === 0) return rendered;
   return `${rendered} ${input.args.map(quoteShellArg).join(" ")}`;
+}
+
+export function resolveRaviCliCommand(
+  command: string,
+  runtime: { execPath?: string; entrypoint?: string } = {},
+): string {
+  if (!/^\s*ravi(?=\s|$)/.test(command)) return command;
+  const execPath = runtime.execPath ?? process.execPath;
+  const entrypoint = runtime.entrypoint ?? process.argv[1];
+  if (!execPath?.trim() || !entrypoint?.trim()) return command;
+  const selfInvocation = `${quoteShellArg(execPath)} ${quoteShellArg(resolve(entrypoint))}`;
+  return command.replace(/^\s*ravi(?=\s|$)/, selfInvocation);
 }
 
 function spawnShellCommand(

--- a/src/apps/service.test.ts
+++ b/src/apps/service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkAppManifests, discoverAppManifests, getAppManifest } from "./service.js";
+import { checkAppManifests, discoverAppManifests, getAppManifest, isPackagedAppRuntime } from "./service.js";
 
 const tempRoots: string[] = [];
 const originalCwd = process.cwd();
@@ -66,6 +66,35 @@ afterEach(() => {
 });
 
 describe("Ravi app manifest service", () => {
+  it("distinguishes packaged discovery from source discovery", () => {
+    expect(isPackagedAppRuntime("/opt/ravi/dist/bundle/index.js")).toBe(true);
+    expect(isPackagedAppRuntime("C:\\ravi\\dist\\bundle\\index.js")).toBe(true);
+    expect(isPackagedAppRuntime("/opt/ravi/src/cli/index.ts")).toBe(false);
+  });
+
+  it("ignores cached mirrors of internal plugins during source discovery", () => {
+    const root = makeRepo();
+    writeManifest(root, "apps", validManifest());
+    const cachedAppDir = join(root, ".cache", "ravi", "plugins", "ravi-system", "apps", "apps");
+    mkdirSync(cachedAppDir, { recursive: true });
+    writeFileSync(join(cachedAppDir, "ravi.app.json"), JSON.stringify(validManifest(), null, 2));
+    const externalAppDir = join(root, ".cache", "ravi", "plugins", "partner-plugin", "apps", "partner");
+    mkdirSync(externalAppDir, { recursive: true });
+    writeFileSync(
+      join(externalAppDir, "ravi.app.json"),
+      JSON.stringify(validManifest({ id: "partner", name: "Partner App" }), null, 2),
+    );
+
+    const apps = discoverAppManifests({
+      cwd: root,
+      env: { ...process.env, HOME: root, RAVI_STATE_DIR: join(root, ".state") },
+    });
+
+    expect(apps.filter((app) => app.id === "apps")).toHaveLength(1);
+    expect(apps.find((app) => app.id === "apps")?.source).toBe("repo");
+    expect(apps.find((app) => app.id === "partner")?.source).toBe("plugin");
+  });
+
   it("discovers and validates repo app manifests", () => {
     const root = makeRepo();
     writeManifest(root, "apps", validManifest());

--- a/src/apps/service.ts
+++ b/src/apps/service.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import { loadInternalPlugins } from "../plugins/internal-loader.js";
+import { discoverPlugins } from "../plugins/index.js";
 import { getRaviStateDir } from "../utils/paths.js";
 import {
   RaviAppError,
@@ -148,10 +150,13 @@ export function discoverAppRoots(options: RaviAppDiscoveryOptions = {}): RaviApp
   const env = options.env ?? process.env;
   const roots: RaviAppDiscoveryRoot[] = [];
   const repoRoot = findRepoRoot(cwd);
+  const packagedRuntime = isPackagedAppRuntime();
 
-  roots.push({ source: "repo", rootPath: join(repoRoot, "src", "apps") });
+  if (!packagedRuntime) {
+    roots.push({ source: "repo", rootPath: join(repoRoot, "src", "apps") });
+  }
 
-  for (const pluginRoot of discoverPluginRoots(repoRoot)) {
+  for (const pluginRoot of discoverPluginRoots(repoRoot, packagedRuntime, env.HOME?.trim() || homedir())) {
     roots.push({ source: "plugin", rootPath: join(pluginRoot, "apps") });
   }
 
@@ -172,11 +177,32 @@ function findRepoRoot(cwd: string): string {
   }
 }
 
-function discoverPluginRoots(repoRoot: string): string[] {
+export function isPackagedAppRuntime(entrypoint = process.argv[1] ?? ""): boolean {
+  return entrypoint.split("\\").join("/").includes("/dist/bundle/");
+}
+
+function discoverPluginRoots(
+  repoRoot: string,
+  packagedRuntime = isPackagedAppRuntime(),
+  homeDir = homedir(),
+): string[] {
+  if (packagedRuntime) {
+    return discoverPlugins().map((plugin) => plugin.path);
+  }
+
   const roots: string[] = [];
-  roots.push(...childDirectories(join(repoRoot, "src", "plugins", "internal")));
-  roots.push(...childDirectories(join(homedir(), "ravi", "plugins")));
-  roots.push(...childDirectories(join(homedir(), ".cache", "ravi", "plugins")));
+  const internalRoots = childDirectories(join(repoRoot, "src", "plugins", "internal"));
+  const internalNames = new Set([
+    ...internalRoots.map((root) => basename(root)),
+    ...loadInternalPlugins().map((plugin) => plugin.name),
+  ]);
+  roots.push(...internalRoots);
+  roots.push(...childDirectories(join(homeDir, "ravi", "plugins")));
+  roots.push(
+    ...childDirectories(join(homeDir, ".cache", "ravi", "plugins")).filter(
+      (root) => !internalNames.has(basename(root)),
+    ),
+  );
   return roots;
 }
 

--- a/src/apps/youtube/app.test.ts
+++ b/src/apps/youtube/app.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { checkAppManifests, getAppManifest } from "../service.js";
+
+const repoRoot = join(import.meta.dir, "../../..");
+
+describe("YouTube Ravi App manifest", () => {
+  it("is discoverable and valid from the repository root", () => {
+    const [check] = checkAppManifests("youtube", {
+      cwd: repoRoot,
+      env: { ...process.env, RAVI_STATE_DIR: join(repoRoot, ".test-state") },
+    });
+    expect(check?.ok).toBe(true);
+    expect(check?.errors).toEqual([]);
+
+    const app = getAppManifest("youtube", {
+      cwd: repoRoot,
+      env: { ...process.env, RAVI_STATE_DIR: join(repoRoot, ".test-state") },
+    });
+    expect(app.source).toBe("repo");
+    expect(app.interfaceNames).toEqual(["cli", "ui"]);
+    expect(app.permissions.optional).toEqual(["youtube:read", "youtube:analytics:read", "youtube:captions:read"]);
+    expect(app.permissions.mutating).toEqual([
+      "youtube:comments:write",
+      "youtube:videos:write",
+      "youtube:videos:delete",
+      "youtube:playlists:write",
+      "youtube:playlists:delete",
+    ]);
+  });
+
+  it("separates read, write, destructive and financial operation classes", () => {
+    const manifest = JSON.parse(readFileSync(join(import.meta.dir, "ravi.app.json"), "utf8")) as {
+      operations: Record<string, { mutating: boolean; permission?: string; command?: string }>;
+      operationClasses: Record<string, string[]>;
+      storage: { sqlite: unknown[]; files: unknown[] };
+      events: { emits: unknown[]; consumes: unknown[] };
+    };
+
+    expect(manifest.operationClasses.read).toContain("youtube.info");
+    expect(manifest.operationClasses.analyticsRead).toContain("youtube.analytics-overview");
+    expect(manifest.operationClasses.write).toContain("youtube.reply");
+    expect(manifest.operationClasses.destructive).toContain("youtube.video-delete");
+    expect(manifest.operationClasses.financial).toEqual([]);
+
+    for (const operationId of manifest.operationClasses.write) {
+      expect(manifest.operations[operationId]?.mutating).toBe(true);
+      expect(manifest.operations[operationId]?.permission).toMatch(/:write$/);
+    }
+    for (const operationId of manifest.operationClasses.destructive) {
+      expect(manifest.operations[operationId]?.mutating).toBe(true);
+      expect(manifest.operations[operationId]?.permission).toMatch(/:delete$/);
+    }
+    for (const operation of Object.values(manifest.operations)) {
+      if (operation.command) expect(operation.command).toContain("--json");
+    }
+
+    expect(manifest.storage).toEqual({ sqlite: [], files: [] });
+    expect(manifest.events).toEqual({ emits: [], consumes: [] });
+  });
+});

--- a/src/apps/youtube/client.test.ts
+++ b/src/apps/youtube/client.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it, mock } from "bun:test";
+import { parseYouTubeCredential, YouTubeClient } from "./client.js";
+
+type RequestRecord = { url: URL; init: RequestInit };
+
+function fakeFetch(handler: (request: RequestRecord) => Response | Promise<Response>): typeof fetch {
+  return mock(async (input: string | URL | Request, init: RequestInit = {}) =>
+    handler({ url: new URL(String(input)), init }),
+  ) as unknown as typeof fetch;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("YouTubeClient", () => {
+  it("reports credential metadata health without resolving a secret or calling fetch", () => {
+    const fetch = fakeFetch(() => {
+      throw new Error("health must not call fetch");
+    });
+    const credentialResolver = mock(async () => {
+      throw new Error("health must not resolve a secret");
+    });
+    const client = new YouTubeClient({
+      connection: "brand",
+      fetch,
+      credentialResolver,
+      connectionInspector: () => ({ status: "active" }),
+    });
+
+    expect(client.health()).toEqual({
+      app: "youtube",
+      connection: "brand",
+      ready: true,
+      credentialConfigured: true,
+      credentialStatus: "active",
+      authenticated: false,
+      externalCheckPerformed: false,
+      message: "Credential metadata is active; authentication was not exercised in Phase 1.",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(credentialResolver).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before fetch when the credential broker has no connection", async () => {
+    const fetch = fakeFetch(() => {
+      throw new Error("missing credentials must fail before fetch");
+    });
+    const client = new YouTubeClient({
+      fetch,
+      credentialResolver: async () => {
+        throw new Error("Vault lookup failed at secret/ravi/credentials/youtube/default");
+      },
+      connectionInspector: () => null,
+    });
+
+    await expect(client.channelInfo()).rejects.toThrow(
+      'YouTube credential unavailable for connection "default". Configure provider "youtube"',
+    );
+    try {
+      await client.channelInfo();
+    } catch (error) {
+      expect(error instanceof Error ? error.message : String(error)).not.toContain("secret/ravi");
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("lists uploads through the uploads playlist and preserves provider pagination", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      const path = request.url.pathname;
+      if (path.endsWith("/channels")) {
+        return json({
+          items: [
+            {
+              id: "UC123",
+              snippet: { title: "Canal", description: "Descrição" },
+              statistics: { subscriberCount: "3", videoCount: "2", viewCount: "40" },
+              contentDetails: { relatedPlaylists: { uploads: "UU123" } },
+            },
+          ],
+        });
+      }
+      if (path.endsWith("/playlistItems")) {
+        return json({
+          items: [
+            { id: "PLI-1", contentDetails: { videoId: "video-1" } },
+            { id: "PLI-2", contentDetails: { videoId: "video-2" } },
+          ],
+          pageInfo: { totalResults: 9 },
+          nextPageToken: "next-2",
+        });
+      }
+      if (path.endsWith("/videos")) {
+        return json({
+          items: [
+            {
+              id: "video-1",
+              snippet: { title: "Primeiro", publishedAt: "2026-07-01T00:00:00Z" },
+              statistics: { viewCount: "10", likeCount: "2", commentCount: "1" },
+              contentDetails: { duration: "PT1M" },
+              status: { privacyStatus: "public" },
+            },
+            {
+              id: "video-2",
+              snippet: { title: "Segundo", publishedAt: "2026-06-01T00:00:00Z" },
+              statistics: { viewCount: "20", likeCount: "4", commentCount: "2" },
+              contentDetails: { duration: "PT2M" },
+              status: { privacyStatus: "unlisted" },
+            },
+          ],
+        });
+      }
+      return json({ error: "unexpected request" }, 500);
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.listVideos({ maxResults: 2, pageToken: "page-1" });
+
+    expect(result.totalResults).toBe(9);
+    expect(result.nextPageToken).toBe("next-2");
+    expect(result.videos.map((video) => video.videoId)).toEqual(["video-1", "video-2"]);
+    expect(requests.map((request) => request.url.pathname)).toEqual([
+      "/youtube/v3/channels",
+      "/youtube/v3/playlistItems",
+      "/youtube/v3/videos",
+    ]);
+    expect(requests[1]?.url.searchParams.get("playlistId")).toBe("UU123");
+    expect(requests[1]?.url.searchParams.get("pageToken")).toBe("page-1");
+    expect(new Headers(requests[0]?.init.headers).get("authorization")).toBe("Bearer unit-test-token");
+  });
+
+  it("searches the authenticated channel with forMine to avoid the channel cap", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (request.url.pathname.endsWith("/channels")) {
+        return json({ items: [{ id: "UC123", contentDetails: { relatedPlaylists: { uploads: "UU123" } } }] });
+      }
+      return json({ items: [] });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    await client.searchVideos("lançamento");
+
+    const search = requests.find((request) => request.url.pathname.endsWith("/search"));
+    expect(search?.url.searchParams.get("channelId")).toBe("UC123");
+    expect(search?.url.searchParams.get("forMine")).toBe("true");
+    expect(search?.url.searchParams.get("type")).toBe("video");
+  });
+
+  it("preserves duplicate and unavailable playlist item identities", async () => {
+    const fetch = fakeFetch((request) => {
+      if (request.url.pathname.endsWith("/playlistItems")) {
+        return json({
+          items: [
+            { id: "PLI-A", snippet: { title: "Vídeo" }, contentDetails: { videoId: "video-1" } },
+            { id: "PLI-B", snippet: { title: "Vídeo repetido" }, contentDetails: { videoId: "video-1" } },
+            { id: "PLI-C", snippet: { title: "Vídeo indisponível" }, contentDetails: { videoId: "video-2" } },
+          ],
+        });
+      }
+      return json({ items: [{ id: "video-1", snippet: { title: "Vídeo" } }] });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.getPlaylistVideos("PL-1");
+
+    expect(result.videos.map((video) => video.playlistItemId)).toEqual(["PLI-A", "PLI-B", "PLI-C"]);
+    expect(result.videos.map((video) => video.videoId)).toEqual(["video-1", "video-1", "video-2"]);
+    expect(result.videos[2]).toMatchObject({ title: "Vídeo indisponível", playlistItemId: "PLI-C" });
+  });
+
+  it("uses the official top-level comment id when publishing a reply", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({ id: "reply-1" });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.replyToComment("comment-1", "Texto aprovado")).toEqual({
+      success: true,
+      replyId: "reply-1",
+    });
+    const recorded = requests[0];
+    expect(recorded?.url.href).toBe("https://www.googleapis.com/youtube/v3/comments?part=snippet");
+    expect(recorded?.init.method).toBe("POST");
+    expect(JSON.parse(String(recorded?.init.body))).toEqual({
+      snippet: { parentId: "comment-1", textOriginal: "Texto aprovado" },
+    });
+  });
+
+  it("preserves mutable video fields and refetches a complete result after update", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (requests.length === 1) {
+        return json({
+          items: [
+            {
+              id: "video-1",
+              snippet: {
+                title: "Título atual",
+                description: "Descrição atual",
+                tags: ["atual"],
+                categoryId: "22",
+                defaultLanguage: "pt-BR",
+              },
+              status: {
+                privacyStatus: "private",
+                embeddable: true,
+                license: "youtube",
+                publicStatsViewable: true,
+                publishAt: "2026-08-01T00:00:00Z",
+                selfDeclaredMadeForKids: false,
+                containsSyntheticMedia: false,
+              },
+            },
+          ],
+        });
+      }
+      if (request.init.method === "PUT") return json({ id: "video-1", snippet: { title: "Título novo" } });
+      return json({
+        items: [
+          {
+            id: "video-1",
+            snippet: { title: "Título novo", description: "Descrição atual" },
+            statistics: { viewCount: "40", likeCount: "4", commentCount: "2" },
+            contentDetails: { duration: "PT2M" },
+            status: { privacyStatus: "public" },
+          },
+        ],
+      });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.updateVideo("video-1", { title: "Título novo", privacyStatus: "public" });
+
+    expect(result).toMatchObject({
+      success: true,
+      video: { title: "Título novo", viewCount: 40, duration: "PT2M", privacyStatus: "public" },
+    });
+    expect(requests[1]?.init.method).toBe("PUT");
+    expect(requests[1]?.url.searchParams.get("part")).toBe("snippet,status");
+    expect(JSON.parse(String(requests[1]?.init.body))).toEqual({
+      id: "video-1",
+      snippet: {
+        title: "Título novo",
+        description: "Descrição atual",
+        tags: ["atual"],
+        categoryId: "22",
+        defaultLanguage: "pt-BR",
+      },
+      status: {
+        privacyStatus: "public",
+        embeddable: true,
+        license: "youtube",
+        publicStatsViewable: true,
+        selfDeclaredMadeForKids: false,
+        containsSyntheticMedia: false,
+      },
+    });
+    expect(requests[2]?.url.searchParams.get("part")).toBe("snippet,statistics,contentDetails,status");
+  });
+
+  it("builds every playlist/video mutation request with fake fetch only", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (request.url.pathname.endsWith("/playlists") && request.init.method === "POST") {
+        return json({ id: "PL-1", snippet: { title: "Nova" }, status: { privacyStatus: "private" } });
+      }
+      if (request.url.pathname.endsWith("/playlistItems") && request.init.method === "POST") {
+        return json({ id: "PLI-1", snippet: { title: "Vídeo" } });
+      }
+      return new Response(null, { status: 204 });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    await client.deleteVideo("video-1");
+    await client.createPlaylist("Nova");
+    await client.deletePlaylist("PL-1");
+    await client.addToPlaylist("PL-1", "video-1");
+    await client.removeFromPlaylist("PLI-1");
+
+    expect(requests.map((request) => `${request.init.method}:${request.url.pathname}`)).toEqual([
+      "DELETE:/youtube/v3/videos",
+      "POST:/youtube/v3/playlists",
+      "DELETE:/youtube/v3/playlists",
+      "POST:/youtube/v3/playlistItems",
+      "DELETE:/youtube/v3/playlistItems",
+    ]);
+    expect(JSON.parse(String(requests[1]?.init.body))).toEqual({
+      snippet: { title: "Nova", description: "" },
+      status: { privacyStatus: "private" },
+    });
+    expect(JSON.parse(String(requests[3]?.init.body))).toEqual({
+      snippet: { playlistId: "PL-1", resourceId: { kind: "youtube#video", videoId: "video-1" } },
+    });
+  });
+
+  it("queries non-monetary Analytics metrics with deterministic dates", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({ rows: [[100, 200, 30, 4, 1, 8, 2, 3, 5]] });
+    });
+    const client = new YouTubeClient({
+      fetch,
+      credential: { accessToken: "unit-test-token" },
+      now: () => new Date("2026-07-13T12:00:00Z"),
+    });
+
+    const result = await client.analyticsOverview({ days: 7 });
+
+    expect(result.overview).toEqual({
+      views: 100,
+      watchTimeMinutes: 200,
+      avgViewDurationSec: 30,
+      subscribersGained: 4,
+      subscribersLost: 1,
+      netSubscribers: 3,
+      likes: 8,
+      dislikes: 2,
+      comments: 3,
+      shares: 5,
+    });
+    const recorded = requests[0];
+    expect(recorded?.url.origin).toBe("https://youtubeanalytics.googleapis.com");
+    expect(recorded?.url.pathname).toBe("/v2/reports");
+    expect(recorded?.url.searchParams.get("startDate")).toBe("2026-07-06");
+    expect(recorded?.url.searchParams.get("endDate")).toBe("2026-07-12");
+    expect(recorded?.url.searchParams.get("metrics")).not.toMatch(/Revenue|cpm|adImpressions/i);
+  });
+
+  it("downloads captions as text and redacts provider secrets from errors", async () => {
+    let mode: "caption" | "error" = "caption";
+    const fetch = fakeFetch(() => {
+      if (mode === "caption") return new Response("1\n00:00:00,000 --> 00:00:01,000\nOlá\n");
+      return json({ error: { access_token: "should-not-leak", message: "denied" } }, 401);
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.downloadCaption("caption-1", { format: "srt" })).toEqual({
+      success: true,
+      captionId: "caption-1",
+      format: "srt",
+      content: "1\n00:00:00,000 --> 00:00:01,000\nOlá\n",
+    });
+
+    mode = "error";
+    let message = "";
+    try {
+      await client.getVideo("video-1");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("[redacted]");
+    expect(message).not.toContain("should-not-leak");
+  });
+
+  it("accepts only a non-empty access-token envelope", () => {
+    expect(parseYouTubeCredential(JSON.stringify({ accessToken: "unit-test-token" }))).toEqual({
+      accessToken: "unit-test-token",
+    });
+    expect(() => parseYouTubeCredential("not-json")).toThrow("must be a JSON object");
+    expect(() => parseYouTubeCredential(JSON.stringify({ refreshToken: "unsupported" }))).toThrow(
+      'missing the "accessToken" field',
+    );
+    expect(() => parseYouTubeCredential(JSON.stringify({ accessToken: "   " }))).toThrow(
+      'missing the "accessToken" field',
+    );
+    expect(parseYouTubeCredential(JSON.stringify({ accessToken: "  trimmed-token  " }))).toEqual({
+      accessToken: "trimmed-token",
+    });
+  });
+});

--- a/src/apps/youtube/client.ts
+++ b/src/apps/youtube/client.ts
@@ -1,0 +1,968 @@
+import { resolveCredentialSecret } from "../../credentials/broker.js";
+import { getCredentialConnection } from "../../credentials/store.js";
+
+export interface YouTubeCredential {
+  accessToken: string;
+}
+
+export interface YouTubeClientOptions {
+  connection?: string;
+  fetch?: typeof globalThis.fetch;
+  /** In-process credential injection for unit tests and the later read-only proof phase. */
+  credential?: YouTubeCredential;
+  /** Test seam that avoids reading a real credential backend. */
+  credentialResolver?: CredentialResolver;
+  /** Read-only metadata seam used by health(); it never resolves a secret. */
+  connectionInspector?: ConnectionInspector;
+  now?: () => Date;
+}
+
+export interface ChannelInfo {
+  channelId: string;
+  title: string;
+  description: string;
+  subscriberCount: number;
+  videoCount: number;
+  viewCount: number;
+  thumbnail: string;
+  uploadsPlaylistId: string;
+  url: string;
+}
+
+export interface VideoInfo {
+  videoId: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  thumbnail: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  duration: string;
+  privacyStatus: string;
+  url: string;
+  playlistItemId?: string;
+}
+
+export interface CommentInfo {
+  threadId: string;
+  commentId: string;
+  author: string;
+  authorChannelUrl: string;
+  text: string;
+  likeCount: number;
+  publishedAt: string;
+  replyCount: number;
+}
+
+export interface PlaylistInfo {
+  playlistId: string;
+  title: string;
+  description: string;
+  thumbnail: string;
+  itemCount: number;
+  publishedAt: string;
+  privacyStatus: string;
+  url: string;
+}
+
+export interface AnalyticsResultTable {
+  kind?: string;
+  columnHeaders?: Array<{ name?: string; dataType?: string; columnType?: string }>;
+  rows?: unknown[][];
+}
+
+type CredentialResolver = (connection: string, action: string) => Promise<YouTubeCredential>;
+type ConnectionInspector = (connection: string) => { status?: string } | null;
+type QueryValue = string | number | boolean | undefined;
+
+const DATA_API = "https://www.googleapis.com/youtube/v3";
+const ANALYTICS_API = "https://youtubeanalytics.googleapis.com/v2";
+
+export class YouTubeClient {
+  readonly #connection: string;
+  readonly #fetch: typeof globalThis.fetch;
+  readonly #credential?: YouTubeCredential;
+  readonly #credentialResolver: CredentialResolver;
+  readonly #connectionInspector: ConnectionInspector;
+  readonly #now: () => Date;
+
+  constructor(options: YouTubeClientOptions = {}) {
+    this.#connection = options.connection ?? "default";
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#credential = options.credential;
+    this.#credentialResolver =
+      options.credentialResolver ??
+      (async (connection, action) =>
+        parseYouTubeCredential(
+          (
+            await resolveCredentialSecret({
+              provider: "youtube",
+              connection,
+              action,
+            })
+          ).secret,
+        ));
+    this.#connectionInspector =
+      options.connectionInspector ?? ((connection) => getCredentialConnection("youtube", connection));
+    this.#now = options.now ?? (() => new Date());
+  }
+
+  health() {
+    const connection = this.#connectionInspector(this.#connection);
+    const credentialConfigured = connection !== null;
+    const credentialStatus = connection?.status ?? "missing";
+    const ready = credentialConfigured && credentialStatus === "active";
+    return {
+      app: "youtube",
+      connection: this.#connection,
+      ready,
+      credentialConfigured,
+      credentialStatus,
+      authenticated: false,
+      externalCheckPerformed: false,
+      message: ready
+        ? "Credential metadata is active; authentication was not exercised in Phase 1."
+        : 'No active YouTube credential connection. Configure provider "youtube" before a later authenticated proof.',
+    };
+  }
+
+  async channelInfo(): Promise<ChannelInfo> {
+    const channel = await this.currentChannel();
+    return normalizeChannel(channel);
+  }
+
+  async listVideos(options: { maxResults?: number; pageToken?: string } = {}) {
+    const channel = normalizeChannel(await this.currentChannel());
+    if (!channel.uploadsPlaylistId) {
+      return { videos: [] as VideoInfo[], totalResults: 0, nextPageToken: undefined as string | undefined };
+    }
+    const playlistItems = await this.dataRequest<ListResponse<PlaylistItemResource>>(
+      "/playlistItems",
+      {
+        part: "contentDetails,snippet",
+        playlistId: channel.uploadsPlaylistId,
+        maxResults: boundedInteger(options.maxResults, 10, 1, 50),
+        pageToken: options.pageToken,
+      },
+      "videos.list",
+    );
+    const ids = (playlistItems.items ?? []).map((item) => item.contentDetails?.videoId ?? "").filter(Boolean);
+    return {
+      videos: await this.videoDetails(ids),
+      totalResults: playlistItems.pageInfo?.totalResults ?? ids.length,
+      nextPageToken: playlistItems.nextPageToken,
+    };
+  }
+
+  async searchVideos(query: string, options: { maxResults?: number; pageToken?: string } = {}) {
+    const channel = normalizeChannel(await this.currentChannel());
+    const response = await this.dataRequest<ListResponse<SearchResource>>(
+      "/search",
+      {
+        part: "snippet",
+        channelId: channel.channelId,
+        forMine: true,
+        q: query,
+        type: "video",
+        order: "date",
+        maxResults: boundedInteger(options.maxResults, 10, 1, 50),
+        pageToken: options.pageToken,
+      },
+      "search.list",
+    );
+    const ids = (response.items ?? []).map((item) => item.id?.videoId ?? "").filter(Boolean);
+    return {
+      query,
+      videos: await this.videoDetails(ids),
+      totalResults: response.pageInfo?.totalResults ?? ids.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async getVideo(videoId: string): Promise<VideoInfo | null> {
+    const videos = await this.videoDetails([videoId]);
+    return videos[0] ?? null;
+  }
+
+  async getVideoStats(videoId: string) {
+    const video = await this.getVideo(videoId);
+    if (!video) throw new Error(`YouTube video not found: ${videoId}`);
+    const publishedAt = new Date(video.publishedAt);
+    const elapsed = this.#now().getTime() - publishedAt.getTime();
+    const daysSincePublish = Number.isFinite(elapsed) ? Math.max(0, Math.floor(elapsed / 86_400_000)) : 0;
+    return {
+      videoId: video.videoId,
+      title: video.title,
+      viewCount: video.viewCount,
+      likeCount: video.likeCount,
+      commentCount: video.commentCount,
+      publishedAt: video.publishedAt,
+      daysSincePublish,
+      viewsPerDay: daysSincePublish > 0 ? Math.round(video.viewCount / daysSincePublish) : video.viewCount,
+    };
+  }
+
+  async listComments(videoId: string, options: { maxResults?: number; pageToken?: string; order?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<CommentThreadResource>>(
+      "/commentThreads",
+      {
+        part: "snippet,replies",
+        videoId,
+        maxResults: boundedInteger(options.maxResults, 20, 1, 100),
+        pageToken: options.pageToken,
+        order: options.order ?? "relevance",
+      },
+      "comments.list",
+    );
+    const comments = (response.items ?? []).map(normalizeComment);
+    return {
+      videoId,
+      comments,
+      totalResults: response.pageInfo?.totalResults ?? comments.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async listUnansweredComments(videoId: string, options: { maxResults?: number; pageToken?: string } = {}) {
+    const response = await this.listComments(videoId, { ...options, order: "time" });
+    const comments = response.comments.filter((comment) => comment.replyCount === 0);
+    return {
+      videoId,
+      comments,
+      totalUnanswered: comments.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async replyToComment(commentId: string, text: string) {
+    const response = await this.dataRequest<CommentResource>("/comments", { part: "snippet" }, "comments.reply", {
+      method: "POST",
+      body: JSON.stringify({ snippet: { parentId: commentId, textOriginal: text } }),
+    });
+    return { success: true, replyId: response.id ?? "" };
+  }
+
+  async listPlaylists(options: { maxResults?: number; pageToken?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<PlaylistResource>>(
+      "/playlists",
+      {
+        part: "snippet,contentDetails,status",
+        mine: true,
+        maxResults: boundedInteger(options.maxResults, 25, 1, 50),
+        pageToken: options.pageToken,
+      },
+      "playlists.list",
+    );
+    const playlists = (response.items ?? []).map(normalizePlaylist);
+    return {
+      playlists,
+      totalResults: response.pageInfo?.totalResults ?? playlists.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async getPlaylistVideos(playlistId: string, options: { maxResults?: number; pageToken?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<PlaylistItemResource>>(
+      "/playlistItems",
+      {
+        part: "snippet,contentDetails,status",
+        playlistId,
+        maxResults: boundedInteger(options.maxResults, 25, 1, 50),
+        pageToken: options.pageToken,
+      },
+      "playlistItems.list",
+    );
+    const items = response.items ?? [];
+    const videoIds = items.map((item) => item.contentDetails?.videoId ?? "").filter(Boolean);
+    const details = await this.videoDetails([...new Set(videoIds)]);
+    const detailsById = new Map(details.map((video) => [video.videoId, video]));
+    const videos = items.map((item) => {
+      const videoId = item.contentDetails?.videoId ?? "";
+      const video = detailsById.get(videoId) ?? unavailableVideo(videoId, item.snippet?.title);
+      return { ...video, playlistItemId: item.id || undefined };
+    });
+    return {
+      playlistId,
+      videos,
+      totalResults: response.pageInfo?.totalResults ?? videos.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async listSubscriptions(options: { maxResults?: number; pageToken?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<SubscriptionResource>>(
+      "/subscriptions",
+      {
+        part: "snippet,contentDetails",
+        mine: true,
+        order: "alphabetical",
+        maxResults: boundedInteger(options.maxResults, 25, 1, 50),
+        pageToken: options.pageToken,
+      },
+      "subscriptions.list",
+    );
+    const subscriptions = (response.items ?? []).map((item) => {
+      const channelId = item.snippet?.resourceId?.channelId ?? "";
+      return {
+        subscriptionId: item.id ?? "",
+        channelId,
+        title: item.snippet?.title ?? "",
+        description: item.snippet?.description ?? "",
+        thumbnail: thumbnail(item.snippet?.thumbnails),
+        publishedAt: item.snippet?.publishedAt ?? "",
+        totalItemCount: numeric(item.contentDetails?.totalItemCount),
+        url: channelId ? `https://www.youtube.com/channel/${channelId}` : "",
+      };
+    });
+    return {
+      subscriptions,
+      totalResults: response.pageInfo?.totalResults ?? subscriptions.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async listCaptions(videoId: string) {
+    const response = await this.dataRequest<ListResponse<CaptionResource>>(
+      "/captions",
+      { part: "snippet", videoId },
+      "captions.list",
+    );
+    const captions = (response.items ?? []).map((item) => ({
+      captionId: item.id ?? "",
+      language: item.snippet?.language ?? "",
+      name: item.snippet?.name ?? "",
+      trackKind: item.snippet?.trackKind ?? "",
+      isAutoSynced: item.snippet?.isAutoSynced ?? false,
+      isDraft: item.snippet?.isDraft ?? false,
+      status: item.snippet?.status ?? "",
+      lastUpdated: item.snippet?.lastUpdated ?? "",
+    }));
+    return { videoId, captions, totalResults: captions.length };
+  }
+
+  async downloadCaption(captionId: string, options: { format?: string; language?: string } = {}) {
+    const format = options.format ?? "srt";
+    const content = await this.dataTextRequest(
+      `/captions/${encodeURIComponent(captionId)}`,
+      { tfmt: format, tlang: options.language },
+      "captions.download",
+    );
+    return { success: true, captionId, format, content };
+  }
+
+  async listVideoCategories(options: { region?: string } = {}) {
+    const region = options.region ?? "BR";
+    const response = await this.dataRequest<ListResponse<VideoCategoryResource>>(
+      "/videoCategories",
+      { part: "snippet", regionCode: region },
+      "videoCategories.list",
+    );
+    const categories = (response.items ?? []).map((item) => ({
+      categoryId: item.id ?? "",
+      title: item.snippet?.title ?? "",
+      assignable: item.snippet?.assignable ?? false,
+    }));
+    return { region, categories, totalResults: categories.length };
+  }
+
+  async analyticsOverview(options: { days?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const data = await this.analyticsQuery(days, {
+      metrics:
+        "views,estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,likes,dislikes,comments,shares",
+    });
+    const row = data.rows?.[0] ?? [];
+    return {
+      period: `${days} days`,
+      overview: {
+        views: numeric(row[0]),
+        watchTimeMinutes: numeric(row[1]),
+        avgViewDurationSec: numeric(row[2]),
+        subscribersGained: numeric(row[3]),
+        subscribersLost: numeric(row[4]),
+        netSubscribers: numeric(row[3]) - numeric(row[4]),
+        likes: numeric(row[5]),
+        dislikes: numeric(row[6]),
+        comments: numeric(row[7]),
+        shares: numeric(row[8]),
+      },
+    };
+  }
+
+  async analyticsSeries(options: { days?: number; metric?: string } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const metric = options.metric ?? "views";
+    const allowed = [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "subscribersGained",
+      "likes",
+      "comments",
+      "shares",
+    ];
+    if (!allowed.includes(metric)) throw new Error(`Invalid YouTube Analytics metric. Use: ${allowed.join(", ")}.`);
+    const data = await this.analyticsQuery(days, { metrics: metric, dimensions: "day", sort: "day" });
+    return { period: `${days} days`, metric, data: analyticsRows(data) };
+  }
+
+  async analyticsTopVideos(options: { days?: number; maxResults?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const maxResults = boundedInteger(options.maxResults, 10, 1, 200);
+    const data = await this.analyticsQuery(days, {
+      metrics: "views,estimatedMinutesWatched,averageViewDuration,likes,comments",
+      dimensions: "video",
+      sort: "-views",
+      maxResults,
+    });
+    const rows = data.rows ?? [];
+    const details = await this.videoDetails(rows.map((row) => String(row[0] ?? "")).filter(Boolean));
+    const titles = new Map(details.map((video) => [video.videoId, video.title]));
+    return {
+      period: `${days} days`,
+      videos: rows.map((row) => ({
+        videoId: String(row[0] ?? ""),
+        title: titles.get(String(row[0] ?? "")) ?? "",
+        views: numeric(row[1]),
+        watchTimeMinutes: numeric(row[2]),
+        avgViewDurationSec: numeric(row[3]),
+        likes: numeric(row[4]),
+        comments: numeric(row[5]),
+      })),
+    };
+  }
+
+  async analyticsTraffic(options: { days?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const data = await this.analyticsQuery(days, {
+      metrics: "views,estimatedMinutesWatched",
+      dimensions: "insightTrafficSourceType",
+      sort: "-views",
+    });
+    return {
+      period: `${days} days`,
+      sources: (data.rows ?? []).map((row) => ({
+        source: String(row[0] ?? ""),
+        views: numeric(row[1]),
+        watchTimeMinutes: numeric(row[2]),
+      })),
+    };
+  }
+
+  async analyticsDemographics(options: { days?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const data = await this.analyticsQuery(days, {
+      metrics: "viewerPercentage",
+      dimensions: "ageGroup,gender",
+    });
+    return {
+      period: `${days} days`,
+      demographics: (data.rows ?? []).map((row) => ({
+        ageGroup: String(row[0] ?? ""),
+        gender: String(row[1] ?? ""),
+        viewerPercentage: numeric(row[2]),
+      })),
+    };
+  }
+
+  async analyticsCountries(options: { days?: number; maxResults?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const maxResults = boundedInteger(options.maxResults, 10, 1, 200);
+    const data = await this.analyticsQuery(days, {
+      metrics: "views,estimatedMinutesWatched,subscribersGained",
+      dimensions: "country",
+      sort: "-views",
+      maxResults,
+    });
+    return {
+      period: `${days} days`,
+      countries: (data.rows ?? []).map((row) => ({
+        country: String(row[0] ?? ""),
+        views: numeric(row[1]),
+        watchTimeMinutes: numeric(row[2]),
+        subscribersGained: numeric(row[3]),
+      })),
+    };
+  }
+
+  async analyticsDevices(options: { days?: number } = {}) {
+    const days = boundedInteger(options.days, 28, 1, 365);
+    const data = await this.analyticsQuery(days, {
+      metrics: "views,estimatedMinutesWatched",
+      dimensions: "deviceType",
+      sort: "-views",
+    });
+    return {
+      period: `${days} days`,
+      devices: (data.rows ?? []).map((row) => ({
+        device: String(row[0] ?? ""),
+        views: numeric(row[1]),
+        watchTimeMinutes: numeric(row[2]),
+      })),
+    };
+  }
+
+  async updateVideo(
+    videoId: string,
+    changes: {
+      title?: string;
+      description?: string;
+      tags?: string[];
+      categoryId?: string;
+      privacyStatus?: "public" | "private" | "unlisted";
+    },
+  ) {
+    const current = await this.dataRequest<ListResponse<VideoResource>>(
+      "/videos",
+      { part: "snippet,status", id: videoId },
+      "videos.get-for-update",
+    );
+    const video = current.items?.[0];
+    if (!video) throw new Error(`YouTube video not found: ${videoId}`);
+    const updatesSnippet =
+      changes.title !== undefined ||
+      changes.description !== undefined ||
+      changes.tags !== undefined ||
+      changes.categoryId !== undefined;
+    const updatesStatus = changes.privacyStatus !== undefined;
+    if (!updatesSnippet && !updatesStatus) throw new Error("Provide at least one video field to update.");
+    const parts = [updatesSnippet ? "snippet" : "", updatesStatus ? "status" : ""].filter(Boolean).join(",");
+    const body: Record<string, unknown> = { id: videoId };
+    if (updatesSnippet) {
+      body.snippet = {
+        title: changes.title ?? video.snippet?.title ?? "",
+        description: changes.description ?? video.snippet?.description ?? "",
+        tags: changes.tags ?? video.snippet?.tags ?? [],
+        categoryId: changes.categoryId ?? video.snippet?.categoryId ?? "",
+        defaultLanguage: video.snippet?.defaultLanguage,
+      };
+    }
+    if (updatesStatus) {
+      const privacyStatus = changes.privacyStatus ?? video.status?.privacyStatus;
+      body.status = {
+        privacyStatus,
+        embeddable: video.status?.embeddable,
+        license: video.status?.license,
+        publicStatsViewable: video.status?.publicStatsViewable,
+        publishAt: privacyStatus === "private" ? video.status?.publishAt : undefined,
+        selfDeclaredMadeForKids: video.status?.selfDeclaredMadeForKids,
+        containsSyntheticMedia: video.status?.containsSyntheticMedia,
+      };
+    }
+    await this.dataRequest<VideoResource>("/videos", { part: parts }, "videos.update", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    const updated = await this.getVideo(videoId);
+    if (!updated) throw new Error(`YouTube video not found after update: ${videoId}`);
+    return { success: true, video: updated };
+  }
+
+  async deleteVideo(videoId: string) {
+    await this.dataRequest<Record<string, never>>("/videos", { id: videoId }, "videos.delete", { method: "DELETE" });
+    return { success: true, deleted: videoId };
+  }
+
+  async createPlaylist(
+    title: string,
+    options: { description?: string; privacyStatus?: "public" | "private" | "unlisted" } = {},
+  ) {
+    const playlist = await this.dataRequest<PlaylistResource>(
+      "/playlists",
+      { part: "snippet,status" },
+      "playlists.create",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          snippet: { title, description: options.description ?? "" },
+          status: { privacyStatus: options.privacyStatus ?? "private" },
+        }),
+      },
+    );
+    return { success: true, playlist: normalizePlaylist(playlist) };
+  }
+
+  async deletePlaylist(playlistId: string) {
+    await this.dataRequest<Record<string, never>>("/playlists", { id: playlistId }, "playlists.delete", {
+      method: "DELETE",
+    });
+    return { success: true, deleted: playlistId };
+  }
+
+  async addToPlaylist(playlistId: string, videoId: string) {
+    const item = await this.dataRequest<PlaylistItemResource>(
+      "/playlistItems",
+      { part: "snippet" },
+      "playlistItems.create",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          snippet: { playlistId, resourceId: { kind: "youtube#video", videoId } },
+        }),
+      },
+    );
+    return {
+      success: true,
+      item: { playlistItemId: item.id ?? "", playlistId, videoId, title: item.snippet?.title ?? "" },
+    };
+  }
+
+  async removeFromPlaylist(playlistItemId: string) {
+    await this.dataRequest<Record<string, never>>("/playlistItems", { id: playlistItemId }, "playlistItems.delete", {
+      method: "DELETE",
+    });
+    return { success: true, removed: playlistItemId };
+  }
+
+  private async currentChannel(): Promise<ChannelResource> {
+    const response = await this.dataRequest<ListResponse<ChannelResource>>(
+      "/channels",
+      { part: "snippet,statistics,contentDetails", mine: true },
+      "channels.info",
+    );
+    const channel = response.items?.[0];
+    if (!channel) throw new Error("No YouTube channel is available to this credential.");
+    return channel;
+  }
+
+  private async videoDetails(ids: string[]): Promise<VideoInfo[]> {
+    if (ids.length === 0) return [];
+    const response = await this.dataRequest<ListResponse<VideoResource>>(
+      "/videos",
+      { part: "snippet,statistics,contentDetails,status", id: ids.join(",") },
+      "videos.list",
+    );
+    const byId = new Map((response.items ?? []).map((video) => [video.id ?? "", normalizeVideo(video)]));
+    return ids.flatMap((id) => (byId.has(id) ? [byId.get(id)!] : []));
+  }
+
+  private async analyticsQuery(days: number, params: Record<string, QueryValue>): Promise<AnalyticsResultTable> {
+    const { startDate, endDate } = dateRange(days, this.#now());
+    return this.requestJson<AnalyticsResultTable>(
+      `${ANALYTICS_API}/reports`,
+      { ids: "channel==MINE", startDate, endDate, ...params },
+      "analytics.query",
+    );
+  }
+
+  private dataRequest<T>(path: string, query: Record<string, QueryValue>, action: string, init?: RequestInit) {
+    return this.requestJson<T>(`${DATA_API}${path}`, query, action, init);
+  }
+
+  private dataTextRequest(path: string, query: Record<string, QueryValue>, action: string) {
+    return this.requestText(`${DATA_API}${path}`, query, action);
+  }
+
+  private async requestJson<T>(
+    baseUrl: string,
+    query: Record<string, QueryValue>,
+    action: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    const response = await this.request(baseUrl, query, action, init);
+    const text = await response.text();
+    if (!response.ok) throw requestError(response.status, text);
+    if (!text) return {} as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`YouTube API returned invalid JSON (${response.status}).`);
+    }
+  }
+
+  private async requestText(baseUrl: string, query: Record<string, QueryValue>, action: string): Promise<string> {
+    const response = await this.request(baseUrl, query, action, {});
+    const text = await response.text();
+    if (!response.ok) throw requestError(response.status, text);
+    return text;
+  }
+
+  private async request(
+    baseUrl: string,
+    query: Record<string, QueryValue>,
+    action: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    const credential = await this.resolveCredential(action);
+    const url = new URL(baseUrl);
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+    return this.#fetch(url, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${credential.accessToken}`,
+        ...(init.body ? { "content-type": "application/json" } : {}),
+        ...init.headers,
+      },
+    });
+  }
+
+  private async resolveCredential(action: string): Promise<YouTubeCredential> {
+    if (this.#credential) return this.#credential;
+    try {
+      return await this.#credentialResolver(this.#connection, action);
+    } catch {
+      throw new Error(
+        `YouTube credential unavailable for connection "${this.#connection}". ` +
+          'Configure provider "youtube" in the Ravi credential broker; OAuth onboarding is outside Phase 1.',
+      );
+    }
+  }
+}
+
+export function parseYouTubeCredential(value: string): YouTubeCredential {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("YouTube credential must be a JSON object.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("YouTube credential must be a JSON object.");
+  }
+  const accessToken = (parsed as Record<string, unknown>).accessToken;
+  if (typeof accessToken !== "string" || accessToken.trim().length === 0) {
+    throw new Error('YouTube credential is missing the "accessToken" field.');
+  }
+  return { accessToken: accessToken.trim() };
+}
+
+interface ListResponse<T> {
+  items?: T[];
+  nextPageToken?: string;
+  pageInfo?: { totalResults?: number; resultsPerPage?: number };
+}
+
+interface ThumbnailSet {
+  default?: { url?: string };
+  medium?: { url?: string };
+  high?: { url?: string };
+}
+
+interface ChannelResource {
+  id?: string;
+  snippet?: { title?: string; description?: string; thumbnails?: ThumbnailSet };
+  statistics?: { subscriberCount?: string; videoCount?: string; viewCount?: string };
+  contentDetails?: { relatedPlaylists?: { uploads?: string } };
+}
+
+interface VideoResource {
+  id?: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+    publishedAt?: string;
+    thumbnails?: ThumbnailSet;
+    tags?: string[];
+    categoryId?: string;
+    defaultLanguage?: string;
+  };
+  statistics?: { viewCount?: string; likeCount?: string; commentCount?: string };
+  contentDetails?: { duration?: string };
+  status?: {
+    privacyStatus?: string;
+    embeddable?: boolean;
+    license?: string;
+    publicStatsViewable?: boolean;
+    publishAt?: string;
+    selfDeclaredMadeForKids?: boolean;
+    containsSyntheticMedia?: boolean;
+  };
+}
+
+interface SearchResource {
+  id?: { videoId?: string };
+}
+
+interface CommentResource {
+  id?: string;
+  snippet?: {
+    authorDisplayName?: string;
+    authorChannelUrl?: string;
+    textDisplay?: string;
+    likeCount?: number;
+    publishedAt?: string;
+  };
+}
+
+interface CommentThreadResource {
+  id?: string;
+  snippet?: { topLevelComment?: CommentResource; totalReplyCount?: number };
+}
+
+interface PlaylistResource {
+  id?: string;
+  snippet?: { title?: string; description?: string; thumbnails?: ThumbnailSet; publishedAt?: string };
+  contentDetails?: { itemCount?: number };
+  status?: { privacyStatus?: string };
+}
+
+interface PlaylistItemResource {
+  id?: string;
+  snippet?: { title?: string };
+  contentDetails?: { videoId?: string };
+}
+
+interface SubscriptionResource {
+  id?: string;
+  snippet?: {
+    resourceId?: { channelId?: string };
+    title?: string;
+    description?: string;
+    thumbnails?: ThumbnailSet;
+    publishedAt?: string;
+  };
+  contentDetails?: { totalItemCount?: number };
+}
+
+interface CaptionResource {
+  id?: string;
+  snippet?: {
+    language?: string;
+    name?: string;
+    trackKind?: string;
+    isAutoSynced?: boolean;
+    isDraft?: boolean;
+    status?: string;
+    lastUpdated?: string;
+  };
+}
+
+interface VideoCategoryResource {
+  id?: string;
+  snippet?: { title?: string; assignable?: boolean };
+}
+
+function normalizeChannel(channel: ChannelResource): ChannelInfo {
+  const channelId = channel.id ?? "";
+  return {
+    channelId,
+    title: channel.snippet?.title ?? "",
+    description: channel.snippet?.description ?? "",
+    subscriberCount: numeric(channel.statistics?.subscriberCount),
+    videoCount: numeric(channel.statistics?.videoCount),
+    viewCount: numeric(channel.statistics?.viewCount),
+    thumbnail: thumbnail(channel.snippet?.thumbnails),
+    uploadsPlaylistId: channel.contentDetails?.relatedPlaylists?.uploads ?? "",
+    url: channelId ? `https://www.youtube.com/channel/${channelId}` : "",
+  };
+}
+
+function normalizeVideo(video: VideoResource): VideoInfo {
+  const videoId = video.id ?? "";
+  return {
+    videoId,
+    title: video.snippet?.title ?? "",
+    description: video.snippet?.description ?? "",
+    publishedAt: video.snippet?.publishedAt ?? "",
+    thumbnail: thumbnail(video.snippet?.thumbnails),
+    viewCount: numeric(video.statistics?.viewCount),
+    likeCount: numeric(video.statistics?.likeCount),
+    commentCount: numeric(video.statistics?.commentCount),
+    duration: video.contentDetails?.duration ?? "",
+    privacyStatus: video.status?.privacyStatus ?? "",
+    url: videoId ? `https://www.youtube.com/watch?v=${videoId}` : "",
+  };
+}
+
+function unavailableVideo(videoId: string, title = ""): VideoInfo {
+  return {
+    videoId,
+    title,
+    description: "",
+    publishedAt: "",
+    thumbnail: "",
+    viewCount: 0,
+    likeCount: 0,
+    commentCount: 0,
+    duration: "",
+    privacyStatus: "",
+    url: videoId ? `https://www.youtube.com/watch?v=${videoId}` : "",
+  };
+}
+
+function normalizeComment(thread: CommentThreadResource): CommentInfo {
+  const comment = thread.snippet?.topLevelComment;
+  return {
+    threadId: thread.id ?? "",
+    commentId: comment?.id ?? "",
+    author: comment?.snippet?.authorDisplayName ?? "",
+    authorChannelUrl: comment?.snippet?.authorChannelUrl ?? "",
+    text: comment?.snippet?.textDisplay ?? "",
+    likeCount: numeric(comment?.snippet?.likeCount),
+    publishedAt: comment?.snippet?.publishedAt ?? "",
+    replyCount: numeric(thread.snippet?.totalReplyCount),
+  };
+}
+
+function normalizePlaylist(playlist: PlaylistResource): PlaylistInfo {
+  const playlistId = playlist.id ?? "";
+  return {
+    playlistId,
+    title: playlist.snippet?.title ?? "",
+    description: playlist.snippet?.description ?? "",
+    thumbnail: thumbnail(playlist.snippet?.thumbnails),
+    itemCount: numeric(playlist.contentDetails?.itemCount),
+    publishedAt: playlist.snippet?.publishedAt ?? "",
+    privacyStatus: playlist.status?.privacyStatus ?? "",
+    url: playlistId ? `https://www.youtube.com/playlist?list=${playlistId}` : "",
+  };
+}
+
+function analyticsRows(data: AnalyticsResultTable): Array<Record<string, string | number | boolean | null>> {
+  const headers = (data.columnHeaders ?? []).map((header) => header.name ?? "");
+  return (data.rows ?? []).map((row) =>
+    Object.fromEntries(headers.map((header, index) => [header, jsonScalar(row[index])])),
+  );
+}
+
+function jsonScalar(value: unknown): string | number | boolean | null {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean" ? value : null;
+}
+
+function dateRange(days: number, now: Date): { startDate: string; endDate: string } {
+  const end = new Date(now);
+  end.setUTCHours(0, 0, 0, 0);
+  end.setUTCDate(end.getUTCDate() - 1);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - days + 1);
+  return { startDate: isoDate(start), endDate: isoDate(end) };
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function boundedInteger(value: number | undefined, fallback: number, min: number, max: number): number {
+  const parsed = value ?? fallback;
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`Expected an integer from ${min} to ${max}.`);
+  }
+  return parsed;
+}
+
+function thumbnail(thumbnails?: ThumbnailSet): string {
+  return thumbnails?.high?.url ?? thumbnails?.medium?.url ?? thumbnails?.default?.url ?? "";
+}
+
+function numeric(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function requestError(status: number, body: string): Error {
+  return new Error(`YouTube API request failed (${status}): ${redact(body) || "empty response"}`);
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/("?(?:access_token|accessToken|refresh_token|client_secret)"?\s*[:=]\s*"?)[^"\s,}]+/gi, "$1[redacted]")
+    .replace(/Bearer\s+[A-Za-z0-9._~-]+/gi, "Bearer [redacted]")
+    .slice(0, 1000);
+}

--- a/src/apps/youtube/ravi.app.json
+++ b/src/apps/youtube/ravi.app.json
@@ -1,0 +1,297 @@
+{
+  "schema": "ravi.app/v1",
+  "id": "youtube",
+  "name": "YouTube",
+  "version": "0.1.0",
+  "description": "Opera canal, vídeos, comentários, playlists, legendas e analytics pelas APIs oficiais do YouTube.",
+  "interfaces": {
+    "cli": {
+      "command": "ravi yt",
+      "json": true,
+      "health": "ravi yt health --json"
+    },
+    "ui": {
+      "routes": [
+        {
+          "id": "main",
+          "path": "/apps/youtube",
+          "label": "YouTube",
+          "icon": "youtube",
+          "view": "overview"
+        }
+      ],
+      "views": [
+        {
+          "id": "overview",
+          "type": "dashboard",
+          "title": "YouTube",
+          "density": "compact",
+          "query": {
+            "operation": "youtube.info"
+          },
+          "actions": [
+            {
+              "id": "videos",
+              "label": "Vídeos",
+              "icon": "video",
+              "operation": "youtube.videos",
+              "placement": "toolbar"
+            },
+            {
+              "id": "analytics",
+              "label": "Analytics",
+              "icon": "chart-line",
+              "operation": "youtube.analytics-overview",
+              "placement": "toolbar"
+            },
+            {
+              "id": "playlists",
+              "label": "Playlists",
+              "icon": "list-video",
+              "operation": "youtube.playlists",
+              "placement": "toolbar"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "operations": {
+    "youtube.check": {
+      "interface": "builtin",
+      "handler": "apps.manifest.check",
+      "mutating": false
+    },
+    "youtube.health": {
+      "interface": "cli",
+      "command": "ravi yt health --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.info": {
+      "interface": "cli",
+      "command": "ravi yt info --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.videos": {
+      "interface": "cli",
+      "command": "ravi yt videos --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.video": {
+      "interface": "cli",
+      "command": "ravi yt video --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.search": {
+      "interface": "cli",
+      "command": "ravi yt search --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.stats": {
+      "interface": "cli",
+      "command": "ravi yt stats --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.comments": {
+      "interface": "cli",
+      "command": "ravi yt comments --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.unanswered": {
+      "interface": "cli",
+      "command": "ravi yt unanswered --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.reply": {
+      "interface": "cli",
+      "command": "ravi yt reply --json {args}",
+      "mutating": true,
+      "permission": "youtube:comments:write"
+    },
+    "youtube.playlists": {
+      "interface": "cli",
+      "command": "ravi yt playlists --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.playlist": {
+      "interface": "cli",
+      "command": "ravi yt playlist --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.subscriptions": {
+      "interface": "cli",
+      "command": "ravi yt subscriptions --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.captions": {
+      "interface": "cli",
+      "command": "ravi yt captions --json {args}",
+      "mutating": false,
+      "permission": "youtube:captions:read"
+    },
+    "youtube.caption-download": {
+      "interface": "cli",
+      "command": "ravi yt caption-download --json {args}",
+      "mutating": false,
+      "permission": "youtube:captions:read"
+    },
+    "youtube.video-categories": {
+      "interface": "cli",
+      "command": "ravi yt video-categories --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.analytics-overview": {
+      "interface": "cli",
+      "command": "ravi yt analytics-overview --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-series": {
+      "interface": "cli",
+      "command": "ravi yt analytics-series --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-top": {
+      "interface": "cli",
+      "command": "ravi yt analytics-top --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-traffic": {
+      "interface": "cli",
+      "command": "ravi yt analytics-traffic --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-demographics": {
+      "interface": "cli",
+      "command": "ravi yt analytics-demographics --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-countries": {
+      "interface": "cli",
+      "command": "ravi yt analytics-countries --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.analytics-devices": {
+      "interface": "cli",
+      "command": "ravi yt analytics-devices --json {args}",
+      "mutating": false,
+      "permission": "youtube:analytics:read"
+    },
+    "youtube.video-update": {
+      "interface": "cli",
+      "command": "ravi yt video-update --json {args}",
+      "mutating": true,
+      "permission": "youtube:videos:write"
+    },
+    "youtube.video-delete": {
+      "interface": "cli",
+      "command": "ravi yt video-delete --json {args}",
+      "mutating": true,
+      "permission": "youtube:videos:delete"
+    },
+    "youtube.playlist-create": {
+      "interface": "cli",
+      "command": "ravi yt playlist-create --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:write"
+    },
+    "youtube.playlist-delete": {
+      "interface": "cli",
+      "command": "ravi yt playlist-delete --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:delete"
+    },
+    "youtube.playlist-add": {
+      "interface": "cli",
+      "command": "ravi yt playlist-add --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:write"
+    },
+    "youtube.playlist-remove": {
+      "interface": "cli",
+      "command": "ravi yt playlist-remove --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:delete"
+    }
+  },
+  "permissions": {
+    "required": [],
+    "optional": ["youtube:read", "youtube:analytics:read", "youtube:captions:read"],
+    "mutating": [
+      "youtube:comments:write",
+      "youtube:videos:write",
+      "youtube:videos:delete",
+      "youtube:playlists:write",
+      "youtube:playlists:delete"
+    ]
+  },
+  "operationClasses": {
+    "read": [
+      "youtube.health",
+      "youtube.info",
+      "youtube.videos",
+      "youtube.video",
+      "youtube.search",
+      "youtube.stats",
+      "youtube.comments",
+      "youtube.unanswered",
+      "youtube.playlists",
+      "youtube.playlist",
+      "youtube.subscriptions",
+      "youtube.captions",
+      "youtube.caption-download",
+      "youtube.video-categories"
+    ],
+    "analyticsRead": [
+      "youtube.analytics-overview",
+      "youtube.analytics-series",
+      "youtube.analytics-top",
+      "youtube.analytics-traffic",
+      "youtube.analytics-demographics",
+      "youtube.analytics-countries",
+      "youtube.analytics-devices"
+    ],
+    "write": ["youtube.reply", "youtube.video-update", "youtube.playlist-create", "youtube.playlist-add"],
+    "destructive": ["youtube.video-delete", "youtube.playlist-delete", "youtube.playlist-remove"],
+    "financial": []
+  },
+  "storage": {
+    "sqlite": [],
+    "files": []
+  },
+  "artifacts": [],
+  "events": {
+    "emits": [],
+    "consumes": []
+  },
+  "skills": [],
+  "health": {
+    "checks": [
+      {
+        "type": "builtin",
+        "handler": "apps.manifest.check"
+      }
+    ]
+  },
+  "versioning": {
+    "compatibility": "semver",
+    "migrations": []
+  }
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -85,3 +85,4 @@ export * from "./watch.js";
 export * from "./whatsapp-dm.js";
 export * from "./work-objects.js";
 export * from "./workflows.js";
+export * from "./youtube.js";

--- a/src/cli/commands/youtube.test.ts
+++ b/src/cli/commands/youtube.test.ts
@@ -1,0 +1,126 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { YouTubeClient } from "../../apps/youtube/client.js";
+import {
+  getCommandAccessMetadata,
+  getCommandsMetadata,
+  getGroupMetadata,
+  getOptionsMetadata,
+  getReturnsMetadata,
+} from "../decorators.js";
+import { YouTubeCommands } from "./youtube.js";
+
+afterEach(() => mock.restore());
+
+describe("YouTubeCommands contract", () => {
+  it("registers every finite command with JSON, typed returns and complete help", () => {
+    const instance = new YouTubeCommands();
+    const commands = getCommandsMetadata(YouTubeCommands);
+    const returns = getReturnsMetadata(YouTubeCommands);
+    const access = getCommandAccessMetadata(YouTubeCommands);
+
+    expect(getGroupMetadata(YouTubeCommands)).toMatchObject({ name: "yt", scope: "open" });
+    expect(commands).toHaveLength(28);
+    expect(returns.size).toBe(commands.length);
+    expect(access.size).toBe(commands.length);
+
+    for (const command of commands) {
+      const options = getOptionsMetadata(instance, command.method);
+      expect(options.some((option) => option.flags.includes("--json"))).toBe(true);
+      expect(command.helpAfter).toContain("USE");
+      expect(command.helpAfter).toContain("NÃO USE");
+      expect(command.helpAfter).toContain("EXAMPLES");
+      expect(command.helpAfter).toContain("ON ERROR");
+      expect(command.helpAfter).toContain("FONTES");
+      expect(returns.has(command.method)).toBe(true);
+      expect(access.has(command.method)).toBe(true);
+    }
+  });
+
+  it("classifies writes and destructive commands with confirmation", () => {
+    const byMethod = getCommandAccessMetadata(YouTubeCommands);
+
+    for (const method of ["reply", "videoUpdate", "playlistCreate", "playlistAdd"]) {
+      expect(byMethod.get(method)).toMatchObject({
+        kind: "mutate",
+        risk: "high",
+        requiresConfirmation: true,
+      });
+    }
+    for (const method of ["videoDelete", "playlistDelete", "playlistRemove"]) {
+      expect(byMethod.get(method)).toMatchObject({
+        kind: "mutate",
+        risk: "destructive",
+        requiresConfirmation: true,
+      });
+    }
+    for (const method of ["health", "info", "videos", "comments", "captions", "analyticsOverview"]) {
+      expect(byMethod.get(method)?.kind).toBe("read");
+    }
+  });
+
+  it("returns and prints the typed channel envelope with an injected client", async () => {
+    const channel = {
+      channelId: "UC123",
+      title: "Canal",
+      description: "Descrição",
+      subscriberCount: 3,
+      videoCount: 2,
+      viewCount: 40,
+      thumbnail: "https://example.test/thumb.jpg",
+      uploadsPlaylistId: "UU123",
+      url: "https://www.youtube.com/channel/UC123",
+    };
+    const client = { channelInfo: mock(async () => channel) } as unknown as YouTubeClient;
+    const factory = mock(() => client);
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    const commands = new YouTubeCommands(factory);
+
+    const result = await commands.info("brand", true);
+
+    expect(factory).toHaveBeenCalledWith("brand");
+    expect(result).toEqual({ success: true, channel });
+    expect(log).toHaveBeenCalledWith(JSON.stringify(result, null, 2));
+    expect(getReturnsMetadata(YouTubeCommands).get("info")?.safeParse(result).success).toBe(true);
+  });
+
+  it("uses a fake client for mutation tests and never reaches the provider", async () => {
+    const replyToComment = mock(async (commentId: string, text: string) => ({
+      success: true as const,
+      replyId: `${commentId}:${text.length}`,
+    }));
+    const client = { replyToComment } as unknown as YouTubeClient;
+    const commands = new YouTubeCommands(() => client);
+    spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await commands.reply("comment-1", "Texto aprovado", "brand", true);
+
+    expect(replyToComment).toHaveBeenCalledWith("comment-1", "Texto aprovado");
+    expect(result).toEqual({ success: true, replyId: "comment-1:14" });
+    expect(getReturnsMetadata(YouTubeCommands).get("reply")?.safeParse(result).success).toBe(true);
+  });
+
+  it("declares safe and bounded defaults in command metadata", () => {
+    const instance = new YouTubeCommands();
+    const optionsFor = (method: string) => getOptionsMetadata(instance, method);
+
+    expect(optionsFor("playlistCreate").find((option) => option.flags.includes("--privacy"))?.defaultValue).toBe(
+      "private",
+    );
+    expect(
+      optionsFor("videos")
+        .find((option) => option.flags.includes("--limit"))
+        ?.schema?.safeParse("50").success,
+    ).toBe(true);
+    expect(
+      optionsFor("videos")
+        .find((option) => option.flags.includes("--limit"))
+        ?.schema?.safeParse("51").success,
+    ).toBe(false);
+    expect(
+      optionsFor("analyticsSeries")
+        .find((option) => option.flags.includes("--metric"))
+        ?.schema?.safeParse("estimatedRevenue").success,
+    ).toBe(false);
+  });
+});

--- a/src/cli/commands/youtube.ts
+++ b/src/cli/commands/youtube.ts
@@ -1,0 +1,1308 @@
+import "reflect-metadata";
+import { z } from "zod";
+import { YouTubeClient } from "../../apps/youtube/client.js";
+import { fail } from "../context.js";
+import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
+import { jsonPrimitiveSchema } from "../return-schemas.js";
+
+const successSchema = z.literal(true);
+const pageTokenSchema = z.string().optional();
+const integerString = (min: number, max: number) =>
+  z
+    .string()
+    .regex(/^\d+$/)
+    .refine((value) => {
+      const parsed = Number(value);
+      return Number.isInteger(parsed) && parsed >= min && parsed <= max;
+    }, `Expected an integer from ${min} to ${max}.`);
+
+const channelSchema = z
+  .object({
+    channelId: z.string(),
+    title: z.string(),
+    description: z.string(),
+    subscriberCount: z.number(),
+    videoCount: z.number(),
+    viewCount: z.number(),
+    thumbnail: z.string(),
+    uploadsPlaylistId: z.string(),
+    url: z.string(),
+  })
+  .strict();
+
+const videoSchema = z
+  .object({
+    videoId: z.string(),
+    title: z.string(),
+    description: z.string(),
+    publishedAt: z.string(),
+    thumbnail: z.string(),
+    viewCount: z.number(),
+    likeCount: z.number(),
+    commentCount: z.number(),
+    duration: z.string(),
+    privacyStatus: z.string(),
+    url: z.string(),
+    playlistItemId: z.string().optional(),
+  })
+  .strict();
+
+const commentSchema = z
+  .object({
+    threadId: z.string(),
+    commentId: z.string(),
+    author: z.string(),
+    authorChannelUrl: z.string(),
+    text: z.string(),
+    likeCount: z.number(),
+    publishedAt: z.string(),
+    replyCount: z.number(),
+  })
+  .strict();
+
+const playlistSchema = z
+  .object({
+    playlistId: z.string(),
+    title: z.string(),
+    description: z.string(),
+    thumbnail: z.string(),
+    itemCount: z.number(),
+    publishedAt: z.string(),
+    privacyStatus: z.string(),
+    url: z.string(),
+  })
+  .strict();
+
+const healthReturnSchema = z
+  .object({
+    success: successSchema,
+    app: z.literal("youtube"),
+    connection: z.string(),
+    ready: z.boolean(),
+    credentialConfigured: z.boolean(),
+    credentialStatus: z.string(),
+    authenticated: z.literal(false),
+    externalCheckPerformed: z.literal(false),
+    message: z.string(),
+  })
+  .strict();
+
+const infoReturnSchema = z.object({ success: successSchema, channel: channelSchema }).strict();
+const videosReturnSchema = z
+  .object({
+    success: successSchema,
+    videos: z.array(videoSchema),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const searchReturnSchema = videosReturnSchema.extend({ query: z.string() }).strict();
+const videoReturnSchema = z.object({ success: successSchema, video: videoSchema }).strict();
+const statsReturnSchema = z
+  .object({
+    success: successSchema,
+    stats: z
+      .object({
+        videoId: z.string(),
+        title: z.string(),
+        viewCount: z.number(),
+        likeCount: z.number(),
+        commentCount: z.number(),
+        publishedAt: z.string(),
+        daysSincePublish: z.number(),
+        viewsPerDay: z.number(),
+      })
+      .strict(),
+  })
+  .strict();
+const commentsReturnSchema = z
+  .object({
+    success: successSchema,
+    videoId: z.string(),
+    comments: z.array(commentSchema),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const unansweredReturnSchema = z
+  .object({
+    success: successSchema,
+    videoId: z.string(),
+    comments: z.array(commentSchema),
+    totalUnanswered: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const replyReturnSchema = z.object({ success: successSchema, replyId: z.string() }).strict();
+const playlistsReturnSchema = z
+  .object({
+    success: successSchema,
+    playlists: z.array(playlistSchema),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const playlistReturnSchema = z
+  .object({
+    success: successSchema,
+    playlistId: z.string(),
+    videos: z.array(videoSchema),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const subscriptionsReturnSchema = z
+  .object({
+    success: successSchema,
+    subscriptions: z.array(
+      z
+        .object({
+          subscriptionId: z.string(),
+          channelId: z.string(),
+          title: z.string(),
+          description: z.string(),
+          thumbnail: z.string(),
+          publishedAt: z.string(),
+          totalItemCount: z.number(),
+          url: z.string(),
+        })
+        .strict(),
+    ),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const captionsReturnSchema = z
+  .object({
+    success: successSchema,
+    videoId: z.string(),
+    captions: z.array(
+      z
+        .object({
+          captionId: z.string(),
+          language: z.string(),
+          name: z.string(),
+          trackKind: z.string(),
+          isAutoSynced: z.boolean(),
+          isDraft: z.boolean(),
+          status: z.string(),
+          lastUpdated: z.string(),
+        })
+        .strict(),
+    ),
+    totalResults: z.number(),
+  })
+  .strict();
+const captionDownloadReturnSchema = z
+  .object({
+    success: successSchema,
+    captionId: z.string(),
+    format: z.string(),
+    content: z.string(),
+  })
+  .strict();
+const videoCategoriesReturnSchema = z
+  .object({
+    success: successSchema,
+    region: z.string(),
+    categories: z.array(z.object({ categoryId: z.string(), title: z.string(), assignable: z.boolean() }).strict()),
+    totalResults: z.number(),
+  })
+  .strict();
+const analyticsOverviewReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    overview: z
+      .object({
+        views: z.number(),
+        watchTimeMinutes: z.number(),
+        avgViewDurationSec: z.number(),
+        subscribersGained: z.number(),
+        subscribersLost: z.number(),
+        netSubscribers: z.number(),
+        likes: z.number(),
+        dislikes: z.number(),
+        comments: z.number(),
+        shares: z.number(),
+      })
+      .strict(),
+  })
+  .strict();
+const analyticsSeriesReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    metric: z.string(),
+    data: z.array(z.record(z.string(), jsonPrimitiveSchema)),
+  })
+  .strict();
+const analyticsTopReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    videos: z.array(
+      z
+        .object({
+          videoId: z.string(),
+          title: z.string(),
+          views: z.number(),
+          watchTimeMinutes: z.number(),
+          avgViewDurationSec: z.number(),
+          likes: z.number(),
+          comments: z.number(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+const analyticsTrafficReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    sources: z.array(z.object({ source: z.string(), views: z.number(), watchTimeMinutes: z.number() }).strict()),
+  })
+  .strict();
+const analyticsDemographicsReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    demographics: z.array(
+      z.object({ ageGroup: z.string(), gender: z.string(), viewerPercentage: z.number() }).strict(),
+    ),
+  })
+  .strict();
+const analyticsCountriesReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    countries: z.array(
+      z
+        .object({
+          country: z.string(),
+          views: z.number(),
+          watchTimeMinutes: z.number(),
+          subscribersGained: z.number(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+const analyticsDevicesReturnSchema = z
+  .object({
+    success: successSchema,
+    period: z.string(),
+    devices: z.array(z.object({ device: z.string(), views: z.number(), watchTimeMinutes: z.number() }).strict()),
+  })
+  .strict();
+const videoUpdateReturnSchema = z.object({ success: successSchema, video: videoSchema }).strict();
+const deleteReturnSchema = z.object({ success: successSchema, deleted: z.string() }).strict();
+const playlistCreateReturnSchema = z.object({ success: successSchema, playlist: playlistSchema }).strict();
+const playlistAddReturnSchema = z
+  .object({
+    success: successSchema,
+    item: z
+      .object({ playlistItemId: z.string(), playlistId: z.string(), videoId: z.string(), title: z.string() })
+      .strict(),
+  })
+  .strict();
+const playlistRemoveReturnSchema = z.object({ success: successSchema, removed: z.string() }).strict();
+
+type YouTubeClientFactory = (connection?: string) => YouTubeClient;
+
+@Group({
+  name: "yt",
+  description: "Operate YouTube Data API v3 and YouTube Analytics API v2 through Ravi credentials",
+  scope: "open",
+})
+export class YouTubeCommands {
+  constructor(
+    private readonly clientFactory: YouTubeClientFactory = (connection) => new YouTubeClient({ connection }),
+  ) {}
+
+  @Command({
+    name: "health",
+    description: "Inspect YouTube credential metadata without resolving a secret or calling Google",
+    helpAfter: readHelp(
+      "Check whether a Ravi credential connection is configured before an authenticated proof.",
+      "Do not use as proof that Google accepted the token; no external request is made.",
+      ["ravi yt health --json", "ravi yt health --connection production --json"],
+      "Ravi credential broker metadata; no provider endpoint.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.credentials", action: "health", risk: "low" })
+  @Returns(healthReturnSchema)
+  async health(
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({ success: true as const, ...this.client(connection).health() }));
+  }
+
+  @Command({
+    name: "info",
+    description: "Return metadata and lifetime counters for the authenticated channel",
+    helpAfter: readHelp(
+      "Confirm which channel the selected credential owns before any write.",
+      "For period metrics, use `ravi yt analytics-overview`.",
+      ["ravi yt info --json", "ravi yt info --connection brand --json"],
+      "YouTube Data API v3 channels.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.channels", action: "info", risk: "low" })
+  @Returns(infoReturnSchema)
+  async info(
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      channel: await this.client(connection).channelInfo(),
+    }));
+  }
+
+  @Command({
+    name: "videos",
+    description: "List videos from the authenticated channel uploads playlist",
+    helpAfter: readHelp(
+      "List recent channel uploads with stable video IDs and a provider page token.",
+      "For text search, use `ravi yt search <query>`.",
+      ["ravi yt videos --limit 10 --json", "ravi yt videos --page <nextPageToken> --json"],
+      "YouTube Data API v3 channels.list, playlistItems.list and videos.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.videos", action: "list", risk: "low" })
+  @Returns(videosReturnSchema)
+  async videos(
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 10)",
+      defaultValue: "10",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listVideos({ maxResults: integer(limit, 10, 1, 50), pageToken: page })),
+    }));
+  }
+
+  @Command({
+    name: "video",
+    description: "Get one video by YouTube video ID",
+    helpAfter: readHelp(
+      "Inspect current metadata and lifetime counters before an update or delete decision.",
+      "To discover IDs, use `ravi yt videos` or `ravi yt search`.",
+      ["ravi yt video dQw4w9WgXcQ --json", "ravi yt video <videoId> --connection brand --json"],
+      "YouTube Data API v3 videos.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.videos", action: "get", risk: "low" })
+  @Returns(videoReturnSchema)
+  async video(
+    @Arg("id", { description: "YouTube video ID", schema: z.string().min(1) }) id: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => {
+      const video = await this.client(connection).getVideo(id);
+      if (!video) fail(`YouTube video not found: ${id}. Recheck the ID with \`ravi yt videos --json\`.`);
+      return { success: true as const, video };
+    });
+  }
+
+  @Command({
+    name: "search",
+    description: "Search videos in the authenticated channel",
+    helpAfter: readHelp(
+      "Find channel videos by text when the video ID is unknown.",
+      "To list uploads without a query, use `ravi yt videos`.",
+      ["ravi yt search embalagem --limit 10 --json", 'ravi yt search "caixa correio" --json'],
+      "YouTube Data API v3 search.list and videos.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.videos", action: "search", risk: "low" })
+  @Returns(searchReturnSchema)
+  async search(
+    @Arg("query", { description: "Search text", schema: z.string().min(1) }) query: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 10)",
+      defaultValue: "10",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).searchVideos(query, {
+        maxResults: integer(limit, 10, 1, 50),
+        pageToken: page,
+      })),
+    }));
+  }
+
+  @Command({
+    name: "stats",
+    description: "Calculate lifetime video counters, age and average views per day",
+    helpAfter: readHelp(
+      "Assess the lifetime pace of one known video.",
+      "For true period metrics, use an `analytics-*` command.",
+      ["ravi yt stats dQw4w9WgXcQ --json", "ravi yt stats <videoId> --connection brand --json"],
+      "YouTube Data API v3 videos.list; age and views/day are local calculations.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.videos", action: "stats", risk: "low" })
+  @Returns(statsReturnSchema)
+  async stats(
+    @Arg("id", { description: "YouTube video ID", schema: z.string().min(1) }) id: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      stats: await this.client(connection).getVideoStats(id),
+    }));
+  }
+
+  @Command({
+    name: "comments",
+    description: "List top-level comment threads for a video",
+    helpAfter: readHelp(
+      "Read comment threads and obtain the top-level commentId used by `reply`.",
+      "For only unanswered threads, use `ravi yt unanswered`.",
+      ["ravi yt comments <videoId> --limit 20 --json", "ravi yt comments <videoId> --page <nextPageToken> --json"],
+      "YouTube Data API v3 commentThreads.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.comments", action: "list", risk: "low" })
+  @Returns(commentsReturnSchema)
+  async comments(
+    @Arg("videoId", { description: "YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-100 (default: 20)",
+      defaultValue: "20",
+      schema: integerString(1, 100),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listComments(videoId, {
+        maxResults: integer(limit, 20, 1, 100),
+        pageToken: page,
+      })),
+    }));
+  }
+
+  @Command({
+    name: "unanswered",
+    description: "List recent comment threads with zero replies",
+    helpAfter: readHelp(
+      "Build a review queue before drafting replies.",
+      "Do not reply automatically; `ravi yt reply` requires explicit confirmation.",
+      ["ravi yt unanswered <videoId> --limit 50 --json", "ravi yt unanswered <videoId> --page <nextPageToken> --json"],
+      "YouTube Data API v3 commentThreads.list; zero-reply filtering is local.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.comments", action: "unanswered", risk: "low" })
+  @Returns(unansweredReturnSchema)
+  async unanswered(
+    @Arg("videoId", { description: "YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Threads inspected, 1-100 (default: 50)",
+      defaultValue: "50",
+      schema: integerString(1, 100),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listUnansweredComments(videoId, {
+        maxResults: integer(limit, 50, 1, 100),
+        pageToken: page,
+      })),
+    }));
+  }
+
+  @Command({
+    name: "reply",
+    description: "Publish a reply to a top-level YouTube comment",
+    helpAfter: mutationHelp(
+      "Publish one externally visible reply after a human approves the exact text.",
+      "Never use for testing or bulk replies; there is no dry-run and retries duplicate replies.",
+      ['ravi yt reply <commentId> "Texto aprovado" --json'],
+      "YouTube Data API v3 comments.insert; requires youtube.force-ssl.",
+      "PUBLIC WRITE: show commentId and the exact reply text, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.comments",
+    action: "reply",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["commentId", "text", "connection"],
+    redactions: ["text"],
+  })
+  @Returns(replyReturnSchema)
+  async reply(
+    @Arg("commentId", { description: "Top-level comment ID from `ravi yt comments`", schema: z.string().min(1) })
+    commentId: string,
+    @Arg("text", { description: "Exact approved reply text", schema: z.string().min(1) }) text: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).replyToComment(commentId, text));
+  }
+
+  @Command({
+    name: "playlists",
+    description: "List playlists owned by the authenticated channel",
+    helpAfter: readHelp(
+      "Discover playlist IDs and avoid duplicate creation.",
+      "For playlist contents, use `ravi yt playlist <playlistId>`.",
+      ["ravi yt playlists --limit 25 --json", "ravi yt playlists --page <nextPageToken> --json"],
+      "YouTube Data API v3 playlists.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.playlists", action: "list", risk: "low" })
+  @Returns(playlistsReturnSchema)
+  async playlists(
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 25)",
+      defaultValue: "25",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listPlaylists({ maxResults: integer(limit, 25, 1, 50), pageToken: page })),
+    }));
+  }
+
+  @Command({
+    name: "playlist",
+    description: "List videos and playlist-item IDs from one playlist",
+    helpAfter: readHelp(
+      "Inspect playlist contents and obtain playlistItemId for safe removal decisions.",
+      "Do not pass a videoId to `playlist-remove`; it requires playlistItemId.",
+      [
+        "ravi yt playlist <playlistId> --limit 25 --json",
+        "ravi yt playlist <playlistId> --page <nextPageToken> --json",
+      ],
+      "YouTube Data API v3 playlistItems.list and videos.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.playlists", action: "get", risk: "low" })
+  @Returns(playlistReturnSchema)
+  async playlist(
+    @Arg("playlistId", { description: "YouTube playlist ID", schema: z.string().min(1) }) playlistId: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 25)",
+      defaultValue: "25",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).getPlaylistVideos(playlistId, {
+        maxResults: integer(limit, 25, 1, 50),
+        pageToken: page,
+      })),
+    }));
+  }
+
+  @Command({
+    name: "subscriptions",
+    description: "List channels followed by the authenticated channel",
+    helpAfter: readHelp(
+      "Audit which channels the authenticated channel follows.",
+      "This does not list the channel's subscribers; that data is not exposed here.",
+      ["ravi yt subscriptions --limit 25 --json", "ravi yt subscriptions --page <nextPageToken> --json"],
+      "YouTube Data API v3 subscriptions.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.subscriptions", action: "list", risk: "low" })
+  @Returns(subscriptionsReturnSchema)
+  async subscriptions(
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 25)",
+      defaultValue: "25",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listSubscriptions({
+        maxResults: integer(limit, 25, 1, 50),
+        pageToken: page,
+      })),
+    }));
+  }
+
+  @Command({
+    name: "captions",
+    description: "List caption tracks for one video",
+    helpAfter: readHelp(
+      "Discover caption track IDs, languages and status.",
+      "To retrieve track content, use `ravi yt caption-download <captionId>`.",
+      ["ravi yt captions <videoId> --json", "ravi yt captions <videoId> --connection brand --json"],
+      "YouTube Data API v3 captions.list; requires OAuth authorization.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.captions", action: "list", risk: "low" })
+  @Returns(captionsReturnSchema)
+  async captions(
+    @Arg("videoId", { description: "YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listCaptions(videoId)),
+    }));
+  }
+
+  @Command({
+    name: "caption-download",
+    description: "Download one caption track as text",
+    helpAfter: readHelp(
+      "Retrieve an owned/downloadable caption for content reuse.",
+      "Do not use before listing tracks; caption IDs are distinct from video IDs.",
+      [
+        "ravi yt caption-download <captionId> --format srt --json",
+        "ravi yt caption-download <captionId> --format vtt --language en --json",
+      ],
+      "YouTube Data API v3 captions.download; requires youtube.force-ssl or youtubepartner.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.captions", action: "download", risk: "low" })
+  @Returns(captionDownloadReturnSchema)
+  async captionDownload(
+    @Arg("captionId", { description: "Caption track ID from `ravi yt captions`", schema: z.string().min(1) })
+    captionId: string,
+    @Option({
+      flags: "--format <fmt>",
+      description: "srt|vtt|ttml (default: srt)",
+      defaultValue: "srt",
+      schema: z.enum(["srt", "vtt", "ttml"]),
+    })
+    format?: string,
+    @Option({ flags: "--language <code>", description: "Optional ISO 639-1 translation language" }) language?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).downloadCaption(captionId, { format, language }));
+  }
+
+  @Command({
+    name: "video-categories",
+    description: "List assignable YouTube video categories for a region",
+    helpAfter: readHelp(
+      "Discover a valid categoryId before updating video metadata.",
+      "Do not assume categories are identical across regions.",
+      ["ravi yt video-categories --region BR --json", "ravi yt video-categories --region US --json"],
+      "YouTube Data API v3 videoCategories.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.video-categories", action: "list", risk: "low" })
+  @Returns(videoCategoriesReturnSchema)
+  async videoCategories(
+    @Option({
+      flags: "-r, --region <code>",
+      description: "ISO 3166-1 alpha-2 region (default: BR)",
+      defaultValue: "BR",
+      schema: z.string().regex(/^[A-Za-z]{2}$/),
+    })
+    region?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listVideoCategories({ region: region?.toUpperCase() })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-overview",
+    description: "Return aggregate channel engagement metrics for a recent period",
+    helpAfter: analyticsHelp(
+      "Review aggregate channel KPIs without monetary metrics.",
+      ["ravi yt analytics-overview --days 28 --json", "ravi yt analytics-overview --days 90 --connection brand --json"],
+      "YouTube Analytics API v2 reports.query, channel basic stats.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "overview", risk: "low" })
+  @Returns(analyticsOverviewReturnSchema)
+  async analyticsOverview(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsOverview({ days: integer(days, 28, 1, 365) })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-series",
+    description: "Return a daily time series for one approved YouTube Analytics metric",
+    helpAfter: analyticsHelp(
+      "Inspect one KPI trend over time.",
+      [
+        "ravi yt analytics-series --metric views --days 28 --json",
+        "ravi yt analytics-series --metric likes --days 90 --json",
+      ],
+      "YouTube Analytics API v2 reports.query with dimension=day.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "series", risk: "low" })
+  @Returns(analyticsSeriesReturnSchema)
+  async analyticsSeries(
+    @Option({
+      flags: "-m, --metric <name>",
+      description:
+        "views|estimatedMinutesWatched|averageViewDuration|subscribersGained|likes|comments|shares (default: views)",
+      defaultValue: "views",
+      schema: z.enum([
+        "views",
+        "estimatedMinutesWatched",
+        "averageViewDuration",
+        "subscribersGained",
+        "likes",
+        "comments",
+        "shares",
+      ]),
+    })
+    metric?: string,
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsSeries({ days: integer(days, 28, 1, 365), metric })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-top",
+    description: "Rank channel videos by views for a recent period",
+    helpAfter: analyticsHelp(
+      "Identify top videos using true period metrics.",
+      ["ravi yt analytics-top --days 28 --limit 10 --json", "ravi yt analytics-top --days 90 --limit 20 --json"],
+      "YouTube Analytics API v2 reports.query with dimension=video plus Data API videos.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "top-videos", risk: "low" })
+  @Returns(analyticsTopReturnSchema)
+  async analyticsTop(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Rows, 1-200 (default: 10)",
+      defaultValue: "10",
+      schema: integerString(1, 200),
+    })
+    limit?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsTopVideos({
+        days: integer(days, 28, 1, 365),
+        maxResults: integer(limit, 10, 1, 200),
+      })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-traffic",
+    description: "Break down recent views and watch time by traffic-source type",
+    helpAfter: analyticsHelp(
+      "Understand where viewers discovered channel videos.",
+      ["ravi yt analytics-traffic --days 28 --json", "ravi yt analytics-traffic --days 90 --json"],
+      "YouTube Analytics API v2 reports.query with insightTrafficSourceType.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "traffic", risk: "low" })
+  @Returns(analyticsTrafficReturnSchema)
+  async analyticsTraffic(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsTraffic({ days: integer(days, 28, 1, 365) })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-demographics",
+    description: "Break down viewer percentage by age group and gender",
+    helpAfter: analyticsHelp(
+      "Inspect the available audience-demographic distribution.",
+      ["ravi yt analytics-demographics --days 28 --json", "ravi yt analytics-demographics --days 90 --json"],
+      "YouTube Analytics API v2 reports.query with ageGroup,gender.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "demographics", risk: "low" })
+  @Returns(analyticsDemographicsReturnSchema)
+  async analyticsDemographics(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsDemographics({ days: integer(days, 28, 1, 365) })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-countries",
+    description: "Break down recent views and watch time by country",
+    helpAfter: analyticsHelp(
+      "Identify the geographic distribution of the audience.",
+      [
+        "ravi yt analytics-countries --days 28 --limit 10 --json",
+        "ravi yt analytics-countries --days 90 --limit 20 --json",
+      ],
+      "YouTube Analytics API v2 reports.query with dimension=country.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "countries", risk: "low" })
+  @Returns(analyticsCountriesReturnSchema)
+  async analyticsCountries(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Rows, 1-200 (default: 10)",
+      defaultValue: "10",
+      schema: integerString(1, 200),
+    })
+    limit?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsCountries({
+        days: integer(days, 28, 1, 365),
+        maxResults: integer(limit, 10, 1, 200),
+      })),
+    }));
+  }
+
+  @Command({
+    name: "analytics-devices",
+    description: "Break down recent views and watch time by device type",
+    helpAfter: analyticsHelp(
+      "Understand which device classes viewers use.",
+      ["ravi yt analytics-devices --days 28 --json", "ravi yt analytics-devices --days 90 --json"],
+      "YouTube Analytics API v2 reports.query with dimension=deviceType.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.analytics", action: "devices", risk: "low" })
+  @Returns(analyticsDevicesReturnSchema)
+  async analyticsDevices(
+    @Option({
+      flags: "-d, --days <n>",
+      description: "Recent days, 1-365 (default: 28)",
+      defaultValue: "28",
+      schema: integerString(1, 365),
+    })
+    days?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).analyticsDevices({ days: integer(days, 28, 1, 365) })),
+    }));
+  }
+
+  @Command({
+    name: "video-update",
+    description: "Update selected metadata on an owned YouTube video",
+    helpAfter: mutationHelp(
+      "Update only explicitly supplied fields after reviewing the current video.",
+      "Never use as a test; this changes provider state and has no dry-run.",
+      [
+        'ravi yt video-update <videoId> --title "Approved title" --json',
+        "ravi yt video-update <videoId> --privacy private --json",
+      ],
+      "YouTube Data API v3 videos.list then videos.update.",
+      "EXTERNAL WRITE: show video ID, current metadata and every proposed field, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.videos",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["id", "title", "description", "tags", "category", "privacy", "connection"],
+  })
+  @Returns(videoUpdateReturnSchema)
+  async videoUpdate(
+    @Arg("id", { description: "Owned YouTube video ID", schema: z.string().min(1) }) id: string,
+    @Option({ flags: "--title <text>", description: "Replacement title" }) title?: string,
+    @Option({ flags: "--description <text>", description: "Replacement description" }) description?: string,
+    @Option({ flags: "--tags <csv>", description: "Replacement comma-separated tag list" }) tags?: string,
+    @Option({ flags: "--category <id>", description: "Replacement category ID" }) categoryId?: string,
+    @Option({
+      flags: "--privacy <status>",
+      description: "public|private|unlisted",
+      schema: z.enum(["public", "private", "unlisted"]),
+    })
+    privacyStatus?: "public" | "private" | "unlisted",
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () =>
+      this.client(connection).updateVideo(id, {
+        title,
+        description,
+        tags: csv(tags),
+        categoryId,
+        privacyStatus,
+      }),
+    );
+  }
+
+  @Command({
+    name: "video-delete",
+    description: "Permanently delete an owned YouTube video",
+    helpAfter: mutationHelp(
+      "Delete only after independently reading the video title and obtaining literal approval.",
+      "To hide a video reversibly, use `video-update --privacy private` instead.",
+      ["ravi yt video <videoId> --json", "ravi yt video-delete <videoId> --json"],
+      "YouTube Data API v3 videos.delete.",
+      "IRREVERSIBLE: show video ID and title, then obtain explicit confirmation that permanent deletion is intended.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.videos",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["id", "connection"],
+  })
+  @Returns(deleteReturnSchema)
+  async videoDelete(
+    @Arg("id", { description: "Owned YouTube video ID", schema: z.string().min(1) }) id: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).deleteVideo(id));
+  }
+
+  @Command({
+    name: "playlist-create",
+    description: "Create a YouTube playlist",
+    helpAfter: mutationHelp(
+      "Create one playlist after checking existing names and approving title/privacy.",
+      "Never retry blindly; duplicate calls create duplicate playlists.",
+      ['ravi yt playlist-create "Approved playlist" --privacy private --json'],
+      "YouTube Data API v3 playlists.insert.",
+      "EXTERNAL WRITE: show title, description and privacy, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "create",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["title", "description", "privacy", "connection"],
+  })
+  @Returns(playlistCreateReturnSchema)
+  async playlistCreate(
+    @Arg("title", { description: "Playlist title", schema: z.string().min(1) }) title: string,
+    @Option({ flags: "--description <text>", description: "Playlist description" }) description?: string,
+    @Option({
+      flags: "--privacy <status>",
+      description: "public|private|unlisted (default: private)",
+      defaultValue: "private",
+      schema: z.enum(["public", "private", "unlisted"]),
+    })
+    privacyStatus?: "public" | "private" | "unlisted",
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).createPlaylist(title, { description, privacyStatus }));
+  }
+
+  @Command({
+    name: "playlist-delete",
+    description: "Permanently delete a YouTube playlist without deleting its videos",
+    helpAfter: mutationHelp(
+      "Delete only after independently listing the playlist and obtaining literal approval.",
+      "To remove one item, use `playlist-remove`; this command deletes the whole playlist.",
+      ["ravi yt playlists --json", "ravi yt playlist-delete <playlistId> --json"],
+      "YouTube Data API v3 playlists.delete.",
+      "IRREVERSIBLE: show playlist ID and title, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["playlistId", "connection"],
+  })
+  @Returns(deleteReturnSchema)
+  async playlistDelete(
+    @Arg("playlistId", { description: "Owned YouTube playlist ID", schema: z.string().min(1) }) playlistId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).deletePlaylist(playlistId));
+  }
+
+  @Command({
+    name: "playlist-add",
+    description: "Add one video to a YouTube playlist",
+    helpAfter: mutationHelp(
+      "Add one reviewed video to one reviewed playlist.",
+      "Never retry blindly; duplicate calls can create duplicate playlist items.",
+      ["ravi yt playlist-add <playlistId> <videoId> --json"],
+      "YouTube Data API v3 playlistItems.insert.",
+      "EXTERNAL WRITE: show playlist ID and video ID/title, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "add",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["playlistId", "videoId", "connection"],
+  })
+  @Returns(playlistAddReturnSchema)
+  async playlistAdd(
+    @Arg("playlistId", { description: "Target YouTube playlist ID", schema: z.string().min(1) }) playlistId: string,
+    @Arg("videoId", { description: "YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).addToPlaylist(playlistId, videoId));
+  }
+
+  @Command({
+    name: "playlist-remove",
+    description: "Remove one playlist item without deleting the video",
+    helpAfter: mutationHelp(
+      "Remove one reviewed playlist item using playlistItemId from `ravi yt playlist`.",
+      "Never pass videoId; a video can appear more than once with distinct item IDs.",
+      ["ravi yt playlist <playlistId> --json", "ravi yt playlist-remove <playlistItemId> --json"],
+      "YouTube Data API v3 playlistItems.delete.",
+      "DESTRUCTIVE CURATION CHANGE: show playlistItemId and video title, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "remove",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["playlistItemId", "connection"],
+  })
+  @Returns(playlistRemoveReturnSchema)
+  async playlistRemove(
+    @Arg("playlistItemId", { description: "Playlist item ID, not video ID", schema: z.string().min(1) })
+    playlistItemId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).removeFromPlaylist(playlistItemId));
+  }
+
+  private client(connection?: string) {
+    return this.clientFactory(connection);
+  }
+
+  private async execute<T>(asJson: boolean | undefined, operation: () => Promise<T>): Promise<T> {
+    try {
+      const payload = await operation();
+      void asJson;
+      console.log(JSON.stringify(payload, null, 2));
+      return payload;
+    } catch (error) {
+      return fail(youtubeError(error));
+    }
+  }
+}
+
+function integer(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    fail(`Expected an integer from ${min} to ${max}.`);
+  }
+  return parsed;
+}
+
+function csv(value?: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function youtubeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${message} Next: run \`ravi yt health --json\` and verify the command arguments; OAuth onboarding is outside Phase 1.`;
+}
+
+function readHelp(use: string, doNotUse: string, examples: string[], source: string): string {
+  return `
+USE
+  ${use}
+
+NÃO USE
+  ${doNotUse}
+
+EXAMPLES
+${examples.map((example) => `  ${example}`).join("\n")}
+
+ON ERROR
+  Credential unavailable -> configure provider "youtube" in the Ravi credential broker.
+  API 4xx/5xx -> inspect the redacted provider message; do not retry writes blindly.
+
+FORMATO
+  --json prints the stable typed response. Provider pagination uses nextPageToken/--page.
+
+FONTES (consultadas em 2026-07-13)
+  ${source}
+  https://developers.google.com/youtube/v3/docs
+`;
+}
+
+function analyticsHelp(use: string, examples: string[], source: string): string {
+  return `${readHelp(
+    use,
+    "Do not request revenue/ad metrics; financial analytics are outside this app and no monetary scope is declared.",
+    examples,
+    source,
+  )}
+REGRAS HARD
+  Read-only analytics only. Requires yt-analytics.readonly and youtube.readonly; never use a monetary scope here.
+
+FONTES ADICIONAIS (consultadas em 2026-07-13)
+  https://developers.google.com/youtube/analytics/reference/reports/query
+  https://developers.google.com/youtube/analytics/channel_reports
+`;
+}
+
+function mutationHelp(use: string, doNotUse: string, examples: string[], source: string, confirmation: string): string {
+  return `${readHelp(use, doNotUse, examples, source)}
+REGRAS HARD
+  No dry-run is available. Never execute for validation, never retry blindly, and always re-read state before mutation.
+
+HITL OBRIGATÓRIO
+  ${confirmation}
+`;
+}

--- a/src/plugins/internal-loader.test.ts
+++ b/src/plugins/internal-loader.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildInternalPluginsArtifact } from "./internal-loader.js";
+
+let root: string | null = null;
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = null;
+});
+
+describe("internal plugin packaging", () => {
+  it("embeds repo Ravi Apps in the ravi-system plugin artifact", () => {
+    root = mkdtempSync(join(tmpdir(), "ravi-plugin-artifact-"));
+    const output = join(root, "internal-plugins.json");
+    buildInternalPluginsArtifact(output);
+
+    const artifact = JSON.parse(readFileSync(output, "utf8")) as {
+      plugins: Array<{ name: string; files: Array<{ path: string }> }>;
+    };
+    const system = artifact.plugins.find((plugin) => plugin.name === "ravi-system");
+    const paths = system?.files.map((file) => file.path) ?? [];
+
+    expect(paths).toContain("apps/apps/ravi.app.json");
+    expect(paths).toContain("apps/youtube/ravi.app.json");
+  });
+});

--- a/src/plugins/internal-loader.ts
+++ b/src/plugins/internal-loader.ts
@@ -56,9 +56,16 @@ export function loadInternalPlugins(): InternalPlugin[] {
 }
 
 export function buildInternalPluginsArtifact(outputFile: string): InternalPluginsArtifact {
+  const plugins = scanInternalPlugins();
+  const systemPlugin = plugins.find((plugin) => plugin.name === "ravi-system");
+  const appsDir = join(moduleDir(), "..", "apps");
+  if (systemPlugin && existsSync(appsDir)) {
+    systemPlugin.files.push(...collectPluginFiles(appsDir, "apps"));
+    systemPlugin.files.sort((left, right) => left.path.localeCompare(right.path));
+  }
   const artifact: InternalPluginsArtifact = {
     schemaVersion: 1,
-    plugins: scanInternalPlugins(),
+    plugins,
   };
   mkdirSync(dirname(outputFile), { recursive: true });
   writeFileSync(outputFile, `${JSON.stringify(artifact, null, 2)}\n`);


### PR DESCRIPTION
## Objective

Move the existing YouTube capability into a native Ravi App contract so agents can use typed, permissioned, packaged commands without depending on SDE.

## Problem

YouTube operations are available only through the legacy SDE surface. Ravi agents have no native app contract, typed SDK surface, granular permissions, or packaged command aliases for this provider.

## Solution

Add a stateless native YouTube Ravi App with 28 decorated commands over the official YouTube Data API and YouTube Analytics API. Credentials resolve through the Ravi broker and every operation fails before provider access when no usable token is configured.

## Practical impact

Agents gain `ravi yt` and `ravi youtube` commands for channels, videos, playlists, comments, captions, and non-monetary analytics. Every command has JSON output, generated SDK types, bounded defaults, and operation-specific permissions.

## What does NOT change

The legacy SDE YouTube implementation, stored data, OAuth setup, broker credential provisioning, database schema, event formats, and financial access remain unchanged. No real provider mutation is part of this pull request.

## Changes

- Add the YouTube app manifest, canonical spec, checks, rationale, and runbook.
- Add a typed client and the `ravi yt` command group with the dynamic `ravi youtube` alias.
- Split permissions across read, captions read, analytics read, write, and destructive operations; no financial operation is declared.
- Generate the TypeScript SDK contract from the command registry.
- Package repository apps in the internal plugin artifact and prevent cached internal mirrors from duplicating source discovery while retaining external cached plugins.
- Add fake-provider regression coverage for all mutations, credential failures, video updates, playlist item identity, comments, captions, analytics, packaging, and aliases.

## How It Works

`ravi yt` and `ravi youtube` route to the current Ravi installation. Commands resolve `youtube:<connection>` credentials through the broker, then call the official provider endpoints. Health is metadata-only and performs no secret resolution or network call. Missing or whitespace-only credentials fail closed before fetch.

## Validation

- Typecheck, build, SDK drift check, Biome, spec gate, quality gate, and diff check pass.
- 33 affected tests pass with 438 assertions; the complete CLI command suite also passes.
- Source and packaged manifest checks each discover one YouTube app with zero warnings or errors.
- The packaged-to-source lifecycle was exercised under one isolated home: internal mirrors are not duplicated and an external cached plugin remains visible.
- Packaged health returns metadata without network access; packaged info fails safely before fetch when credentials are absent.
- The canonical first test segment previously passed 522/522. A pre-push repeat passed 520/522 with two unrelated database hooks reaching the exact 5 second timeout. The later task/project segment has 37 existing environment failures because the user task profile overrides the built-in fixture; none touches this diff.
- Independent code review approved the production change with no remaining findings.

## Risks

Provider response shapes and scheduling rules are the main integration risk. The client uses documented endpoints, refetches complete videos after updates, preserves unavailable playlist item identity, rejects invalid scheduled-public updates, and is covered with deterministic fake fetches. Shared app packaging and generated SDK files may overlap with pull request #261.

## Rollback

Revert the single feature commit. The legacy SDE YouTube implementation and its data remain untouched.

## Follow-ups

Configure a real broker credential and run an authenticated read-only smoke test after credential approval. OAuth onboarding and provider credential provisioning remain separate operational work.

## Notes for Reviewer

No real Google credential, authentication, network call, comment, playlist, or video mutation was used during validation. The app intentionally omits monetary Analytics metrics and financial permissions.