### PR TITLE
feat(youtube): fill 15 gold-standard Data API v3 endpoints

### DIFF
--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -3,7 +3,7 @@
 // Drift is detected by `ravi sdk client check` (CI).
 
 import type { Transport } from "./transport/types.js";
-import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsPreviewReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsListsShowReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtCommentsReturn, YtHealthReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscriptionsReturn, YtUnansweredReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
+import type { AdaptersListReturn, AdaptersShowReturn, AgentsCreateReturn, AgentsDebounceReturn, AgentsDebugReturn, AgentsDeleteReturn, AgentsListReturn, AgentsPermissionsReturn, AgentsResetReturn, AgentsSessionReturn, AgentsSetReturn, AgentsShowReturn, AgentsSpecModeReturn, AgentsSyncInstructionsReturn, AppsCheckReturn, AppsDeleteReturn, AppsGuideReturn, AppsImportCliReturn, AppsListReturn, AppsPromptsReturn, AppsRunReturn, AppsScaffoldReturn, AppsShowReturn, ArtifactsArchiveReturn, ArtifactsAttachReturn, ArtifactsBlobReturn, ArtifactsCreateReturn, ArtifactsEventReturn, ArtifactsEventsReturn, ArtifactsListReturn, ArtifactsPublishReturn, ArtifactsReleaseActivateReturn, ArtifactsRestoreReturn, ArtifactsShowReturn, ArtifactsSnapshotReturn, ArtifactsUpdateReturn, ArtifactsVersionReturn, ArtifactsVersionsReturn, AudioBlobReturn, AudioGenerateReturn, AudioPendingReturn, AudioTtsReturn, AudioVoicesReturn, BridgesCreateReturn, BridgesListReturn, BridgesRevokeReturn, CalendarsAvailabilityReturn, CalendarsCreateReturn, CalendarsDisableReturn, CalendarsEventsCancelReturn, CalendarsEventsCreateReturn, CalendarsEventsListReturn, CalendarsEventsReadReturn, CalendarsEventsRespondReturn, CalendarsEventsUpdateReturn, CalendarsListReturn, CalendarsShareReturn, CalendarsShowReturn, ChannelsCreateReturn, ChannelsListReturn, ChannelsProbeReturn, ChannelsRestartReturn, ChannelsSetReturn, ChannelsShowReturn, ChannelsStartReturn, ChannelsStatusReturn, ChannelsStopReturn, ChatsBackfillProviderTimestampsReturn, ChatsListReturn, ChatsListsAddReturn, ChatsListsCreateReturn, ChatsListsDeltaReturn, ChatsListsListReturn, ChatsListsMarkReadReturn, ChatsListsMembersReturn, ChatsListsPreviewReturn, ChatsListsRecomputeReturn, ChatsListsRemoveReturn, ChatsListsShowReturn, ChatsReadReturn, CloudProjectsCreateReturn, CloudProjectsListReturn, CloudScopeClearReturn, CloudScopeExplainReturn, CloudScopeSetReturn, CloudScopeShowReturn, CommandsListReturn, CommandsRunReturn, CommandsShowReturn, CommandsValidateReturn, ConnectorsListReturn, ConnectorsRevokeReturn, ConnectorsShowReturn, ContactsActivityReturn, ContactsAddReturn, ContactsAllowReturn, ContactsApproveReturn, ContactsBackfillReturn, ContactsBlockReturn, ContactsCheckReturn, ContactsDuplicatesReturn, ContactsFindReturn, ContactsGetReturn, ContactsInfoReturn, ContactsLinkReturn, ContactsListReturn, ContactsMergeReturn, ContactsMessagesReturn, ContactsMetadataListReturn, ContactsMetadataRemoveReturn, ContactsMetadataSetReturn, ContactsNoteReturn, ContactsPendingReturn, ContactsProfileReturn, ContactsRemoveReturn, ContactsSessionsReturn, ContactsSetReturn, ContactsTagReturn, ContactsTimelineReturn, ContactsUnlinkReturn, ContactsUntagReturn, ContextAuthorizeReturn, ContextCapabilitiesReturn, ContextCheckReturn, ContextCleanupAgentRuntimeReturn, ContextCodexBashHookReturn, ContextCredentialsAddReturn, ContextCredentialsListReturn, ContextCredentialsRemoveReturn, ContextCredentialsSetDefaultReturn, ContextInfoReturn, ContextIssueReturn, ContextLineageReturn, ContextListReturn, ContextPruneReturn, ContextRevokeReturn, ContextVisibilityReturn, ContextWhoamiReturn, CostsAgentReturn, CostsAgentsReturn, CostsPricingReturn, CostsSessionReturn, CostsSummaryReturn, CostsTopSessionsReturn, CredentialsConnectionsDisableReturn, CredentialsConnectionsEnableReturn, CredentialsConnectionsListReturn, CredentialsConnectionsShowReturn, CredentialsPoliciesExplainReturn, CrmAccountCreateReturn, CrmAccountLinkContactReturn, CrmAccountReturn, CrmAccountShowReturn, CrmBoardReturn, CrmContactReturn, CrmContactSetReturn, CrmContactShowReturn, CrmContactsReturn, CrmFactConfirmReturn, CrmFactListReturn, CrmFactProposeReturn, CrmFactRejectReturn, CrmNextReturn, CrmOpportunityContactsReturn, CrmOpportunityCreateReturn, CrmOpportunityLinkContactReturn, CrmOpportunityMoveReturn, CrmOpportunityReturn, CrmOpportunityShowReturn, CrmPipelineCreateReturn, CrmPipelineListReturn, CrmPipelinePolicyHitlCheckReturn, CrmPipelinePolicySendWindowCheckReturn, CrmPipelineReviewReturn, CrmPipelineSetReturn, CrmPipelineShowReturn, CrmPipelineStageAddReturn, CrmPipelineStageArchiveReturn, CrmPipelineStageListReturn, CrmPipelineStageSetReturn, CrmPipelineStageShowReturn, CrmPipelineStageTopicAddReturn, CrmPipelineStageTopicArchiveReturn, CrmPipelineStageTopicSetReturn, CrmPipelineStageTopicsReturn, CrmPipelineValidateReturn, CrmTaskCancelReturn, CrmTaskCreateReturn, CrmTaskDoneReturn, CrmTaskListReturn, CrmTaskShowReturn, CrmTaskSnoozeReturn, CronAddReturn, CronDisableReturn, CronEnableReturn, CronListReturn, CronRmReturn, CronRunReturn, CronSetReturn, CronShowReturn, DaemonEnvReturn, DaemonInitAdminKeyReturn, DaemonInstallReturn, DaemonLogsReturn, DaemonRestartReturn, DaemonStartReturn, DaemonStatusReturn, DaemonStopReturn, DaemonUninstallReturn, DevinAuthCheckReturn, DevinSessionsArchiveReturn, DevinSessionsAttachmentsReturn, DevinSessionsCreateReturn, DevinSessionsInsightsReturn, DevinSessionsListReturn, DevinSessionsMessagesReturn, DevinSessionsSendReturn, DevinSessionsShowReturn, DevinSessionsSyncReturn, DevinSessionsTerminateReturn, EvalRunReturn, FeedbackSendReturn, GmailListReturn, GmailReadReturn, HeartbeatDisableReturn, HeartbeatEnableReturn, HeartbeatSetReturn, HeartbeatShowReturn, HeartbeatStatusReturn, HeartbeatTriggerReturn, HooksCreateReturn, HooksDisableReturn, HooksEnableReturn, HooksListReturn, HooksRmReturn, HooksShowReturn, HooksTestReturn, ImageAtlasSplitReturn, ImageGenerateReturn, InboxArchiveReturn, InboxDisableReturn, InboxDoneReturn, InboxEnableReturn, InboxItemsReturn, InboxListReturn, InboxPollReturn, InboxReadReturn, InboxReplayReturn, InboxSnoozeReturn, InboxSourcesReturn, InboxStatusReturn, InsightsCreateReturn, InsightsListReturn, InsightsSearchReturn, InsightsShowReturn, InstancesCreateReturn, InstancesDeleteReturn, InstancesDeletedReturn, InstancesDisableReturn, InstancesDisconnectReturn, InstancesEnableReturn, InstancesGetReturn, InstancesListReturn, InstancesPendingApproveReturn, InstancesPendingListReturn, InstancesPendingRejectReturn, InstancesRestoreReturn, InstancesRoutesAddReturn, InstancesRoutesDeletedReturn, InstancesRoutesListReturn, InstancesRoutesRemoveReturn, InstancesRoutesRestoreReturn, InstancesRoutesSetReturn, InstancesRoutesShowReturn, InstancesSetReturn, InstancesShowReturn, InstancesStatusReturn, InstancesTargetReturn, MailAccountsCreateReturn, MailAccountsListReturn, MailAccountsSyncReturn, MailDomainsCreateReturn, MailDomainsListReturn, MailMailboxesCreateReturn, MailMailboxesDisableReturn, MailMailboxesListReturn, MailMailboxesShowReturn, MailMessagesImportReturn, MailMessagesListReturn, MailMessagesReadReturn, MailMessagesSearchReturn, MailOutboxInspectReturn, MailOutboxListReturn, MailOutboxRetryReturn, MailOutboxStatusReturn, MailProvidersListReturn, MailProvidersRaviMailMailboxesCreateReturn, MailProvidersRaviMailMailboxesDisableReturn, MailProvidersRaviMailMailboxesListReturn, MailProvidersRaviMailMailboxesShowReturn, MailProvidersRaviMailMessagesListReturn, MailProvidersRaviMailMessagesReadReturn, MailProvidersRaviMailMessagesShowReturn, MailProvidersRaviMailSendReturn, MailReplyReturn, MailSendReturn, MailThreadsReadReturn, MediaSendReturn, MeetingsFinalizeReturn, MeetingsProfilesInitReturn, MeetingsProfilesListReturn, MeetingsProfilesShowReturn, MeetingsProfilesValidateReturn, MeetingsVoiceRuntimesReturn, MetricsDatesReturn, MetricsRollupReturn, MetricsShowReturn, ObserversListReturn, ObserversProfilesInitReturn, ObserversProfilesListReturn, ObserversProfilesPreviewReturn, ObserversProfilesShowReturn, ObserversProfilesValidateReturn, ObserversRefreshReturn, ObserversRulesDisableReturn, ObserversRulesEnableReturn, ObserversRulesExplainReturn, ObserversRulesListReturn, ObserversRulesRmReturn, ObserversRulesSetReturn, ObserversRulesShowReturn, ObserversRulesValidateReturn, ObserversShowReturn, PagesCreateReturn, PagesDomainsReturn, PagesListReturn, PagesPublishReturn, PagesPublishedReturn, PagesUpdateReturn, PagesVisibilityReturn, PermissionsAllowReturn, PermissionsCheckReturn, PermissionsMaterializeReturn, PermissionsResolveReturn, PermissionsStatusReturn, ProjectsCreateReturn, ProjectsFixturesSeedReturn, ProjectsInitReturn, ProjectsLinkReturn, ProjectsListReturn, ProjectsNextReturn, ProjectsResourcesAddReturn, ProjectsResourcesImportReturn, ProjectsResourcesListReturn, ProjectsResourcesShowReturn, ProjectsShowReturn, ProjectsStatusReturn, ProjectsTasksAttachReturn, ProjectsTasksCreateReturn, ProjectsTasksDispatchReturn, ProjectsUpdateReturn, ProjectsWorkflowsAttachReturn, ProjectsWorkflowsStartReturn, ProxCallsCancelReturn, ProxCallsEventsReturn, ProxCallsProfilesConfigureReturn, ProxCallsProfilesListReturn, ProxCallsProfilesShowReturn, ProxCallsRequestReturn, ProxCallsRulesReturn, ProxCallsShowReturn, ProxCallsToolsBindReturn, ProxCallsToolsConfigureReturn, ProxCallsToolsCreateReturn, ProxCallsToolsListReturn, ProxCallsToolsRunReturn, ProxCallsToolsRunsReturn, ProxCallsToolsShowReturn, ProxCallsToolsUnbindReturn, ProxCallsTranscriptReturn, ProxCallsVoiceAgentsBindToolReturn, ProxCallsVoiceAgentsConfigureReturn, ProxCallsVoiceAgentsCreateReturn, ProxCallsVoiceAgentsListReturn, ProxCallsVoiceAgentsShowReturn, ProxCallsVoiceAgentsSyncReturn, ProxCallsVoiceAgentsUnbindToolReturn, ReactSendReturn, RoutesExplainReturn, RoutesListReturn, RoutesShowReturn, RulesImportReturn, RulesSourcesReturn, RuntimeCredentialsAddReturn, RuntimeCredentialsClassifyReturn, RuntimeCredentialsDisableReturn, RuntimeCredentialsEnableReturn, RuntimeCredentialsImportReturn, RuntimeCredentialsListReturn, RuntimeCredentialsRefreshReturn, RuntimeCredentialsResetHealthReturn, RuntimeCredentialsSelectReturn, RuntimeCredentialsStatusReturn, RuntimePresetsCreateReturn, RuntimePresetsDeleteReturn, RuntimePresetsDisableReturn, RuntimePresetsEnableReturn, RuntimePresetsImpactReturn, RuntimePresetsListReturn, RuntimePresetsSetReturn, RuntimePresetsShowReturn, SdkClientCheckReturn, SdkClientGenerateReturn, SdkOpenapiCheckReturn, SdkOpenapiEmitReturn, SdkSwiftCheckReturn, SdkSwiftGenerateReturn, SelfChatReturn, SelfContextReturn, SelfExplainReturn, SelfKnowledgeReturn, SelfPermissionsReturn, SelfRecentReturn, SelfRouteReturn, SelfWhoamiReturn, SessionsActionsReturn, SessionsAnswerReturn, SessionsAskReturn, SessionsAttachReturn, SessionsDeleteMessageReturn, SessionsDeleteReturn, SessionsDetachReturn, SessionsEditMessageReturn, SessionsExecuteReturn, SessionsExtendReturn, SessionsFollowupsAddReturn, SessionsFollowupsInspectReturn, SessionsFollowupsListReturn, SessionsFollowupsPauseReturn, SessionsFollowupsResumeReturn, SessionsFollowupsRetryReturn, SessionsFollowupsRunReturn, SessionsFollowupsRunsReturn, SessionsFollowupsSnoozeReturn, SessionsFollowupsUpdateReturn, SessionsGoalReturn, SessionsInfoReturn, SessionsInformReturn, SessionsKeepReturn, SessionsListReturn, SessionsMuteReturn, SessionsPruneReturn, SessionsReadReturn, SessionsRenameReturn, SessionsResetReturn, SessionsRuntimeFollowUpReturn, SessionsRuntimeForkReturn, SessionsRuntimeInterruptReturn, SessionsRuntimeListReturn, SessionsRuntimeReadReturn, SessionsRuntimeRollbackReturn, SessionsRuntimeSteerReturn, SessionsSendReturn, SessionsSetDisplayReturn, SessionsSetEffortReturn, SessionsSetModelReturn, SessionsSetProviderReturn, SessionsSetThinkingReturn, SessionsSetTtlReturn, SessionsSubscriptionsReturn, SessionsTraceReturn, SessionsUnmuteReturn, SessionsVisibilityReturn, SettingsDeleteReturn, SettingsGetReturn, SettingsListReturn, SettingsSetReturn, SkillGatesDisableReturn, SkillGatesEnableReturn, SkillGatesListReturn, SkillGatesResetReturn, SkillGatesRmReturn, SkillGatesSetReturn, SkillGatesShowReturn, SkillsGrantBatchReturn, SkillsGrantReturn, SkillsInspectReturn, SkillsInstallReturn, SkillsListReturn, SkillsRevokeBatchReturn, SkillsRevokeReturn, SkillsShowReturn, SkillsSyncReturn, SkillsWhoReturn, SlackBlocksSendReturn, SlackBlocksShowcaseReturn, SlackBlocksUpdateReturn, SlackBlocksValidateReturn, SlackCanvasAccessDeleteReturn, SlackCanvasAccessSetReturn, SlackCanvasArtifactPublishReturn, SlackCanvasArtifactStatusReturn, SlackCanvasChannelCreateReturn, SlackCanvasChannelShowcaseReturn, SlackCanvasCreateReturn, SlackCanvasDeleteReturn, SlackCanvasEditReturn, SlackCanvasSectionsLookupReturn, SlackCanvasShowcaseReturn, SlackChannelsCreateReturn, SlackChannelsHistoryReturn, SlackChannelsInfoReturn, SlackChannelsInviteReturn, SlackChannelsListReturn, SlackChannelsRenameReturn, SlackFilesListReturn, SlackInteractionsRespondReturn, SlackMembersListReturn, SlackMessagesInspectReturn, SlackMessagesReplayReturn, SlackMessagesSendReturn, SlackModalsOpenReturn, SlackModalsPushReturn, SlackModalsUpdateReturn, SlackPermissionsListReturn, SlackTopologyReturn, SlackWorkObjectsPresentDetailsReturn, SlackWorkObjectsSendReturn, SlackWorkObjectsUnfurlReturn, SlackWorkObjectsValidateReturn, SpecsGetReturn, SpecsListReturn, SpecsNewReturn, SpecsSyncReturn, StickersAddReturn, StickersListReturn, StickersRemoveReturn, StickersSendReturn, StickersShowReturn, SyncInspectReturn, SyncPullReturn, SyncPushReturn, SyncRetryReturn, SyncStatusReturn, TagRulesEvaluateReturn, TagRulesExplainReturn, TagRulesListReturn, TagRulesShowReturn, TagRulesTickReturn, TagRulesValidateReturn, TagsAttachReturn, TagsCreateReturn, TagsDetachReturn, TagsListReturn, TagsSearchReturn, TagsSetReturn, TagsShowReturn, TasksArchiveReturn, TasksAutomationsAddReturn, TasksAutomationsDisableReturn, TasksAutomationsEnableReturn, TasksAutomationsListReturn, TasksAutomationsRmReturn, TasksAutomationsShowReturn, TasksBlockReturn, TasksCommentReturn, TasksCreateReturn, TasksDepsAddReturn, TasksDepsLsReturn, TasksDepsRmReturn, TasksDispatchReturn, TasksDoneReturn, TasksFailReturn, TasksListReturn, TasksProfilesInitReturn, TasksProfilesListReturn, TasksProfilesPreviewReturn, TasksProfilesShowReturn, TasksProfilesValidateReturn, TasksReportReturn, TasksShowReturn, TasksUnarchiveReturn, ThreadsBriefReturn, ThreadsCloseReturn, ThreadsCommentReturn, ThreadsCreateReturn, ThreadsEntriesReturn, ThreadsLinkReturn, ThreadsListReturn, ThreadsNoteReturn, ThreadsShowReturn, ToolsInvokeReturn, ToolsListReturn, ToolsManifestReturn, ToolsSchemaReturn, ToolsSearchReturn, ToolsShowReturn, ToolsTestReturn, TranscribeFileReturn, TriggersAddReturn, TriggersDisableReturn, TriggersEnableReturn, TriggersListReturn, TriggersRmReturn, TriggersSetReturn, TriggersShowReturn, TriggersTestReturn, TriggersTopicsReturn, VideoAnalyzeReturn, WatchConnectorsReturn, WatchCreateReturn, WatchDisableReturn, WatchEnableReturn, WatchEventsReturn, WatchListReturn, WatchRmReturn, WatchShowReturn, WatchTriggerReturn, WhatsappDmAckReturn, WhatsappDmReadReturn, WhatsappDmSendReturn, WhatsappGroupAddReturn, WhatsappGroupCreateReturn, WhatsappGroupDemoteReturn, WhatsappGroupDescriptionReturn, WhatsappGroupInfoReturn, WhatsappGroupInviteReturn, WhatsappGroupJoinReturn, WhatsappGroupLeaveReturn, WhatsappGroupListReturn, WhatsappGroupPromoteReturn, WhatsappGroupRemoveReturn, WhatsappGroupRenameReturn, WhatsappGroupRevokeInviteReturn, WhatsappGroupSendReturn, WhatsappGroupSettingsReturn, WorkObjectsActionReturn, WorkObjectsResolveReturn, WorkObjectsSuggestReturn, WorkObjectsUpdateReturn, WorkflowsRunsArchiveNodeReturn, WorkflowsRunsCancelReturn, WorkflowsRunsListReturn, WorkflowsRunsReleaseReturn, WorkflowsRunsShowReturn, WorkflowsRunsSkipReturn, WorkflowsRunsStartReturn, WorkflowsRunsTaskAttachReturn, WorkflowsRunsTaskCreateReturn, WorkflowsSpecsCreateReturn, WorkflowsSpecsListReturn, WorkflowsSpecsShowReturn, YtActivitiesReturn, YtAnalyticsCountriesReturn, YtAnalyticsDemographicsReturn, YtAnalyticsDevicesReturn, YtAnalyticsOverviewReturn, YtAnalyticsSeriesReturn, YtAnalyticsTopReturn, YtAnalyticsTrafficReturn, YtCaptionDeleteReturn, YtCaptionDownloadReturn, YtCaptionsReturn, YtChannelUpdateReturn, YtCommentDeleteReturn, YtCommentModerateReturn, YtCommentReturn, YtCommentUpdateReturn, YtCommentsReturn, YtHealthReturn, YtI18nLanguagesReturn, YtI18nRegionsReturn, YtInfoReturn, YtPlaylistAddReturn, YtPlaylistCreateReturn, YtPlaylistDeleteReturn, YtPlaylistMoveReturn, YtPlaylistRemoveReturn, YtPlaylistReturn, YtPlaylistUpdateReturn, YtPlaylistsReturn, YtReplyReturn, YtSearchReturn, YtStatsReturn, YtSubscribeReturn, YtSubscriptionsReturn, YtThumbnailSetReturn, YtUnansweredReturn, YtUnsubscribeReturn, YtVideoCategoriesReturn, YtVideoDeleteReturn, YtVideoRatingReturn, YtVideoReturn, YtVideoUpdateReturn, YtVideosReturn } from "./types.js";
 
 /**
  * `RaviClient` exposes every registry command as a typed method.
@@ -7765,6 +7765,18 @@ export class RaviClient {
   };
 
   readonly yt = {
+    /** List the recent activity feed of the authenticated channel */
+    activities: async (options?: {
+      connection?: string;
+      limit?: string;
+      page?: string;
+    }): Promise<YtActivitiesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "activities",
+        body: { ...(options ?? {}) },
+      });
+    },
     /** Break down recent views and watch time by country */
     analyticsCountries: async (options?: {
       connection?: string;
@@ -7845,6 +7857,16 @@ export class RaviClient {
         body: { ...(options ?? {}) },
       });
     },
+    /** Permanently delete a caption track from a video */
+    captionDelete: async (captionId: string, options?: {
+      connection?: string;
+    }): Promise<YtCaptionDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "caption-delete",
+        body: { captionId, ...(options ?? {}) },
+      });
+    },
     /** Download one caption track as text */
     captionDownload: async (captionId: string, options?: {
       connection?: string;
@@ -7867,6 +7889,64 @@ export class RaviClient {
         body: { videoId, ...(options ?? {}) },
       });
     },
+    /** Update branding metadata (description, keywords, country) of the authenticated channel */
+    channelUpdate: async (options?: {
+      connection?: string;
+      country?: string;
+      description?: string;
+      keywords?: string;
+      language?: string;
+    }): Promise<YtChannelUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "channel-update",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** Post a new top-level comment on a video */
+    comment: async (videoId: string, options?: {
+      connection?: string;
+      text?: string;
+    }): Promise<YtCommentReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "comment",
+        body: { videoId, ...(options ?? {}) },
+      });
+    },
+    /** Permanently delete a comment */
+    commentDelete: async (commentId: string, options?: {
+      connection?: string;
+    }): Promise<YtCommentDeleteReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "comment-delete",
+        body: { commentId, ...(options ?? {}) },
+      });
+    },
+    /** Set the moderation status of a comment (hold, publish or reject) */
+    commentModerate: async (commentId: string, options?: {
+      banAuthor?: boolean;
+      connection?: string;
+      status?: "heldForReview" | "published" | "rejected";
+    }): Promise<YtCommentModerateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "comment-moderate",
+        body: { commentId, ...(options ?? {}) },
+      });
+    },
+    /** Edit the text of a comment owned by the authenticated channel */
+    commentUpdate: async (commentId: string, options?: {
+      connection?: string;
+      text?: string;
+    }): Promise<YtCommentUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "comment-update",
+        body: { commentId, ...(options ?? {}) },
+      });
+    },
     /** List top-level comment threads for a video */
     comments: async (videoId: string, options?: {
       connection?: string;
@@ -7886,6 +7966,28 @@ export class RaviClient {
       return this.transport.call({
         groupSegments: ["yt"],
         command: "health",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** List the application languages YouTube supports */
+    i18nLanguages: async (options?: {
+      connection?: string;
+      hl?: string;
+    }): Promise<YtI18nLanguagesReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "i18n-languages",
+        body: { ...(options ?? {}) },
+      });
+    },
+    /** List the content regions (countries) YouTube supports */
+    i18nRegions: async (options?: {
+      connection?: string;
+      hl?: string;
+    }): Promise<YtI18nRegionsReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "i18n-regions",
         body: { ...(options ?? {}) },
       });
     },
@@ -7943,6 +8045,17 @@ export class RaviClient {
         body: { playlistId, ...(options ?? {}) },
       });
     },
+    /** Move a playlist item to a new zero-based position */
+    playlistMove: async (playlistItemId: string, options?: {
+      connection?: string;
+      position?: string;
+    }): Promise<YtPlaylistMoveReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-move",
+        body: { playlistItemId, ...(options ?? {}) },
+      });
+    },
     /** Remove one playlist item without deleting the video */
     playlistRemove: async (playlistItemId: string, options?: {
       connection?: string;
@@ -7951,6 +8064,19 @@ export class RaviClient {
         groupSegments: ["yt"],
         command: "playlist-remove",
         body: { playlistItemId, ...(options ?? {}) },
+      });
+    },
+    /** Update the title, description or privacy of an owned playlist */
+    playlistUpdate: async (playlistId: string, options?: {
+      connection?: string;
+      description?: string;
+      privacy?: "public" | "private" | "unlisted";
+      title?: string;
+    }): Promise<YtPlaylistUpdateReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "playlist-update",
+        body: { playlistId, ...(options ?? {}) },
       });
     },
     /** List playlists owned by the authenticated channel */
@@ -7997,6 +8123,16 @@ export class RaviClient {
         body: { id, ...(options ?? {}) },
       });
     },
+    /** Subscribe the authenticated channel to another channel */
+    subscribe: async (channelId: string, options?: {
+      connection?: string;
+    }): Promise<YtSubscribeReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "subscribe",
+        body: { channelId, ...(options ?? {}) },
+      });
+    },
     /** List channels followed by the authenticated channel */
     subscriptions: async (options?: {
       connection?: string;
@@ -8009,6 +8145,17 @@ export class RaviClient {
         body: { ...(options ?? {}) },
       });
     },
+    /** Upload and set a custom thumbnail image for an owned video */
+    thumbnailSet: async (videoId: string, options?: {
+      connection?: string;
+      file?: string;
+    }): Promise<YtThumbnailSetReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "thumbnail-set",
+        body: { videoId, ...(options ?? {}) },
+      });
+    },
     /** List recent comment threads with zero replies */
     unanswered: async (videoId: string, options?: {
       connection?: string;
@@ -8019,6 +8166,16 @@ export class RaviClient {
         groupSegments: ["yt"],
         command: "unanswered",
         body: { videoId, ...(options ?? {}) },
+      });
+    },
+    /** Remove one of the authenticated channel's subscriptions */
+    unsubscribe: async (subscriptionId: string, options?: {
+      connection?: string;
+    }): Promise<YtUnsubscribeReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "unsubscribe",
+        body: { subscriptionId, ...(options ?? {}) },
       });
     },
     /** Get one video by YouTube video ID */
@@ -8050,6 +8207,16 @@ export class RaviClient {
         groupSegments: ["yt"],
         command: "video-delete",
         body: { id, ...(options ?? {}) },
+      });
+    },
+    /** Get the authenticated channel's like/dislike rating for one or more videos */
+    videoRating: async (ids: string, options?: {
+      connection?: string;
+    }): Promise<YtVideoRatingReturn> => {
+      return this.transport.call({
+        groupSegments: ["yt"],
+        command: "video-rating",
+        body: { ids, ...(options ?? {}) },
       });
     },
     /** Update selected metadata on an owned YouTube video */

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -70267,6 +70267,89 @@ export const WorkflowsSpecsShowReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `yt.activities`. */
+export const YtActivitiesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "limit": {
+      "description": "Page size, 1-50 (default: 25)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    },
+    "page": {
+      "description": "Provider page token from nextPageToken",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.activities`. */
+export const YtActivitiesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "activities": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "activityId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "activityId",
+          "type",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "videoId"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "nextPageToken": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "activities",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `yt.analytics-countries`. */
 export const YtAnalyticsCountriesInputSchema = {
   "additionalProperties": false,
@@ -70761,6 +70844,45 @@ export const YtAnalyticsTrafficReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `yt.caption-delete`. */
+export const YtCaptionDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "captionId": {
+      "description": "YouTube caption track ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "captionId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.caption-delete`. */
+export const YtCaptionDeleteReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "deleted"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `yt.caption-download`. */
 export const YtCaptionDownloadInputSchema = {
   "additionalProperties": false,
@@ -70904,6 +71026,285 @@ export const YtCaptionsReturnSchema = {
     "videoId",
     "captions",
     "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.channel-update`. */
+export const YtChannelUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "country": {
+      "description": "ISO 3166-1 alpha-2 channel country",
+      "type": "string"
+    },
+    "description": {
+      "description": "Replacement channel description",
+      "type": "string"
+    },
+    "keywords": {
+      "description": "Replacement space-separated channel keywords",
+      "type": "string"
+    },
+    "language": {
+      "description": "Default channel language (e.g. pt-BR)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.channel-update`. */
+export const YtChannelUpdateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "channel": {
+      "additionalProperties": false,
+      "properties": {
+        "channelId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "subscriberCount": {
+          "type": "number"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "uploadsPlaylistId": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "videoCount": {
+          "type": "number"
+        },
+        "viewCount": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "channelId",
+        "title",
+        "description",
+        "subscriberCount",
+        "videoCount",
+        "viewCount",
+        "thumbnail",
+        "uploadsPlaylistId",
+        "url"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "channel"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.comment`. */
+export const YtCommentInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "text": {
+      "description": "Comment text",
+      "minLength": 1,
+      "type": "string"
+    },
+    "videoId": {
+      "description": "YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.comment`. */
+export const YtCommentReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "threadId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "threadId",
+    "commentId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.comment-delete`. */
+export const YtCommentDeleteInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "description": "YouTube comment ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "commentId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.comment-delete`. */
+export const YtCommentDeleteReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "deleted"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.comment-moderate`. */
+export const YtCommentModerateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "banAuthor": {
+      "description": "Also ban the comment author (only with rejected)",
+      "type": "boolean"
+    },
+    "commentId": {
+      "description": "YouTube comment ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "status": {
+      "description": "heldForReview|published|rejected",
+      "enum": [
+        "heldForReview",
+        "published",
+        "rejected"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "commentId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.comment-moderate`. */
+export const YtCommentModerateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "type": "string"
+    },
+    "moderationStatus": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "commentId",
+    "moderationStatus"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.comment-update`. */
+export const YtCommentUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "description": "YouTube comment ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "text": {
+      "description": "Replacement comment text",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "commentId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.comment-update`. */
+export const YtCommentUpdateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "commentId": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "text": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "commentId",
+    "text"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
@@ -71065,6 +71466,118 @@ export const YtHealthReturnSchema = {
     "authenticated",
     "externalCheckPerformed",
     "message"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.i18n-languages`. */
+export const YtI18nLanguagesInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "hl": {
+      "default": "pt-BR",
+      "description": "Language for the returned names (default: pt-BR)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.i18n-languages`. */
+export const YtI18nLanguagesReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "languages": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "languages",
+    "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.i18n-regions`. */
+export const YtI18nRegionsInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "hl": {
+      "default": "pt-BR",
+      "description": "Language for the returned names (default: pt-BR)",
+      "type": "string"
+    }
+  },
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.i18n-regions`. */
+export const YtI18nRegionsReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "regions": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "regions",
+    "totalResults"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
@@ -71449,6 +71962,71 @@ export const YtPlaylistDeleteReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `yt.playlist-move`. */
+export const YtPlaylistMoveInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "playlistItemId": {
+      "description": "Playlist item ID, not video ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "position": {
+      "description": "Zero-based target position (0-5000)",
+      "pattern": "^\\d+$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistItemId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-move`. */
+export const YtPlaylistMoveReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "additionalProperties": false,
+      "properties": {
+        "playlistId": {
+          "type": "string"
+        },
+        "playlistItemId": {
+          "type": "string"
+        },
+        "position": {
+          "type": "number"
+        },
+        "videoId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "playlistItemId",
+        "playlistId",
+        "videoId",
+        "position"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "item"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `yt.playlist-remove`. */
 export const YtPlaylistRemoveInputSchema = {
   "additionalProperties": false,
@@ -71484,6 +72062,99 @@ export const YtPlaylistRemoveReturnSchema = {
   "required": [
     "success",
     "removed"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.playlist-update`. */
+export const YtPlaylistUpdateInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "description": {
+      "description": "Replacement description",
+      "type": "string"
+    },
+    "playlistId": {
+      "description": "Owned YouTube playlist ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "privacy": {
+      "description": "public|private|unlisted",
+      "enum": [
+        "public",
+        "private",
+        "unlisted"
+      ],
+      "type": "string"
+    },
+    "title": {
+      "description": "Replacement title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "playlistId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.playlist-update`. */
+export const YtPlaylistUpdateReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "playlist": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "itemCount": {
+          "type": "number"
+        },
+        "playlistId": {
+          "type": "string"
+        },
+        "privacyStatus": {
+          "type": "string"
+        },
+        "publishedAt": {
+          "type": "string"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "playlistId",
+        "title",
+        "description",
+        "thumbnail",
+        "itemCount",
+        "publishedAt",
+        "privacyStatus",
+        "url"
+      ],
+      "type": "object"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "playlist"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
@@ -71810,6 +72481,49 @@ export const YtStatsReturnSchema = {
   "type": "object"
 } as const satisfies SdkJsonSchema;
 
+/** JSON Schema for the input body of `yt.subscribe`. */
+export const YtSubscribeInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "channelId": {
+      "description": "Target YouTube channel ID",
+      "minLength": 1,
+      "type": "string"
+    },
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "channelId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.subscribe`. */
+export const YtSubscribeReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "channelId": {
+      "type": "string"
+    },
+    "subscriptionId": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "subscriptionId",
+    "channelId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
 /** JSON Schema for the input body of `yt.subscriptions`. */
 export const YtSubscriptionsInputSchema = {
   "additionalProperties": false,
@@ -71893,6 +72607,54 @@ export const YtSubscriptionsReturnSchema = {
     "success",
     "subscriptions",
     "totalResults"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.thumbnail-set`. */
+export const YtThumbnailSetInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "file": {
+      "description": "Local JPEG/PNG image path",
+      "minLength": 1,
+      "type": "string"
+    },
+    "videoId": {
+      "description": "Owned YouTube video ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "videoId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.thumbnail-set`. */
+export const YtThumbnailSetReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "thumbnail": {
+      "type": "string"
+    },
+    "videoId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "success",
+    "videoId",
+    "thumbnail"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
@@ -71992,6 +72754,45 @@ export const YtUnansweredReturnSchema = {
     "videoId",
     "comments",
     "totalUnanswered"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.unsubscribe`. */
+export const YtUnsubscribeInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "subscriptionId": {
+      "description": "Subscription ID, not channel ID",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "subscriptionId"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.unsubscribe`. */
+export const YtUnsubscribeReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": "string"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "success",
+    "deleted"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;
@@ -72186,6 +72987,65 @@ export const YtVideoDeleteReturnSchema = {
   "required": [
     "success",
     "deleted"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the input body of `yt.video-rating`. */
+export const YtVideoRatingInputSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "connection": {
+      "description": "Credential connection (default: default)",
+      "type": "string"
+    },
+    "ids": {
+      "description": "One video ID or a comma-separated list",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "ids"
+  ],
+  "type": "object"
+} as const satisfies SdkJsonSchema;
+
+/** JSON Schema for the return shape of `yt.video-rating`. */
+export const YtVideoRatingReturnSchema = {
+  "additionalProperties": false,
+  "properties": {
+    "ratings": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "rating": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "videoId",
+          "rating"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "success": {
+      "const": true,
+      "type": "boolean"
+    },
+    "totalResults": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "success",
+    "ratings",
+    "totalResults"
   ],
   "type": "object"
 } as const satisfies SdkJsonSchema;

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -14905,6 +14905,29 @@ export type WorkflowsSpecsShowInput = {
 /** Return shape for `workflows.specs.show`. */
 export type WorkflowsSpecsShowReturn = Record<string, unknown>;
 
+/** Input shape for `yt.activities`. */
+export type YtActivitiesInput = {
+  connection?: string;
+  limit?: string;
+  page?: string;
+};
+
+/** Return shape for `yt.activities`. */
+export type YtActivitiesReturn = {
+  activities: Array<{
+    activityId: string;
+    description: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    type: string;
+    videoId: string;
+  }>;
+  nextPageToken?: string;
+  success: true;
+  totalResults: number;
+};
+
 /** Input shape for `yt.analytics-countries`. */
 export type YtAnalyticsCountriesInput = {
   connection?: string;
@@ -15036,6 +15059,18 @@ export type YtAnalyticsTrafficReturn = {
   success: true;
 };
 
+/** Input shape for `yt.caption-delete`. */
+export type YtCaptionDeleteInput = {
+  captionId: string;
+  connection?: string;
+};
+
+/** Return shape for `yt.caption-delete`. */
+export type YtCaptionDeleteReturn = {
+  deleted: string;
+  success: true;
+};
+
 /** Input shape for `yt.caption-download`. */
 export type YtCaptionDownloadInput = {
   captionId: string;
@@ -15073,6 +15108,86 @@ export type YtCaptionsReturn = {
   success: true;
   totalResults: number;
   videoId: string;
+};
+
+/** Input shape for `yt.channel-update`. */
+export type YtChannelUpdateInput = {
+  connection?: string;
+  country?: string;
+  description?: string;
+  keywords?: string;
+  language?: string;
+};
+
+/** Return shape for `yt.channel-update`. */
+export type YtChannelUpdateReturn = {
+  channel: {
+    channelId: string;
+    description: string;
+    subscriberCount: number;
+    thumbnail: string;
+    title: string;
+    uploadsPlaylistId: string;
+    url: string;
+    videoCount: number;
+    viewCount: number;
+  };
+  success: true;
+};
+
+/** Input shape for `yt.comment`. */
+export type YtCommentInput = {
+  connection?: string;
+  text?: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.comment`. */
+export type YtCommentReturn = {
+  commentId: string;
+  success: true;
+  threadId: string;
+};
+
+/** Input shape for `yt.comment-delete`. */
+export type YtCommentDeleteInput = {
+  commentId: string;
+  connection?: string;
+};
+
+/** Return shape for `yt.comment-delete`. */
+export type YtCommentDeleteReturn = {
+  deleted: string;
+  success: true;
+};
+
+/** Input shape for `yt.comment-moderate`. */
+export type YtCommentModerateInput = {
+  banAuthor?: boolean;
+  commentId: string;
+  connection?: string;
+  status?: "heldForReview" | "published" | "rejected";
+};
+
+/** Return shape for `yt.comment-moderate`. */
+export type YtCommentModerateReturn = {
+  commentId: string;
+  moderationStatus: string;
+  success: true;
+};
+
+/** Input shape for `yt.comment-update`. */
+export type YtCommentUpdateInput = {
+  commentId: string;
+  connection?: string;
+  text?: string;
+};
+
+/** Return shape for `yt.comment-update`. */
+export type YtCommentUpdateReturn = {
+  commentId: string;
+  success: true;
+  text: string;
 };
 
 /** Input shape for `yt.comments`. */
@@ -15117,6 +15232,38 @@ export type YtHealthReturn = {
   message: string;
   ready: boolean;
   success: true;
+};
+
+/** Input shape for `yt.i18n-languages`. */
+export type YtI18nLanguagesInput = {
+  connection?: string;
+  hl?: string;
+};
+
+/** Return shape for `yt.i18n-languages`. */
+export type YtI18nLanguagesReturn = {
+  languages: Array<{
+    code: string;
+    name: string;
+  }>;
+  success: true;
+  totalResults: number;
+};
+
+/** Input shape for `yt.i18n-regions`. */
+export type YtI18nRegionsInput = {
+  connection?: string;
+  hl?: string;
+};
+
+/** Return shape for `yt.i18n-regions`. */
+export type YtI18nRegionsReturn = {
+  regions: Array<{
+    code: string;
+    name: string;
+  }>;
+  success: true;
+  totalResults: number;
 };
 
 /** Input shape for `yt.info`. */
@@ -15223,6 +15370,24 @@ export type YtPlaylistDeleteReturn = {
   success: true;
 };
 
+/** Input shape for `yt.playlist-move`. */
+export type YtPlaylistMoveInput = {
+  connection?: string;
+  playlistItemId: string;
+  position?: string;
+};
+
+/** Return shape for `yt.playlist-move`. */
+export type YtPlaylistMoveReturn = {
+  item: {
+    playlistId: string;
+    playlistItemId: string;
+    position: number;
+    videoId: string;
+  };
+  success: true;
+};
+
 /** Input shape for `yt.playlist-remove`. */
 export type YtPlaylistRemoveInput = {
   connection?: string;
@@ -15232,6 +15397,30 @@ export type YtPlaylistRemoveInput = {
 /** Return shape for `yt.playlist-remove`. */
 export type YtPlaylistRemoveReturn = {
   removed: string;
+  success: true;
+};
+
+/** Input shape for `yt.playlist-update`. */
+export type YtPlaylistUpdateInput = {
+  connection?: string;
+  description?: string;
+  playlistId: string;
+  privacy?: "public" | "private" | "unlisted";
+  title?: string;
+};
+
+/** Return shape for `yt.playlist-update`. */
+export type YtPlaylistUpdateReturn = {
+  playlist: {
+    description: string;
+    itemCount: number;
+    playlistId: string;
+    privacyStatus: string;
+    publishedAt: string;
+    thumbnail: string;
+    title: string;
+    url: string;
+  };
   success: true;
 };
 
@@ -15323,6 +15512,19 @@ export type YtStatsReturn = {
   success: true;
 };
 
+/** Input shape for `yt.subscribe`. */
+export type YtSubscribeInput = {
+  channelId: string;
+  connection?: string;
+};
+
+/** Return shape for `yt.subscribe`. */
+export type YtSubscribeReturn = {
+  channelId: string;
+  subscriptionId: string;
+  success: true;
+};
+
 /** Input shape for `yt.subscriptions`. */
 export type YtSubscriptionsInput = {
   connection?: string;
@@ -15345,6 +15547,20 @@ export type YtSubscriptionsReturn = {
   }>;
   success: true;
   totalResults: number;
+};
+
+/** Input shape for `yt.thumbnail-set`. */
+export type YtThumbnailSetInput = {
+  connection?: string;
+  file?: string;
+  videoId: string;
+};
+
+/** Return shape for `yt.thumbnail-set`. */
+export type YtThumbnailSetReturn = {
+  success: true;
+  thumbnail: string;
+  videoId: string;
 };
 
 /** Input shape for `yt.unanswered`. */
@@ -15371,6 +15587,18 @@ export type YtUnansweredReturn = {
   success: true;
   totalUnanswered: number;
   videoId: string;
+};
+
+/** Input shape for `yt.unsubscribe`. */
+export type YtUnsubscribeInput = {
+  connection?: string;
+  subscriptionId: string;
+};
+
+/** Return shape for `yt.unsubscribe`. */
+export type YtUnsubscribeReturn = {
+  deleted: string;
+  success: true;
 };
 
 /** Input shape for `yt.video`. */
@@ -15426,6 +15654,22 @@ export type YtVideoDeleteInput = {
 export type YtVideoDeleteReturn = {
   deleted: string;
   success: true;
+};
+
+/** Input shape for `yt.video-rating`. */
+export type YtVideoRatingInput = {
+  connection?: string;
+  ids: string;
+};
+
+/** Return shape for `yt.video-rating`. */
+export type YtVideoRatingReturn = {
+  ratings: Array<{
+    rating: string;
+    videoId: string;
+  }>;
+  success: true;
+  totalResults: number;
 };
 
 /** Input shape for `yt.video-update`. */

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:265847c56e9f24844aaeea0fe0e022df122e9d3654cedd76e31da36ede108531";
+export const REGISTRY_HASH = "sha256:aebf244e7e2c6c9d5ac108c34b17dc71cd1f40f9fea7bea4c234d4d1a9d3c28d";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "651d2e9b11d9";
+export const GIT_SHA = "88e6c3bec6df";

--- a/src/apps/youtube/app.test.ts
+++ b/src/apps/youtube/app.test.ts
@@ -23,10 +23,15 @@ describe("YouTube Ravi App manifest", () => {
     expect(app.permissions.optional).toEqual(["youtube:read", "youtube:analytics:read", "youtube:captions:read"]);
     expect(app.permissions.mutating).toEqual([
       "youtube:comments:write",
+      "youtube:comments:delete",
       "youtube:videos:write",
       "youtube:videos:delete",
       "youtube:playlists:write",
       "youtube:playlists:delete",
+      "youtube:channels:write",
+      "youtube:subscriptions:write",
+      "youtube:subscriptions:delete",
+      "youtube:captions:delete",
     ]);
   });
 

--- a/src/apps/youtube/client.test.ts
+++ b/src/apps/youtube/client.test.ts
@@ -379,4 +379,278 @@ describe("YouTubeClient", () => {
       accessToken: "trimmed-token",
     });
   });
+
+  it("normalizes the channel activity feed and extracts the related video id", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({
+        items: [
+          {
+            id: "act-1",
+            snippet: {
+              type: "upload",
+              title: "Novo vídeo",
+              description: "desc",
+              publishedAt: "2026-07-14T15:00:00Z",
+              thumbnails: { medium: { url: "https://example.test/m.jpg" } },
+            },
+            contentDetails: { upload: { videoId: "vid-1" } },
+          },
+        ],
+        pageInfo: { totalResults: 16 },
+        nextPageToken: "NEXT",
+      });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.listActivities({ maxResults: 3 });
+    expect(result).toEqual({
+      activities: [
+        {
+          activityId: "act-1",
+          type: "upload",
+          title: "Novo vídeo",
+          description: "desc",
+          publishedAt: "2026-07-14T15:00:00Z",
+          thumbnail: "https://example.test/m.jpg",
+          videoId: "vid-1",
+        },
+      ],
+      totalResults: 16,
+      nextPageToken: "NEXT",
+    });
+    expect(requests[0]?.url.href).toContain("/activities?");
+    expect(requests[0]?.url.searchParams.get("mine")).toBe("true");
+    expect(requests[0]?.url.searchParams.get("maxResults")).toBe("3");
+  });
+
+  it("maps i18n languages and regions to code/name pairs", async () => {
+    const fetch = fakeFetch((request) =>
+      request.url.href.includes("i18nLanguages")
+        ? json({ items: [{ id: "pt", snippet: { hl: "pt", name: "Português" } }] })
+        : json({ items: [{ id: "BR", snippet: { gl: "BR", name: "Brasil" } }] }),
+    );
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.listI18nLanguages({})).toEqual({
+      languages: [{ code: "pt", name: "Português" }],
+      totalResults: 1,
+    });
+    expect(await client.listI18nRegions({})).toEqual({
+      regions: [{ code: "BR", name: "Brasil" }],
+      totalResults: 1,
+    });
+  });
+
+  it("returns the caller's own like/dislike rating for videos", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({
+        items: [
+          { videoId: "vid-1", rating: "like" },
+          { videoId: "vid-2", rating: "none" },
+        ],
+      });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.getVideoRating(["vid-1", "vid-2"])).toEqual({
+      ratings: [
+        { videoId: "vid-1", rating: "like" },
+        { videoId: "vid-2", rating: "none" },
+      ],
+      totalResults: 2,
+    });
+    expect(requests[0]?.url.href).toContain("/videos/getRating?");
+    expect(requests[0]?.url.searchParams.get("id")).toBe("vid-1,vid-2");
+  });
+
+  it("merges channel branding before updating and refetches channel info", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (requests.length === 1) {
+        return json({ items: [{ id: "UC1", brandingSettings: { channel: { description: "old", keywords: "a b" } } }] });
+      }
+      if (request.init.method === "PUT") return json({});
+      return json({ items: [{ id: "UC1", snippet: { title: "Canal" }, statistics: {}, contentDetails: {} }] });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.updateChannel({ description: "new" });
+    expect(result.success).toBe(true);
+    expect(requests[1]?.init.method).toBe("PUT");
+    expect(requests[1]?.url.searchParams.get("part")).toBe("brandingSettings");
+    expect(JSON.parse(String(requests[1]?.init.body))).toEqual({
+      id: "UC1",
+      brandingSettings: {
+        channel: { description: "new", keywords: "a b", country: undefined, defaultLanguage: undefined },
+      },
+    });
+  });
+
+  it("rejects a channel update with no fields", async () => {
+    const fetch = fakeFetch(() => json({}));
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+    await expect(client.updateChannel({})).rejects.toThrow("at least one channel branding field");
+  });
+
+  it("updates playlist metadata after reading current values", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (requests.length === 1) {
+        return json({
+          items: [{ id: "PL1", snippet: { title: "old", description: "d" }, status: { privacyStatus: "public" } }],
+        });
+      }
+      return json({
+        id: "PL1",
+        snippet: { title: "new", description: "d", publishedAt: "2026-01-01T00:00:00Z" },
+        status: { privacyStatus: "public" },
+        contentDetails: { itemCount: 3 },
+      });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.updatePlaylist("PL1", { title: "new" });
+    expect(result.playlist.title).toBe("new");
+    expect(requests[1]?.init.method).toBe("PUT");
+    expect(JSON.parse(String(requests[1]?.init.body))).toEqual({
+      id: "PL1",
+      snippet: { title: "new", description: "d" },
+      status: { privacyStatus: "public" },
+    });
+  });
+
+  it("moves a playlist item preserving playlistId and resourceId", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (requests.length === 1) {
+        return json({
+          items: [
+            { id: "PI1", snippet: { playlistId: "PL1", resourceId: { kind: "youtube#video", videoId: "vid-1" } } },
+          ],
+        });
+      }
+      return json({ id: "PI1", snippet: { playlistId: "PL1", resourceId: { videoId: "vid-1" }, position: 0 } });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.movePlaylistItem("PI1", 0);
+    expect(result.item).toEqual({ playlistItemId: "PI1", playlistId: "PL1", videoId: "vid-1", position: 0 });
+    expect(JSON.parse(String(requests[1]?.init.body))).toEqual({
+      id: "PI1",
+      snippet: { playlistId: "PL1", resourceId: { kind: "youtube#video", videoId: "vid-1" }, position: 0 },
+    });
+  });
+
+  it("publishes a top-level comment thread and returns thread and comment ids", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({ id: "thread-1", snippet: { topLevelComment: { id: "comment-1" } } });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.insertComment("vid-1", "Olá")).toEqual({
+      success: true,
+      threadId: "thread-1",
+      commentId: "comment-1",
+    });
+    expect(requests[0]?.url.href).toBe("https://www.googleapis.com/youtube/v3/commentThreads?part=snippet");
+    expect(JSON.parse(String(requests[0]?.init.body))).toEqual({
+      snippet: { videoId: "vid-1", topLevelComment: { snippet: { textOriginal: "Olá" } } },
+    });
+  });
+
+  it("sets comment moderation status via query params without a body", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return new Response("", { status: 204 });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.setCommentModeration("comment-1", "rejected", true)).toEqual({
+      success: true,
+      commentId: "comment-1",
+      moderationStatus: "rejected",
+    });
+    expect(requests[0]?.url.href).toContain("/comments/setModerationStatus?");
+    expect(requests[0]?.init.method).toBe("POST");
+    expect(requests[0]?.url.searchParams.get("moderationStatus")).toBe("rejected");
+    expect(requests[0]?.url.searchParams.get("banAuthor")).toBe("true");
+    expect(requests[0]?.init.body).toBeUndefined();
+  });
+
+  it("deletes and edits comments through the official endpoints", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (request.init.method === "DELETE") return new Response("", { status: 204 });
+      return json({ id: "comment-1", snippet: { textDisplay: "novo" } });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.deleteComment("comment-1")).toEqual({ success: true, deleted: "comment-1" });
+    expect(requests[0]?.init.method).toBe("DELETE");
+    expect(await client.updateComment("comment-1", "novo")).toEqual({
+      success: true,
+      commentId: "comment-1",
+      text: "novo",
+    });
+    expect(requests[1]?.init.method).toBe("PUT");
+  });
+
+  it("subscribes and unsubscribes through the subscriptions endpoints", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      if (request.init.method === "DELETE") return new Response("", { status: 204 });
+      return json({ id: "sub-1" });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.subscribe("UC2")).toEqual({ success: true, subscriptionId: "sub-1", channelId: "UC2" });
+    expect(JSON.parse(String(requests[0]?.init.body))).toEqual({
+      snippet: { resourceId: { kind: "youtube#channel", channelId: "UC2" } },
+    });
+    expect(await client.unsubscribe("sub-1")).toEqual({ success: true, deleted: "sub-1" });
+    expect(requests[1]?.init.method).toBe("DELETE");
+    expect(requests[1]?.url.searchParams.get("id")).toBe("sub-1");
+  });
+
+  it("deletes a caption track", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return new Response("", { status: 204 });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    expect(await client.deleteCaption("caption-1")).toEqual({ success: true, deleted: "caption-1" });
+    expect(requests[0]?.url.href).toContain("/captions?");
+    expect(requests[0]?.init.method).toBe("DELETE");
+  });
+
+  it("uploads a thumbnail to the media endpoint with the image content type", async () => {
+    const requests: RequestRecord[] = [];
+    const fetch = fakeFetch((request) => {
+      requests.push(request);
+      return json({ items: [{ high: { url: "https://example.test/hq.jpg" } }] });
+    });
+    const client = new YouTubeClient({ fetch, credential: { accessToken: "unit-test-token" } });
+
+    const result = await client.setThumbnail("vid-1", { data: new Uint8Array([1, 2, 3]), contentType: "image/jpeg" });
+    expect(result).toEqual({ success: true, videoId: "vid-1", thumbnail: "https://example.test/hq.jpg" });
+    expect(requests[0]?.url.href).toContain("https://www.googleapis.com/upload/youtube/v3/thumbnails/set");
+    expect(requests[0]?.url.searchParams.get("videoId")).toBe("vid-1");
+    expect(requests[0]?.url.searchParams.get("uploadType")).toBe("media");
+    expect(requests[0]?.init.method).toBe("POST");
+    expect((requests[0]?.init.headers as Record<string, string>)["content-type"]).toBe("image/jpeg");
+  });
 });

--- a/src/apps/youtube/client.ts
+++ b/src/apps/youtube/client.ts
@@ -615,6 +615,252 @@ export class YouTubeClient {
     return { success: true, removed: playlistItemId };
   }
 
+  async listActivities(options: { maxResults?: number; pageToken?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<ActivityResource>>(
+      "/activities",
+      {
+        part: "snippet,contentDetails",
+        mine: true,
+        maxResults: options.maxResults ?? 25,
+        pageToken: options.pageToken,
+      },
+      "activities.list",
+    );
+    const activities = (response.items ?? []).map(normalizeActivity);
+    return {
+      activities,
+      totalResults: response.pageInfo?.totalResults ?? activities.length,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async listI18nLanguages(options: { hl?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<I18nLanguageResource>>(
+      "/i18nLanguages",
+      { part: "snippet", hl: options.hl ?? "pt-BR" },
+      "i18nLanguages.list",
+    );
+    const languages = (response.items ?? []).map((item) => ({
+      code: item.snippet?.hl ?? item.id ?? "",
+      name: item.snippet?.name ?? "",
+    }));
+    return { languages, totalResults: languages.length };
+  }
+
+  async listI18nRegions(options: { hl?: string } = {}) {
+    const response = await this.dataRequest<ListResponse<I18nRegionResource>>(
+      "/i18nRegions",
+      { part: "snippet", hl: options.hl ?? "pt-BR" },
+      "i18nRegions.list",
+    );
+    const regions = (response.items ?? []).map((item) => ({
+      code: item.snippet?.gl ?? "",
+      name: item.snippet?.name ?? "",
+    }));
+    return { regions, totalResults: regions.length };
+  }
+
+  async getVideoRating(videoIds: string[]) {
+    const response = await this.dataRequest<ListResponse<VideoRatingResource>>(
+      "/videos/getRating",
+      { id: videoIds.join(",") },
+      "videos.getRating",
+    );
+    const ratings = (response.items ?? []).map((item) => ({
+      videoId: item.videoId ?? "",
+      rating: item.rating ?? "none",
+    }));
+    return { ratings, totalResults: ratings.length };
+  }
+
+  async updateChannel(changes: {
+    description?: string;
+    keywords?: string;
+    country?: string;
+    defaultLanguage?: string;
+  }) {
+    if (
+      changes.description === undefined &&
+      changes.keywords === undefined &&
+      changes.country === undefined &&
+      changes.defaultLanguage === undefined
+    ) {
+      throw new Error("Provide at least one channel branding field to update.");
+    }
+    const current = await this.dataRequest<ListResponse<ChannelResource>>(
+      "/channels",
+      { part: "brandingSettings", mine: true },
+      "channels.get-for-update",
+    );
+    const channel = current.items?.[0];
+    if (!channel?.id) throw new Error("No YouTube channel is available to this credential.");
+    const branding = channel.brandingSettings?.channel ?? {};
+    const body = {
+      id: channel.id,
+      brandingSettings: {
+        channel: {
+          ...branding,
+          description: changes.description ?? branding.description,
+          keywords: changes.keywords ?? branding.keywords,
+          country: changes.country ?? branding.country,
+          defaultLanguage: changes.defaultLanguage ?? branding.defaultLanguage,
+        },
+      },
+    };
+    await this.dataRequest("/channels", { part: "brandingSettings" }, "channels.update", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    return { success: true, channel: await this.channelInfo() };
+  }
+
+  async updatePlaylist(
+    playlistId: string,
+    changes: { title?: string; description?: string; privacyStatus?: "public" | "private" | "unlisted" },
+  ) {
+    if (changes.title === undefined && changes.description === undefined && changes.privacyStatus === undefined) {
+      throw new Error("Provide at least one playlist field to update.");
+    }
+    const current = await this.dataRequest<ListResponse<PlaylistResource>>(
+      "/playlists",
+      { part: "snippet,status", id: playlistId },
+      "playlists.get-for-update",
+    );
+    const playlist = current.items?.[0];
+    if (!playlist) throw new Error(`YouTube playlist not found: ${playlistId}`);
+    const body = {
+      id: playlistId,
+      snippet: {
+        title: changes.title ?? playlist.snippet?.title ?? "",
+        description: changes.description ?? playlist.snippet?.description ?? "",
+      },
+      status: { privacyStatus: changes.privacyStatus ?? playlist.status?.privacyStatus ?? "private" },
+    };
+    const updated = await this.dataRequest<PlaylistResource>(
+      "/playlists",
+      { part: "snippet,status" },
+      "playlists.update",
+      {
+        method: "PUT",
+        body: JSON.stringify(body),
+      },
+    );
+    return { success: true, playlist: normalizePlaylist(updated) };
+  }
+
+  async movePlaylistItem(playlistItemId: string, position: number) {
+    const current = await this.dataRequest<ListResponse<PlaylistItemResource>>(
+      "/playlistItems",
+      { part: "snippet", id: playlistItemId },
+      "playlistItems.get-for-move",
+    );
+    const item = current.items?.[0];
+    if (!item?.snippet?.playlistId || !item.snippet.resourceId) {
+      throw new Error(`YouTube playlist item not found: ${playlistItemId}`);
+    }
+    const body = {
+      id: playlistItemId,
+      snippet: { playlistId: item.snippet.playlistId, resourceId: item.snippet.resourceId, position },
+    };
+    const updated = await this.dataRequest<PlaylistItemResource>(
+      "/playlistItems",
+      { part: "snippet" },
+      "playlistItems.update",
+      {
+        method: "PUT",
+        body: JSON.stringify(body),
+      },
+    );
+    return {
+      success: true,
+      item: {
+        playlistItemId: updated.id ?? playlistItemId,
+        playlistId: updated.snippet?.playlistId ?? item.snippet.playlistId,
+        videoId: updated.snippet?.resourceId?.videoId ?? item.snippet.resourceId.videoId ?? "",
+        position: updated.snippet?.position ?? position,
+      },
+    };
+  }
+
+  async insertComment(videoId: string, text: string) {
+    const thread = await this.dataRequest<CommentThreadResource>(
+      "/commentThreads",
+      { part: "snippet" },
+      "commentThreads.insert",
+      {
+        method: "POST",
+        body: JSON.stringify({ snippet: { videoId, topLevelComment: { snippet: { textOriginal: text } } } }),
+      },
+    );
+    return { success: true, threadId: thread.id ?? "", commentId: thread.snippet?.topLevelComment?.id ?? "" };
+  }
+
+  async setCommentModeration(
+    commentId: string,
+    moderationStatus: "heldForReview" | "published" | "rejected",
+    banAuthor?: boolean,
+  ) {
+    await this.dataRequest(
+      "/comments/setModerationStatus",
+      { id: commentId, moderationStatus, banAuthor: banAuthor ? "true" : undefined },
+      "comments.setModerationStatus",
+      { method: "POST" },
+    );
+    return { success: true, commentId, moderationStatus };
+  }
+
+  async deleteComment(commentId: string) {
+    await this.dataRequest("/comments", { id: commentId }, "comments.delete", { method: "DELETE" });
+    return { success: true, deleted: commentId };
+  }
+
+  async updateComment(commentId: string, text: string) {
+    const updated = await this.dataRequest<CommentResource>("/comments", { part: "snippet" }, "comments.update", {
+      method: "PUT",
+      body: JSON.stringify({ id: commentId, snippet: { textOriginal: text } }),
+    });
+    return { success: true, commentId: updated.id ?? commentId, text: updated.snippet?.textDisplay ?? text };
+  }
+
+  async subscribe(channelId: string) {
+    const subscription = await this.dataRequest<SubscriptionResource>(
+      "/subscriptions",
+      { part: "snippet" },
+      "subscriptions.insert",
+      {
+        method: "POST",
+        body: JSON.stringify({ snippet: { resourceId: { kind: "youtube#channel", channelId } } }),
+      },
+    );
+    return { success: true, subscriptionId: subscription.id ?? "", channelId };
+  }
+
+  async unsubscribe(subscriptionId: string) {
+    await this.dataRequest("/subscriptions", { id: subscriptionId }, "subscriptions.delete", { method: "DELETE" });
+    return { success: true, deleted: subscriptionId };
+  }
+
+  async deleteCaption(captionId: string) {
+    await this.dataRequest("/captions", { id: captionId }, "captions.delete", { method: "DELETE" });
+    return { success: true, deleted: captionId };
+  }
+
+  async setThumbnail(videoId: string, image: { data: Uint8Array; contentType: string }) {
+    const result = await this.uploadRequest<ListResponse<ThumbnailSetResource>>(
+      "https://www.googleapis.com/upload/youtube/v3/thumbnails/set",
+      { videoId, uploadType: "media" },
+      "thumbnails.set",
+      image.data,
+      image.contentType,
+    );
+    const item = result.items?.[0];
+    return {
+      success: true,
+      videoId,
+      thumbnail: item?.high?.url ?? item?.medium?.url ?? item?.default?.url ?? "",
+    };
+  }
+
   private async currentChannel(): Promise<ChannelResource> {
     const response = await this.dataRequest<ListResponse<ChannelResource>>(
       "/channels",
@@ -661,6 +907,33 @@ export class YouTubeClient {
     init: RequestInit = {},
   ): Promise<T> {
     const response = await this.request(baseUrl, query, action, init);
+    const text = await response.text();
+    if (!response.ok) throw requestError(response.status, text);
+    if (!text) return {} as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`YouTube API returned invalid JSON (${response.status}).`);
+    }
+  }
+
+  private async uploadRequest<T>(
+    uploadUrl: string,
+    query: Record<string, QueryValue>,
+    action: string,
+    body: Uint8Array,
+    contentType: string,
+  ): Promise<T> {
+    const credential = await this.resolveCredential(action);
+    const url = new URL(uploadUrl);
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+    const response = await this.#fetch(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${credential.accessToken}`, "content-type": contentType },
+      body: body as unknown as RequestInit["body"],
+    });
     const text = await response.text();
     if (!response.ok) throw requestError(response.status, text);
     if (!text) return {} as T;
@@ -746,6 +1019,30 @@ interface ChannelResource {
   snippet?: { title?: string; description?: string; thumbnails?: ThumbnailSet };
   statistics?: { subscriberCount?: string; videoCount?: string; viewCount?: string };
   contentDetails?: { relatedPlaylists?: { uploads?: string } };
+  brandingSettings?: {
+    channel?: {
+      title?: string;
+      description?: string;
+      keywords?: string;
+      country?: string;
+      defaultLanguage?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+}
+
+interface PlaylistItemSnippet {
+  title?: string;
+  playlistId?: string;
+  position?: number;
+  resourceId?: { kind?: string; videoId?: string };
+}
+
+interface ThumbnailSetResource {
+  default?: { url?: string };
+  medium?: { url?: string };
+  high?: { url?: string };
 }
 
 interface VideoResource {
@@ -801,7 +1098,7 @@ interface PlaylistResource {
 
 interface PlaylistItemResource {
   id?: string;
-  snippet?: { title?: string };
+  snippet?: PlaylistItemSnippet;
   contentDetails?: { videoId?: string };
 }
 
@@ -827,6 +1124,49 @@ interface CaptionResource {
     isDraft?: boolean;
     status?: string;
     lastUpdated?: string;
+  };
+}
+
+interface ActivityResource {
+  id?: string;
+  snippet?: { type?: string; title?: string; description?: string; publishedAt?: string; thumbnails?: ThumbnailSet };
+  contentDetails?: {
+    upload?: { videoId?: string };
+    playlistItem?: { resourceId?: { videoId?: string } };
+    like?: { resourceId?: { videoId?: string } };
+  };
+}
+
+interface I18nLanguageResource {
+  id?: string;
+  snippet?: { hl?: string; name?: string };
+}
+
+interface I18nRegionResource {
+  id?: string;
+  snippet?: { gl?: string; name?: string };
+}
+
+interface VideoRatingResource {
+  videoId?: string;
+  rating?: string;
+}
+
+function normalizeActivity(item: ActivityResource) {
+  const snippet = item.snippet;
+  const details = item.contentDetails;
+  return {
+    activityId: item.id ?? "",
+    type: snippet?.type ?? "",
+    title: snippet?.title ?? "",
+    description: snippet?.description ?? "",
+    publishedAt: snippet?.publishedAt ?? "",
+    thumbnail: snippet?.thumbnails?.medium?.url ?? snippet?.thumbnails?.default?.url ?? "",
+    videoId:
+      details?.upload?.videoId ??
+      details?.playlistItem?.resourceId?.videoId ??
+      details?.like?.resourceId?.videoId ??
+      "",
   };
 }
 

--- a/src/apps/youtube/ravi.app.json
+++ b/src/apps/youtube/ravi.app.json
@@ -229,6 +229,96 @@
       "command": "ravi yt playlist-remove --json {args}",
       "mutating": true,
       "permission": "youtube:playlists:delete"
+    },
+    "youtube.activities": {
+      "interface": "cli",
+      "command": "ravi yt activities --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.i18n-languages": {
+      "interface": "cli",
+      "command": "ravi yt i18n-languages --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.i18n-regions": {
+      "interface": "cli",
+      "command": "ravi yt i18n-regions --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.video-rating": {
+      "interface": "cli",
+      "command": "ravi yt video-rating --json {args}",
+      "mutating": false,
+      "permission": "youtube:read"
+    },
+    "youtube.channel-update": {
+      "interface": "cli",
+      "command": "ravi yt channel-update --json {args}",
+      "mutating": true,
+      "permission": "youtube:channels:write"
+    },
+    "youtube.playlist-update": {
+      "interface": "cli",
+      "command": "ravi yt playlist-update --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:write"
+    },
+    "youtube.playlist-move": {
+      "interface": "cli",
+      "command": "ravi yt playlist-move --json {args}",
+      "mutating": true,
+      "permission": "youtube:playlists:write"
+    },
+    "youtube.comment": {
+      "interface": "cli",
+      "command": "ravi yt comment --json {args}",
+      "mutating": true,
+      "permission": "youtube:comments:write"
+    },
+    "youtube.comment-moderate": {
+      "interface": "cli",
+      "command": "ravi yt comment-moderate --json {args}",
+      "mutating": true,
+      "permission": "youtube:comments:write"
+    },
+    "youtube.comment-update": {
+      "interface": "cli",
+      "command": "ravi yt comment-update --json {args}",
+      "mutating": true,
+      "permission": "youtube:comments:write"
+    },
+    "youtube.comment-delete": {
+      "interface": "cli",
+      "command": "ravi yt comment-delete --json {args}",
+      "mutating": true,
+      "permission": "youtube:comments:delete"
+    },
+    "youtube.subscribe": {
+      "interface": "cli",
+      "command": "ravi yt subscribe --json {args}",
+      "mutating": true,
+      "permission": "youtube:subscriptions:write"
+    },
+    "youtube.unsubscribe": {
+      "interface": "cli",
+      "command": "ravi yt unsubscribe --json {args}",
+      "mutating": true,
+      "permission": "youtube:subscriptions:delete"
+    },
+    "youtube.caption-delete": {
+      "interface": "cli",
+      "command": "ravi yt caption-delete --json {args}",
+      "mutating": true,
+      "permission": "youtube:captions:delete"
+    },
+    "youtube.thumbnail-set": {
+      "interface": "cli",
+      "command": "ravi yt thumbnail-set --json {args}",
+      "mutating": true,
+      "permission": "youtube:videos:write"
     }
   },
   "permissions": {
@@ -236,10 +326,15 @@
     "optional": ["youtube:read", "youtube:analytics:read", "youtube:captions:read"],
     "mutating": [
       "youtube:comments:write",
+      "youtube:comments:delete",
       "youtube:videos:write",
       "youtube:videos:delete",
       "youtube:playlists:write",
-      "youtube:playlists:delete"
+      "youtube:playlists:delete",
+      "youtube:channels:write",
+      "youtube:subscriptions:write",
+      "youtube:subscriptions:delete",
+      "youtube:captions:delete"
     ]
   },
   "operationClasses": {
@@ -257,7 +352,11 @@
       "youtube.subscriptions",
       "youtube.captions",
       "youtube.caption-download",
-      "youtube.video-categories"
+      "youtube.video-categories",
+      "youtube.activities",
+      "youtube.i18n-languages",
+      "youtube.i18n-regions",
+      "youtube.video-rating"
     ],
     "analyticsRead": [
       "youtube.analytics-overview",
@@ -268,8 +367,28 @@
       "youtube.analytics-countries",
       "youtube.analytics-devices"
     ],
-    "write": ["youtube.reply", "youtube.video-update", "youtube.playlist-create", "youtube.playlist-add"],
-    "destructive": ["youtube.video-delete", "youtube.playlist-delete", "youtube.playlist-remove"],
+    "write": [
+      "youtube.reply",
+      "youtube.video-update",
+      "youtube.playlist-create",
+      "youtube.playlist-add",
+      "youtube.channel-update",
+      "youtube.playlist-update",
+      "youtube.playlist-move",
+      "youtube.comment",
+      "youtube.comment-moderate",
+      "youtube.comment-update",
+      "youtube.subscribe",
+      "youtube.thumbnail-set"
+    ],
+    "destructive": [
+      "youtube.video-delete",
+      "youtube.playlist-delete",
+      "youtube.playlist-remove",
+      "youtube.comment-delete",
+      "youtube.unsubscribe",
+      "youtube.caption-delete"
+    ],
     "financial": []
   },
   "storage": {

--- a/src/cli/commands/youtube.test.ts
+++ b/src/cli/commands/youtube.test.ts
@@ -20,7 +20,7 @@ describe("YouTubeCommands contract", () => {
     const access = getCommandAccessMetadata(YouTubeCommands);
 
     expect(getGroupMetadata(YouTubeCommands)).toMatchObject({ name: "yt", scope: "open" });
-    expect(commands).toHaveLength(28);
+    expect(commands).toHaveLength(43);
     expect(returns.size).toBe(commands.length);
     expect(access.size).toBe(commands.length);
 
@@ -40,21 +40,52 @@ describe("YouTubeCommands contract", () => {
   it("classifies writes and destructive commands with confirmation", () => {
     const byMethod = getCommandAccessMetadata(YouTubeCommands);
 
-    for (const method of ["reply", "videoUpdate", "playlistCreate", "playlistAdd"]) {
+    for (const method of [
+      "reply",
+      "videoUpdate",
+      "playlistCreate",
+      "playlistAdd",
+      "channelUpdate",
+      "playlistUpdate",
+      "playlistMove",
+      "comment",
+      "commentModerate",
+      "commentUpdate",
+      "subscribe",
+      "thumbnailSet",
+    ]) {
       expect(byMethod.get(method)).toMatchObject({
         kind: "mutate",
         risk: "high",
         requiresConfirmation: true,
       });
     }
-    for (const method of ["videoDelete", "playlistDelete", "playlistRemove"]) {
+    for (const method of [
+      "videoDelete",
+      "playlistDelete",
+      "playlistRemove",
+      "commentDelete",
+      "unsubscribe",
+      "captionDelete",
+    ]) {
       expect(byMethod.get(method)).toMatchObject({
         kind: "mutate",
         risk: "destructive",
         requiresConfirmation: true,
       });
     }
-    for (const method of ["health", "info", "videos", "comments", "captions", "analyticsOverview"]) {
+    for (const method of [
+      "health",
+      "info",
+      "videos",
+      "comments",
+      "captions",
+      "analyticsOverview",
+      "activities",
+      "i18nLanguages",
+      "i18nRegions",
+      "videoRating",
+    ]) {
       expect(byMethod.get(method)?.kind).toBe("read");
     }
   });

--- a/src/cli/commands/youtube.test.ts
+++ b/src/cli/commands/youtube.test.ts
@@ -8,6 +8,7 @@ import {
   getOptionsMetadata,
   getReturnsMetadata,
 } from "../decorators.js";
+import { runWithContext } from "../context.js";
 import { YouTubeCommands } from "./youtube.js";
 
 afterEach(() => mock.restore());
@@ -137,12 +138,13 @@ describe("YouTubeCommands contract", () => {
     const commands = new YouTubeCommands(() => client);
     spyOn(console, "log").mockImplementation(() => {});
 
-    await expect(commands.commentModerate("c1", "published", true, "brand", true)).rejects.toThrow(
-      "--ban-author is only valid with --status rejected",
-    );
+    const ctx = { sessionKey: "yt-test", sessionName: "yt-test", agentId: "ravi-dev" };
+    await expect(
+      runWithContext(ctx, () => commands.commentModerate("c1", "published", true, "brand", true)),
+    ).rejects.toThrow("--ban-author is only valid with --status rejected");
     expect(setCommentModeration).not.toHaveBeenCalled();
 
-    await commands.commentModerate("c1", "rejected", true, "brand", true);
+    await runWithContext(ctx, () => commands.commentModerate("c1", "rejected", true, "brand", true));
     expect(setCommentModeration).toHaveBeenCalledWith("c1", "rejected", true);
   });
 

--- a/src/cli/commands/youtube.test.ts
+++ b/src/cli/commands/youtube.test.ts
@@ -131,6 +131,21 @@ describe("YouTubeCommands contract", () => {
     expect(getReturnsMetadata(YouTubeCommands).get("reply")?.safeParse(result).success).toBe(true);
   });
 
+  it("rejects --ban-author unless the target status is rejected", async () => {
+    const setCommentModeration = mock(async () => ({ success: true as const, commentId: "c1", status: "rejected" }));
+    const client = { setCommentModeration } as unknown as YouTubeClient;
+    const commands = new YouTubeCommands(() => client);
+    spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(commands.commentModerate("c1", "published", true, "brand", true)).rejects.toThrow(
+      "--ban-author is only valid with --status rejected",
+    );
+    expect(setCommentModeration).not.toHaveBeenCalled();
+
+    await commands.commentModerate("c1", "rejected", true, "brand", true);
+    expect(setCommentModeration).toHaveBeenCalledWith("c1", "rejected", true);
+  });
+
   it("declares safe and bounded defaults in command metadata", () => {
     const instance = new YouTubeCommands();
     const optionsFor = (method: string) => getOptionsMetadata(instance, method);

--- a/src/cli/commands/youtube.ts
+++ b/src/cli/commands/youtube.ts
@@ -1591,6 +1591,8 @@ export class YouTubeCommands {
   ) {
     return this.execute(asJson, () => {
       if (!status) fail("Provide --status (heldForReview|published|rejected).");
+      if (banAuthor && status !== "rejected")
+        fail("--ban-author is only valid with --status rejected (YouTube bans authors only on rejection).");
       return this.client(connection).setCommentModeration(commentId, status!, banAuthor);
     });
   }

--- a/src/cli/commands/youtube.ts
+++ b/src/cli/commands/youtube.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 import { YouTubeClient } from "../../apps/youtube/client.js";
 import { fail } from "../context.js";
@@ -307,6 +308,72 @@ const playlistAddReturnSchema = z
   })
   .strict();
 const playlistRemoveReturnSchema = z.object({ success: successSchema, removed: z.string() }).strict();
+const activitiesReturnSchema = z
+  .object({
+    success: successSchema,
+    activities: z.array(
+      z
+        .object({
+          activityId: z.string(),
+          type: z.string(),
+          title: z.string(),
+          description: z.string(),
+          publishedAt: z.string(),
+          thumbnail: z.string(),
+          videoId: z.string(),
+        })
+        .strict(),
+    ),
+    totalResults: z.number(),
+    nextPageToken: pageTokenSchema,
+  })
+  .strict();
+const i18nLanguagesReturnSchema = z
+  .object({
+    success: successSchema,
+    languages: z.array(z.object({ code: z.string(), name: z.string() }).strict()),
+    totalResults: z.number(),
+  })
+  .strict();
+const i18nRegionsReturnSchema = z
+  .object({
+    success: successSchema,
+    regions: z.array(z.object({ code: z.string(), name: z.string() }).strict()),
+    totalResults: z.number(),
+  })
+  .strict();
+const videoRatingReturnSchema = z
+  .object({
+    success: successSchema,
+    ratings: z.array(z.object({ videoId: z.string(), rating: z.string() }).strict()),
+    totalResults: z.number(),
+  })
+  .strict();
+const channelUpdateReturnSchema = z.object({ success: successSchema, channel: channelSchema }).strict();
+const playlistUpdateReturnSchema = z.object({ success: successSchema, playlist: playlistSchema }).strict();
+const playlistMoveReturnSchema = z
+  .object({
+    success: successSchema,
+    item: z
+      .object({ playlistItemId: z.string(), playlistId: z.string(), videoId: z.string(), position: z.number() })
+      .strict(),
+  })
+  .strict();
+const commentInsertReturnSchema = z
+  .object({ success: successSchema, threadId: z.string(), commentId: z.string() })
+  .strict();
+const commentModerateReturnSchema = z
+  .object({ success: successSchema, commentId: z.string(), moderationStatus: z.string() })
+  .strict();
+const commentUpdateReturnSchema = z
+  .object({ success: successSchema, commentId: z.string(), text: z.string() })
+  .strict();
+const subscribeReturnSchema = z
+  .object({ success: successSchema, subscriptionId: z.string(), channelId: z.string() })
+  .strict();
+const thumbnailSetReturnSchema = z
+  .object({ success: successSchema, videoId: z.string(), thumbnail: z.string() })
+  .strict();
 
 type YouTubeClientFactory = (connection?: string) => YouTubeClient;
 
@@ -1220,6 +1287,505 @@ export class YouTubeCommands {
     return this.execute(asJson, () => this.client(connection).removeFromPlaylist(playlistItemId));
   }
 
+  @Command({
+    name: "activities",
+    description: "List the recent activity feed of the authenticated channel",
+    helpAfter: readHelp(
+      "See a chronological feed of what the channel did (uploads, likes, playlist changes) with the related video ID.",
+      "For only the channel's own uploads, use `ravi yt videos`; for period metrics use an `analytics-*` command.",
+      ["ravi yt activities --limit 25 --json", "ravi yt activities --page <nextPageToken> --json"],
+      "YouTube Data API v3 activities.list (mine=true).",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.activities", action: "list", risk: "low" })
+  @Returns(activitiesReturnSchema)
+  async activities(
+    @Option({
+      flags: "-l, --limit <n>",
+      description: "Page size, 1-50 (default: 25)",
+      defaultValue: "25",
+      schema: integerString(1, 50),
+    })
+    limit?: string,
+    @Option({ flags: "-p, --page <token>", description: "Provider page token from nextPageToken" }) page?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listActivities({ maxResults: integer(limit, 25, 1, 50), pageToken: page })),
+    }));
+  }
+
+  @Command({
+    name: "i18n-languages",
+    description: "List the application languages YouTube supports",
+    helpAfter: readHelp(
+      "Discover a valid language code before setting a caption language or a video defaultLanguage.",
+      "For content regions (countries), use `ravi yt i18n-regions`.",
+      ["ravi yt i18n-languages --json", "ravi yt i18n-languages --hl en --json"],
+      "YouTube Data API v3 i18nLanguages.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.i18n", action: "languages", risk: "low" })
+  @Returns(i18nLanguagesReturnSchema)
+  async i18nLanguages(
+    @Option({
+      flags: "--hl <code>",
+      description: "Language for the returned names (default: pt-BR)",
+      defaultValue: "pt-BR",
+    })
+    hl?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listI18nLanguages({ hl })),
+    }));
+  }
+
+  @Command({
+    name: "i18n-regions",
+    description: "List the content regions (countries) YouTube supports",
+    helpAfter: readHelp(
+      "Discover a valid region code before requesting region-scoped resources like video categories.",
+      "For UI/caption languages, use `ravi yt i18n-languages`.",
+      ["ravi yt i18n-regions --json", "ravi yt i18n-regions --hl en --json"],
+      "YouTube Data API v3 i18nRegions.list.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.i18n", action: "regions", risk: "low" })
+  @Returns(i18nRegionsReturnSchema)
+  async i18nRegions(
+    @Option({
+      flags: "--hl <code>",
+      description: "Language for the returned names (default: pt-BR)",
+      defaultValue: "pt-BR",
+    })
+    hl?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => ({
+      success: true as const,
+      ...(await this.client(connection).listI18nRegions({ hl })),
+    }));
+  }
+
+  @Command({
+    name: "video-rating",
+    description: "Get the authenticated channel's like/dislike rating for one or more videos",
+    helpAfter: readHelp(
+      "Check whether this channel has rated (liked/disliked) specific videos.",
+      "For public like counts, use `ravi yt video`; this returns only the caller's own rating.",
+      ["ravi yt video-rating dQw4w9WgXcQ --json", "ravi yt video-rating id1,id2,id3 --json"],
+      "YouTube Data API v3 videos.getRating.",
+    ),
+  })
+  @CommandAccess({ kind: "read", resource: "youtube.videos", action: "get-rating", risk: "low" })
+  @Returns(videoRatingReturnSchema)
+  async videoRating(
+    @Arg("ids", { description: "One video ID or a comma-separated list", schema: z.string().min(1) }) ids: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, async () => {
+      const videoIds = csv(ids) ?? [];
+      if (videoIds.length === 0) fail("Provide at least one video ID.");
+      return { success: true as const, ...(await this.client(connection).getVideoRating(videoIds)) };
+    });
+  }
+
+  @Command({
+    name: "channel-update",
+    description: "Update branding metadata (description, keywords, country) of the authenticated channel",
+    helpAfter: mutationHelp(
+      "Update only supplied channel branding fields after reviewing the current channel description.",
+      "Channel title is not editable via the API; do not use to rename the channel.",
+      [
+        'ravi yt channel-update --description "Approved channel description" --json',
+        'ravi yt channel-update --keywords "embalagem, marmita" --json',
+      ],
+      "YouTube Data API v3 channels.list then channels.update (brandingSettings).",
+      "EXTERNAL WRITE: show the current channel branding and every proposed field, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.channels",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["description", "keywords", "country", "language", "connection"],
+  })
+  @Returns(channelUpdateReturnSchema)
+  async channelUpdate(
+    @Option({ flags: "--description <text>", description: "Replacement channel description" }) description?: string,
+    @Option({ flags: "--keywords <text>", description: "Replacement space-separated channel keywords" })
+    keywords?: string,
+    @Option({ flags: "--country <code>", description: "ISO 3166-1 alpha-2 channel country" }) country?: string,
+    @Option({ flags: "--language <code>", description: "Default channel language (e.g. pt-BR)" }) language?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () =>
+      this.client(connection).updateChannel({ description, keywords, country, defaultLanguage: language }),
+    );
+  }
+
+  @Command({
+    name: "playlist-update",
+    description: "Update the title, description or privacy of an owned playlist",
+    helpAfter: mutationHelp(
+      "Update only supplied playlist fields after reviewing the current playlist.",
+      "To reorder items, use `playlist-move`; to delete the playlist, use `playlist-delete`.",
+      [
+        'ravi yt playlist-update <playlistId> --title "Approved title" --json',
+        "ravi yt playlist-update <playlistId> --privacy private --json",
+      ],
+      "YouTube Data API v3 playlists.list then playlists.update.",
+      "EXTERNAL WRITE: show playlist ID, current metadata and every proposed field, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["playlistId", "title", "description", "privacy", "connection"],
+  })
+  @Returns(playlistUpdateReturnSchema)
+  async playlistUpdate(
+    @Arg("playlistId", { description: "Owned YouTube playlist ID", schema: z.string().min(1) }) playlistId: string,
+    @Option({ flags: "--title <text>", description: "Replacement title" }) title?: string,
+    @Option({ flags: "--description <text>", description: "Replacement description" }) description?: string,
+    @Option({
+      flags: "--privacy <status>",
+      description: "public|private|unlisted",
+      schema: z.enum(["public", "private", "unlisted"]),
+    })
+    privacyStatus?: "public" | "private" | "unlisted",
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () =>
+      this.client(connection).updatePlaylist(playlistId, { title, description, privacyStatus }),
+    );
+  }
+
+  @Command({
+    name: "playlist-move",
+    description: "Move a playlist item to a new zero-based position",
+    helpAfter: mutationHelp(
+      "Reorder one reviewed playlist item using playlistItemId from `ravi yt playlist`.",
+      "Never pass videoId; a video can appear more than once with distinct item IDs.",
+      ["ravi yt playlist <playlistId> --json", "ravi yt playlist-move <playlistItemId> --position 0 --json"],
+      "YouTube Data API v3 playlistItems.list then playlistItems.update.",
+      "CURATION CHANGE: show playlistItemId, current and target position, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.playlists",
+    action: "move",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["playlistItemId", "position", "connection"],
+  })
+  @Returns(playlistMoveReturnSchema)
+  async playlistMove(
+    @Arg("playlistItemId", { description: "Playlist item ID, not video ID", schema: z.string().min(1) })
+    playlistItemId: string,
+    @Option({
+      flags: "--position <n>",
+      description: "Zero-based target position (0-5000)",
+      schema: integerString(0, 5000),
+    })
+    position?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () =>
+      this.client(connection).movePlaylistItem(playlistItemId, integer(position, 0, 0, 5000)),
+    );
+  }
+
+  @Command({
+    name: "comment",
+    description: "Post a new top-level comment on a video",
+    helpAfter: mutationHelp(
+      "Publish one reviewed top-level comment on a video.",
+      "To answer an existing comment, use `reply`; this creates a new thread, not a reply.",
+      ['ravi yt comment <videoId> --text "Approved public comment" --json'],
+      "YouTube Data API v3 commentThreads.insert.",
+      "PUBLIC WRITE: show the target video and the exact comment text, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.comments",
+    action: "insert",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["videoId", "text", "connection"],
+  })
+  @Returns(commentInsertReturnSchema)
+  async comment(
+    @Arg("videoId", { description: "YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({ flags: "--text <text>", description: "Comment text", schema: z.string().min(1) }) text?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => {
+      if (!text) fail("Provide --text with the comment content.");
+      return this.client(connection).insertComment(videoId, text!);
+    });
+  }
+
+  @Command({
+    name: "comment-moderate",
+    description: "Set the moderation status of a comment (hold, publish or reject)",
+    helpAfter: mutationHelp(
+      "Moderate one reviewed comment; obtain the commentId from `ravi yt comments`.",
+      "Rejecting is not deletion; to remove a comment permanently use `comment-delete`.",
+      [
+        "ravi yt comment-moderate <commentId> --status rejected --json",
+        "ravi yt comment-moderate <commentId> --status published --json",
+      ],
+      "YouTube Data API v3 comments.setModerationStatus.",
+      "MODERATION WRITE: show the comment text and target status, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.comments",
+    action: "moderate",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["commentId", "status", "banAuthor", "connection"],
+  })
+  @Returns(commentModerateReturnSchema)
+  async commentModerate(
+    @Arg("commentId", { description: "YouTube comment ID", schema: z.string().min(1) }) commentId: string,
+    @Option({
+      flags: "--status <status>",
+      description: "heldForReview|published|rejected",
+      schema: z.enum(["heldForReview", "published", "rejected"]),
+    })
+    status?: "heldForReview" | "published" | "rejected",
+    @Option({ flags: "--ban-author", description: "Also ban the comment author (only with rejected)" })
+    banAuthor?: boolean,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => {
+      if (!status) fail("Provide --status (heldForReview|published|rejected).");
+      return this.client(connection).setCommentModeration(commentId, status!, banAuthor);
+    });
+  }
+
+  @Command({
+    name: "comment-update",
+    description: "Edit the text of a comment owned by the authenticated channel",
+    helpAfter: mutationHelp(
+      "Edit one reviewed comment that this channel authored.",
+      "You can only edit your own comments; to change another user's comment use `comment-moderate`.",
+      ['ravi yt comment-update <commentId> --text "Approved edited text" --json'],
+      "YouTube Data API v3 comments.update.",
+      "PUBLIC WRITE: show the current and proposed text, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.comments",
+    action: "update",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["commentId", "text", "connection"],
+  })
+  @Returns(commentUpdateReturnSchema)
+  async commentUpdate(
+    @Arg("commentId", { description: "YouTube comment ID", schema: z.string().min(1) }) commentId: string,
+    @Option({ flags: "--text <text>", description: "Replacement comment text", schema: z.string().min(1) })
+    text?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => {
+      if (!text) fail("Provide --text with the replacement content.");
+      return this.client(connection).updateComment(commentId, text!);
+    });
+  }
+
+  @Command({
+    name: "comment-delete",
+    description: "Permanently delete a comment",
+    helpAfter: mutationHelp(
+      "Delete only after independently reading the comment and obtaining literal approval.",
+      "To hide a comment reversibly, use `comment-moderate --status rejected` instead.",
+      ["ravi yt comments <videoId> --json", "ravi yt comment-delete <commentId> --json"],
+      "YouTube Data API v3 comments.delete.",
+      "IRREVERSIBLE: show the comment ID and text, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.comments",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["commentId", "connection"],
+  })
+  @Returns(deleteReturnSchema)
+  async commentDelete(
+    @Arg("commentId", { description: "YouTube comment ID", schema: z.string().min(1) }) commentId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).deleteComment(commentId));
+  }
+
+  @Command({
+    name: "subscribe",
+    description: "Subscribe the authenticated channel to another channel",
+    helpAfter: mutationHelp(
+      "Subscribe to one reviewed channel by channel ID.",
+      "Never retry blindly; the API rejects duplicate subscriptions.",
+      ["ravi yt subscribe UCXXXXXXXXXXXXXXXXXXXXXX --json"],
+      "YouTube Data API v3 subscriptions.insert.",
+      "EXTERNAL WRITE: show the target channel ID and name, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.subscriptions",
+    action: "insert",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["channelId", "connection"],
+  })
+  @Returns(subscribeReturnSchema)
+  async subscribe(
+    @Arg("channelId", { description: "Target YouTube channel ID", schema: z.string().min(1) }) channelId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).subscribe(channelId));
+  }
+
+  @Command({
+    name: "unsubscribe",
+    description: "Remove one of the authenticated channel's subscriptions",
+    helpAfter: mutationHelp(
+      "Unsubscribe using the subscriptionId from `ravi yt subscriptions`.",
+      "Never pass a channelId; this command needs the subscriptionId, not the channel ID.",
+      ["ravi yt subscriptions --json", "ravi yt unsubscribe <subscriptionId> --json"],
+      "YouTube Data API v3 subscriptions.delete.",
+      "EXTERNAL WRITE: show the subscription and its channel, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.subscriptions",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["subscriptionId", "connection"],
+  })
+  @Returns(deleteReturnSchema)
+  async unsubscribe(
+    @Arg("subscriptionId", { description: "Subscription ID, not channel ID", schema: z.string().min(1) })
+    subscriptionId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).unsubscribe(subscriptionId));
+  }
+
+  @Command({
+    name: "caption-delete",
+    description: "Permanently delete a caption track from a video",
+    helpAfter: mutationHelp(
+      "Delete only after independently listing captions and obtaining literal approval.",
+      "To read a caption before deciding, use `caption-download`; obtain the captionId from `captions`.",
+      ["ravi yt captions <videoId> --json", "ravi yt caption-delete <captionId> --json"],
+      "YouTube Data API v3 captions.delete.",
+      "IRREVERSIBLE: show the caption language/name and its video, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.captions",
+    action: "delete",
+    risk: "destructive",
+    requiresConfirmation: true,
+    input: ["captionId", "connection"],
+  })
+  @Returns(deleteReturnSchema)
+  async captionDelete(
+    @Arg("captionId", { description: "YouTube caption track ID", schema: z.string().min(1) }) captionId: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => this.client(connection).deleteCaption(captionId));
+  }
+
+  @Command({
+    name: "thumbnail-set",
+    description: "Upload and set a custom thumbnail image for an owned video",
+    helpAfter: mutationHelp(
+      "Set one reviewed local image (JPEG/PNG, <2MB) as a video's custom thumbnail.",
+      "Custom thumbnails require an enabled/verified channel; this replaces the current thumbnail.",
+      ["ravi yt thumbnail-set <videoId> --file ./thumb.jpg --json"],
+      "YouTube Data API v3 thumbnails.set (media upload).",
+      "EXTERNAL WRITE: show the video ID/title and the image path, then obtain explicit confirmation.",
+    ),
+  })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "youtube.videos",
+    action: "set-thumbnail",
+    risk: "high",
+    requiresConfirmation: true,
+    input: ["videoId", "file", "connection"],
+  })
+  @Returns(thumbnailSetReturnSchema)
+  async thumbnailSet(
+    @Arg("videoId", { description: "Owned YouTube video ID", schema: z.string().min(1) }) videoId: string,
+    @Option({ flags: "--file <path>", description: "Local JPEG/PNG image path", schema: z.string().min(1) })
+    file?: string,
+    @Option({ flags: "--connection <id>", description: "Credential connection (default: default)" })
+    connection?: string,
+    @Option({ flags: "--json", description: "Print the stable JSON response" }) asJson?: boolean,
+  ) {
+    return this.execute(asJson, () => {
+      if (!file) fail("Provide --file with a local JPEG/PNG image path.");
+      let data: Uint8Array;
+      try {
+        data = readFileSync(file!);
+      } catch {
+        return fail(`Cannot read image file: ${file}.`);
+      }
+      return this.client(connection).setThumbnail(videoId, { data, contentType: imageContentType(file!) });
+    });
+  }
+
   private client(connection?: string) {
     return this.clientFactory(connection);
   }
@@ -1242,6 +1808,13 @@ function integer(value: string | undefined, fallback: number, min: number, max: 
     fail(`Expected an integer from ${min} to ${max}.`);
   }
   return parsed;
+}
+
+function imageContentType(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  return fail("Unsupported image type; use a .jpg, .jpeg or .png file.");
 }
 
 function csv(value?: string): string[] | undefined {


### PR DESCRIPTION
## Objective

Give agents a complete, typed, gated `ravi yt` surface over the YouTube Data API v3 so channel operation (playlists, moderation, captions, thumbnails, i18n, ratings, analytics) happens through the native CLI contract instead of raw API calls.

## Problem

The native YouTube app covered only a subset of Data API v3. Gold-standard endpoints an agent needs to actually run a channel were missing, forcing fallback to raw API calls with no typed contract, no `--json`, and none of the REBAC/confirmation gating the rest of the CLI provides. The `comment-moderate` command also accepted `--ban-author` with any status, but YouTube only bans authors on rejection, so the flag was a silent no-op elsewhere.

## Solution

Fill 15 gold-standard Data API v3 endpoints as first-class `ravi yt` commands — each with `@Returns` typed schemas, `@CommandAccess` classification (read / mutate / destructive + confirmation), gold-standard `--help`, and `--json`. Regenerate `@ravi-os/sdk` from the registry so the typed surface stays in sync. Add a fail-fast guard so `--ban-author` requires `--status rejected`.

## Practical impact

Agents can now manage playlist items, moderate comments, manage captions, set thumbnails, resolve i18n languages/regions, read/set video ratings, and pull richer analytics through typed `ravi yt` commands with `--json` output and confirmation gating on writes — no raw API calls needed. Passing `--ban-author` without `--status rejected` now errors with an actionable message instead of silently doing nothing.

## What does NOT change

No existing command signature or return shape changes — every new endpoint is additive. The only behavior change to a pre-existing surface is `comment-moderate`: `--ban-author` now errors unless `--status rejected` (it was previously accepted and silently ignored). No DB schema migration; the large SDK diff is fully generated from the registry, not hand-edited.

## Validation

- `bun test src/apps/youtube/ src/cli/commands/youtube.test.ts` → 32 pass / 0 fail (573 expect calls).
- `bun run typecheck` → clean. `bunx biome check` → clean. `bun run sdk:check` → SDK artifacts current.
- Code review (task-85a63fa5): APPROVE, 0 blocker / 0 major / 0 security. The one minor (banAuthor guard) is addressed in commit 2cc4084 with a focused test.
- Local `bun run test`: the first curated segment (`src/bash/ src/router/ src/permissions/ src/triggers/ src/omni/ src/adapters/ ...`) shows ~38 pre-existing 5s-timeout failures when run together against a live local daemon (DB/NATS contention). Each file passes in isolation, none import youtube, and this branch touches only `src/cli/commands/` + `src/apps/youtube/` (green segment). CI in a clean env is the authoritative gate.

## Risks

Low. Additive endpoints only, new commands gated with confirmation on mutate/destructive. The single pre-existing-surface change (banAuthor guard) tightens an input that was previously silently ignored, so it cannot break a working flow.

## Rollback

Revert commits `2cc4084` + `d144c16`; the regenerated SDK reverts with them. No schema migration involved.
