### PR TITLE
fix(crm): filter visible records before pagination

### DIFF
--- a/src/cli/commands/crm.test.ts
+++ b/src/cli/commands/crm.test.ts
@@ -18,6 +18,8 @@ let pipelineRecords: Array<Record<string, unknown>> = [];
 let pipelineStageRecords: Array<Record<string, unknown>> = [];
 let pipelineTopicRecords: Array<Record<string, unknown>> = [];
 let factRecords: Array<Record<string, unknown>> = [];
+let scopeEnforced = false;
+let readableContactIds = new Set<string>();
 let lastAccountCreateInput: Record<string, unknown> | null = null;
 let lastOpportunityCreateInput: Record<string, unknown> | null = null;
 let lastTaskCreateInput: Record<string, unknown> | null = null;
@@ -45,6 +47,24 @@ function pageRecords<T>(
   };
 }
 
+function filterReadableRecords<T extends Record<string, unknown>>(
+  records: T[],
+  options: { readableContactIds?: readonly string[] | null } = {},
+): T[] {
+  if (options.readableContactIds == null) return records;
+  const readable = new Set(options.readableContactIds);
+  return records.filter((record) => {
+    const direct = record.contactId ?? record.contact_id;
+    const contactId =
+      typeof direct === "string"
+        ? direct
+        : record.entityType === "contact" && typeof record.entityId === "string"
+          ? record.entityId
+          : null;
+    return contactId === null || readable.has(contactId);
+  });
+}
+
 mock.module("../context.js", () => ({
   ...actualCliContextModule,
   fail: (message: string) => {
@@ -53,9 +73,9 @@ mock.module("../context.js", () => ({
 }));
 
 mock.module("../../permissions/scope.js", () => ({
-  getScopeContext: () => undefined,
-  isScopeEnforced: () => false,
-  canAccessContact: () => true,
+  getScopeContext: () => ({ agentId: "scoped-agent" }),
+  isScopeEnforced: () => scopeEnforced,
+  canAccessContact: (_scopeCtx: unknown, contact: { id: string }) => readableContactIds.has(contact.id),
 }));
 
 mock.module("../../contacts.js", () => ({
@@ -74,8 +94,16 @@ mock.module("../../contacts.js", () => ({
           facts: [],
         }
       : null,
-  listCrmNextActions: (options: { limit?: string; offset?: string }) => pageRecords(nextActionRecords, options),
-  listCrmContactCards: (options: { limit?: string; offset?: string }) => pageRecords(contactCardRecords, options),
+  getAllContactAccessRecords: () =>
+    contactCardRecords.map((record) => ({
+      id: String(record.contactId),
+      tags: [],
+      identityValues: [],
+    })),
+  listCrmNextActions: (options: { limit?: string; offset?: string; readableContactIds?: readonly string[] }) =>
+    pageRecords(filterReadableRecords(nextActionRecords, options), options),
+  listCrmContactCards: (options: { limit?: string; offset?: string; readableContactIds?: readonly string[] }) =>
+    pageRecords(filterReadableRecords(contactCardRecords, options), options),
   listCrmOpportunityBoard: (options: { pipelineRef?: string } = {}) =>
     options.pipelineRef
       ? opportunityBoardRecords.filter((record) => record.pipelineId === options.pipelineRef)
@@ -252,7 +280,8 @@ mock.module("../../contacts.js", () => ({
       isPrimary: input.isPrimary === true,
     };
   },
-  listCrmFacts: (options: { limit?: string; offset?: string }) => pageRecords(factRecords, options),
+  listCrmFacts: (options: { limit?: string; offset?: string; readableContactIds?: readonly string[] }) =>
+    pageRecords(filterReadableRecords(factRecords, options), options),
   proposeCrmFact: (input: Record<string, unknown>) => {
     lastFactInput = input;
     return {
@@ -284,7 +313,8 @@ mock.module("../../contacts.js", () => ({
           ...crmTask,
         }
       : null,
-  listCrmTasks: (options: { limit?: string; offset?: string }) => pageRecords(taskRecords, options),
+  listCrmTasks: (options: { limit?: string; offset?: string; readableContactIds?: readonly string[] }) =>
+    pageRecords(filterReadableRecords(taskRecords, options), options),
   createCrmTask: (input: Record<string, unknown>) => {
     lastTaskCreateInput = input;
     return { id: "crm_task_1", title: input.title, contactId: input.contactRef ?? null };
@@ -343,6 +373,8 @@ function silenceLogs(run: () => unknown): void {
 
 describe("CRM commands", () => {
   beforeEach(() => {
+    scopeEnforced = false;
+    readableContactIds = new Set<string>();
     crmContactProfile = {
       contactId: "contact-1",
       lifecycle: "lead",
@@ -479,6 +511,91 @@ describe("CRM commands", () => {
     expect(payload.total).toBe(1);
     expect((payload.pagination as Record<string, unknown>).returned).toBe(1);
     expect((payload.items as Array<Record<string, unknown>>)[0]?.taskId).toBe("crm_task_1");
+  });
+
+  it("applies contact visibility before paginating CRM list surfaces", () => {
+    scopeEnforced = true;
+    const hiddenContactIds = Array.from({ length: 60 }, (_, index) => `contact-hidden-${index + 1}`);
+    const visibleContactId = "contact-visible";
+    readableContactIds.add(visibleContactId);
+    contactCardRecords = [
+      ...hiddenContactIds.map((contactId) => ({ contactId, displayName: contactId })),
+      { contactId: visibleContactId, displayName: "Visible" },
+    ];
+    taskRecords = [
+      ...hiddenContactIds.slice(0, 30).map((contactId, index) => ({ id: `task-hidden-${index}`, contactId })),
+      { id: "task-visible", contactId: visibleContactId },
+    ];
+    nextActionRecords = [
+      ...hiddenContactIds.slice(0, 30).map((contactId, index) => ({ taskId: `task-hidden-${index}`, contactId })),
+      { taskId: "task-visible", contactId: visibleContactId },
+    ];
+    factRecords = [
+      ...hiddenContactIds.slice(0, 30).map((contactId, index) => ({
+        id: `fact-hidden-${index}`,
+        entityType: "contact",
+        entityId: contactId,
+      })),
+      { id: "fact-visible", entityType: "contact", entityId: visibleContactId },
+    ];
+
+    const contactsPayload = captureJson(() => {
+      new ACrmCommands().contacts(undefined, undefined, "10", "0", true);
+    });
+    const tasksPayload = captureJson(() => {
+      new CrmTaskCommands().list(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "10",
+        "0",
+        true,
+      );
+    });
+    const factsPayload = captureJson(() => {
+      new CrmFactCommands().list(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "10",
+        "0",
+        true,
+      );
+    });
+    const nextPayload = captureJson(() => {
+      new ACrmCommands().next(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "10",
+        "0",
+        true,
+      );
+    });
+
+    expect(contactsPayload.total).toBe(1);
+    expect((contactsPayload.items as Array<Record<string, unknown>>)[0]?.contactId).toBe(visibleContactId);
+    expect(tasksPayload.total).toBe(1);
+    expect((tasksPayload.items as Array<Record<string, unknown>>)[0]?.id).toBe("task-visible");
+    expect(factsPayload.total).toBe(1);
+    expect((factsPayload.items as Array<Record<string, unknown>>)[0]?.id).toBe("fact-visible");
+    expect(nextPayload.total).toBe(1);
+    expect((nextPayload.items as Array<Record<string, unknown>>)[0]?.taskId).toBe("task-visible");
   });
 
   it("adds snake_case aliases to CRM task JSON surfaces", () => {

--- a/src/cli/commands/crm.ts
+++ b/src/cli/commands/crm.ts
@@ -38,6 +38,7 @@ import {
   createCrmPipelineStageTopic,
   createCrmTask,
   getCrmAccount,
+  getAllContactAccessRecords,
   getContactDetails,
   getCrmContactProfile,
   getCrmOpportunity,
@@ -413,16 +414,20 @@ function renderNextAction(action: {
 
 let cachedRoutes: ReturnType<typeof dbListRoutes> | null = null;
 
-function routeAgentForCrmContact(contactRef: string): string | null {
-  const details = getContactDetails(contactRef);
-  if (!details) return null;
+function routeAgentForIdentityValues(identityValues: string[]): string | null {
   if (!cachedRoutes) cachedRoutes = dbListRoutes();
-  for (const identity of details.platformIdentities) {
-    const value = identity.normalizedPlatformUserId.toLowerCase();
+  for (const identityValue of identityValues) {
+    const value = identityValue.toLowerCase();
     const match = cachedRoutes.find((route) => route.pattern === value);
     if (match) return match.agent;
   }
   return null;
+}
+
+function routeAgentForCrmContact(contactRef: string): string | null {
+  const details = getContactDetails(contactRef);
+  if (!details) return null;
+  return routeAgentForIdentityValues(details.platformIdentities.map((identity) => identity.normalizedPlatformUserId));
 }
 
 function canReadCrmContact(contactRef: string): boolean {
@@ -443,6 +448,23 @@ function canReadCrmContact(contactRef: string): boolean {
 function assertCanReadCrmContact(contactRef: string): void {
   if (canReadCrmContact(contactRef)) return;
   fail(`Contact not found: ${contactRef}`);
+}
+
+function canReadCrmContactRecord(
+  scopeCtx: ReturnType<typeof getScopeContext>,
+  contact: { id: string; tags: string[]; identityValues: string[] },
+): boolean {
+  const contactAgent = routeAgentForIdentityValues(contact.identityValues);
+  const contactSessions = contactAgent ? [{ agentId: contactAgent }] : [];
+  return canAccessContact(scopeCtx, contact, null, contactSessions);
+}
+
+function listReadableCrmContactIds(): string[] | undefined {
+  const scopeCtx = getScopeContext();
+  if (!isScopeEnforced(scopeCtx)) return undefined;
+  return getAllContactAccessRecords()
+    .filter((contact) => canReadCrmContactRecord(scopeCtx, contact))
+    .map((contact) => contact.id);
 }
 
 function contactIdsFromCrmRecord(record: object): string[] {
@@ -477,16 +499,6 @@ function filterCrmRecordsByContact<T extends object>(records: T[]): T[] {
     if (contactIds.length === 0) return true;
     return contactIds.some((contactId) => canReadCrmContact(contactId));
   });
-}
-
-function visiblePage<T extends object>(page: { total: number; limit: number; offset: number; items: T[] }) {
-  if (!isScopeEnforced(getScopeContext())) return page;
-  const items = filterCrmRecordsByContact(page.items);
-  return {
-    ...page,
-    total: items.length,
-    items,
-  };
 }
 
 function showCrmContactProfile(contactRef: string, asJson?: boolean) {
@@ -818,20 +830,19 @@ export class ACrmCommands {
   ) {
     const ownerFilter = parseOwner(owner);
     if (contact) assertCanReadCrmContact(contact);
-    const page = visiblePage(
-      listCrmNextActions({
-        ...ownerFilter,
-        contactRef: contact,
-        accountId: account,
-        opportunityId: opportunity,
-        taskType,
-        dueToday: Boolean(dueToday),
-        dueBefore,
-        dueAfter,
-        limit,
-        offset,
-      }),
-    );
+    const page = listCrmNextActions({
+      ...ownerFilter,
+      contactRef: contact,
+      accountId: account,
+      opportunityId: opportunity,
+      taskType,
+      dueToday: Boolean(dueToday),
+      dueBefore,
+      dueAfter,
+      limit,
+      offset,
+      readableContactIds: listReadableCrmContactIds(),
+    });
     const pagination = buildCliOffsetPagination({
       baseCommand: ["ravi", "crm", "next"],
       limit: page.limit,
@@ -916,7 +927,13 @@ export class ACrmCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     const ownerFilter = parseOwner(owner);
-    const page = visiblePage(listCrmContactCards({ ...ownerFilter, lifecycle, limit, offset }));
+    const page = listCrmContactCards({
+      ...ownerFilter,
+      lifecycle,
+      limit,
+      offset,
+      readableContactIds: listReadableCrmContactIds(),
+    });
     const pagination = buildCliOffsetPagination({
       baseCommand: ["ravi", "crm", "contacts"],
       limit: page.limit,
@@ -2224,19 +2241,18 @@ export class CrmFactCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     if (contactRef) assertCanReadCrmContact(contactRef);
-    const page = visiblePage(
-      listCrmFacts({
-        entityType,
-        entityId,
-        contactRef,
-        accountId,
-        opportunityId,
-        status,
-        key,
-        limit,
-        offset,
-      }),
-    );
+    const page = listCrmFacts({
+      entityType,
+      entityId,
+      contactRef,
+      accountId,
+      opportunityId,
+      status,
+      key,
+      limit,
+      offset,
+      readableContactIds: listReadableCrmContactIds(),
+    });
     const pagination = buildCliOffsetPagination({
       baseCommand: ["ravi", "crm", "fact", "list"],
       limit: page.limit,
@@ -2521,21 +2537,20 @@ export class CrmTaskCommands {
   ) {
     const ownerFilter = parseOwner(owner);
     if (contact) assertCanReadCrmContact(contact);
-    const page = visiblePage(
-      listCrmTasks({
-        ...ownerFilter,
-        contactRef: contact,
-        accountId: account,
-        opportunityId: opportunity,
-        taskType,
-        status,
-        dueToday: Boolean(dueToday),
-        dueBefore,
-        dueAfter,
-        limit,
-        offset,
-      }),
-    );
+    const page = listCrmTasks({
+      ...ownerFilter,
+      contactRef: contact,
+      accountId: account,
+      opportunityId: opportunity,
+      taskType,
+      status,
+      dueToday: Boolean(dueToday),
+      dueBefore,
+      dueAfter,
+      limit,
+      offset,
+      readableContactIds: listReadableCrmContactIds(),
+    });
     const pagination = buildCliOffsetPagination({
       baseCommand: ["ravi", "crm", "task", "list"],
       limit: page.limit,

--- a/src/contacts.identity-model.test.ts
+++ b/src/contacts.identity-model.test.ts
@@ -20,6 +20,7 @@ import {
   confirmCrmFact,
   deleteContact,
   findContactsByTag,
+  getAllContactAccessRecords,
   getAllContacts,
   getCrmContactProfile,
   getCrmOpportunity,
@@ -34,6 +35,7 @@ import {
   linkCrmAccountContact,
   linkCrmOpportunityContact,
   listCrmActivityParticipants,
+  listCrmContactCards,
   listCrmFacts,
   listCrmNextActions,
   listCrmOpportunityContacts,
@@ -60,6 +62,7 @@ import {
   upsertAgentPlatformIdentity,
   upsertContact,
 } from "./contacts.js";
+import { attachTagSlugsToAsset } from "./tags/helpers.js";
 import {
   dbFindChatReadingList,
   dbListChatMessages,
@@ -183,6 +186,90 @@ describe("contacts identity graph schema", () => {
       "table:crm_tasks",
     ]);
     expect(row).toEqual({ lifecycle: "lead", policy_status: "allowed" });
+  });
+
+  it("filters readable CRM contacts before counting and paginating list surfaces", () => {
+    upsertContact("5511999910151", "Hidden One", "allowed", "manual");
+    upsertContact("5511999910152", "Hidden Two", "allowed", "manual");
+    upsertContact("5511999910153", "Visible", "allowed", "manual");
+    const hiddenOne = getContact("5511999910151")!;
+    const hiddenTwo = getContact("5511999910152")!;
+    const visible = getContact("5511999910153")!;
+
+    for (const contact of [hiddenOne, hiddenTwo, visible]) {
+      createCrmTask({ title: `Follow up ${contact.id}`, contactRef: contact.id, source: "test" });
+      proposeCrmFact({
+        entityType: "contact",
+        entityId: contact.id,
+        key: "visibility.test",
+        value: contact.id,
+        source: "test",
+      });
+    }
+    const unlinkedTask = createCrmTask({
+      title: "Unlinked session follow-up",
+      sessionKey: "session-unlinked",
+      source: "test",
+    });
+    const unlinkedFact = proposeCrmFact({
+      entityType: "segment",
+      entityId: "segment-unlinked",
+      key: "visibility.unlinked",
+      value: true,
+      source: "test",
+    });
+    addContactTag(visible.phone, "visible-tag");
+    attachTagSlugsToAsset({
+      assetType: "contact",
+      assetId: visible.id,
+      tags: ["vip-canonical"],
+      source: "test",
+      createdBy: "test",
+    });
+
+    const readableContactIds = [visible.id];
+    const contacts = listCrmContactCards({ readableContactIds, limit: 1 });
+    const tasks = listCrmTasks({ readableContactIds, limit: 10 });
+    const nextActions = listCrmNextActions({ readableContactIds, limit: 10 });
+    const facts = listCrmFacts({ readableContactIds, limit: 10 });
+
+    expect(contacts.total).toBe(1);
+    expect(contacts.items.map((contact) => contact.contactId)).toEqual([visible.id]);
+    expect(tasks.total).toBe(2);
+    expect(tasks.items.some((task) => task.contactId === visible.id)).toBe(true);
+    expect(tasks.items.map((task) => task.id)).toContain(unlinkedTask.id);
+    expect(nextActions.total).toBe(2);
+    expect(nextActions.items.some((action) => action.contactId === visible.id)).toBe(true);
+    expect(nextActions.items.map((action) => action.taskId)).toContain(unlinkedTask.id);
+    expect(facts.total).toBe(2);
+    expect(facts.items.some((fact) => fact.contactId === visible.id)).toBe(true);
+    expect(facts.items.map((fact) => fact.id)).toContain(unlinkedFact.id);
+    expect(listCrmContactCards({ readableContactIds: [] }).total).toBe(0);
+
+    const tasksWithoutReadableContacts = listCrmTasks({ readableContactIds: [] });
+    const nextActionsWithoutReadableContacts = listCrmNextActions({ readableContactIds: [] });
+    const factsWithoutReadableContacts = listCrmFacts({ readableContactIds: [] });
+    expect(tasksWithoutReadableContacts.items.map((task) => task.id)).toEqual([unlinkedTask.id]);
+    expect(nextActionsWithoutReadableContacts.items.map((action) => action.taskId)).toEqual([unlinkedTask.id]);
+    expect(factsWithoutReadableContacts.items.map((fact) => fact.id)).toEqual([unlinkedFact.id]);
+
+    linkContactIdentity(visible.id, {
+      channel: "telegram",
+      platformUserId: "visible-z",
+      instanceId: "instance-z",
+    });
+    linkContactIdentity(visible.id, {
+      channel: "telegram",
+      platformUserId: "visible-a",
+      instanceId: "instance-a",
+    });
+    const compatibilityDetails = getContactDetails(visible.id)!;
+    const accessRecords = getAllContactAccessRecords();
+    expect(accessRecords.map((contact) => contact.id).sort()).toEqual([hiddenOne.id, hiddenTwo.id, visible.id].sort());
+    expect(accessRecords.find((contact) => contact.id === visible.id)).toMatchObject({
+      tags: ["visible-tag", "vip-canonical"],
+      identityValues: compatibilityDetails.platformIdentities.map((identity) => identity.normalizedPlatformUserId),
+    });
   });
 
   it("writes CRM events append-only and mirrors contact-related events into contact timeline", () => {

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -10,6 +10,7 @@ import {
   canonicalTagSlugsForAsset,
   replaceMirroredTagSlugsForAsset,
 } from "./tags/helpers.js";
+import { dbFindTagBindings } from "./tags/tag-db.js";
 import { detachTagFromSelector, searchTagBindingsForSelector } from "./tags/service.js";
 import { buildSqlWhereClause, countRows, normalizeLimitOffsetPage, type ListPage } from "./utils/pagination.js";
 import { nats } from "./nats.js";
@@ -2055,7 +2056,15 @@ export interface SnoozeCrmTaskInput extends CrmMutationOptions {
   snoozedUntil: string;
 }
 
-export interface ListCrmTasksOptions {
+interface CrmReadableContactFilterOptions {
+  /**
+   * Internal authorization boundary for paginated CRM reads. Undefined means
+   * unrestricted; an empty array means no linked contact is readable.
+   */
+  readableContactIds?: readonly string[] | null;
+}
+
+export interface ListCrmTasksOptions extends CrmReadableContactFilterOptions {
   limit?: number | string | null;
   offset?: number | string | null;
   contactRef?: string | null;
@@ -2087,7 +2096,7 @@ export interface CrmNextAction {
   ownerId: string | null;
 }
 
-export interface ListCrmNextActionsOptions {
+export interface ListCrmNextActionsOptions extends CrmReadableContactFilterOptions {
   limit?: number | string | null;
   offset?: number | string | null;
   contactRef?: string | null;
@@ -2122,7 +2131,7 @@ export interface CrmContactCard {
   updatedAt: string;
 }
 
-export interface ListCrmContactCardsOptions {
+export interface ListCrmContactCardsOptions extends CrmReadableContactFilterOptions {
   limit?: number | string | null;
   offset?: number | string | null;
   lifecycle?: CrmContactLifecycle | string | null;
@@ -2296,7 +2305,7 @@ export interface UpdateCrmFactStatusInput extends CrmMutationOptions {
   factId: string;
 }
 
-export interface ListCrmFactsOptions {
+export interface ListCrmFactsOptions extends CrmReadableContactFilterOptions {
   limit?: number | string | null;
   offset?: number | string | null;
   entityType?: CrmEntityType | string | null;
@@ -2357,6 +2366,12 @@ export interface Contact {
   interaction_count: number;
   created_at: string;
   updated_at: string;
+}
+
+export interface ContactAccessRecord {
+  id: string;
+  tags: string[];
+  identityValues: string[];
 }
 
 interface CanonicalContactRow {
@@ -4796,6 +4811,23 @@ function formatCompactDate(value: string): string {
   return date.toISOString().slice(0, 10);
 }
 
+function addReadableContactIdsFilter(input: {
+  where: string[];
+  params: Array<string | number>;
+  readableContactIds?: readonly string[] | null;
+  targetExpression?: string;
+  unlinkedExpression?: string;
+}): void {
+  if (input.readableContactIds == null) return;
+  const contactIds = [...new Set(input.readableContactIds.map((contactId) => contactId.trim()).filter(Boolean))];
+  const targetExpression = input.targetExpression ?? "contact_id";
+  const readableExpression = `${targetExpression} IN (SELECT value FROM json_each(?))`;
+  input.where.push(
+    input.unlinkedExpression ? `((${input.unlinkedExpression}) OR ${readableExpression})` : readableExpression,
+  );
+  input.params.push(JSON.stringify(contactIds));
+}
+
 export function listCrmContactCards(options: ListCrmContactCardsOptions = {}): ListPage<CrmContactCard> {
   const database = ensureDb();
   const where: string[] = [];
@@ -4809,6 +4841,7 @@ export function listCrmContactCards(options: ListCrmContactCardsOptions = {}): L
     where.push("owner_type = ?", "owner_id = ?");
     params.push(owner.ownerType!, owner.ownerId!);
   }
+  addReadableContactIdsFilter({ where, params, readableContactIds: options.readableContactIds });
   const { limit, offset } = normalizeLimitOffsetPage(options, { defaultLimit: 50, maxLimit: 500 });
   const total = countRows({ db: database, table: "crm_contact_cards", where, params });
   const rows = database
@@ -6380,6 +6413,12 @@ export function listCrmTasks(options: ListCrmTasksOptions = {}): ListPage<CrmTas
     where.push("due_at >= ?");
     params.push(options.dueAfter.trim());
   }
+  addReadableContactIdsFilter({
+    where,
+    params,
+    readableContactIds: options.readableContactIds,
+    unlinkedExpression: "contact_id IS NULL",
+  });
   const { limit, offset } = normalizeLimitOffsetPage(options, { defaultLimit: 25, maxLimit: 500 });
   const total = countRows({ db: database, table: "crm_tasks", where, params });
   const rows = database
@@ -6490,6 +6529,12 @@ export function listCrmNextActions(options: ListCrmNextActionsOptions = {}): Lis
     where.push("due_at >= ?");
     params.push(options.dueAfter.trim());
   }
+  addReadableContactIdsFilter({
+    where,
+    params,
+    readableContactIds: options.readableContactIds,
+    unlinkedExpression: "contact_id IS NULL",
+  });
   const { limit, offset } = normalizeLimitOffsetPage(options, { defaultLimit: 25, maxLimit: 500 });
   const total = countRows({ db: database, table: "crm_next_actions", where, params });
   const rows = database
@@ -6769,6 +6814,13 @@ export function listCrmFacts(options: ListCrmFactsOptions = {}): ListPage<CrmFac
     where.push("key = ?");
     params.push(normalizeCrmFactKey(options.key));
   }
+  addReadableContactIdsFilter({
+    where,
+    params,
+    readableContactIds: options.readableContactIds,
+    targetExpression: "COALESCE(contact_id, CASE WHEN entity_type = 'contact' THEN entity_id END)",
+    unlinkedExpression: "contact_id IS NULL AND entity_type <> 'contact'",
+  });
   const { limit, offset } = normalizeLimitOffsetPage(options, { defaultLimit: 25, maxLimit: 500 });
   const total = countRows({ db: database, table: "crm_facts", where, params });
   const rows = database
@@ -8846,6 +8898,66 @@ export function getAllContacts(): Contact[] {
     )
     .all() as CanonicalContactRow[];
   return rows.map((row) => rowToCanonicalCompatContact(database, row));
+}
+
+/**
+ * Load only the contact fields needed by authorization checks. The preload is
+ * intentionally set-based so paginated CRM reads do not issue identity and
+ * policy queries once per contact.
+ */
+export function getAllContactAccessRecords(): ContactAccessRecord[] {
+  const database = ensureDb();
+  const rows = database
+    .prepare(
+      `
+      SELECT c.id, cp.tags_json
+      FROM contacts c
+      LEFT JOIN contact_policies cp ON cp.contact_id = c.id
+      ORDER BY c.id
+    `,
+    )
+    .all() as Array<{ id: string; tags_json: string | null }>;
+  const identityRows = database
+    .prepare(
+      `
+      SELECT owner_id, normalized_platform_user_id, platform_user_id
+      FROM platform_identities
+      WHERE owner_type = 'contact' AND owner_id IS NOT NULL
+      ORDER BY owner_id, is_primary DESC, channel, normalized_platform_user_id
+    `,
+    )
+    .all() as Array<{
+    owner_id: string;
+    normalized_platform_user_id: string;
+    platform_user_id: string;
+  }>;
+
+  const identitiesByContact = new Map<string, string[]>();
+  for (const identity of identityRows) {
+    const values = identitiesByContact.get(identity.owner_id) ?? [];
+    values.push(identity.normalized_platform_user_id || identity.platform_user_id);
+    identitiesByContact.set(identity.owner_id, values);
+  }
+
+  const contactIds = new Set(rows.map((row) => row.id));
+  const canonicalTagsByContact = new Map<string, string[]>();
+  for (const binding of dbFindTagBindings({ assetType: "contact" })) {
+    if (!contactIds.has(binding.assetId)) continue;
+    const tags = canonicalTagsByContact.get(binding.assetId) ?? [];
+    tags.push(binding.tagSlug);
+    canonicalTagsByContact.set(binding.assetId, tags);
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    tags: mergeTagLists(
+      contactTagsFromJson(row.tags_json)
+        .map((tag) => normalizeCanonicalTagSlug(tag))
+        .filter((tag): tag is string => tag !== null),
+      canonicalTagsByContact.get(row.id) ?? [],
+    ),
+    identityValues: identitiesByContact.get(row.id) ?? [],
+  }));
 }
 
 /**


### PR DESCRIPTION
## Objective

Make scoped public CRM list commands return the complete readable universe with totals and pagination that match the underlying records.

## Problem

Scoped CRM reads applied contact visibility after SQL pagination. If the readable contacts were outside the first page, `contacts list`, `task list`, and `fact list` reported zero even though readable records existed.

## Solution

Resolve the readable contact set before counting and paginating CRM records, then apply that set in the store query. This keeps totals, page contents, and `hasMore` aligned with the caller's actual visibility.

## Changes

- Add set-based loading of contact access records, identities, and canonical tags.
- Filter contacts, tasks, facts, and next actions before `COUNT`, `LIMIT`, and `OFFSET`.
- Preserve CRM records that do not reference a contact.
- Merge and deduplicate policy tags with canonical contact tags.
- Add regression coverage for pagination, missing-contact records, canonical-only tags, and multi-instance ordering.

## How It Works

The command layer builds the caller's readable contact ID set once. Store queries receive that set and constrain linked rows before pagination. Access metadata is loaded in batches, avoiding per-contact queries while preserving fail-closed scope behavior.

## Practical impact

CRM consumers can list contacts, tasks, facts, and next actions without receiving a false zero merely because visible contacts fall outside the first unfiltered page.

## What does NOT change

Public return schemas, authorization grants, unscoped query behavior, database schema, and customer data remain unchanged.

## Validation

- Fresh consumer session using the candidate bundle returned contacts=777, tasks=403, and facts=121; read-only SQLite counts at the same point were exactly 777/403/121.
- Focused CRM and identity-model tests: 52 passed, 0 failed.
- CI-equivalent `bun run test`: passed with exit 0 in a clean detached snapshot.
- Build, TypeScript typecheck, SDK drift check, and `git diff --check`: passed.
- Biome: 887 files checked with no fixes required.
- Pull-request quality gate: passed; no spec or uncovered runtime-path changes.
- Independent code review: approved with no remaining findings.

## Risks

Scoped list commands now preload the readable contact access set. The set-based path loaded 777 real access records in approximately 209 ms. Unscoped behavior and the public return schema are unchanged.

## Rollback

Revert commit `953a416`. No database migration, data rewrite, or public schema rollback is required.

## Follow-ups

Deploy the merged artifact through the standard daemon release path and repeat the three read-only CRM counts against the running daemon.

## Notes for Reviewer

Please focus on visibility filtering before pagination, records without contact IDs, tag merging, and the absence of per-contact queries. This change does not alter customer data or authorization grants.
