### PR TITLE
Add native Google Business Profile read-only app

### DIFF
--- a/.ravi/specs/apps/google-business-profile/CHECKS.md
+++ b/.ravi/specs/apps/google-business-profile/CHECKS.md
@@ -1,0 +1,56 @@
+# Google Business Profile Ravi App / CHECKS
+
+## Checks
+
+- Manifest validation MUST pass with exactly one `google-business-profile` app
+  and zero errors or warnings.
+- The focused client, app and CLI suites MUST pass without network access or a
+  real credential.
+- App health (`ravi apps check google-business-profile --json`) MUST be
+  credential-free manifest validation and MUST NOT perform an authenticated
+  request.
+- Every command invoked without a configured credential MUST fail before any
+  Google request with an actionable missing-credential error.
+- Read, write and destructive operations MUST carry distinct `CommandAccess`
+  declarations and manifest permissions; every mutation MUST require
+  confirmation.
+- Public commands MUST declare a concrete JSON return schema and MUST be
+  generated into the TypeScript SDK; `sdk:check` MUST report no drift.
+- Secret values (`clientSecret`, `refreshToken`, verification PINs) MUST NOT
+  appear in any command output or trace.
+- Generated command and SDK artifacts MUST remain current, and typecheck, build
+  and Biome checks MUST pass.
+- Legacy `sde gbp --help` MUST remain present and unchanged.
+
+Run from the repository/worktree root:
+
+```bash
+bun run gen:commands
+bun test src/apps/google-business-profile src/cli/commands/google-business-profile.test.ts
+bun src/cli/index.ts apps check google-business-profile --json
+bun src/cli/index.ts gbp --help
+bun run sdk:generate
+bun run sdk:check
+bun run typecheck
+bun run build
+bunx biome check src/apps/google-business-profile src/cli/commands/google-business-profile.ts src/cli/commands/google-business-profile.test.ts
+```
+
+Credential-failure regression with no real backend or network:
+
+```bash
+RAVI_STATE_DIR=/tmp/ravi-gbp-empty bun src/cli/index.ts gbp locations --account accounts/000 --json
+```
+
+Expected: exit 1 with an actionable missing-credential message before any Google
+request. Do not add a token to make this check pass.
+
+Static preservation checks:
+
+```bash
+git diff --name-only origin/dev...HEAD
+rg -n "sde|gbp-token|business-token" src/apps/google-business-profile src/cli/commands/google-business-profile.ts
+```
+
+Expected: no SDE dependency or legacy token path in implementation code.
+Mentions in tests/specs may only assert their absence.

--- a/.ravi/specs/apps/google-business-profile/RUNBOOK.md
+++ b/.ravi/specs/apps/google-business-profile/RUNBOOK.md
@@ -1,0 +1,39 @@
+# Google Business Profile Ravi App / RUNBOOK
+
+## Debug Flow
+
+1. Validate discovery without executing app code:
+
+   ```bash
+   bun src/cli/index.ts apps check google-business-profile --json
+   bun src/cli/index.ts apps show google-business-profile --json
+   ```
+
+2. Inspect the command surface without resolving a secret:
+
+   ```bash
+   bun src/cli/index.ts gbp --help
+   ```
+
+3. If a command fails with a missing-credential error, do not read or import the
+   `sde gbp` token files. Credential onboarding belongs to a later approved
+   phase; credentials resolve only through the Ravi broker under provider
+   `google-business-profile`.
+
+4. If a mock-transport unit test fails, inspect the exact official endpoint,
+   method, query and body recorded by the test. The implementation constants and
+   request builders are in `src/apps/google-business-profile/client.ts`.
+
+5. If the CLI is absent, run `bun run gen:commands` and verify
+   `src/cli/commands/index.ts` exports `google-business-profile.js`. Do not edit
+   the barrel manually.
+
+6. If SDK checks fail after a CLI contract change, run `bun run sdk:generate`,
+   inspect the generated TypeScript and Swift SDK diffs, then rerun
+   `bun run sdk:check`. `GIT_SHA` churn in `version.ts` is masked by the drift
+   check and can be ignored.
+
+7. Never debug Phase 1 by running reply, update, delete, create or admin
+   mutations against Google. Those paths are validated only with a mock
+   transport until separately approved. PINs and secret values must stay
+   redacted in every output and trace.

--- a/.ravi/specs/apps/google-business-profile/SPEC.md
+++ b/.ravi/specs/apps/google-business-profile/SPEC.md
@@ -1,0 +1,134 @@
+---
+id: apps/google-business-profile
+title: "Google Business Profile"
+kind: capability
+domain: apps
+capability: google-business-profile
+capabilities:
+  - manifest
+  - cli
+  - operations
+tags:
+  - apps
+  - google-business-profile
+applies_to:
+  - src/apps/google-business-profile
+  - src/cli/commands/google-business-profile.ts
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+# Google Business Profile Ravi App
+
+`confirmed_official_contract: yes`
+`implementation_decision: GO`
+`verified_at: 2026-07-13`
+
+## Objective
+
+Provide a native, portable Google Business Profile capability through Ravi CLI,
+SDK and Apps. A clean Ravi installation must not require the external `sde`
+binary, its token files or organization-specific account/location defaults.
+
+## Contract
+
+- Credentials resolve through Ravi's credential broker under provider
+  `google-business-profile` and a caller-selected connection.
+- The secret is a JSON envelope containing `clientId`, `clientSecret` and
+  `refreshToken`; secret values never appear in command output or traces.
+- Every command receives explicit account/location resource identifiers. No
+  account, location or website is compiled into Ravi and no new persistence is
+  introduced.
+- Native Phase 1 operations cover accounts, locations, reviews, local posts,
+  media, performance, search keywords, categories, attributes, verifications
+  and account/location administrators.
+- Read, write and destructive operations have distinct `CommandAccess`
+  declarations and manifest permissions. Every mutation requires confirmation.
+- Public commands declare a concrete JSON return schema and are generated into
+  the TypeScript SDK.
+- The App manifest delegates only to native `ravi gbp` commands. App health is
+  credential-free manifest validation.
+
+## Official sources
+
+- Federated API overview:
+  `https://developers.google.com/my-business/ref_overview`.
+- Account Management v1 discovery/reference:
+  `https://mybusinessaccountmanagement.googleapis.com/$discovery/rest?version=v1`
+  and `https://developers.google.com/my-business/reference/accountmanagement/rest`.
+- Business Information v1 discovery/reference:
+  `https://mybusinessbusinessinformation.googleapis.com/$discovery/rest?version=v1`
+  and `https://developers.google.com/my-business/reference/businessinformation/rest`.
+- Business Profile Performance v1 discovery/reference:
+  `https://businessprofileperformance.googleapis.com/$discovery/rest?version=v1`
+  and `https://developers.google.com/my-business/reference/performance/rest`.
+- Verifications v1 discovery/reference:
+  `https://mybusinessverifications.googleapis.com/$discovery/rest?version=v1`
+  and `https://developers.google.com/my-business/reference/verifications/rest`.
+- Google My Business v4.9 REST reference for reviews, local posts and media:
+  `https://developers.google.com/my-business/reference/rest`.
+- Authentication scope for this surface:
+  `https://www.googleapis.com/auth/business.manage`.
+
+The official overview confirms the federated API model and retains Google My
+Business v4.9 for functionality not moved to specialized APIs. The v1 discovery
+documents were fetched without authentication and used as the method/path
+contract. No provider operation was executed.
+
+## Operation matrix
+
+| operacao_sde | categoria | risco_read_write | endpoint_ou_recurso_oficial | status_decisao | justificativa | fonte_oficial | observacoes_para_ravi_dev |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| auth-url, auth | setup | auth | OAuth 2.0 | aguardar | Real authentication is outside Phase 1. | GBP overview/basic setup | Credential broker only; no legacy token import. |
+| config | setup | local-write | none | ignorar | Native commands require explicit account/location resources. | Federated resource model | No new DB/file persistence. |
+| health | setup | read | none | migrar | Credential-free app validation is deterministic. | Ravi Apps manifest contract | `ravi apps check google-business-profile --json`. |
+| locations, info, account-get | account/location | read | Account Management v1 + Business Information v1 | migrar | Official list/get methods and masks confirmed. | v1 discovery documents | Native `accounts`, `account-get`, `locations`, `location-get`. |
+| account-create, account-patch, location-create | account/location | write | v1 create/patch methods | adicionar | Official but rare onboarding operations are not needed for the core Phase 1 surface. | v1 discovery documents | Keep SDE fallback until a dedicated onboarding contract is approved. |
+| update-location, update-location-full, update-service-area, update-hours, update-special-hours, update-more-hours | location | write | `PATCH v1/{name=locations/*}` | migrar | One masked native update replaces field-specific wrappers. | Business Information v1 | `location-update`, high risk, confirmation. |
+| location-delete | location | destructive | `DELETE v1/{name=locations/*}` | migrar | Official deletion confirmed. | Business Information v1 | Dedicated delete permission and confirmation. |
+| reviews, review-get, reviews-summary, reviews-batch | reviews | read | My Business v4.9 reviews list/get/batchGet | migrar | Native list/get cover primary data; summaries remain deterministic consumers. | v4.9 REST reference | `reviews`, `review-get`; batch summary can be added without changing the client contract. |
+| review-reply | reviews | public-write | `PUT v4/{review}/reply` | migrar | Official public mutation confirmed. | v4.9 reviews reference | High risk and exact-text confirmation. |
+| review-reply-delete | reviews | destructive | `DELETE v4/{review}/reply` | migrar | Official deletion confirmed. | v4.9 reviews reference | Dedicated delete permission. |
+| posts, post-get | local-posts | read | My Business v4.9 localPosts list/get | migrar | Official read methods confirmed. | v4.9 localPosts reference | Bounded provider pagination. |
+| post-create, post-update | local-posts | public-write | My Business v4.9 localPosts create/patch | migrar | Official public mutations confirmed. | v4.9 localPosts reference | High risk, payload + mask, confirmation. |
+| post-delete | local-posts | destructive | My Business v4.9 localPosts delete | migrar | Official deletion confirmed. | v4.9 localPosts reference | Dedicated delete permission. |
+| media, media-get | media | read | My Business v4.9 media list/get | migrar | Official read methods confirmed. | v4.9 media reference | Bounded provider pagination. |
+| media-create, media-update | media | public-write | My Business v4.9 media create/patch | migrar | Official mutations confirmed. | v4.9 media reference | Source URL/data-ref payload, high risk. |
+| media-delete | media | destructive | My Business v4.9 media delete | migrar | Official deletion confirmed. | v4.9 media reference | Dedicated delete permission. |
+| media-start-upload, media-customers, media-customer-get | media | read/write | My Business v4.9 media upload/customer resources | adicionar | Official but binary/customer-specific flows need a separate bounded contract. | v4.9 media reference | Legacy remains available. |
+| performance, multi-daily-metrics, search-keywords | analytics | read | Performance v1 time-series and monthly keyword methods | migrar | Official read-only reporting methods confirmed. | Performance v1 discovery | Explicit dates/months; no inferred production defaults. |
+| categories, category-get, categories-batch | taxonomy | read | Business Information v1 categories | migrar | Core paginated category search is implemented. | Business Information v1 discovery | `categories`; get/batch may be added later. |
+| attributes | attributes | read | `GET v1/{name=locations/*}/attributes` | migrar | Official read method confirmed. | Business Information v1 discovery | Native `attributes`. |
+| update-attributes, attributes-list, attributes-google-updated, google-updated | attributes/location | read/write | Business Information v1 attribute/update resources | adicionar | Official, but not part of the core location payload contract. | Business Information v1 discovery | Keep explicit permissions when added. |
+| verifications, verification-options | verification | read | Verifications v1 list/fetchVerificationOptions | migrar | Official methods confirmed. | Verifications v1 discovery | Medium-risk reads. |
+| verify, verification-complete | verification | write | Verifications v1 verify/complete | migrar | Official verification mutations confirmed. | Verifications v1 discovery | High risk and confirmation; PIN redacted. |
+| verification-token, voice-of-merchant | verification | read/write | Verifications v1 token/VoiceOfMerchant methods | adicionar | Official specialized endpoints confirmed but not needed for core Phase 1. | Verifications v1 discovery | No endpoint invention. |
+| admins, location-admins | access-control | read | Account Management v1 admins list | migrar | Account and location parents share the official Admin model. | Account Management v1 discovery | Native `admins <accounts/...|locations/...>`. |
+| admin-add, admin-patch, location-admin-add, location-admin-patch | access-control | write | Account Management v1 admins create/patch | migrar | Official access mutations confirmed. | Account Management v1 discovery | High risk and confirmation. |
+| admin-delete, location-admin-delete | access-control | destructive | Account Management v1 admins delete | migrar | Official access removal confirmed. | Account Management v1 discovery | Dedicated delete permission. |
+| invitations, invitation-accept, invitation-decline, location-transfer | access-control | write | Account Management v1 invitations/transfer | adicionar | Official, but separate ownership lifecycle needs dedicated HITL semantics. | Account Management v1 discovery | Legacy stays available. |
+| notifications, place-actions, lodging, food-menus, chains, google-locations-search | specialized | mixed | Official federated v1/v4 resources | adicionar | Provider contracts are confirmed; specialized workflows are outside the compact core surface. | GBP federated overview + discovery docs | Add as separate bounded operations, never generic raw request. |
+| Q&A, Business Calls | deprecated | none | discontinued | ignorar | Official/legacy source marks these services discontinued. | GBP references + legacy evidence | Do not recreate removed endpoints. |
+
+There are no financial operations in the official or implemented surface.
+
+## Non-goals
+
+- Obtaining, importing or testing a real OAuth credential/token.
+- Making any authenticated or production request.
+- Changing existing agents, grants, skills, schema, NATS events or provider policy.
+- Replacing or disabling any `sde gbp` operation.
+- Executing Google mutations as part of validation.
+- Adding generic raw-request access to unmodeled provider endpoints.
+
+## Validation
+
+- `ravi apps check google-business-profile --json`.
+- `bun test src/apps/google-business-profile src/cli/commands/google-business-profile.test.ts`.
+- `bun run gen:commands && bun run sdk:generate && bun run sdk:check`.
+- `bun run typecheck && bun run build`.
+- Mock transport verifies official paths/methods, credential failure and secret
+  redaction without authenticated calls.
+- Legacy `sde gbp --help` remains present and unchanged.

--- a/.ravi/specs/apps/google-business-profile/WHY.md
+++ b/.ravi/specs/apps/google-business-profile/WHY.md
@@ -1,0 +1,64 @@
+# Google Business Profile Ravi App / WHY
+
+## Rationale
+
+`confirmed_official_contract: yes` on 2026-07-13.
+
+The Google Business Profile federated API overview confirms the current resource
+model: specialized v1 APIs (Account Management, Business Information, Business
+Profile Performance, Verifications) plus the retained Google My Business v4.9
+REST reference for reviews, local posts and media. The v1 discovery documents
+were fetched without authentication and used as the method/path contract. This
+is sufficient to implement a native, portable capability without treating the
+external `sde` binary or its token files as the source of truth.
+
+Official sources:
+
+- Federated API overview: <https://developers.google.com/my-business/ref_overview>
+- Account Management v1: <https://developers.google.com/my-business/reference/accountmanagement/rest>
+- Business Information v1: <https://developers.google.com/my-business/reference/businessinformation/rest>
+- Business Profile Performance v1: <https://developers.google.com/my-business/reference/performance/rest>
+- Verifications v1: <https://developers.google.com/my-business/reference/verifications/rest>
+- Google My Business v4.9 (reviews/posts/media): <https://developers.google.com/my-business/reference/rest>
+- OAuth scope: `https://www.googleapis.com/auth/business.manage`
+
+The client is native rather than an `sde` wrapper because the official REST
+contract is clear and bounded. It accepts a credential envelope (`clientId`,
+`clientSecret`, `refreshToken`) from the Ravi credential broker under provider
+`google-business-profile`; secret values never appear in command output or
+traces. This lets the structure, command contract, permissions and failure
+behavior be tested with a mock transport, without a real credential or any
+authenticated request.
+
+## Legacy Gaps Corrected
+
+- Legacy `sde gbp` compiles organization-specific account/location defaults. The
+  native app requires explicit account/location resource identifiers on every
+  command, so a clean Ravi installation carries no embedded org state.
+- Field-specific update wrappers (`update-hours`, `update-service-area`, etc.)
+  collapse into one masked `location-update` following the official
+  `PATCH v1/{name=locations/*}` contract with an explicit update mask.
+- Legacy `config` persistence is dropped: no new DB/file persistence is
+  introduced; every operation is provider-owned data or a deterministic
+  consumer of it.
+- Real `auth-url`/`auth` OAuth onboarding is intentionally not migrated in this
+  phase; credentials resolve only through the broker.
+
+## Operation Matrix
+
+The authoritative operation matrix (per-operation category, read/write risk,
+official endpoint, migrate/add/ignore decision and source) lives in `SPEC.md`
+under "Operation matrix". There are no financial operations in the official or
+implemented surface.
+
+## Rejected Alternatives
+
+- **SDE wrapper:** rejected because it would retain legacy token-file coupling
+  and organization-specific defaults despite a clear official API.
+- **Credential/token import from SDE:** rejected because Phase 1 forbids real
+  token use and legacy secret access.
+- **Database/cache:** rejected because all outputs are provider-owned data or
+  deterministic derivations; persistence adds no lineage needed for Phase 1.
+- **Generic raw-request access:** rejected because unmodeled provider endpoints
+  must be added as separate bounded operations, never as a raw passthrough.
+- **NATS events:** rejected because no new cross-system lifecycle is introduced.

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -3,7 +3,7 @@
 // Drift is detected by `ravi sdk client check` (CI).
 
 import type { Transport } from "./transport/types.js";
-import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
+import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GbpAccountGetReturn, GbpAccountsReturn, GbpAdminAddReturn, GbpAdminDeleteReturn, GbpAdminUpdateReturn, GbpAdminsReturn, GbpAttributesReturn, GbpCategoriesReturn, GbpLocationDeleteReturn, GbpLocationGetReturn, GbpLocationUpdateReturn, GbpLocationsReturn, GbpMediaCreateReturn, GbpMediaDeleteReturn, GbpMediaGetReturn, GbpMediaReturn, GbpMediaUpdateReturn, GbpPerformanceReturn, GbpPostCreateReturn, GbpPostDeleteReturn, GbpPostGetReturn, GbpPostUpdateReturn, GbpPostsReturn, GbpReviewGetReturn, GbpReviewReplyDeleteReturn, GbpReviewReplyReturn, GbpReviewsReturn, GbpSearchKeywordsReturn, GbpVerificationCompleteReturn, GbpVerificationOptionsReturn, GbpVerificationsReturn, GbpVerifyReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
 
 /**
  * `RaviClient` exposes every registry command as a typed method.
@@ -2675,6 +2675,368 @@ export class RaviClient {
         groupSegments: ["feedback"],
         command: "send",
         body: { message, ...(options ?? {}) },
+      });
+    }
+  };
+
+  readonly gbp = {
+    /** Get one Google Business Profile account */
+    accountGet: async (account: string, options?: {
+      connection?: string;
+    }): Promise<GbpAccountGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "account-get",
+        body: { account, ...(options ?? {}) },
+      });
+    },
+    /** List Google Business Profile accounts available to the credential */
+    accounts: async (options?: {
+      connection?: string;
+      cursor?: string;
+      limit?: string;
+    }): Promise<GbpAccountsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "accounts",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Invite an administrator to an account or location */
+    adminAdd: async (parent: string, email: string, options?: {
+      connection?: string;
+      role?: string;
+    }): Promise<GbpAdminAddReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "admin-add",
+        body: { parent, email, ...(options ?? {}) },
+      });
+    },
+    /** Remove an account or location administrator */
+    adminDelete: async (admin: string, options?: {
+      connection?: string;
+    }): Promise<GbpAdminDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "admin-delete",
+        body: { admin, ...(options ?? {}) },
+      });
+    },
+    /** Update the role of an account or location administrator */
+    adminUpdate: async (admin: string, options?: {
+      connection?: string;
+      role?: string;
+    }): Promise<GbpAdminUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "admin-update",
+        body: { admin, ...(options ?? {}) },
+      });
+    },
+    /** List administrators for an account or location */
+    admins: async (parent: string, options?: {
+      connection?: string;
+    }): Promise<GbpAdminsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "admins",
+        body: { parent, ...(options ?? {}) },
+      });
+    },
+    /** Get current attributes for a location */
+    attributes: async (location: string, options?: {
+      connection?: string;
+    }): Promise<GbpAttributesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "attributes",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** List official Google Business Profile categories */
+    categories: async (options?: {
+      connection?: string;
+      cursor?: string;
+      filter?: string;
+      language?: string;
+      limit?: string;
+      region?: string;
+    }): Promise<GbpCategoriesReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "categories",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Delete a Google Business Profile location */
+    locationDelete: async (location: string, options?: {
+      connection?: string;
+    }): Promise<GbpLocationDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "location-delete",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** Get one Google Business Profile location */
+    locationGet: async (location: string, options?: {
+      connection?: string;
+      mask?: string;
+    }): Promise<GbpLocationGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "location-get",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** Update selected fields on a Google Business Profile location */
+    locationUpdate: async (location: string, options?: {
+      connection?: string;
+      mask?: string;
+      payload?: string;
+    }): Promise<GbpLocationUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "location-update",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** List locations owned by a Google Business Profile account */
+    locations: async (account: string, options?: {
+      connection?: string;
+      cursor?: string;
+      limit?: string;
+      mask?: string;
+    }): Promise<GbpLocationsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "locations",
+        body: { account, ...(options ?? {}) },
+      });
+    },
+    /** List media for a Google Business Profile location */
+    media: async (account: string, location: string, options?: {
+      connection?: string;
+      cursor?: string;
+      limit?: string;
+    }): Promise<GbpMediaReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "media",
+        body: { account, location, ...(options ?? {}) },
+      });
+    },
+    /** Publish a media item from an official MediaItem payload */
+    mediaCreate: async (account: string, location: string, options?: {
+      connection?: string;
+      payload?: string;
+    }): Promise<GbpMediaCreateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "media-create",
+        body: { account, location, ...(options ?? {}) },
+      });
+    },
+    /** Delete a media item */
+    mediaDelete: async (account: string, location: string, media: string, options?: {
+      connection?: string;
+    }): Promise<GbpMediaDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "media-delete",
+        body: { account, location, media, ...(options ?? {}) },
+      });
+    },
+    /** Get one media item */
+    mediaGet: async (account: string, location: string, media: string, options?: {
+      connection?: string;
+    }): Promise<GbpMediaGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "media-get",
+        body: { account, location, media, ...(options ?? {}) },
+      });
+    },
+    /** Update mutable metadata on a media item */
+    mediaUpdate: async (account: string, location: string, media: string, options?: {
+      connection?: string;
+      mask?: string;
+      payload?: string;
+    }): Promise<GbpMediaUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "media-update",
+        body: { account, location, media, ...(options ?? {}) },
+      });
+    },
+    /** Fetch daily Google Business Profile performance metrics */
+    performance: async (location: string, options?: {
+      connection?: string;
+      end?: string;
+      metrics?: string;
+      start?: string;
+    }): Promise<GbpPerformanceReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "performance",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** Publish a local post */
+    postCreate: async (account: string, location: string, options?: {
+      connection?: string;
+      payload?: string;
+    }): Promise<GbpPostCreateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "post-create",
+        body: { account, location, ...(options ?? {}) },
+      });
+    },
+    /** Delete a local post */
+    postDelete: async (account: string, location: string, post: string, options?: {
+      connection?: string;
+    }): Promise<GbpPostDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "post-delete",
+        body: { account, location, post, ...(options ?? {}) },
+      });
+    },
+    /** Get one local post */
+    postGet: async (account: string, location: string, post: string, options?: {
+      connection?: string;
+    }): Promise<GbpPostGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "post-get",
+        body: { account, location, post, ...(options ?? {}) },
+      });
+    },
+    /** Update selected fields on a local post */
+    postUpdate: async (account: string, location: string, post: string, options?: {
+      connection?: string;
+      mask?: string;
+      payload?: string;
+    }): Promise<GbpPostUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "post-update",
+        body: { account, location, post, ...(options ?? {}) },
+      });
+    },
+    /** List local posts for a Google Business Profile location */
+    posts: async (account: string, location: string, options?: {
+      connection?: string;
+      cursor?: string;
+      limit?: string;
+    }): Promise<GbpPostsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "posts",
+        body: { account, location, ...(options ?? {}) },
+      });
+    },
+    /** Get one Google Business Profile review */
+    reviewGet: async (account: string, location: string, review: string, options?: {
+      connection?: string;
+    }): Promise<GbpReviewGetReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "review-get",
+        body: { account, location, review, ...(options ?? {}) },
+      });
+    },
+    /** Publish or replace the public reply to a review */
+    reviewReply: async (account: string, location: string, review: string, options?: {
+      comment?: string;
+      connection?: string;
+    }): Promise<GbpReviewReplyReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "review-reply",
+        body: { account, location, review, ...(options ?? {}) },
+      });
+    },
+    /** Delete the public reply from a review */
+    reviewReplyDelete: async (account: string, location: string, review: string, options?: {
+      connection?: string;
+    }): Promise<GbpReviewReplyDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "review-reply-delete",
+        body: { account, location, review, ...(options ?? {}) },
+      });
+    },
+    /** List reviews for a Google Business Profile location */
+    reviews: async (account: string, location: string, options?: {
+      connection?: string;
+      cursor?: string;
+      limit?: string;
+    }): Promise<GbpReviewsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "reviews",
+        body: { account, location, ...(options ?? {}) },
+      });
+    },
+    /** List monthly search keyword impressions for a location */
+    searchKeywords: async (location: string, options?: {
+      connection?: string;
+      cursor?: string;
+      endMonth?: string;
+      limit?: string;
+      startMonth?: string;
+    }): Promise<GbpSearchKeywordsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "search-keywords",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** Complete a pending verification with a PIN */
+    verificationComplete: async (verification: string, options?: {
+      connection?: string;
+      pin?: string;
+    }): Promise<GbpVerificationCompleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "verification-complete",
+        body: { verification, ...(options ?? {}) },
+      });
+    },
+    /** Fetch available verification methods for a location */
+    verificationOptions: async (location: string, options?: {
+      connection?: string;
+      language?: string;
+    }): Promise<GbpVerificationOptionsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "verification-options",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** List verification attempts for a location */
+    verifications: async (location: string, options?: {
+      connection?: string;
+    }): Promise<GbpVerificationsReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "verifications",
+        body: { location, ...(options ?? {}) },
+      });
+    },
+    /** Start a location verification using an official method and input payload */
+    verify: async (location: string, method: string, options?: {
+      connection?: string;
+      language?: string;
+      payload?: string;
+    }): Promise<GbpVerifyReturn> => {
+      return this.transport.call({
+        groupSegments: ["gbp"],
+        command: "verify",
+        body: { location, method, ...(options ?? {}) },
       });
     }
   };

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -29360,6 +29360,2505 @@ export const FeedbackSendReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `gbp.account-get`. */
+export const GbpAccountGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "description": "Account id or accounts/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.account-get`. */
+export const GbpAccountGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.accounts`. */
+export const GbpAccountsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "cursor": {
+      "description": "Provider page token from the previous response",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 100 (default: 50)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.accounts`. */
+export const GbpAccountsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.admin-add`. */
+export const GbpAdminAddInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "email": {
+      "format": "email",
+      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+      "type": "string"
+    },
+    "parent": {
+      "description": "Full accounts/{id} or locations/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "role": {
+      "default": "MANAGER",
+      "description": "Official AdminRole value (default: MANAGER)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "email",
+    "parent"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.admin-add`. */
+export const GbpAdminAddReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.admin-delete`. */
+export const GbpAdminDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "admin": {
+      "description": "Full accounts/.../admins/... or locations/.../admins/... name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "admin"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.admin-delete`. */
+export const GbpAdminDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.admin-update`. */
+export const GbpAdminUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "admin": {
+      "description": "Full accounts/.../admins/... or locations/.../admins/... name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "role": {
+      "description": "Required official AdminRole value",
+      "type": "string"
+    }
+  },
+  "required": [
+    "admin"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.admin-update`. */
+export const GbpAdminUpdateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.admins`. */
+export const GbpAdminsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "parent": {
+      "description": "Full accounts/{id} or locations/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "parent"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.admins`. */
+export const GbpAdminsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.attributes`. */
+export const GbpAttributesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.attributes`. */
+export const GbpAttributesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.categories`. */
+export const GbpCategoriesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "cursor": {
+      "type": "string"
+    },
+    "filter": {
+      "description": "Display-name filter",
+      "type": "string"
+    },
+    "language": {
+      "default": "pt-BR",
+      "description": "BCP-47 language code (default: pt-BR)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 100 (default: 50)",
+      "type": "string"
+    },
+    "region": {
+      "default": "BR",
+      "description": "CLDR region code (default: BR)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.categories`. */
+export const GbpCategoriesReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.location-delete`. */
+export const GbpLocationDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location id or locations/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.location-delete`. */
+export const GbpLocationDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.location-get`. */
+export const GbpLocationGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location id or locations/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "mask": {
+      "description": "Business Information read mask",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.location-get`. */
+export const GbpLocationGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.location-update`. */
+export const GbpLocationUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location id or locations/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "mask": {
+      "description": "Required update mask",
+      "type": "string"
+    },
+    "payload": {
+      "description": "Location JSON object",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.location-update`. */
+export const GbpLocationUpdateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.locations`. */
+export const GbpLocationsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "description": "Account id or accounts/{id} resource name",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "cursor": {
+      "description": "Provider page token from the previous response",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 100 (default: 50)",
+      "type": "string"
+    },
+    "mask": {
+      "description": "Business Information read mask",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.locations`. */
+export const GbpLocationsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.media`. */
+export const GbpMediaInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "cursor": {
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 2500 (default: 50)",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.media`. */
+export const GbpMediaReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.media-create`. */
+export const GbpMediaCreateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "payload": {
+      "description": "MediaItem JSON object",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.media-create`. */
+export const GbpMediaCreateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.media-delete`. */
+export const GbpMediaDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "media": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "media"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.media-delete`. */
+export const GbpMediaDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.media-get`. */
+export const GbpMediaGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "media": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "media"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.media-get`. */
+export const GbpMediaGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.media-update`. */
+export const GbpMediaUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "mask": {
+      "description": "Required update mask",
+      "type": "string"
+    },
+    "media": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "payload": {
+      "description": "MediaItem JSON object",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "media"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.media-update`. */
+export const GbpMediaUpdateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.performance`. */
+export const GbpPerformanceInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "end": {
+      "description": "Required end date YYYY-MM-DD",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "metrics": {
+      "description": "Required DailyMetric values, comma-separated",
+      "type": "string"
+    },
+    "start": {
+      "description": "Required start date YYYY-MM-DD",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.performance`. */
+export const GbpPerformanceReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.post-create`. */
+export const GbpPostCreateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "payload": {
+      "description": "LocalPost JSON object",
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.post-create`. */
+export const GbpPostCreateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.post-delete`. */
+export const GbpPostDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "post": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "post"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.post-delete`. */
+export const GbpPostDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.post-get`. */
+export const GbpPostGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "post": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "post"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.post-get`. */
+export const GbpPostGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.post-update`. */
+export const GbpPostUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "mask": {
+      "description": "Required update mask",
+      "type": "string"
+    },
+    "payload": {
+      "description": "LocalPost JSON object",
+      "type": "string"
+    },
+    "post": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "post"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.post-update`. */
+export const GbpPostUpdateReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.posts`. */
+export const GbpPostsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "cursor": {
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 100 (default: 50)",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.posts`. */
+export const GbpPostsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.review-get`. */
+export const GbpReviewGetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "review": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "review"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.review-get`. */
+export const GbpReviewGetReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.review-reply`. */
+export const GbpReviewReplyInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "comment": {
+      "description": "Public reply text",
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "review": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "review"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.review-reply`. */
+export const GbpReviewReplyReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.review-reply-delete`. */
+export const GbpReviewReplyDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "review": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location",
+    "review"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.review-reply-delete`. */
+export const GbpReviewReplyDeleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.reviews`. */
+export const GbpReviewsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "description": "Account id or accounts/{id}",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "cursor": {
+      "description": "Provider page token from the previous response",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 50 (default: 50)",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location id or locations/{id}",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "account",
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.reviews`. */
+export const GbpReviewsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.search-keywords`. */
+export const GbpSearchKeywordsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "cursor": {
+      "type": "string"
+    },
+    "endMonth": {
+      "description": "Required last month YYYY-MM",
+      "pattern": "^\\d{4}-\\d{2}$",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size from 1 to 100 (default: 50)",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "startMonth": {
+      "description": "Required first month YYYY-MM",
+      "pattern": "^\\d{4}-\\d{2}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.search-keywords`. */
+export const GbpSearchKeywordsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.verification-complete`. */
+export const GbpVerificationCompleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "pin": {
+      "description": "Verification PIN",
+      "type": "string"
+    },
+    "verification": {
+      "description": "Full locations/.../verifications/... name",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "verification"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.verification-complete`. */
+export const GbpVerificationCompleteReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.verification-options`. */
+export const GbpVerificationOptionsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "language": {
+      "default": "pt-BR",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.verification-options`. */
+export const GbpVerificationOptionsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.verifications`. */
+export const GbpVerificationsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "location"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.verifications`. */
+export const GbpVerificationsReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `gbp.verify`. */
+export const GbpVerifyInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "type": "string"
+    },
+    "language": {
+      "default": "pt-BR",
+      "type": "string"
+    },
+    "location": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "method": {
+      "description": "Official VerificationMethod value, for example SMS or ADDRESS",
+      "minLength": 1,
+      "type": "string"
+    },
+    "payload": {
+      "description": "Optional method input JSON object",
+      "type": "string"
+    }
+  },
+  "required": [
+    "location",
+    "method"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `gbp.verify`. */
+export const GbpVerifyReturnSchema = {
+  "$defs": {
+    "__schema0": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `gmail.list`. */
 export const GmailListInputSchema = {
   "additionalProperties": false,

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -5840,6 +5840,420 @@ export type FeedbackSendReturn = {
   url: string;
 };
 
+/** Input shape for `gbp.account-get`. */
+export type GbpAccountGetInput = {
+  account: string;
+  connection?: string;
+};
+
+/** Return shape for `gbp.account-get`. */
+export type GbpAccountGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.accounts`. */
+export type GbpAccountsInput = {
+  connection?: string;
+  cursor?: string;
+  limit?: string;
+};
+
+/** Return shape for `gbp.accounts`. */
+export type GbpAccountsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.admin-add`. */
+export type GbpAdminAddInput = {
+  connection?: string;
+  email: string;
+  parent: string;
+  role?: string;
+};
+
+/** Return shape for `gbp.admin-add`. */
+export type GbpAdminAddReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.admin-delete`. */
+export type GbpAdminDeleteInput = {
+  admin: string;
+  connection?: string;
+};
+
+/** Return shape for `gbp.admin-delete`. */
+export type GbpAdminDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.admin-update`. */
+export type GbpAdminUpdateInput = {
+  admin: string;
+  connection?: string;
+  role?: string;
+};
+
+/** Return shape for `gbp.admin-update`. */
+export type GbpAdminUpdateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.admins`. */
+export type GbpAdminsInput = {
+  connection?: string;
+  parent: string;
+};
+
+/** Return shape for `gbp.admins`. */
+export type GbpAdminsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.attributes`. */
+export type GbpAttributesInput = {
+  connection?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.attributes`. */
+export type GbpAttributesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.categories`. */
+export type GbpCategoriesInput = {
+  connection?: string;
+  cursor?: string;
+  filter?: string;
+  language?: string;
+  limit?: string;
+  region?: string;
+};
+
+/** Return shape for `gbp.categories`. */
+export type GbpCategoriesReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.location-delete`. */
+export type GbpLocationDeleteInput = {
+  connection?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.location-delete`. */
+export type GbpLocationDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.location-get`. */
+export type GbpLocationGetInput = {
+  connection?: string;
+  location: string;
+  mask?: string;
+};
+
+/** Return shape for `gbp.location-get`. */
+export type GbpLocationGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.location-update`. */
+export type GbpLocationUpdateInput = {
+  connection?: string;
+  location: string;
+  mask?: string;
+  payload?: string;
+};
+
+/** Return shape for `gbp.location-update`. */
+export type GbpLocationUpdateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.locations`. */
+export type GbpLocationsInput = {
+  account: string;
+  connection?: string;
+  cursor?: string;
+  limit?: string;
+  mask?: string;
+};
+
+/** Return shape for `gbp.locations`. */
+export type GbpLocationsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.media`. */
+export type GbpMediaInput = {
+  account: string;
+  connection?: string;
+  cursor?: string;
+  limit?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.media`. */
+export type GbpMediaReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.media-create`. */
+export type GbpMediaCreateInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  payload?: string;
+};
+
+/** Return shape for `gbp.media-create`. */
+export type GbpMediaCreateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.media-delete`. */
+export type GbpMediaDeleteInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  media: string;
+};
+
+/** Return shape for `gbp.media-delete`. */
+export type GbpMediaDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.media-get`. */
+export type GbpMediaGetInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  media: string;
+};
+
+/** Return shape for `gbp.media-get`. */
+export type GbpMediaGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.media-update`. */
+export type GbpMediaUpdateInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  mask?: string;
+  media: string;
+  payload?: string;
+};
+
+/** Return shape for `gbp.media-update`. */
+export type GbpMediaUpdateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.performance`. */
+export type GbpPerformanceInput = {
+  connection?: string;
+  end?: string;
+  location: string;
+  metrics?: string;
+  start?: string;
+};
+
+/** Return shape for `gbp.performance`. */
+export type GbpPerformanceReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.post-create`. */
+export type GbpPostCreateInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  payload?: string;
+};
+
+/** Return shape for `gbp.post-create`. */
+export type GbpPostCreateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.post-delete`. */
+export type GbpPostDeleteInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  post: string;
+};
+
+/** Return shape for `gbp.post-delete`. */
+export type GbpPostDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.post-get`. */
+export type GbpPostGetInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  post: string;
+};
+
+/** Return shape for `gbp.post-get`. */
+export type GbpPostGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.post-update`. */
+export type GbpPostUpdateInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  mask?: string;
+  payload?: string;
+  post: string;
+};
+
+/** Return shape for `gbp.post-update`. */
+export type GbpPostUpdateReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.posts`. */
+export type GbpPostsInput = {
+  account: string;
+  connection?: string;
+  cursor?: string;
+  limit?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.posts`. */
+export type GbpPostsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.review-get`. */
+export type GbpReviewGetInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  review: string;
+};
+
+/** Return shape for `gbp.review-get`. */
+export type GbpReviewGetReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.review-reply`. */
+export type GbpReviewReplyInput = {
+  account: string;
+  comment?: string;
+  connection?: string;
+  location: string;
+  review: string;
+};
+
+/** Return shape for `gbp.review-reply`. */
+export type GbpReviewReplyReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.review-reply-delete`. */
+export type GbpReviewReplyDeleteInput = {
+  account: string;
+  connection?: string;
+  location: string;
+  review: string;
+};
+
+/** Return shape for `gbp.review-reply-delete`. */
+export type GbpReviewReplyDeleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.reviews`. */
+export type GbpReviewsInput = {
+  account: string;
+  connection?: string;
+  cursor?: string;
+  limit?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.reviews`. */
+export type GbpReviewsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.search-keywords`. */
+export type GbpSearchKeywordsInput = {
+  connection?: string;
+  cursor?: string;
+  endMonth?: string;
+  limit?: string;
+  location: string;
+  startMonth?: string;
+};
+
+/** Return shape for `gbp.search-keywords`. */
+export type GbpSearchKeywordsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.verification-complete`. */
+export type GbpVerificationCompleteInput = {
+  connection?: string;
+  pin?: string;
+  verification: string;
+};
+
+/** Return shape for `gbp.verification-complete`. */
+export type GbpVerificationCompleteReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.verification-options`. */
+export type GbpVerificationOptionsInput = {
+  connection?: string;
+  language?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.verification-options`. */
+export type GbpVerificationOptionsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.verifications`. */
+export type GbpVerificationsInput = {
+  connection?: string;
+  location: string;
+};
+
+/** Return shape for `gbp.verifications`. */
+export type GbpVerificationsReturn = {
+  result: unknown;
+};
+
+/** Input shape for `gbp.verify`. */
+export type GbpVerifyInput = {
+  connection?: string;
+  language?: string;
+  location: string;
+  method: string;
+  payload?: string;
+};
+
+/** Return shape for `gbp.verify`. */
+export type GbpVerifyReturn = {
+  result: unknown;
+};
+
 /** Input shape for `gmail.list`. */
 export type GmailListInput = {
   connector?: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:fd6e955f784edd28bac6aef04d0bc579b0a68524078dc1068837a7a859991a0f";
+export const REGISTRY_HASH = "sha256:5183e3ec44f86327b6dff9e52abd35b78231ed04108843a69d548a17f558181f";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "bd8147fc0120";
+export const GIT_SHA = "59f18b7985ef";

--- a/src/apps/google-business-profile/app.test.ts
+++ b/src/apps/google-business-profile/app.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+describe("Google Business Profile App contract", () => {
+  const manifest = JSON.parse(readFileSync(join(root, "ravi.app.json"), "utf8")) as {
+    id: string;
+    interfaces: { cli: { command: string; health: string } };
+    operations: Record<string, { interface: string; command?: string; mutating?: boolean; permission?: string }>;
+    permissions: { required: string[]; mutating: string[] };
+    skills: string[];
+  };
+
+  it("uses a non-recursive native CLI and credential-free health check", () => {
+    expect(manifest.id).toBe("google-business-profile");
+    expect(manifest.interfaces.cli.command).toBe("ravi gbp");
+    expect(manifest.interfaces.cli.health).toBe("ravi apps check google-business-profile --json");
+    expect(manifest.interfaces.cli.health).not.toContain("accounts");
+  });
+
+  it("declares the implemented native operations without wrapping SDE", () => {
+    const commands = Object.values(manifest.operations).flatMap((operation) =>
+      operation.command ? [operation.command] : [],
+    );
+    expect(commands).toHaveLength(32);
+    expect(commands.every((command) => command.startsWith("ravi gbp "))).toBe(true);
+    expect(commands.some((command) => command.includes("sde"))).toBe(false);
+  });
+
+  it("separates reads, writes and destructive permissions with no financial surface", () => {
+    const operations = Object.values(manifest.operations);
+    const readPermissions = operations
+      .filter((operation) => !operation.mutating && operation.permission)
+      .map((operation) => operation.permission as string);
+    const mutatingPermissions = operations
+      .filter((operation) => operation.mutating)
+      .map((operation) => operation.permission as string);
+
+    expect(readPermissions.every((permission) => permission.endsWith(":read"))).toBe(true);
+    expect(mutatingPermissions.some((permission) => permission.endsWith(":write"))).toBe(true);
+    expect(mutatingPermissions.some((permission) => permission.endsWith(":delete"))).toBe(true);
+    expect([...readPermissions, ...mutatingPermissions].some((permission) => permission.includes("financial"))).toBe(
+      false,
+    );
+    expect(new Set(manifest.permissions.required)).toEqual(new Set(readPermissions));
+    expect(new Set(manifest.permissions.mutating)).toEqual(new Set(mutatingPermissions));
+  });
+
+  it("keeps agent teaching changes outside this implementation task", () => {
+    expect(manifest.skills).toEqual([]);
+  });
+});

--- a/src/apps/google-business-profile/client.test.ts
+++ b/src/apps/google-business-profile/client.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "bun:test";
+import { GoogleBusinessProfileClient, parseCredential } from "./client.js";
+
+const fakeCredential = { clientId: "test-client", clientSecret: "test-secret", refreshToken: "test-refresh" };
+
+interface Call {
+  url: string;
+  method: string;
+  body: string | null;
+  authorization: string | null;
+}
+
+function recordingFetch(calls: Call[]) {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({
+      url,
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : null,
+      authorization: new Headers(init?.headers).get("authorization"),
+    });
+    if (url === "https://oauth2.googleapis.com/token") return Response.json({ access_token: "test-access-token" });
+    return Response.json({ ok: true });
+  }) as unknown as typeof fetch;
+}
+
+describe("GoogleBusinessProfileClient", () => {
+  it("accepts only the portable credential envelope", () => {
+    expect(parseCredential('{"clientId":"id","clientSecret":"secret","refreshToken":"refresh"}')).toEqual({
+      clientId: "id",
+      clientSecret: "secret",
+      refreshToken: "refresh",
+    });
+    expect(() => parseCredential('{"clientId":"id"}')).toThrow("clientSecret");
+    expect(() => parseCredential("not-json")).toThrow("must be JSON");
+  });
+
+  it("fails closed before network access when credential resolution fails", async () => {
+    let fetchCalls = 0;
+    const client = new GoogleBusinessProfileClient({
+      fetch: (async () => {
+        fetchCalls += 1;
+        return Response.json({});
+      }) as unknown as typeof fetch,
+      credentialResolver: async () => {
+        throw new Error("Google Business Profile credential is not configured");
+      },
+    });
+
+    await expect(client.listAccounts()).rejects.toThrow("credential is not configured");
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("uses official federated read endpoints with fake transport only", async () => {
+    const calls: Call[] = [];
+    const client = new GoogleBusinessProfileClient({ credential: fakeCredential, fetch: recordingFetch(calls) });
+
+    await client.listAccounts(25, "next");
+    await client.getAccount("123");
+    await client.listLocations("123", "name,title", 25, "next");
+    await client.getLocation("456", "name,title");
+    await client.listReviews("123", "456", 25, "next");
+    await client.getReview("123", "456", "review-1");
+    await client.listPosts("123", "456", 25, "next");
+    await client.getPost("123", "456", "post-1");
+    await client.listMedia("123", "456", 25, "next");
+    await client.getMedia("123", "456", "media-1");
+    await client.performance("456", ["WEBSITE_CLICKS", "CALL_CLICKS"], "2026-06-01", "2026-06-30");
+    await client.searchKeywords("456", "2026-01", "2026-06", 25, "next");
+    await client.listCategories("BR", "pt-BR", "embalagem", 25, "next");
+    await client.getAttributes("456");
+    await client.listVerifications("456");
+    await client.fetchVerificationOptions("456", "pt-BR");
+    await client.listAdmins("accounts/123");
+
+    expect(calls[0]?.url).toBe("https://oauth2.googleapis.com/token");
+    expect(calls.slice(1).every((call) => call.authorization === "Bearer test-access-token")).toBe(true);
+    expect(calls.slice(1).map(({ url, method }) => ({ url, method }))).toEqual([
+      {
+        url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts?pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      { url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts/123", method: "GET" },
+      {
+        url: "https://mybusinessbusinessinformation.googleapis.com/v1/accounts/123/locations?readMask=name%2Ctitle&pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      {
+        url: "https://mybusinessbusinessinformation.googleapis.com/v1/locations/456?readMask=name%2Ctitle",
+        method: "GET",
+      },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/reviews?pageSize=25&pageToken=next&orderBy=updateTime+desc",
+        method: "GET",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/reviews/review-1", method: "GET" },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/localPosts?pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/localPosts/post-1", method: "GET" },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/media?pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/media/media-1", method: "GET" },
+      {
+        url: "https://businessprofileperformance.googleapis.com/v1/locations/456:fetchMultiDailyMetricsTimeSeries?dailyMetrics=WEBSITE_CLICKS&dailyMetrics=CALL_CLICKS&dailyRange.startDate.year=2026&dailyRange.startDate.month=6&dailyRange.startDate.day=1&dailyRange.endDate.year=2026&dailyRange.endDate.month=6&dailyRange.endDate.day=30",
+        method: "GET",
+      },
+      {
+        url: "https://businessprofileperformance.googleapis.com/v1/locations/456/searchkeywords/impressions/monthly?monthlyRange.startMonth.year=2026&monthlyRange.startMonth.month=1&monthlyRange.endMonth.year=2026&monthlyRange.endMonth.month=6&pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      {
+        url: "https://mybusinessbusinessinformation.googleapis.com/v1/categories?regionCode=BR&languageCode=pt-BR&filter=displayName%3Dembalagem&view=FULL&pageSize=25&pageToken=next",
+        method: "GET",
+      },
+      { url: "https://mybusinessbusinessinformation.googleapis.com/v1/locations/456/attributes", method: "GET" },
+      { url: "https://mybusinessverifications.googleapis.com/v1/locations/456/verifications", method: "GET" },
+      {
+        url: "https://mybusinessverifications.googleapis.com/v1/locations/456:fetchVerificationOptions",
+        method: "POST",
+      },
+      { url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts/123/admins", method: "GET" },
+    ]);
+    expect(JSON.parse(calls.at(-2)?.body ?? "null")).toEqual({ languageCode: "pt-BR" });
+  });
+
+  it("uses official methods for writes without making live calls", async () => {
+    const calls: Call[] = [];
+    const client = new GoogleBusinessProfileClient({ credential: fakeCredential, fetch: recordingFetch(calls) });
+
+    await client.updateLocation("456", { websiteUri: "https://example.test" }, "websiteUri");
+    await client.deleteLocation("456");
+    await client.updateReviewReply("123", "456", "review-1", "Obrigado");
+    await client.deleteReviewReply("123", "456", "review-1");
+    await client.createPost("123", "456", { topicType: "STANDARD", summary: "Novidade" });
+    await client.updatePost("123", "456", "post-1", { summary: "Novo" }, "summary");
+    await client.deletePost("123", "456", "post-1");
+    await client.createMedia("123", "456", { mediaFormat: "PHOTO", sourceUrl: "https://example.test/a.jpg" });
+    await client.updateMedia(
+      "123",
+      "456",
+      "media-1",
+      { locationAssociation: { category: "COVER" } },
+      "locationAssociation",
+    );
+    await client.deleteMedia("123", "456", "media-1");
+    await client.verify("456", "SMS", { phoneNumber: "+551100000000" }, "pt-BR");
+    await client.completeVerification("locations/456/verifications/789", "123456");
+    await client.createAdmin("accounts/123", "person@example.test", "MANAGER");
+    await client.updateAdmin("accounts/123/admins/789", "OWNER");
+    await client.deleteAdmin("accounts/123/admins/789");
+
+    expect(calls.slice(1).map(({ url, method }) => ({ url, method }))).toEqual([
+      {
+        url: "https://mybusinessbusinessinformation.googleapis.com/v1/locations/456?updateMask=websiteUri",
+        method: "PATCH",
+      },
+      { url: "https://mybusinessbusinessinformation.googleapis.com/v1/locations/456", method: "DELETE" },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/reviews/review-1/reply", method: "PUT" },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/reviews/review-1/reply",
+        method: "DELETE",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/localPosts", method: "POST" },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/localPosts/post-1?updateMask=summary",
+        method: "PATCH",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/localPosts/post-1", method: "DELETE" },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/media", method: "POST" },
+      {
+        url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/media/media-1?updateMask=locationAssociation",
+        method: "PATCH",
+      },
+      { url: "https://mybusiness.googleapis.com/v4/accounts/123/locations/456/media/media-1", method: "DELETE" },
+      { url: "https://mybusinessverifications.googleapis.com/v1/locations/456:verify", method: "POST" },
+      {
+        url: "https://mybusinessverifications.googleapis.com/v1/locations/456/verifications/789:complete",
+        method: "POST",
+      },
+      { url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts/123/admins", method: "POST" },
+      {
+        url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts/123/admins/789?updateMask=role",
+        method: "PATCH",
+      },
+      { url: "https://mybusinessaccountmanagement.googleapis.com/v1/accounts/123/admins/789", method: "DELETE" },
+    ]);
+    expect(JSON.parse(calls[11]?.body ?? "null")).toEqual({
+      method: "SMS",
+      languageCode: "pt-BR",
+      phoneNumber: "+551100000000",
+    });
+  });
+
+  it("redacts OAuth fields from provider errors", async () => {
+    const client = new GoogleBusinessProfileClient({
+      credential: fakeCredential,
+      fetch: (async (input: string | URL | Request) => {
+        if (String(input) === "https://oauth2.googleapis.com/token")
+          return Response.json({ access_token: "test-access-token" });
+        return Response.json(
+          { access_token: "do-not-leak", refresh_token: "do-not-leak", client_secret: "do-not-leak" },
+          { status: 401 },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    await expect(client.listAccounts()).rejects.toThrow("[redacted]");
+    await expect(client.listAccounts()).rejects.not.toThrow("do-not-leak");
+  });
+});

--- a/src/apps/google-business-profile/client.ts
+++ b/src/apps/google-business-profile/client.ts
@@ -1,0 +1,360 @@
+import { resolveCredentialSecret } from "../../credentials/broker.js";
+
+export interface GoogleBusinessProfileCredential {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}
+
+export type GbpJson = Record<string, unknown>;
+
+type CredentialResolver = (connection: string) => Promise<GoogleBusinessProfileCredential>;
+
+export interface GoogleBusinessProfileClientOptions {
+  connection?: string;
+  fetch?: typeof globalThis.fetch;
+  /** In-process injection for isolated tests and controlled migrations. */
+  credential?: GoogleBusinessProfileCredential;
+  /** Test seam proving missing credentials fail before network access. */
+  credentialResolver?: CredentialResolver;
+}
+
+const ACCOUNT_MANAGEMENT = "https://mybusinessaccountmanagement.googleapis.com/v1";
+const BUSINESS_INFORMATION = "https://mybusinessbusinessinformation.googleapis.com/v1";
+const PERFORMANCE = "https://businessprofileperformance.googleapis.com/v1";
+const VERIFICATIONS = "https://mybusinessverifications.googleapis.com/v1";
+const MY_BUSINESS_V4 = "https://mybusiness.googleapis.com/v4";
+
+export class GoogleBusinessProfileClient {
+  readonly #connection: string;
+  readonly #fetch: typeof globalThis.fetch;
+  readonly #credential?: GoogleBusinessProfileCredential;
+  readonly #credentialResolver: CredentialResolver;
+  #accessToken: string | null = null;
+
+  constructor(options: GoogleBusinessProfileClientOptions = {}) {
+    this.#connection = options.connection ?? "default";
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#credential = options.credential;
+    this.#credentialResolver =
+      options.credentialResolver ??
+      (async (connection) =>
+        parseCredential(
+          (
+            await resolveCredentialSecret({
+              provider: "google-business-profile",
+              connection,
+              action: "auth.check",
+            })
+          ).secret,
+        ));
+  }
+
+  listAccounts(pageSize = 50, pageToken?: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, "/accounts", { query: { pageSize, pageToken } });
+  }
+
+  getAccount(account: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, `/${accountName(account)}`);
+  }
+
+  listLocations(account: string, readMask: string, pageSize = 50, pageToken?: string): Promise<GbpJson> {
+    return this.request(BUSINESS_INFORMATION, `/${accountName(account)}/locations`, {
+      query: { readMask, pageSize, pageToken },
+    });
+  }
+
+  getLocation(location: string, readMask: string): Promise<GbpJson> {
+    return this.request(BUSINESS_INFORMATION, `/${locationName(location)}`, { query: { readMask } });
+  }
+
+  updateLocation(location: string, body: GbpJson, updateMask: string): Promise<GbpJson> {
+    return this.request(BUSINESS_INFORMATION, `/${locationName(location)}`, {
+      method: "PATCH",
+      query: { updateMask },
+      body,
+    });
+  }
+
+  deleteLocation(location: string): Promise<GbpJson> {
+    return this.request(BUSINESS_INFORMATION, `/${locationName(location)}`, { method: "DELETE" });
+  }
+
+  listReviews(account: string, location: string, pageSize = 50, pageToken?: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${scopedLocation(account, location)}/reviews`, {
+      query: { pageSize, pageToken, orderBy: "updateTime desc" },
+    });
+  }
+
+  getReview(account: string, location: string, review: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "reviews", review)}`);
+  }
+
+  updateReviewReply(account: string, location: string, review: string, comment: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "reviews", review)}/reply`, {
+      method: "PUT",
+      body: { comment },
+    });
+  }
+
+  deleteReviewReply(account: string, location: string, review: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "reviews", review)}/reply`, {
+      method: "DELETE",
+    });
+  }
+
+  listPosts(account: string, location: string, pageSize = 50, pageToken?: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${scopedLocation(account, location)}/localPosts`, {
+      query: { pageSize, pageToken },
+    });
+  }
+
+  getPost(account: string, location: string, post: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "localPosts", post)}`);
+  }
+
+  createPost(account: string, location: string, body: GbpJson): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${scopedLocation(account, location)}/localPosts`, {
+      method: "POST",
+      body,
+    });
+  }
+
+  updatePost(account: string, location: string, post: string, body: GbpJson, updateMask: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "localPosts", post)}`, {
+      method: "PATCH",
+      query: { updateMask },
+      body,
+    });
+  }
+
+  deletePost(account: string, location: string, post: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "localPosts", post)}`, {
+      method: "DELETE",
+    });
+  }
+
+  listMedia(account: string, location: string, pageSize = 50, pageToken?: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${scopedLocation(account, location)}/media`, {
+      query: { pageSize, pageToken },
+    });
+  }
+
+  getMedia(account: string, location: string, media: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "media", media)}`);
+  }
+
+  createMedia(account: string, location: string, body: GbpJson): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${scopedLocation(account, location)}/media`, {
+      method: "POST",
+      body,
+    });
+  }
+
+  updateMedia(account: string, location: string, media: string, body: GbpJson, updateMask: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "media", media)}`, {
+      method: "PATCH",
+      query: { updateMask },
+      body,
+    });
+  }
+
+  deleteMedia(account: string, location: string, media: string): Promise<GbpJson> {
+    return this.request(MY_BUSINESS_V4, `/${childName(scopedLocation(account, location), "media", media)}`, {
+      method: "DELETE",
+    });
+  }
+
+  performance(location: string, metrics: string[], startDate: string, endDate: string): Promise<GbpJson> {
+    return this.request(PERFORMANCE, `/${locationName(location)}:fetchMultiDailyMetricsTimeSeries`, {
+      query: {
+        dailyMetrics: metrics,
+        "dailyRange.startDate.year": startDate.slice(0, 4),
+        "dailyRange.startDate.month": Number(startDate.slice(5, 7)),
+        "dailyRange.startDate.day": Number(startDate.slice(8, 10)),
+        "dailyRange.endDate.year": endDate.slice(0, 4),
+        "dailyRange.endDate.month": Number(endDate.slice(5, 7)),
+        "dailyRange.endDate.day": Number(endDate.slice(8, 10)),
+      },
+    });
+  }
+
+  searchKeywords(location: string, startMonth: string, endMonth: string, pageSize = 50, pageToken?: string) {
+    return this.request(PERFORMANCE, `/${locationName(location)}/searchkeywords/impressions/monthly`, {
+      query: {
+        "monthlyRange.startMonth.year": startMonth.slice(0, 4),
+        "monthlyRange.startMonth.month": Number(startMonth.slice(5, 7)),
+        "monthlyRange.endMonth.year": endMonth.slice(0, 4),
+        "monthlyRange.endMonth.month": Number(endMonth.slice(5, 7)),
+        pageSize,
+        pageToken,
+      },
+    });
+  }
+
+  listCategories(regionCode = "BR", languageCode = "pt-BR", filter?: string, pageSize = 50, pageToken?: string) {
+    return this.request(BUSINESS_INFORMATION, "/categories", {
+      query: {
+        regionCode,
+        languageCode,
+        filter: filter ? `displayName=${filter}` : undefined,
+        view: "FULL",
+        pageSize,
+        pageToken,
+      },
+    });
+  }
+
+  getAttributes(location: string): Promise<GbpJson> {
+    return this.request(BUSINESS_INFORMATION, `/${locationName(location)}/attributes`);
+  }
+
+  listVerifications(location: string): Promise<GbpJson> {
+    return this.request(VERIFICATIONS, `/${locationName(location)}/verifications`);
+  }
+
+  fetchVerificationOptions(location: string, languageCode = "pt-BR"): Promise<GbpJson> {
+    return this.request(VERIFICATIONS, `/${locationName(location)}:fetchVerificationOptions`, {
+      method: "POST",
+      body: { languageCode },
+    });
+  }
+
+  verify(location: string, method: string, body: GbpJson = {}, languageCode = "pt-BR"): Promise<GbpJson> {
+    return this.request(VERIFICATIONS, `/${locationName(location)}:verify`, {
+      method: "POST",
+      body: { method, languageCode, ...body },
+    });
+  }
+
+  completeVerification(verification: string, pin: string): Promise<GbpJson> {
+    return this.request(VERIFICATIONS, `/${verificationName(verification)}:complete`, {
+      method: "POST",
+      body: { pin },
+    });
+  }
+
+  listAdmins(parent: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, `/${parentName(parent)}/admins`);
+  }
+
+  createAdmin(parent: string, email: string, role: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, `/${parentName(parent)}/admins`, {
+      method: "POST",
+      body: { admin: email, role },
+    });
+  }
+
+  updateAdmin(admin: string, role: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, `/${adminName(admin)}`, {
+      method: "PATCH",
+      query: { updateMask: "role" },
+      body: { name: adminName(admin), role },
+    });
+  }
+
+  deleteAdmin(admin: string): Promise<GbpJson> {
+    return this.request(ACCOUNT_MANAGEMENT, `/${adminName(admin)}`, { method: "DELETE" });
+  }
+
+  private async request(
+    base: string,
+    path: string,
+    options: {
+      method?: string;
+      query?: Record<string, string | number | string[] | undefined>;
+      body?: GbpJson;
+    } = {},
+  ): Promise<GbpJson> {
+    const token = await this.accessToken();
+    const url = new URL(`${base}${path}`);
+    for (const [key, raw] of Object.entries(options.query ?? {})) {
+      if (raw === undefined) continue;
+      for (const value of Array.isArray(raw) ? raw : [raw]) url.searchParams.append(key, String(value));
+    }
+    const response = await this.#fetch(url, {
+      method: options.method ?? "GET",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+    const text = await response.text();
+    if (!response.ok) throw new Error(`Google Business Profile request failed (${response.status}): ${redact(text)}`);
+    return text ? (JSON.parse(text) as GbpJson) : {};
+  }
+
+  private async accessToken(): Promise<string> {
+    if (this.#accessToken) return this.#accessToken;
+    const credential = this.#credential ?? (await this.#credentialResolver(this.#connection));
+    const response = await this.#fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: credential.clientId,
+        client_secret: credential.clientSecret,
+        refresh_token: credential.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    });
+    const payload = (await response.json()) as { access_token?: string; error?: string };
+    if (!response.ok || !payload.access_token)
+      throw new Error(`Google OAuth refresh failed: ${payload.error ?? response.status}`);
+    this.#accessToken = payload.access_token;
+    return payload.access_token;
+  }
+}
+
+export function parseCredential(value: string): GoogleBusinessProfileCredential {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("Google Business Profile credential must be JSON.");
+  }
+  if (!parsed || typeof parsed !== "object") throw new Error("Google Business Profile credential must be an object.");
+  const record = parsed as Record<string, unknown>;
+  for (const field of ["clientId", "clientSecret", "refreshToken"] as const) {
+    if (typeof record[field] !== "string" || !record[field])
+      throw new Error(`Google Business Profile credential misses ${field}.`);
+  }
+  return record as unknown as GoogleBusinessProfileCredential;
+}
+
+function accountName(value: string): string {
+  return value.startsWith("accounts/") ? value : `accounts/${value}`;
+}
+
+function locationName(value: string): string {
+  if (value.startsWith("locations/")) return value;
+  const id = value.includes("/locations/") ? value.split("/locations/").at(-1) : value;
+  return `locations/${id}`;
+}
+
+function scopedLocation(account: string, location: string): string {
+  if (location.startsWith("accounts/")) return location;
+  return `${accountName(account)}/locations/${location.replace(/^locations\//, "")}`;
+}
+
+function childName(parent: string, collection: string, value: string): string {
+  return value.includes(`/${collection}/`) ? value : `${parent}/${collection}/${value}`;
+}
+
+function parentName(value: string): string {
+  if (value.startsWith("accounts/") || value.startsWith("locations/")) return value;
+  throw new Error("Admin parent must start with accounts/ or locations/.");
+}
+
+function adminName(value: string): string {
+  if (/^(accounts|locations)\/.+\/admins\/.+/.test(value)) return value;
+  throw new Error("Admin name must be a full accounts/.../admins/... or locations/.../admins/... resource name.");
+}
+
+function verificationName(value: string): string {
+  if (/^locations\/.+\/verifications\/.+/.test(value)) return value;
+  throw new Error("Verification name must be a full locations/.../verifications/... resource name.");
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/("(?:access_token|refresh_token|client_secret)"\s*:\s*")[^"]+/gi, "$1[redacted]")
+    .slice(0, 1000);
+}

--- a/src/apps/google-business-profile/ravi.app.json
+++ b/src/apps/google-business-profile/ravi.app.json
@@ -1,0 +1,259 @@
+{
+  "schema": "ravi.app/v1",
+  "id": "google-business-profile",
+  "name": "Google Business Profile",
+  "version": "0.1.0",
+  "description": "Manage Google Business Profile accounts, locations, reviews, posts, media and performance.",
+  "interfaces": {
+    "cli": {
+      "command": "ravi gbp",
+      "json": true,
+      "health": "ravi apps check google-business-profile --json"
+    }
+  },
+  "operations": {
+    "google-business-profile.help": {
+      "interface": "builtin",
+      "handler": "apps.help",
+      "mutating": false
+    },
+    "google-business-profile.show": {
+      "interface": "builtin",
+      "handler": "apps.manifest.show",
+      "mutating": false
+    },
+    "google-business-profile.check": {
+      "interface": "builtin",
+      "handler": "apps.manifest.check",
+      "mutating": false
+    },
+    "google-business-profile.accounts": {
+      "interface": "cli",
+      "command": "ravi gbp accounts --json {args}",
+      "mutating": false,
+      "permission": "gbp:accounts:read"
+    },
+    "google-business-profile.account-get": {
+      "interface": "cli",
+      "command": "ravi gbp account-get --json {args}",
+      "mutating": false,
+      "permission": "gbp:accounts:read"
+    },
+    "google-business-profile.locations": {
+      "interface": "cli",
+      "command": "ravi gbp locations --json {args}",
+      "mutating": false,
+      "permission": "gbp:locations:read"
+    },
+    "google-business-profile.location-get": {
+      "interface": "cli",
+      "command": "ravi gbp location-get --json {args}",
+      "mutating": false,
+      "permission": "gbp:locations:read"
+    },
+    "google-business-profile.location-update": {
+      "interface": "cli",
+      "command": "ravi gbp location-update --json {args}",
+      "mutating": true,
+      "permission": "gbp:locations:write"
+    },
+    "google-business-profile.location-delete": {
+      "interface": "cli",
+      "command": "ravi gbp location-delete --json {args}",
+      "mutating": true,
+      "permission": "gbp:locations:delete"
+    },
+    "google-business-profile.reviews": {
+      "interface": "cli",
+      "command": "ravi gbp reviews --json {args}",
+      "mutating": false,
+      "permission": "gbp:reviews:read"
+    },
+    "google-business-profile.review-get": {
+      "interface": "cli",
+      "command": "ravi gbp review-get --json {args}",
+      "mutating": false,
+      "permission": "gbp:reviews:read"
+    },
+    "google-business-profile.review-reply": {
+      "interface": "cli",
+      "command": "ravi gbp review-reply --json {args}",
+      "mutating": true,
+      "permission": "gbp:reviews:write"
+    },
+    "google-business-profile.review-reply-delete": {
+      "interface": "cli",
+      "command": "ravi gbp review-reply-delete --json {args}",
+      "mutating": true,
+      "permission": "gbp:reviews:delete"
+    },
+    "google-business-profile.posts": {
+      "interface": "cli",
+      "command": "ravi gbp posts --json {args}",
+      "mutating": false,
+      "permission": "gbp:posts:read"
+    },
+    "google-business-profile.post-get": {
+      "interface": "cli",
+      "command": "ravi gbp post-get --json {args}",
+      "mutating": false,
+      "permission": "gbp:posts:read"
+    },
+    "google-business-profile.post-create": {
+      "interface": "cli",
+      "command": "ravi gbp post-create --json {args}",
+      "mutating": true,
+      "permission": "gbp:posts:write"
+    },
+    "google-business-profile.post-update": {
+      "interface": "cli",
+      "command": "ravi gbp post-update --json {args}",
+      "mutating": true,
+      "permission": "gbp:posts:write"
+    },
+    "google-business-profile.post-delete": {
+      "interface": "cli",
+      "command": "ravi gbp post-delete --json {args}",
+      "mutating": true,
+      "permission": "gbp:posts:delete"
+    },
+    "google-business-profile.media": {
+      "interface": "cli",
+      "command": "ravi gbp media --json {args}",
+      "mutating": false,
+      "permission": "gbp:media:read"
+    },
+    "google-business-profile.media-get": {
+      "interface": "cli",
+      "command": "ravi gbp media-get --json {args}",
+      "mutating": false,
+      "permission": "gbp:media:read"
+    },
+    "google-business-profile.media-create": {
+      "interface": "cli",
+      "command": "ravi gbp media-create --json {args}",
+      "mutating": true,
+      "permission": "gbp:media:write"
+    },
+    "google-business-profile.media-update": {
+      "interface": "cli",
+      "command": "ravi gbp media-update --json {args}",
+      "mutating": true,
+      "permission": "gbp:media:write"
+    },
+    "google-business-profile.media-delete": {
+      "interface": "cli",
+      "command": "ravi gbp media-delete --json {args}",
+      "mutating": true,
+      "permission": "gbp:media:delete"
+    },
+    "google-business-profile.performance": {
+      "interface": "cli",
+      "command": "ravi gbp performance --json {args}",
+      "mutating": false,
+      "permission": "gbp:performance:read"
+    },
+    "google-business-profile.search-keywords": {
+      "interface": "cli",
+      "command": "ravi gbp search-keywords --json {args}",
+      "mutating": false,
+      "permission": "gbp:performance:read"
+    },
+    "google-business-profile.categories": {
+      "interface": "cli",
+      "command": "ravi gbp categories --json {args}",
+      "mutating": false,
+      "permission": "gbp:categories:read"
+    },
+    "google-business-profile.attributes": {
+      "interface": "cli",
+      "command": "ravi gbp attributes --json {args}",
+      "mutating": false,
+      "permission": "gbp:attributes:read"
+    },
+    "google-business-profile.verifications": {
+      "interface": "cli",
+      "command": "ravi gbp verifications --json {args}",
+      "mutating": false,
+      "permission": "gbp:verifications:read"
+    },
+    "google-business-profile.verification-options": {
+      "interface": "cli",
+      "command": "ravi gbp verification-options --json {args}",
+      "mutating": false,
+      "permission": "gbp:verifications:read"
+    },
+    "google-business-profile.verify": {
+      "interface": "cli",
+      "command": "ravi gbp verify --json {args}",
+      "mutating": true,
+      "permission": "gbp:verifications:write"
+    },
+    "google-business-profile.verification-complete": {
+      "interface": "cli",
+      "command": "ravi gbp verification-complete --json {args}",
+      "mutating": true,
+      "permission": "gbp:verifications:write"
+    },
+    "google-business-profile.admins": {
+      "interface": "cli",
+      "command": "ravi gbp admins --json {args}",
+      "mutating": false,
+      "permission": "gbp:admins:read"
+    },
+    "google-business-profile.admin-add": {
+      "interface": "cli",
+      "command": "ravi gbp admin-add --json {args}",
+      "mutating": true,
+      "permission": "gbp:admins:write"
+    },
+    "google-business-profile.admin-update": {
+      "interface": "cli",
+      "command": "ravi gbp admin-update --json {args}",
+      "mutating": true,
+      "permission": "gbp:admins:write"
+    },
+    "google-business-profile.admin-delete": {
+      "interface": "cli",
+      "command": "ravi gbp admin-delete --json {args}",
+      "mutating": true,
+      "permission": "gbp:admins:delete"
+    }
+  },
+  "permissions": {
+    "required": [
+      "gbp:accounts:read",
+      "gbp:locations:read",
+      "gbp:reviews:read",
+      "gbp:posts:read",
+      "gbp:media:read",
+      "gbp:performance:read",
+      "gbp:categories:read",
+      "gbp:attributes:read",
+      "gbp:verifications:read",
+      "gbp:admins:read"
+    ],
+    "optional": [],
+    "mutating": [
+      "gbp:locations:write",
+      "gbp:locations:delete",
+      "gbp:reviews:write",
+      "gbp:reviews:delete",
+      "gbp:posts:write",
+      "gbp:posts:delete",
+      "gbp:media:write",
+      "gbp:media:delete",
+      "gbp:verifications:write",
+      "gbp:admins:write",
+      "gbp:admins:delete"
+    ]
+  },
+  "storage": { "sqlite": [], "files": [] },
+  "artifacts": [],
+  "events": { "emits": [], "consumes": [] },
+  "skills": [],
+  "health": {
+    "checks": [{ "type": "builtin", "handler": "apps.manifest.check" }]
+  },
+  "versioning": { "compatibility": "semver", "migrations": [] }
+}

--- a/src/cli/commands/google-business-profile.test.ts
+++ b/src/cli/commands/google-business-profile.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getCommandAccessMetadata,
+  getCommandsMetadata,
+  getOptionsMetadata,
+  getReturnsMetadata,
+} from "../decorators.js";
+import { GoogleBusinessProfileCommands } from "./google-business-profile.js";
+
+const readMethods = [
+  "accounts",
+  "accountGet",
+  "locations",
+  "locationGet",
+  "reviews",
+  "reviewGet",
+  "posts",
+  "postGet",
+  "media",
+  "mediaGet",
+  "performance",
+  "searchKeywords",
+  "categories",
+  "attributes",
+  "verifications",
+  "verificationOptions",
+  "admins",
+] as const;
+
+const highRiskMutations = [
+  "locationUpdate",
+  "reviewReply",
+  "postCreate",
+  "postUpdate",
+  "mediaCreate",
+  "mediaUpdate",
+  "verify",
+  "verificationComplete",
+  "adminAdd",
+  "adminUpdate",
+] as const;
+
+const destructiveMutations = [
+  "locationDelete",
+  "reviewReplyDelete",
+  "postDelete",
+  "mediaDelete",
+  "adminDelete",
+] as const;
+
+describe("Google Business Profile CLI contract", () => {
+  it("declares access, typed returns, rich help and --json for every command", () => {
+    const commands = getCommandsMetadata(GoogleBusinessProfileCommands);
+    const access = getCommandAccessMetadata(GoogleBusinessProfileCommands);
+    const returns = getReturnsMetadata(GoogleBusinessProfileCommands);
+
+    expect(commands).toHaveLength(32);
+    expect(access.size).toBe(commands.length);
+    expect(returns.size).toBe(commands.length);
+    for (const command of commands) {
+      expect(getOptionsMetadata(GoogleBusinessProfileCommands.prototype, command.method)).toContainEqual(
+        expect.objectContaining({ flags: "--json" }),
+      );
+      expect(command.helpAfter).toContain("EXAMPLES");
+      expect(command.helpAfter).toContain("ON ERROR");
+      expect(command.helpAfter).toContain("SOURCES");
+    }
+  });
+
+  it("separates reads, high-risk writes and destructive mutations", () => {
+    const access = getCommandAccessMetadata(GoogleBusinessProfileCommands);
+
+    for (const method of readMethods) expect(access.get(method)).toMatchObject({ kind: "read" });
+    for (const method of highRiskMutations) {
+      expect(access.get(method)).toMatchObject({
+        kind: "mutate",
+        risk: "high",
+        requiresConfirmation: true,
+      });
+    }
+    for (const method of destructiveMutations) {
+      expect(access.get(method)).toMatchObject({
+        kind: "mutate",
+        risk: "destructive",
+        requiresConfirmation: true,
+      });
+    }
+    expect(Array.from(access.values()).some((entry) => entry.resource.includes("financial"))).toBe(false);
+  });
+
+  it("rejects malformed payloads and required options before credential access", async () => {
+    const commands = new GoogleBusinessProfileCommands();
+
+    await expect(commands.locationUpdate("456", "websiteUri", "not-json")).rejects.toThrow(
+      "--payload must be a JSON object",
+    );
+    await expect(commands.performance("456", undefined, "2026-06-01", "2026-06-30")).rejects.toThrow(
+      "--metrics is required",
+    );
+    await expect(commands.adminUpdate("admin-789", "OWNER")).rejects.toThrow("Admin name must be a full");
+  });
+});

--- a/src/cli/commands/google-business-profile.ts
+++ b/src/cli/commands/google-business-profile.ts
@@ -1,0 +1,919 @@
+import "reflect-metadata";
+import { z } from "zod";
+import { GoogleBusinessProfileClient, type GbpJson } from "../../apps/google-business-profile/client.js";
+import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
+import { jsonValueSchema } from "../return-schemas.js";
+
+const resourceSchema = z.string().min(1);
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD");
+const monthSchema = z.string().regex(/^\d{4}-\d{2}$/, "Expected YYYY-MM");
+const wrappedSchema = z.object({ result: jsonValueSchema }).strict();
+const defaultLocationReadMask =
+  "name,title,storeCode,websiteUri,phoneNumbers,regularHours,categories,metadata,profile,serviceArea";
+
+@Group({
+  name: "gbp",
+  description: "Operate Google Business Profile through credentials stored in Ravi",
+  scope: "open",
+})
+export class GoogleBusinessProfileCommands {
+  private client(connection?: string) {
+    return new GoogleBusinessProfileClient({ connection });
+  }
+
+  @Command({
+    name: "accounts",
+    description: "List Google Business Profile accounts available to the credential",
+    helpAfter: readHelp("ravi gbp accounts", "ravi gbp accounts --limit 25 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.accounts", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async accounts(
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 100 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>", description: "Provider page token from the previous response" })
+    cursor?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).listAccounts(integer(limit, 50, 1, 100), cursor));
+  }
+
+  @Command({
+    name: "account-get",
+    description: "Get one Google Business Profile account",
+    helpAfter: readHelp("ravi gbp account-get accounts/123", "ravi gbp account-get 123 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.accounts", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async accountGet(
+    @Arg("account", { description: "Account id or accounts/{id} resource name", schema: resourceSchema })
+    account: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).getAccount(account));
+  }
+
+  @Command({
+    name: "locations",
+    description: "List locations owned by a Google Business Profile account",
+    helpAfter: readHelp(
+      "ravi gbp locations accounts/123",
+      "ravi gbp locations 123 --limit 25 --mask name,title,metadata --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.locations", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async locations(
+    @Arg("account", { description: "Account id or accounts/{id} resource name", schema: resourceSchema })
+    account: string,
+    @Option({ flags: "--mask <fields>", description: "Business Information read mask" }) mask?: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 100 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>", description: "Provider page token from the previous response" })
+    cursor?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).listLocations(
+        account,
+        mask ?? defaultLocationReadMask,
+        integer(limit, 50, 1, 100),
+        cursor,
+      ),
+    );
+  }
+
+  @Command({
+    name: "location-get",
+    description: "Get one Google Business Profile location",
+    helpAfter: readHelp(
+      "ravi gbp location-get locations/456",
+      "ravi gbp location-get 456 --mask name,title,regularHours --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.locations", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async locationGet(
+    @Arg("location", { description: "Location id or locations/{id} resource name", schema: resourceSchema })
+    location: string,
+    @Option({ flags: "--mask <fields>", description: "Business Information read mask" }) mask?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).getLocation(location, mask ?? defaultLocationReadMask));
+  }
+
+  @Command({
+    name: "location-update",
+    description: "Update selected fields on a Google Business Profile location",
+    helpAfter: mutateHelp(
+      'ravi gbp location-update locations/456 --mask websiteUri --payload \'{"websiteUri":"https://example.com"}\'',
+      'ravi gbp location-update 456 --mask regularHours --payload \'{"regularHours":{"periods":[]}}\' --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.locations",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["location", "mask", "payload"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async locationUpdate(
+    @Arg("location", { description: "Location id or locations/{id} resource name", schema: resourceSchema })
+    location: string,
+    @Option({ flags: "--mask <fields>", description: "Required update mask" }) mask?: string,
+    @Option({ flags: "--payload <json>", description: "Location JSON object" }) payload?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).updateLocation(location, jsonObject(payload), required(mask, "--mask")));
+  }
+
+  @Command({
+    name: "location-delete",
+    description: "Delete a Google Business Profile location",
+    helpAfter: destructiveHelp("ravi gbp location-delete locations/456", "ravi gbp location-delete 456 --json"),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.locations",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(wrappedSchema)
+  async locationDelete(
+    @Arg("location", { description: "Location id or locations/{id} resource name", schema: resourceSchema })
+    location: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteLocation(location));
+  }
+
+  @Command({
+    name: "reviews",
+    description: "List reviews for a Google Business Profile location",
+    helpAfter: readHelp("ravi gbp reviews accounts/123 locations/456", "ravi gbp reviews 123 456 --limit 25 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.reviews", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async reviews(
+    @Arg("account", { description: "Account id or accounts/{id}", schema: resourceSchema }) account: string,
+    @Arg("location", { description: "Location id or locations/{id}", schema: resourceSchema }) location: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 50 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>", description: "Provider page token from the previous response" })
+    cursor?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+  ) {
+    return wrap(await this.client(connection).listReviews(account, location, integer(limit, 50, 1, 50), cursor));
+  }
+
+  @Command({
+    name: "review-get",
+    description: "Get one Google Business Profile review",
+    helpAfter: readHelp(
+      "ravi gbp review-get 123 456 REVIEW_ID",
+      "ravi gbp review-get accounts/123 locations/456 REVIEW_ID --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.reviews", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async reviewGet(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("review", { schema: resourceSchema }) review: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getReview(account, location, review));
+  }
+
+  @Command({
+    name: "review-reply",
+    description: "Publish or replace the public reply to a review",
+    helpAfter: mutateHelp(
+      "ravi gbp review-reply 123 456 REVIEW_ID --comment 'Obrigado pelo feedback.'",
+      "ravi gbp review-reply accounts/123 locations/456 REVIEW_ID --comment 'Vamos resolver pelo canal privado.' --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.reviews",
+    action: "reply",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["account", "location", "review", "comment"],
+    redactions: ["comment"],
+  })
+  @Returns(wrappedSchema)
+  async reviewReply(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("review", { schema: resourceSchema }) review: string,
+    @Option({ flags: "--comment <text>", description: "Public reply text" }) comment?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).updateReviewReply(account, location, review, required(comment, "--comment")),
+    );
+  }
+
+  @Command({
+    name: "review-reply-delete",
+    description: "Delete the public reply from a review",
+    helpAfter: destructiveHelp(
+      "ravi gbp review-reply-delete 123 456 REVIEW_ID",
+      "ravi gbp review-reply-delete accounts/123 locations/456 REVIEW_ID --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.reviews",
+    action: "delete-reply",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(wrappedSchema)
+  async reviewReplyDelete(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("review", { schema: resourceSchema }) review: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteReviewReply(account, location, review));
+  }
+
+  @Command({
+    name: "posts",
+    description: "List local posts for a Google Business Profile location",
+    helpAfter: readHelp("ravi gbp posts 123 456", "ravi gbp posts 123 456 --limit 25 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.posts", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async posts(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 100 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>" }) cursor?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).listPosts(account, location, integer(limit, 50, 1, 100), cursor));
+  }
+
+  @Command({
+    name: "post-get",
+    description: "Get one local post",
+    helpAfter: readHelp("ravi gbp post-get 123 456 POST_ID", "ravi gbp post-get 123 456 POST_ID --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.posts", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async postGet(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("post", { schema: resourceSchema }) post: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getPost(account, location, post));
+  }
+
+  @Command({
+    name: "post-create",
+    description: "Publish a local post",
+    helpAfter: mutateHelp(
+      'ravi gbp post-create 123 456 --payload \'{"topicType":"STANDARD","summary":"Novidade"}\'',
+      'ravi gbp post-create 123 456 --payload \'{"topicType":"STANDARD","summary":"Novidade"}\' --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.posts",
+    action: "create",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["account", "location", "payload"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async postCreate(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--payload <json>", description: "LocalPost JSON object" }) payload?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).createPost(account, location, jsonObject(payload)));
+  }
+
+  @Command({
+    name: "post-update",
+    description: "Update selected fields on a local post",
+    helpAfter: mutateHelp(
+      'ravi gbp post-update 123 456 POST_ID --mask summary --payload \'{"summary":"Texto novo"}\'',
+      'ravi gbp post-update 123 456 POST_ID --mask callToAction --payload \'{"callToAction":{"actionType":"LEARN_MORE","url":"https://example.com"}}\' --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.posts",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["account", "location", "post", "mask", "payload"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async postUpdate(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("post", { schema: resourceSchema }) post: string,
+    @Option({ flags: "--mask <fields>", description: "Required update mask" }) mask?: string,
+    @Option({ flags: "--payload <json>", description: "LocalPost JSON object" }) payload?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).updatePost(account, location, post, jsonObject(payload), required(mask, "--mask")),
+    );
+  }
+
+  @Command({
+    name: "post-delete",
+    description: "Delete a local post",
+    helpAfter: destructiveHelp("ravi gbp post-delete 123 456 POST_ID", "ravi gbp post-delete 123 456 POST_ID --json"),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.posts",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(wrappedSchema)
+  async postDelete(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("post", { schema: resourceSchema }) post: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deletePost(account, location, post));
+  }
+
+  @Command({
+    name: "media",
+    description: "List media for a Google Business Profile location",
+    helpAfter: readHelp("ravi gbp media 123 456", "ravi gbp media 123 456 --limit 25 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.media", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async media(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 2500 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>" }) cursor?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).listMedia(account, location, integer(limit, 50, 1, 2500), cursor));
+  }
+
+  @Command({
+    name: "media-get",
+    description: "Get one media item",
+    helpAfter: readHelp("ravi gbp media-get 123 456 MEDIA_KEY", "ravi gbp media-get 123 456 MEDIA_KEY --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.media", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async mediaGet(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("media", { schema: resourceSchema }) media: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getMedia(account, location, media));
+  }
+
+  @Command({
+    name: "media-create",
+    description: "Publish a media item from an official MediaItem payload",
+    helpAfter: mutateHelp(
+      'ravi gbp media-create 123 456 --payload \'{"mediaFormat":"PHOTO","sourceUrl":"https://example.com/photo.jpg","locationAssociation":{"category":"COVER"}}\'',
+      'ravi gbp media-create 123 456 --payload \'{"mediaFormat":"PHOTO","sourceUrl":"https://example.com/photo.jpg","locationAssociation":{"category":"PROFILE"}}\' --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.media",
+    action: "create",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["account", "location", "payload"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async mediaCreate(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--payload <json>", description: "MediaItem JSON object" }) payload?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).createMedia(account, location, jsonObject(payload)));
+  }
+
+  @Command({
+    name: "media-update",
+    description: "Update mutable metadata on a media item",
+    helpAfter: mutateHelp(
+      'ravi gbp media-update 123 456 MEDIA_KEY --mask locationAssociation --payload \'{"locationAssociation":{"category":"PROFILE"}}\'',
+      'ravi gbp media-update 123 456 MEDIA_KEY --mask locationAssociation --payload \'{"locationAssociation":{"category":"COVER"}}\' --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.media",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["account", "location", "media", "mask", "payload"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async mediaUpdate(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("media", { schema: resourceSchema }) media: string,
+    @Option({ flags: "--mask <fields>", description: "Required update mask" }) mask?: string,
+    @Option({ flags: "--payload <json>", description: "MediaItem JSON object" }) payload?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).updateMedia(
+        account,
+        location,
+        media,
+        jsonObject(payload),
+        required(mask, "--mask"),
+      ),
+    );
+  }
+
+  @Command({
+    name: "media-delete",
+    description: "Delete a media item",
+    helpAfter: destructiveHelp(
+      "ravi gbp media-delete 123 456 MEDIA_KEY",
+      "ravi gbp media-delete 123 456 MEDIA_KEY --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.media",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(wrappedSchema)
+  async mediaDelete(
+    @Arg("account", { schema: resourceSchema }) account: string,
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("media", { schema: resourceSchema }) media: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteMedia(account, location, media));
+  }
+
+  @Command({
+    name: "performance",
+    description: "Fetch daily Google Business Profile performance metrics",
+    helpAfter: readHelp(
+      "ravi gbp performance 456 --metrics BUSINESS_IMPRESSIONS_DESKTOP_MAPS,WEBSITE_CLICKS --start 2026-06-01 --end 2026-06-30",
+      "ravi gbp performance locations/456 --metrics CALL_CLICKS --start 2026-06-01 --end 2026-06-30 --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.performance", action: "read", risk: "low" })
+  @Returns(wrappedSchema)
+  async performance(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--metrics <csv>", description: "Required DailyMetric values, comma-separated" }) metrics?: string,
+    @Option({ flags: "--start <date>", description: "Required start date YYYY-MM-DD", schema: dateSchema })
+    start?: string,
+    @Option({ flags: "--end <date>", description: "Required end date YYYY-MM-DD", schema: dateSchema }) end?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).performance(
+        location,
+        csv(required(metrics, "--metrics")),
+        required(start, "--start"),
+        required(end, "--end"),
+      ),
+    );
+  }
+
+  @Command({
+    name: "search-keywords",
+    description: "List monthly search keyword impressions for a location",
+    helpAfter: readHelp(
+      "ravi gbp search-keywords 456 --start-month 2026-01 --end-month 2026-06",
+      "ravi gbp search-keywords locations/456 --start-month 2026-01 --end-month 2026-06 --limit 50 --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.performance", action: "keywords", risk: "low" })
+  @Returns(wrappedSchema)
+  async searchKeywords(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--start-month <month>", description: "Required first month YYYY-MM", schema: monthSchema })
+    start?: string,
+    @Option({ flags: "--end-month <month>", description: "Required last month YYYY-MM", schema: monthSchema })
+    end?: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 100 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>" }) cursor?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).searchKeywords(
+        location,
+        required(start, "--start-month"),
+        required(end, "--end-month"),
+        integer(limit, 50, 1, 100),
+        cursor,
+      ),
+    );
+  }
+
+  @Command({
+    name: "categories",
+    description: "List official Google Business Profile categories",
+    helpAfter: readHelp(
+      "ravi gbp categories --filter embalagem",
+      "ravi gbp categories --region BR --language pt-BR --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.categories", action: "list", risk: "low" })
+  @Returns(wrappedSchema)
+  async categories(
+    @Option({ flags: "--filter <text>", description: "Display-name filter" }) filter?: string,
+    @Option({ flags: "--region <code>", description: "CLDR region code (default: BR)", defaultValue: "BR" })
+    region?: string,
+    @Option({ flags: "--language <code>", description: "BCP-47 language code (default: pt-BR)", defaultValue: "pt-BR" })
+    language?: string,
+    @Option({ flags: "--limit <n>", description: "Page size from 1 to 100 (default: 50)" }) limit?: string,
+    @Option({ flags: "--cursor <token>" }) cursor?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).listCategories(
+        region ?? "BR",
+        language ?? "pt-BR",
+        filter,
+        integer(limit, 50, 1, 100),
+        cursor,
+      ),
+    );
+  }
+
+  @Command({
+    name: "attributes",
+    description: "Get current attributes for a location",
+    helpAfter: readHelp("ravi gbp attributes 456", "ravi gbp attributes locations/456 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.attributes", action: "get", risk: "low" })
+  @Returns(wrappedSchema)
+  async attributes(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).getAttributes(location));
+  }
+
+  @Command({
+    name: "verifications",
+    description: "List verification attempts for a location",
+    helpAfter: readHelp("ravi gbp verifications 456", "ravi gbp verifications locations/456 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.verifications", action: "list", risk: "medium" })
+  @Returns(wrappedSchema)
+  async verifications(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).listVerifications(location));
+  }
+
+  @Command({
+    name: "verification-options",
+    description: "Fetch available verification methods for a location",
+    helpAfter: readHelp(
+      "ravi gbp verification-options 456",
+      "ravi gbp verification-options locations/456 --language pt-BR --json",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.verifications", action: "options", risk: "medium" })
+  @Returns(wrappedSchema)
+  async verificationOptions(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Option({ flags: "--language <code>", defaultValue: "pt-BR" }) language?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).fetchVerificationOptions(location, language ?? "pt-BR"));
+  }
+
+  @Command({
+    name: "verify",
+    description: "Start a location verification using an official method and input payload",
+    helpAfter: mutateHelp(
+      'ravi gbp verify 456 SMS --payload \'{"phoneNumber":"+551100000000"}\'',
+      'ravi gbp verify locations/456 ADDRESS --payload \'{"mailerContact":"Responsavel"}\' --language pt-BR --json',
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.verifications",
+    action: "verify",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["location", "payload", "language"],
+    redactions: ["payload"],
+  })
+  @Returns(wrappedSchema)
+  async verify(
+    @Arg("location", { schema: resourceSchema }) location: string,
+    @Arg("method", {
+      description: "Official VerificationMethod value, for example SMS or ADDRESS",
+      schema: resourceSchema,
+    })
+    method: string,
+    @Option({ flags: "--payload <json>", description: "Optional method input JSON object" })
+    payload?: string,
+    @Option({ flags: "--language <code>", defaultValue: "pt-BR" }) language?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(
+      await this.client(connection).verify(location, method, jsonObject(payload ?? "{}"), language ?? "pt-BR"),
+    );
+  }
+
+  @Command({
+    name: "verification-complete",
+    description: "Complete a pending verification with a PIN",
+    helpAfter: mutateHelp(
+      "ravi gbp verification-complete locations/456/verifications/789 --pin 123456",
+      "ravi gbp verification-complete locations/456/verifications/789 --pin 123456 --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.verifications",
+    action: "complete",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["verification", "pin"],
+    redactions: ["pin"],
+  })
+  @Returns(wrappedSchema)
+  async verificationComplete(
+    @Arg("verification", { description: "Full locations/.../verifications/... name", schema: resourceSchema })
+    verification: string,
+    @Option({ flags: "--pin <pin>", description: "Verification PIN" }) pin?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).completeVerification(verification, required(pin, "--pin")));
+  }
+
+  @Command({
+    name: "admins",
+    description: "List administrators for an account or location",
+    helpAfter: readHelp("ravi gbp admins accounts/123", "ravi gbp admins locations/456 --json"),
+  })
+  @CommandAccess({ kind: "read", resource: "google-business-profile.admins", action: "list", risk: "medium" })
+  @Returns(wrappedSchema)
+  async admins(
+    @Arg("parent", { description: "Full accounts/{id} or locations/{id} resource name", schema: resourceSchema })
+    parent: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).listAdmins(parent));
+  }
+
+  @Command({
+    name: "admin-add",
+    description: "Invite an administrator to an account or location",
+    helpAfter: mutateHelp(
+      "ravi gbp admin-add accounts/123 pessoa@example.com --role MANAGER",
+      "ravi gbp admin-add locations/456 pessoa@example.com --role MANAGER --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.admins",
+    action: "create",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["parent", "email", "role"],
+    redactions: ["email"],
+  })
+  @Returns(wrappedSchema)
+  async adminAdd(
+    @Arg("parent", { description: "Full accounts/{id} or locations/{id} resource name", schema: resourceSchema })
+    parent: string,
+    @Arg("email", { schema: z.string().email() }) email: string,
+    @Option({
+      flags: "--role <role>",
+      description: "Official AdminRole value (default: MANAGER)",
+      defaultValue: "MANAGER",
+    })
+    role?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).createAdmin(parent, email, role ?? "MANAGER"));
+  }
+
+  @Command({
+    name: "admin-update",
+    description: "Update the role of an account or location administrator",
+    helpAfter: mutateHelp(
+      "ravi gbp admin-update accounts/123/admins/789 --role OWNER",
+      "ravi gbp admin-update locations/456/admins/789 --role MANAGER --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.admins",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["admin", "role"],
+  })
+  @Returns(wrappedSchema)
+  async adminUpdate(
+    @Arg("admin", {
+      description: "Full accounts/.../admins/... or locations/.../admins/... name",
+      schema: resourceSchema,
+    })
+    admin: string,
+    @Option({ flags: "--role <role>", description: "Required official AdminRole value" }) role?: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).updateAdmin(admin, required(role, "--role")));
+  }
+
+  @Command({
+    name: "admin-delete",
+    description: "Remove an account or location administrator",
+    helpAfter: destructiveHelp(
+      "ravi gbp admin-delete accounts/123/admins/789",
+      "ravi gbp admin-delete locations/456/admins/789 --json",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "google-business-profile.admins",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+  })
+  @Returns(wrappedSchema)
+  async adminDelete(
+    @Arg("admin", {
+      description: "Full accounts/.../admins/... or locations/.../admins/... name",
+      schema: resourceSchema,
+    })
+    admin: string,
+    @Option({ flags: "--connection <id>" }) connection?: string,
+  ) {
+    return wrap(await this.client(connection).deleteAdmin(admin));
+  }
+}
+
+for (const command of [
+  "accounts",
+  "accountGet",
+  "locations",
+  "locationGet",
+  "locationUpdate",
+  "locationDelete",
+  "reviews",
+  "reviewGet",
+  "reviewReply",
+  "reviewReplyDelete",
+  "posts",
+  "postGet",
+  "postCreate",
+  "postUpdate",
+  "postDelete",
+  "media",
+  "mediaGet",
+  "mediaCreate",
+  "mediaUpdate",
+  "mediaDelete",
+  "performance",
+  "searchKeywords",
+  "categories",
+  "attributes",
+  "verifications",
+  "verificationOptions",
+  "verify",
+  "verificationComplete",
+  "admins",
+  "adminAdd",
+  "adminUpdate",
+  "adminDelete",
+] as const) {
+  const method = GoogleBusinessProfileCommands.prototype[command];
+  Option({ flags: "--json", description: "Print the stable JSON response envelope" })(
+    GoogleBusinessProfileCommands.prototype,
+    command,
+    method.length,
+  );
+}
+
+function wrap(result: GbpJson) {
+  const payload = { result };
+  console.log(JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+function required(value: string | undefined, option: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${option} is required.`);
+  return normalized;
+}
+
+function integer(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max)
+    throw new Error(`Expected integer from ${min} to ${max}.`);
+  return parsed;
+}
+
+function csv(value: string): string[] {
+  const values = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (!values.length) throw new Error("--metrics must contain at least one DailyMetric value.");
+  return values;
+}
+
+function jsonObject(value: string | undefined): GbpJson {
+  const input = required(value, "--payload");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    throw new Error("--payload must be a JSON object.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error("--payload must decode to a JSON object.");
+  return parsed as GbpJson;
+}
+
+function readHelp(exampleA: string, exampleB: string): string {
+  return `
+USE
+  Read provider state without changing Google Business Profile data.
+DO NOT USE
+  Do not use as an authentication setup flow; credentials are brokered by Ravi.
+EXAMPLES
+  ${exampleA}
+  ${exampleB}
+ON ERROR
+  Missing credential -> configure provider google-business-profile in Ravi; invalid input -> correct the named argument.
+SOURCES
+  Google Business Profile official REST references, verified 2026-07-13.`;
+}
+
+function mutateHelp(exampleA: string, exampleB: string): string {
+  return `
+USE
+  Change one explicitly named Google Business Profile resource after reviewing the payload.
+DO NOT USE
+  Do not batch, infer missing fields, or use this command as a dry run.
+HITL REQUIRED
+  Obtain confirmation for the exact resource and payload before execution.
+EXAMPLES
+  ${exampleA}
+  ${exampleB}
+ON ERROR
+  Missing credential -> configure provider google-business-profile; provider rejection -> inspect the official field mask and policy.
+SOURCES
+  Google Business Profile official REST references, verified 2026-07-13.`;
+}
+
+function destructiveHelp(exampleA: string, exampleB: string): string {
+  return `
+USE
+  Permanently remove one explicitly named Google Business Profile resource.
+DO NOT USE
+  Do not execute without a verified backup/rollback plan and explicit approval.
+HITL REQUIRED
+  Confirm the full resource name and irreversible effect immediately before execution.
+EXAMPLES
+  ${exampleA}
+  ${exampleB}
+ON ERROR
+  Missing credential -> configure provider google-business-profile; not found -> re-read the resource before retrying.
+SOURCES
+  Google Business Profile official REST references, verified 2026-07-13.`;
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -33,6 +33,7 @@ export * from "./eval.js";
 export * from "./events.js";
 export * from "./feedback.js";
 export * from "./gmail.js";
+export * from "./google-business-profile.js";
 export * from "./group.js";
 export * from "./heartbeat.js";
 export * from "./hooks.js";


### PR DESCRIPTION
## Objective

Add a native Google Business Profile app to Ravi so agents can read profile data
(accounts, locations, reviews, posts, media, performance) through the official
Google Business Profile APIs. This lands the app read-first: every write operation
is declared but gated, and the default agent surface is read-only.

## Problem

Ravi had no first-class integration with Google Business Profile. Reading business
listings, reviews, or local performance required ad-hoc scripts with no manifest,
no permission scoping, and no discovery through the apps registry.

## Solution

A new `google-business-profile` app under `src/apps/`, backed by a typed API client
and a `ravi gbp` CLI command group. The `ravi.app.json` manifest declares each
operation with an explicit `mutating` flag and a per-operation permission
(`gbp:*:read` for reads), so read and write surfaces are separated at the contract
level and discoverable via `ravi apps show/check google-business-profile`.

## Practical impact

- `ravi gbp accounts`, `locations`, `reviews`, `posts`, `media`, `performance`,
  `search-keywords`, `categories`, `admins` and their `*-get` variants return data
  as read-only operations (`mutating: false`).
- The app is discoverable and validatable through the apps registry.
- Credentials are resolved through the app credential resolver; secrets are never
  echoed (a test asserts token/secret values are redacted from error output).

## What does NOT change

- No existing app, CLI command, or shared apps-infra file is modified — the change
  is isolated to the new app directory, its CLI command, the command index entry,
  and the regenerated SDK artifacts.
- Write operations (update/delete/reply/create/verify/admin-mutate) are declared for
  completeness but are `mutating: true`; this PR does not wire them into any
  automated or agent-default flow.
- No daemon deploy, migration, or runtime behavior change for other subsystems.

## Validation

- `bun run typecheck` — passes.
- `bunx biome check src/apps/google-business-profile src/cli/commands/google-business-profile.ts` — clean, 5 files.
- `bun test src/apps/google-business-profile src/cli/commands/google-business-profile.test.ts` — 12 pass / 0 fail (194 assertions).
- `bun run sdk:check` — SDK client artifacts current after regeneration.

## Risks

- Read operations call live Google APIs; they require a valid Google Business
  Profile credential to be configured. With no credential, the client fails with a
  clear "credential is not configured" error (covered by a test).
- New public CLI surface (`ravi gbp`) and new `@Returns` schemas are added; the SDK
  was regenerated in the same commit so the registry and SDK stay in sync.

## Rollback

Revert the single commit. The app is self-contained (new directory + one CLI command
+ index entry + SDK regen), so reverting removes the `ravi gbp` surface entirely with
no residual effect on other apps or the apps registry.

## Follow-ups

- Wire write operations behind explicit human/agent authorization before enabling any
  mutating flow.
- Share the CLI-self-resolution and apps-bundling infra improvements (currently landing
  through the YouTube/GSC app PRs) so app operations invoked via the apps router resolve
  the `ravi` binary consistently.
