### PR TITLE
fix(sdk): return structured session responses

### DIFF
--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -51532,9 +51532,142 @@ export const SessionsReadInputSchema = {
 
 /** JSON Schema for the return shape of `sessions.read`. */
 export const SessionsReadReturnSchema = {
-  "additionalProperties": {},
-  "properties": {},
-  "type": "object"
+  "anyOf": [
+    {
+      "additionalProperties": {},
+      "properties": {
+        "count": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "role": {
+                    "enum": [
+                      "user",
+                      "assistant"
+                    ],
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "time": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role",
+                  "text",
+                  "time"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "createdAt": {
+                    "type": "number"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "role",
+                  "content",
+                  "createdAt",
+                  "source"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "session": {
+          "additionalProperties": {},
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionKey",
+            "label",
+            "agentId"
+          ],
+          "type": "object"
+        },
+        "totalMessages": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "transcript": {
+          "additionalProperties": {},
+          "properties": {
+            "available": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "available"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "session",
+        "transcript",
+        "messages"
+      ],
+      "type": "object"
+    },
+    {
+      "additionalProperties": {},
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "messageId": {
+          "type": "string"
+        },
+        "meta": {},
+        "ok": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ok"
+      ],
+      "type": "object"
+    }
+  ]
 } as const satisfies SdkJsonSchema;
 
 /** JSON Schema for the input body of `sessions.rename`. */
@@ -52002,7 +52135,98 @@ export const SessionsSendInputSchema = {
 /** JSON Schema for the return shape of `sessions.send`. */
 export const SessionsSendReturnSchema = {
   "additionalProperties": {},
-  "properties": {},
+  "properties": {
+    "action": {
+      "const": "send",
+      "type": "string"
+    },
+    "createdSession": {
+      "type": "boolean"
+    },
+    "delivery": {
+      "additionalProperties": {},
+      "properties": {},
+      "type": "object"
+    },
+    "mode": {
+      "enum": [
+        "fire-and-forget",
+        "wait"
+      ],
+      "type": "string"
+    },
+    "promptLength": {
+      "maximum": 9007199254740991,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "published": {
+      "type": "boolean"
+    },
+    "response": {
+      "additionalProperties": false,
+      "properties": {
+        "length": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "length",
+        "text"
+      ],
+      "type": "object"
+    },
+    "session": {
+      "additionalProperties": {},
+      "properties": {
+        "agentId": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "sessionKey",
+        "label",
+        "agentId"
+      ],
+      "type": "object"
+    },
+    "thread": {
+      "anyOf": [
+        {
+          "additionalProperties": {},
+          "properties": {},
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "action",
+    "mode",
+    "published",
+    "createdSession",
+    "session",
+    "promptLength",
+    "delivery",
+    "thread"
+  ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
 

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -10651,7 +10651,41 @@ export type SessionsReadInput = {
 };
 
 /** Return shape for `sessions.read`. */
-export type SessionsReadReturn = Record<string, unknown>;
+export type SessionsReadReturn = ({
+  count?: number;
+  messages: Array<({
+    role: "user" | "assistant";
+    text: string;
+    time: string;
+    [k: string]: unknown;
+  }) | ({
+    content: string;
+    createdAt: number;
+    id: string;
+    role: string;
+    source: string;
+    [k: string]: unknown;
+  })>;
+  session: {
+    agentId: string;
+    label: string;
+    name?: string;
+    sessionKey: string;
+    [k: string]: unknown;
+  };
+  totalMessages?: number;
+  transcript: {
+    available: boolean;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}) | ({
+  error?: string;
+  messageId?: string;
+  meta?: unknown;
+  ok: boolean;
+  [k: string]: unknown;
+});
 
 /** Input shape for `sessions.rename`. */
 export type SessionsRenameInput = {
@@ -10810,7 +10844,27 @@ export type SessionsSendInput = {
 };
 
 /** Return shape for `sessions.send`. */
-export type SessionsSendReturn = Record<string, unknown>;
+export type SessionsSendReturn = {
+  action: "send";
+  createdSession: boolean;
+  delivery: Record<string, unknown>;
+  mode: "fire-and-forget" | "wait";
+  promptLength: number;
+  published: boolean;
+  response?: {
+    length: number;
+    text: string;
+  };
+  session: {
+    agentId: string;
+    label: string;
+    name?: string;
+    sessionKey: string;
+    [k: string]: unknown;
+  };
+  thread: (Record<string, unknown>) | null;
+  [k: string]: unknown;
+};
 
 /** Input shape for `sessions.set-display`. */
 export type SessionsSetDisplayInput = {

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:0286da8e3ed437abc6427ea5454a63f0ced4b0c2d64af0d0f79a0db3e14993dc";
+export const REGISTRY_HASH = "sha256:265847c56e9f24844aaeea0fe0e022df122e9d3654cedd76e31da36ede108531";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "af8fc53f6007";
+export const GIT_SHA = "651d2e9b11d9";

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -47,6 +47,7 @@ let renameSessionNameError: Error | null = null;
 let renameRouteReferencesUpdated = 0;
 let effortUpdates: Array<{ sessionKey: string; effort: string | null }> = [];
 const runtimeLiveStates = new Map<string, Record<string, unknown>>();
+let toolContext: Record<string, unknown> | undefined;
 
 function defaultTurnUsageSummary(): Record<string, unknown> {
   return {
@@ -88,7 +89,7 @@ mock.module("../decorators.js", () => ({
 }));
 
 mock.module("../context.js", () => ({
-  getContext: () => undefined,
+  getContext: () => toolContext,
   fail: (message: string) => {
     throw new Error(message);
   },
@@ -333,6 +334,7 @@ async function captureLogsAsync(run: () => Promise<void>): Promise<string> {
 }
 
 beforeEach(() => {
+  toolContext = undefined;
   chatHistory = [];
   chatHistoryByChat = [];
   messageMetadataRows = [];
@@ -467,6 +469,44 @@ describe("SessionCommands delivery barriers", () => {
     expect(publishedPrompts).toHaveLength(1);
     expect(publishedPrompts[0]?.payload.deliveryBarrier).toBe("after_response");
     expect(publishedPrompts[0]?.payload.deliveryBarrierSource).toBe("default");
+  });
+
+  it("returns a structured receipt when invoked through the SDK gateway context", async () => {
+    toolContext = { suppressCliOutput: true, sessionKey: "agent:main:origin" };
+    const commands = new SessionCommands();
+    let payload: Record<string, unknown> | undefined;
+
+    const output = await captureLogsAsync(async () => {
+      payload = (await commands.send("dev", "hello")) as Record<string, unknown>;
+    });
+
+    expect(payload!).toMatchObject({
+      action: "send",
+      mode: "fire-and-forget",
+      published: true,
+      promptLength: 5,
+      session: { sessionKey: "agent:dev:main", name: "dev" },
+    });
+    expect(output).toBe("");
+  });
+
+  it("returns the waited response when invoked through the SDK gateway context", async () => {
+    toolContext = { suppressCliOutput: true, sessionKey: "agent:main:origin" };
+    const commands = new SessionCommands();
+    (commands as any).streamToSession = async (...args: unknown[]) => {
+      const options = args[7] as { onResponse?: (chunk: string) => void };
+      options.onResponse?.("pong");
+      return 4;
+    };
+
+    const payload = await commands.send("dev", "hello", undefined, true);
+
+    expect(payload).toMatchObject({
+      action: "send",
+      mode: "wait",
+      published: true,
+      response: { length: 4, text: "pong" },
+    });
   });
 
   it("keeps explicit immediate delivery for cross-session prompts", async () => {
@@ -1318,6 +1358,29 @@ describe("SessionCommands read", () => {
       chatId: "63295117615153@lid",
       sourceMessageId: "wamid-1",
     });
+  });
+
+  it("returns normalized history when invoked through the SDK gateway context", () => {
+    toolContext = { suppressCliOutput: true, sessionKey: "agent:main:origin" };
+    chatHistory = [
+      {
+        id: 1,
+        session_id: "main-dm-615153",
+        role: "assistant",
+        content: "resposta remota",
+        sdk_session_id: "provider-current",
+        created_at: "2026-04-20 04:29:35",
+      },
+    ];
+
+    let payload: { transcript: { source: string }; messages: Array<{ text: string }> } | undefined;
+    const output = captureLogs(() => {
+      payload = new SessionCommands().read("main-dm-615153", "10") as typeof payload;
+    });
+
+    expect(payload!.transcript.source).toBe("chat-db");
+    expect(payload!.messages).toEqual([expect.objectContaining({ text: "resposta remota" })]);
+    expect(output).toBe("");
   });
 
   it("defaults to a safe read count when --count is invalid", () => {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -237,9 +237,82 @@ const sessionSetProviderReturnSchema = z.object({
   effectiveProvider: z.string(),
   appliesOn: z.literal("next-turn-runtime-restart"),
 });
+const sessionCommandTargetReturnSchema = z
+  .object({
+    sessionKey: z.string(),
+    name: z.string().optional(),
+    label: z.string(),
+    agentId: z.string(),
+  })
+  .passthrough();
+const sessionSendReturnSchema = z
+  .object({
+    action: z.literal("send"),
+    mode: z.enum(["fire-and-forget", "wait"]),
+    published: z.boolean(),
+    createdSession: z.boolean(),
+    session: sessionCommandTargetReturnSchema,
+    promptLength: z.number().int().nonnegative(),
+    delivery: z.object({}).passthrough(),
+    thread: z.object({}).passthrough().nullable(),
+    response: z
+      .object({
+        length: z.number().int().nonnegative(),
+        text: z.string(),
+      })
+      .optional(),
+  })
+  .passthrough();
+const normalizedSessionMessageReturnSchema = z
+  .object({
+    role: z.enum(["user", "assistant"]),
+    text: z.string(),
+    time: z.string(),
+  })
+  .passthrough();
+const workspaceSessionMessageReturnSchema = z
+  .object({
+    id: z.string(),
+    role: z.string(),
+    content: z.string(),
+    createdAt: z.number(),
+    source: z.string(),
+  })
+  .passthrough();
+const sessionReadHistoryReturnSchema = z
+  .object({
+    session: sessionCommandTargetReturnSchema,
+    transcript: z
+      .object({
+        available: z.boolean(),
+      })
+      .passthrough(),
+    messages: z.array(z.union([normalizedSessionMessageReturnSchema, workspaceSessionMessageReturnSchema])),
+    totalMessages: z.number().int().nonnegative().optional(),
+    count: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+const sessionReadMessageReturnSchema = z
+  .object({
+    ok: z.boolean(),
+    messageId: z.string().optional(),
+    error: z.string().optional(),
+    meta: z.unknown().optional(),
+  })
+  .passthrough();
+const sessionReadReturnSchema = z.union([sessionReadHistoryReturnSchema, sessionReadMessageReturnSchema]);
 
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
+}
+
+function shouldReturnStructuredResult(asJson?: boolean): boolean {
+  return asJson === true || getContext()?.suppressCliOutput === true;
+}
+
+function returnStructuredResult<T>(payload: T, asJson?: boolean): T {
+  if (asJson) printJson(payload);
+  return payload;
 }
 
 function printJsonl(payload: unknown): void {
@@ -3632,9 +3705,10 @@ export class SessionCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" })
     asJson?: boolean,
   ) {
+    const structuredResult = shouldReturnStructuredResult(asJson);
     let createdSession = false;
     const session = this.resolveTarget(nameOrKey, agentId, {
-      silent: Boolean(asJson),
+      silent: structuredResult,
       onCreated: () => {
         createdSession = true;
       },
@@ -3656,8 +3730,12 @@ export class SessionCommands {
     });
     const deliveryBarrier = delivery.barrier;
 
-    if (asJson && (interactive || !prompt)) {
-      fail("sessions send --json requires a prompt and cannot be combined with --interactive.");
+    if (structuredResult && (interactive || !prompt)) {
+      fail(
+        asJson
+          ? "sessions send --json requires a prompt and cannot be combined with --interactive."
+          : "sessions.send through the SDK requires a prompt and cannot use interactive mode.",
+      );
       return;
     }
 
@@ -3713,7 +3791,7 @@ export class SessionCommands {
     }
 
     if (wait) {
-      if (asJson) {
+      if (structuredResult) {
         let responseText = "";
         let chars = 0;
         try {
@@ -3757,8 +3835,7 @@ export class SessionCommands {
             text: responseText,
           },
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
 
       console.log(`\n📤 Sending to ${sessionName}\n`);
@@ -3812,7 +3889,7 @@ export class SessionCommands {
         if (preparedThread) markThreadHandoffFailed(preparedThread.handoff.id, errorToMessage(error));
         throw error;
       }
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           action: "send",
           mode: "fire-and-forget",
@@ -3823,8 +3900,7 @@ export class SessionCommands {
           delivery: deliveryJson,
           thread: preparedThread ? buildSendThreadJson(preparedThread) : null,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
       console.log(`📤 Sent to ${sessionName}`);
     }
@@ -4137,6 +4213,7 @@ export class SessionCommands {
     })
     messageId?: string,
   ) {
+    const structuredResult = shouldReturnStructuredResult(asJson);
     const target = nameOrKey?.trim() || resolveCurrentSessionRef();
     if (!target) {
       fail(
@@ -4162,7 +4239,7 @@ export class SessionCommands {
     if (chatHistory.length > 0) {
       const messages = chatHistory.map(normalizeChatDbMessage);
       const totalMessages = countHistory(sessionLabel);
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           session: buildSessionJson(session),
           transcript: {
@@ -4174,8 +4251,7 @@ export class SessionCommands {
           totalMessages,
           count: messages.length,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
 
       console.log(`\n💬 ${sessionLabel} — last ${messages.length} of ${totalMessages} messages\n`);
@@ -4188,7 +4264,7 @@ export class SessionCommands {
     if (chatDbByChat.length > 0) {
       const messages = chatDbByChat.map(normalizeChatDbMessage);
       const totalMessages = countHistoryByChatIds(chatIdVariants, session.agentId);
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           session: buildSessionJson(session),
           transcript: {
@@ -4202,8 +4278,7 @@ export class SessionCommands {
           totalMessages,
           count: messages.length,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
 
       console.log(`\n💬 ${sessionLabel} — last ${messages.length} of ${totalMessages} same-chat messages\n`);
@@ -4213,7 +4288,7 @@ export class SessionCommands {
 
     const messageMetadata = readMessageMetadataFallback(session, maxMessages);
     if (messageMetadata.length > 0) {
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           session: buildSessionJson(session),
           transcript: {
@@ -4226,8 +4301,7 @@ export class SessionCommands {
           totalMessages: messageMetadata.length,
           count: messageMetadata.length,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
 
       console.log(`\n💬 ${sessionLabel} — last ${messageMetadata.length} message metadata entries\n`);
@@ -4237,7 +4311,7 @@ export class SessionCommands {
 
     const providerSessionId = session.providerSessionId ?? session.sdkSessionId;
     if (!providerSessionId) {
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           session: buildSessionJson(session),
           transcript: {
@@ -4248,8 +4322,7 @@ export class SessionCommands {
           totalMessages: 0,
           count: 0,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
       console.log("⚠️  No runtime session — no history available");
       return;
@@ -4265,7 +4338,7 @@ export class SessionCommands {
     });
 
     if (!transcript.path) {
-      if (asJson) {
+      if (structuredResult) {
         const payload = {
           session: buildSessionJson(session),
           transcript: {
@@ -4277,8 +4350,7 @@ export class SessionCommands {
           totalMessages: 0,
           count: 0,
         };
-        printJson(payload);
-        return payload;
+        return returnStructuredResult(payload, asJson);
       }
       console.log(`⚠️  ${transcript.reason ?? "Transcript not found"}`);
       return;
@@ -4290,7 +4362,7 @@ export class SessionCommands {
     const messages = extractNormalizedTranscriptMessages(raw, session.runtimeProvider);
 
     const recent = messages.slice(-maxMessages);
-    if (asJson) {
+    if (structuredResult) {
       const payload = {
         session: buildSessionJson(session),
         transcript: {
@@ -4304,8 +4376,7 @@ export class SessionCommands {
         totalMessages: messages.length,
         count: recent.length,
       };
-      printJson(payload);
-      return payload;
+      return returnStructuredResult(payload, asJson);
     }
 
     console.log(`\n💬 ${sessionLabel} — last ${recent.length} of ${messages.length} provider transcript messages\n`);
@@ -5727,10 +5798,10 @@ declareCommandReturns(SessionCommands, {
   list: pagedItemsReturnSchema,
   mute: commandEnvelopeReturnSchema,
   prune: commandEnvelopeReturnSchema,
-  read: commandEnvelopeReturnSchema,
+  read: sessionReadReturnSchema,
   rename: commandEnvelopeReturnSchema,
   reset: commandEnvelopeReturnSchema,
-  send: commandEnvelopeReturnSchema,
+  send: sessionSendReturnSchema,
   setDisplay: commandEnvelopeReturnSchema,
   setProvider: sessionSetProviderReturnSchema,
   setModel: commandEnvelopeReturnSchema,

--- a/tests/integration/sdk-roundtrip.test.ts
+++ b/tests/integration/sdk-roundtrip.test.ts
@@ -16,8 +16,11 @@ import "reflect-metadata";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { ArtifactsCommands } from "../../src/cli/commands/artifacts.js";
+import { SessionCommands } from "../../src/cli/commands/sessions.js";
 import { buildRegistry } from "../../src/cli/registry-snapshot.js";
 import { createArtifact } from "../../src/artifacts/store.js";
+import { saveMessage } from "../../src/db.js";
+import { getOrCreateSession } from "../../src/router/sessions.js";
 import {
   cleanupIsolatedRaviState,
   createIsolatedRaviState,
@@ -30,13 +33,17 @@ import { RaviClient } from "../../packages/ravi-os-sdk/src/index.js";
 import { createHttpTransport } from "../../packages/ravi-os-sdk/src/transport/http.js";
 import { RaviValidationError } from "../../packages/ravi-os-sdk/src/errors.js";
 
-const registry = buildRegistry([ArtifactsCommands]);
+const registry = buildRegistry([ArtifactsCommands, SessionCommands]);
 const allowedContext: ContextRecord = {
   contextId: "ctx_sdk_roundtrip",
   contextKey: "rctx_sdk_roundtrip",
   kind: "test-runtime",
   agentId: "sdk-roundtrip-agent",
-  capabilities: [{ permission: "execute", objectType: "group", objectId: "artifacts", source: "test" }],
+  capabilities: [
+    { permission: "execute", objectType: "group", objectId: "artifacts", source: "test" },
+    { permission: "execute", objectType: "group", objectId: "sessions", source: "test" },
+    { permission: "access", objectType: "session", objectId: "managed-sdk-roundtrip", source: "test" },
+  ],
   metadata: { authorityMode: "delegated" },
   createdAt: Date.now(),
 };
@@ -102,6 +109,22 @@ describe("SDK round-trip — RaviClient over http transport", () => {
     expect(result.artifact.kind).toBe("report");
     expect(Array.isArray(result.links)).toBe(true);
     expect(Array.isArray(result.events)).toBe(true);
+  });
+
+  it("sessions.read returns normalized history instead of an empty gateway envelope", async () => {
+    const sessionName = "managed-sdk-roundtrip";
+    getOrCreateSession("agent:sdk-roundtrip-agent:managed", allowedContext.agentId!, stateDir!, {
+      name: sessionName,
+    });
+    saveMessage(sessionName, "user", "pergunta remota");
+    saveMessage(sessionName, "assistant", "resposta remota");
+
+    const result = await buildClient().sessions.read(sessionName, { count: "10" });
+
+    expect("messages" in result).toBe(true);
+    if (!("messages" in result)) throw new Error("sessions.read did not return history");
+    expect(result.transcript.source).toBe("chat-db");
+    expect(result.messages.map((message) => message.text)).toEqual(["pergunta remota", "resposta remota"]);
   });
 
   it("maps 4xx validation errors to RaviValidationError", async () => {


### PR DESCRIPTION
## Objective

Make `sessions.send` and `sessions.read` usable through the generated Ravi SDK by returning typed, structured command results. Preserve the existing human CLI output and keep SDK gateway execution silent.

## Problem

- The SDK gateway successfully executed both commands but received `undefined`, which the dispatcher normalized to `{}`.
- The commands used the CLI-only `asJson` rendering flag to decide whether to return data, while SDK generation intentionally removes rendering flags.

## Solution

- Use the existing gateway execution context to request structured results without exposing `asJson` in the SDK contract.
- Return a send receipt, waited response text, and normalized bounded session history from the command handlers.
- Add precise return schemas, regenerate SDK types, and cover the full `RaviClient -> HTTP gateway -> SessionCommands` path.

## Practical impact

Managed Ravi controllers can send a prompt and read normalized session history through `@ravi-os/sdk` instead of receiving empty envelopes. Direct CLI users retain the current human-readable behavior.

## What does NOT change

This PR does not add email behavior, centralized NATS, public guest HTTP, inter-agent communication, or Console-side policy. It also does not change SDK authentication or permission checks.

## Validation

- Focused session command tests: 37 passed.
- SDK, codegen, and real HTTP round-trip tests: 29 passed.
- `make quality`, `bun run sdk:check`, `bun run build`, and `git diff --check` passed.
- The full pre-push hook passed SDK drift, build, typecheck, and the complete test suite.

## Risks

The behavioral change is limited to SDK gateway callers that previously received `{}` and now receive documented structured payloads. Generated return types become more precise, so incorrect downstream assumptions may surface as compile-time errors.

## Rollback

Revert commit `0d13a6e` to restore the previous command return behavior and regenerate the SDK artifacts from the reverted registry.

## Follow-ups

After review and merge, use this contract from the Console Managed Ravi controller for the private SDK chat flow.