### PR TITLE
Add canonical turn provenance and reaction policies

### DIFF
--- a/.ravi/specs/cron/CHECKS.md
+++ b/.ravi/specs/cron/CHECKS.md
@@ -19,3 +19,9 @@ ravi doctor --json | jq '.checks[] | select(.id == "cron.targets")'
 - Findings MUST use stable ids (`cron.agent_missing`, `cron.reply_session_missing`, `cron.routing_derived_key`, `cron.routing_unresolved`). The check fails if an unexpected id appears.
 - Evidence MUST be bounded (max 20 findings). The check fails if the findings array exceeds the cap.
 - Fix hints MUST be safe read-only commands. The check fails if a fix hint suggests a destructive mutation.
+
+## Cron Creation MUST Be Durably Idempotent
+
+- Repeating `cron add` with the same explicit idempotency key and the same normalized input MUST return the original target with `changedCount=0`.
+- Reusing an explicit key for different input MUST fail.
+- Replaying the same observer rule/source-turn/action after a one-shot target was deleted MUST NOT recreate the cron.

--- a/.ravi/specs/cron/SPEC.md
+++ b/.ravi/specs/cron/SPEC.md
@@ -35,3 +35,6 @@ target resolution, and operational inspection.
 - Cron jobs MUST NOT mutate routing, sessions, agents, or channel state.
 - Shell jobs and agent jobs are distinct execution modes with different target semantics.
 - Target resolution MUST be read-only and computed at inspection time.
+- `cron add --idempotency-key <key>` MUST create at most one normalized action for that key and MUST reject reuse with different action content.
+- Cron creation from an observer turn with source turn ids MUST automatically derive durable idempotency from `(ruleId, sourceTurnIds, cron.add, action fingerprint)`.
+- Reaction idempotency MUST survive deletion of the target cron, including `--delete-after` one-shots, so replaying the source observation cannot recreate it.

--- a/.ravi/specs/runtime/SPEC.md
+++ b/.ravi/specs/runtime/SPEC.md
@@ -51,6 +51,7 @@ The runtime abstraction exists so new execution engines can be added without cop
 - `RuntimeHostStreamingSession`: host-side live state for one session process/stream.
 - `RuntimeSessionContinuity`: resume, fork, rebase, and replay planning from Ravi-owned prompt atoms and provider state.
 - `RuntimeEvent`: canonical event stream consumed by the Ravi host event loop.
+- `TurnProvenance`: canonical cause of the effective turn, independent from actor authority and reply surface.
 - `RuntimeEventLoop`: canonical event consumer that emits NATS events, traces, tool events, responses, cost/tokens, and provider state.
 - `CloudTraceExport`: optional exporter that mirrors selected local runtime traces to a linked remote control plane without making remote storage required for local execution.
 
@@ -79,11 +80,14 @@ The runtime abstraction exists so new execution engines can be added without cop
 - Runtime pool backpressure MUST be represented as its own dispatch state. A session waiting for a pool slot MUST NOT be reported as an in-flight cold start until a slot has actually been reserved.
 - Dispatch trace rows MUST use the canonical `session_key` when a session row exists. `session_name` MAY be included as a secondary lookup field, but MUST NOT replace the canonical key.
 - Cloud trace export MUST be asynchronous and best-effort by default. A failed export MUST NOT fail, block, or delay local runtime execution.
-- Background starts such as task and observation sessions MUST NOT be able to consume all runtime start capacity when interactive channel sessions are waiting. The dispatcher SHOULD reserve a small configurable capacity lane for interactive sessions.
+- Background starts such as cron, trigger, heartbeat, task, and observation turns MUST NOT be able to consume all runtime start capacity when interactive channel sessions are waiting. The dispatcher SHOULD reserve a small configurable capacity lane for interactive sessions.
 - Provider turns that stop emitting runtime events MUST be bounded by a host-side inactivity timeout. On timeout the event loop MUST record `session.timeout` plus a terminal `turn.failed` snapshot with status `timeout`, abort the provider process, preserve pending/current turn messages, and restart from the stashed queue when possible.
 - Stalled-turn recovery MUST be explicit and traceable. Silent clearing of `turnActive` or dropping queued messages is forbidden.
 - External compaction announcements (the user-facing "compacting"/"compacted" runtime responses) are user-facing runtime responses. They MUST NOT be emitted for automation-originated turns (cron, trigger, session followup, heartbeat, and other background automation). Human/channel turns MAY continue to emit them when `announceCompaction` is enabled and sentinel mode does not suppress them.
-- The origin decision for external compaction announcements MUST be centralized in a runtime-owned classifier over the turn effectively executing, not scattered prompt-marker checks in the event loop. The classifier reuses existing turn metadata (`_cron`, `_trigger`, `_sessionFollowup`, `_heartbeat`, `actorType=automation` with `automationId`, `identityProvenance.source`, and the `suppressPresence` routing hint; `suppressPresence` alone MUST NOT be the only signal).
+- Turn origin MUST be classified once per effective turn and snapshotted as `currentTurnProvenance`. `turn.origin` MUST describe the producer cause (`human`, `cron`, `trigger`, `session-followup`, `heartbeat`, `observer`, `task`, `daemon-restart`, and fallbacks), while actor authority and reply surface remain separate dimensions. A cron replying to a human chat is still a cron turn.
+- Pool admission, external compaction announcements, runtime trace/audit payloads, observer events, and trigger anti-loop checks MUST consume canonical turn provenance. Compatibility checks MAY remain for older event producers, but MUST NOT replace provenance.
+- `adapter.request`, `prompt.received`, and normalized runtime/tool events SHOULD expose the turn provenance snapshot. Observation events MUST retain their own snapshot so delayed/debounced batches do not inherit a later turn's cause.
+- Side-effecting reactions derived from observation events MUST use a durable action ledger keyed by rule, source turn, action type, and normalized action. Target deletion MUST NOT erase that idempotency record.
 - Internal compaction observability (runtime status, the `runtime.status` trace, live state, skill visibility reset, and logs) MUST be preserved for every origin even when the external announcement is suppressed. Suppressing announcements MUST NOT suppress final assistant responses from automations.
 - New providers MUST add provider contract tests, event normalization tests, and runtime capability matrix coverage before live use.
 

--- a/.ravi/specs/runtime/observation-plane/rules/SPEC.md
+++ b/.ravi/specs/runtime/observation-plane/rules/SPEC.md
@@ -95,6 +95,20 @@ Selectors MAY match:
 - route/chat/contact metadata when explicitly exposed;
 - tags attached to agents, sessions, tasks, projects, contacts, or profiles.
 
+Rules MAY also store a boolean `selector` predicate over three bounded roots:
+
+- `source.*`: durable source/session/chat descriptor fields;
+- `turn.*`: canonical `TurnProvenance`, including `turn.origin` and `turn.background`;
+- `event.*`: the individual observation event.
+
+Example:
+
+```text
+turn.background == "false" && source.agentId != "ravi-workflow-router"
+```
+
+Source-only predicates SHOULD be evaluated before binding creation. Predicates that reference `turn.*` or `event.*` MUST be deferred and evaluated for each event before delivery. Invalid observer predicates MUST fail closed and validation MUST report them. The legacy `metadata.sourceExclusions` object MAY be accepted as compatibility input, but new policy SHOULD use `selector`.
+
 A matched rule creates or reuses one observer binding. Binding creation MUST be idempotent.
 
 Matching MUST be deterministic. For the same source session metadata, rule set, and tag set, Ravi MUST produce the same observer set.
@@ -221,7 +235,9 @@ Rules MAY apply:
 - on project/profile metadata changes;
 - on operator replay.
 
-Existing observer bindings SHOULD survive rule edits unless the operator requests reconciliation. Reconciliation behavior MUST be explicit: `future-only`, `attach-missing`, `detach-disabled`, or `full-reconcile`.
+Existing observer bindings SHOULD survive rule edits unless the operator requests reconciliation. Reconciliation behavior MUST be explicit: `attach-missing`, `detach-disabled`, `refresh-profile`, or `full-reconcile`. Disabling an obsolete binding MUST preserve its observer history.
+
+Observation delivery MUST be durably idempotent per binding and event id. A retry after a publish failure MAY reclaim the event; a successful delivery MUST NOT be published twice for the same `(bindingId, eventId)` pair. Observer prompts SHOULD carry the unique source trace turn ids. Side-effecting reaction executors MUST use those ids with the rule id and normalized action for durable action idempotency.
 
 ## Invariants
 
@@ -251,17 +267,17 @@ The implementation SHOULD eventually expose:
 ```bash
 ravi observers rules list
 ravi observers rules show <id>
-ravi observers rules set <id> <observer-agent> [--provider <runtime>] [--model <model>] [--profile <observer-profile>]
+ravi observers rules set <id> <observer-agent> [--provider <runtime>] [--model <model>] [--profile <observer-profile>] [--selector <expression>]
 ravi observers rules enable <id>
 ravi observers rules disable <id>
 ravi observers rules validate
 ravi observers rules explain --session <session>
-ravi observers refresh <session>
+ravi observers refresh <session> [--reconcile attach-missing|detach-disabled|refresh-profile|full-reconcile]
 ```
 
 `explain` MUST show matched rules, unmatched rules, selected tags, created bindings, skipped bindings, and conflicts.
 
-`refresh` MUST apply the current rule set to an already-existing source session, creating missing bindings idempotently.
+`refresh` MUST apply the current rule set to an already-existing source session, creating missing bindings idempotently. Explicit reconciliation modes MUST also expose disabled bindings and refreshed profile snapshots.
 
 ## Acceptance Criteria
 

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -2356,6 +2356,7 @@ export class RaviClient {
       envFile?: string;
       every?: string;
       exec?: string;
+      idempotencyKey?: string;
       isolated?: boolean;
       message?: string;
       onError?: string;
@@ -3860,11 +3861,13 @@ export class RaviClient {
       }
     },
     /** Apply observer rules to an existing source session */
-    refresh: async (session: string): Promise<ObserversRefreshReturn> => {
+    refresh: async (session: string, options?: {
+      reconcile?: string;
+    }): Promise<ObserversRefreshReturn> => {
       return this.transport.call({
         groupSegments: ["observers"],
         command: "refresh",
-        body: { session },
+        body: { session, ...(options ?? {}) },
       });
     },
     rules: {
@@ -3925,6 +3928,7 @@ export class RaviClient {
         provider?: string;
         role?: string;
         scope?: string;
+        selector?: string;
         sourceAgent?: string;
         sourceProfile?: string;
         sourceProject?: string;

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -26252,6 +26252,10 @@ export const CronAddInputSchema = {
       "description": "Alias for --shell",
       "type": "string"
     },
+    "idempotencyKey": {
+      "description": "Durable create idempotency key",
+      "type": "string"
+    },
     "isolated": {
       "description": "Run in isolated session",
       "type": "boolean"
@@ -42345,6 +42349,10 @@ export const ObserversProfilesValidateReturnSchema = {
 export const ObserversRefreshInputSchema = {
   "additionalProperties": false,
   "properties": {
+    "reconcile": {
+      "description": "attach-missing|detach-disabled|refresh-profile|full-reconcile",
+      "type": "string"
+    },
     "session": {
       "description": "Source session name or key",
       "type": "string"
@@ -42713,6 +42721,10 @@ export const ObserversRulesSetInputSchema = {
     },
     "scope": {
       "description": "global|agent|session|task|profile|project|tag",
+      "type": "string"
+    },
+    "selector": {
+      "description": "Predicate over source.*, turn.* and event.*; use 'clear' to remove",
       "type": "string"
     },
     "sourceAgent": {

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -5216,6 +5216,7 @@ export type CronAddInput = {
   envFile?: string;
   every?: string;
   exec?: string;
+  idempotencyKey?: string;
   isolated?: boolean;
   message?: string;
   name: string;
@@ -8269,6 +8270,7 @@ export type ObserversProfilesValidateReturn = {
 
 /** Input shape for `observers.refresh`. */
 export type ObserversRefreshInput = {
+  reconcile?: string;
   session: string;
 };
 
@@ -8371,6 +8373,7 @@ export type ObserversRulesSetInput = {
   provider?: string;
   role?: string;
   scope?: string;
+  selector?: string;
   sourceAgent?: string;
   sourceProfile?: string;
   sourceProject?: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:265847c56e9f24844aaeea0fe0e022df122e9d3654cedd76e31da36ede108531";
+export const REGISTRY_HASH = "sha256:2ab4adf7588d6ed03844f0672cd4c420f1330fa60da1e2532e0aca498d16a18f";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "88e6c3bec6df";
+export const GIT_SHA = "599f41fa4e59";

--- a/src/cli/commands/cron-commands.test.ts
+++ b/src/cli/commands/cron-commands.test.ts
@@ -12,6 +12,8 @@ let cronJob: Record<string, unknown> | null = null;
 let cronJobs: Record<string, unknown>[] = [];
 let mockScopeContext: Record<string, unknown> | undefined;
 let mockScopeEnforced = false;
+let mockCliContext: Record<string, unknown> | undefined;
+let creationIdempotency: unknown;
 
 mock.module("../decorators.js", () => ({
   Group: () => () => {},
@@ -34,7 +36,7 @@ mock.module("../decorators.js", () => ({
 }));
 
 mock.module("../context.js", () => ({
-  getContext: () => undefined,
+  getContext: () => mockCliContext,
   fail: (message: string) => {
     throw new Error(message);
   },
@@ -107,7 +109,8 @@ mock.module("../../router/router-db.js", () => ({
 }));
 
 mock.module("../../cron/index.js", () => ({
-  dbCreateCronJob: (input: Record<string, unknown>) => {
+  createCronJobIdempotently: (input: Record<string, unknown>, idempotency?: unknown) => {
+    creationIdempotency = idempotency;
     cronJob = {
       id: "cron-created",
       enabled: true,
@@ -118,7 +121,7 @@ mock.module("../../cron/index.js", () => ({
       nextRunAt: 2,
       ...input,
     };
-    return cronJob;
+    return { created: true, targetId: "cron-created", job: cronJob };
   },
   dbGetCronJob: () => cronJob,
   dbListCronJobs: () => (cronJobs.length > 0 ? cronJobs : cronJob ? [cronJob] : []),
@@ -171,6 +174,8 @@ describe("CronCommands --json", () => {
     emitMock.mockClear();
     mockScopeContext = undefined;
     mockScopeEnforced = false;
+    mockCliContext = undefined;
+    creationIdempotency = undefined;
     cronJobs = [];
     cronJob = {
       id: "cron-1",
@@ -229,6 +234,77 @@ describe("CronCommands --json", () => {
     await expect(
       new CronCommands().add("Bad", undefined, "30m", undefined, undefined, "hello", "echo no"),
     ).rejects.toThrow("--message cannot be combined with --shell/--exec");
+  });
+
+  it("derives durable creation idempotency from observer source turns", async () => {
+    mockCliContext = {
+      agentId: "observer",
+      sessionKey: "obs:binding-1",
+      context: {
+        metadata: {
+          observation: { ruleId: "proactive-followups", sourceTurnIds: ["turn-2", "turn-1", "turn-1"] },
+        },
+      },
+    };
+
+    await captureJson(() =>
+      new CronCommands().add(
+        "Proactive follow-up",
+        undefined,
+        undefined,
+        "2026-07-21T09:00:00-03:00",
+        undefined,
+        "Check the source session",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+        undefined,
+        true,
+      ),
+    );
+
+    expect(creationIdempotency).toEqual({
+      observer: { ruleId: "proactive-followups", sourceTurnIds: ["turn-1", "turn-2"] },
+    });
+  });
+
+  it("lets an explicit idempotency key override observer-derived context", async () => {
+    mockCliContext = {
+      context: {
+        metadata: { observation: { ruleId: "proactive-followups", sourceTurnIds: ["turn-1"] } },
+      },
+    };
+
+    await captureJson(() =>
+      new CronCommands().add(
+        "Proactive follow-up",
+        undefined,
+        "30m",
+        undefined,
+        undefined,
+        "Check the source session",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        "operator-key",
+      ),
+    );
+
+    expect(creationIdempotency).toEqual({ explicitKey: "operator-key" });
   });
 
   it("returns updated cron job data for set --json", async () => {

--- a/src/cli/commands/cron.ts
+++ b/src/cli/commands/cron.ts
@@ -14,7 +14,7 @@ import { deriveSourceFromSessionKey } from "../../router/session-key.js";
 import { resolveSession } from "../../router/sessions.js";
 import { getDefaultTimezone, getAccountForAgent, getDefaultAgentId, dbGetAgent } from "../../router/router-db.js";
 import {
-  dbCreateCronJob,
+  createCronJobIdempotently,
   dbGetCronJob,
   dbListCronJobs,
   dbUpdateCronJob,
@@ -60,6 +60,25 @@ function normalizeCronOnError(value: string | undefined): string | undefined {
     fail(`Invalid --on-error value: ${value}. Use notify-session:<session>`);
   }
   return `${prefix}${trimmed.slice(prefix.length).trim()}`;
+}
+
+function resolveObserverCronIdempotencyContext(): { ruleId: string; sourceTurnIds: string[] } | undefined {
+  const metadata = getContext()?.context?.metadata;
+  const observation = metadata?.observation;
+  if (!observation || typeof observation !== "object" || Array.isArray(observation)) return undefined;
+  const record = observation as Record<string, unknown>;
+  const ruleId = typeof record.ruleId === "string" ? record.ruleId.trim() : "";
+  const sourceTurnIds = Array.isArray(record.sourceTurnIds)
+    ? [
+        ...new Set(
+          record.sourceTurnIds
+            .filter((value): value is string => typeof value === "string")
+            .map((value) => value.trim())
+            .filter(Boolean),
+        ),
+      ].sort()
+    : [];
+  return ruleId && sourceTurnIds.length > 0 ? { ruleId, sourceTurnIds } : undefined;
 }
 
 function resolveCronRouting(job: CronJob): CronRoutingResolution {
@@ -336,6 +355,8 @@ export class CronCommands {
     account?: string,
     @Option({ flags: "--description <text>", description: "Job description" }) description?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
+    @Option({ flags: "--idempotency-key <key>", description: "Durable create idempotency key" })
+    idempotencyKey?: string,
   ) {
     const warnings: string[] = [];
     const shellCommand = shell?.trim() || exec?.trim();
@@ -449,22 +470,44 @@ export class CronCommands {
     };
 
     try {
-      const job = dbCreateCronJob(input);
+      const observerIdempotency = resolveObserverCronIdempotencyContext();
+      const creation = createCronJobIdempotently(
+        input,
+        idempotencyKey !== undefined
+          ? { explicitKey: idempotencyKey }
+          : observerIdempotency
+            ? { observer: observerIdempotency }
+            : undefined,
+      );
+      const job = creation.job;
 
       // Signal daemon to refresh timers
-      await nats.emit("ravi.cron.refresh", {});
+      if (creation.created) await nats.emit("ravi.cron.refresh", {});
 
       const payload = {
-        status: "created" as const,
-        target: { type: "cron" as const, id: job.id },
-        changedCount: 1,
+        status: creation.created ? ("created" as const) : ("deduplicated" as const),
+        target: { type: "cron" as const, id: creation.targetId },
+        changedCount: creation.created ? 1 : 0,
         warnings,
-        job: serializeCronJob(job),
+        job: job ? serializeCronJob(job) : null,
+        ...(creation.reaction
+          ? {
+              idempotency: {
+                keyHash: creation.reaction.keyHash,
+                source: creation.reaction.keySource,
+                deduplicated: !creation.created,
+              },
+            }
+          : {}),
       };
 
       if (asJson) {
         printJson(payload);
+      } else if (!creation.created) {
+        console.log(`\n= Cron action already handled: ${creation.targetId}`);
+        if (!job) console.log("  The original one-shot job has already been removed.");
       } else {
+        if (!job) fail("Created cron job could not be reloaded.");
         console.log(`\n✓ Created job: ${job.id}`);
         console.log(`  Name:       ${job.name}`);
         console.log(`  Mode:       ${job.executionType}`);

--- a/src/cli/commands/observers.ts
+++ b/src/cli/commands/observers.ts
@@ -28,11 +28,12 @@ import {
   dbListObserverRules,
   dbSetObserverRuleEnabled,
   dbUpsertObserverRule,
-  ensureObserverBindingsForSession,
   explainObserverRulesForSession,
+  reconcileObserverBindingsForSession,
   validateObserverRules,
   type ObservationDeliveryPolicy,
   type ObserverMode,
+  type ObserverReconcileMode,
   type ObserverRuleInput,
   type ObserverScope,
   type ObserverTagTargetType,
@@ -126,6 +127,7 @@ function serializeRule(rule: ReturnType<typeof dbListObserverRules>[number]): Re
     tagSlug: rule.tagSlug ?? null,
     tagInherited: rule.tagInherited,
     permissionGrants: rule.permissionGrants,
+    selector: rule.selector ?? null,
     metadata: rule.metadata ?? null,
     createdAt: rule.createdAt,
     updatedAt: rule.updatedAt,
@@ -151,6 +153,7 @@ function serializeBinding(binding: ReturnType<typeof dbListObserverBindings>[num
     eventTypes: binding.eventTypes,
     deliveryPolicy: binding.deliveryPolicy,
     permissionGrants: binding.permissionGrants,
+    selector: binding.selector ?? null,
     metadata: binding.metadata ?? null,
     enabled: binding.enabled,
     createdAt: binding.createdAt,
@@ -170,6 +173,7 @@ function printBinding(binding: ReturnType<typeof dbListObserverBindings>[number]
   console.log(`  Profile:  ${binding.observerProfileId ?? "default"}@${binding.observerProfileVersion ?? "current"}`);
   console.log(`  Rule:     ${binding.ruleId}`);
   console.log(`  Events:   ${binding.eventTypes.join(", ")}`);
+  if (binding.selector) console.log(`  Selector: ${binding.selector}`);
   if (binding.metadata?.observerPolicy) {
     console.log(`  Policy:   ${JSON.stringify(binding.metadata.observerPolicy)}`);
   }
@@ -194,6 +198,7 @@ function printRule(rule: ReturnType<typeof dbListObserverRules>[number]): void {
   console.log(`  Profile:  ${rule.observerProfileId ?? "default"}`);
   console.log(`  Delivery: ${rule.deliveryPolicy}`);
   console.log(`  Events:   ${rule.eventTypes.join(", ")}`);
+  if (rule.selector) console.log(`  Selector: ${rule.selector}`);
   const selectors = [
     rule.sourceAgentId ? `agent=${rule.sourceAgentId}` : null,
     rule.sourceSession ? `session=${rule.sourceSession}` : null,
@@ -325,19 +330,36 @@ export class ObserverCommands {
   refresh(
     @Arg("session", { description: "Source session name or key" })
     sessionName: string,
+    @Option({
+      flags: "--reconcile <mode>",
+      description: "attach-missing|detach-disabled|refresh-profile|full-reconcile",
+    })
+    reconcileMode?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" })
     asJson?: boolean,
   ) {
     const session = getSessionByName(sessionName) ?? getSession(sessionName);
     if (!session) fail(`Session not found: ${sessionName}`);
-    const result = ensureObserverBindingsForSession({
+    const allowedModes = new Set<ObserverReconcileMode>([
+      "attach-missing",
+      "detach-disabled",
+      "refresh-profile",
+      "full-reconcile",
+    ]);
+    const mode = (reconcileMode?.trim() || "attach-missing") as ObserverReconcileMode;
+    if (!allowedModes.has(mode)) fail(`Invalid observer reconcile mode: ${reconcileMode}`);
+    const result = reconcileObserverBindingsForSession({
       sessionName: session.name ?? sessionName,
       session,
+      mode,
     });
     const payload = {
       source: result.source,
       total: result.bindings.length,
       created: result.created.map(serializeBinding),
+      disabled: result.disabled.map(serializeBinding),
+      refreshedProfiles: result.refreshedProfiles.map(serializeBinding),
+      mode: result.mode,
       bindings: result.bindings.map(serializeBinding),
       skipped: result.skipped,
     };
@@ -345,7 +367,7 @@ export class ObserverCommands {
       printJson(payload);
     } else {
       console.log(
-        `Refreshed observer bindings for ${session.name ?? sessionName}: ${result.bindings.length} total, ${result.created.length} created.`,
+        `Refreshed observer bindings for ${session.name ?? sessionName}: ${result.bindings.length} total, ${result.created.length} created, ${result.disabled.length} disabled, ${result.refreshedProfiles.length} profiles refreshed.`,
       );
     }
     return payload;
@@ -513,6 +535,11 @@ export class ObserverRuleCommands {
     })
     permissionsCsv?: string,
     @Option({
+      flags: "--selector <expression>",
+      description: "Predicate over source.*, turn.* and event.*; use 'clear' to remove",
+    })
+    selector?: string,
+    @Option({
       flags: "--meta <json>",
       description: "Free JSON metadata for the rule",
     })
@@ -528,6 +555,7 @@ export class ObserverRuleCommands {
     const parsedEventTypes = parseCsv(eventTypesCsv);
     const parsedPriority = parseInteger(priorityStr, "priority");
     const parsedPermissions = parseCsv(permissionsCsv);
+    const parsedSelector = parseClearableText(selector);
     const parsedMetadata = parseJsonObject(metadataJson);
     const input: ObserverRuleInput = {
       id,
@@ -552,6 +580,7 @@ export class ObserverRuleCommands {
       ...(tagTargetType?.trim() ? { tagTargetType: tagTargetType.trim() as ObserverTagTargetType } : {}),
       ...(tagInherited ? { tagInherited: true } : {}),
       ...(parsedPermissions ? { permissionGrants: parsedPermissions } : {}),
+      ...(parsedSelector !== undefined ? { selector: parsedSelector } : {}),
       ...(parsedMetadata ? { metadata: parsedMetadata } : {}),
       ...(disabled === true ? { enabled: false } : {}),
     };

--- a/src/cron/idempotency.test.ts
+++ b/src/cron/idempotency.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getDb } from "../router/router-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { dbDeleteCronJob } from "./cron-db.js";
+import { createCronJobIdempotently } from "./idempotency.js";
+import type { CronJobInput } from "./types.js";
+
+let stateDir: string | null = null;
+
+const input: CronJobInput = {
+  name: "Proactive follow-up",
+  schedule: { type: "at", at: Date.now() + 60_000 },
+  message: "Check the source session",
+  agentId: "proactive-followup-observer",
+  replySession: "agent:observer:slack:main:group:C123",
+  sessionTarget: "main",
+  deleteAfterRun: true,
+};
+
+describe("cron creation idempotency", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-cron-idempotency-test-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("deduplicates observer actions by rule, source turn and normalized action", () => {
+    const idempotency = {
+      observer: { ruleId: "proactive-followups", sourceTurnIds: ["turn-1"] },
+    };
+    const first = createCronJobIdempotently(input, idempotency);
+    const retry = createCronJobIdempotently(input, idempotency);
+
+    expect(first.created).toBe(true);
+    expect(retry).toMatchObject({ created: false, targetId: first.targetId });
+    expect(retry.job?.id).toBe(first.targetId);
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM cron_jobs").get() as { count: number }).toEqual({ count: 1 });
+  });
+
+  it("does not recreate a completed one-shot reaction after its job is deleted", () => {
+    const idempotency = {
+      observer: { ruleId: "proactive-followups", sourceTurnIds: ["turn-deleted"] },
+    };
+    const first = createCronJobIdempotently(input, idempotency);
+    dbDeleteCronJob(first.targetId);
+
+    const retry = createCronJobIdempotently(input, idempotency);
+
+    expect(retry).toMatchObject({ created: false, targetId: first.targetId, job: null });
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM reaction_actions").get() as { count: number }).toEqual({
+      count: 1,
+    });
+  });
+
+  it("allows two distinct actions from the same observer source turn", () => {
+    const idempotency = {
+      observer: { ruleId: "proactive-followups", sourceTurnIds: ["turn-2"] },
+    };
+    const first = createCronJobIdempotently(input, idempotency);
+    const second = createCronJobIdempotently({ ...input, message: "A different follow-up" }, idempotency);
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(true);
+    expect(second.targetId).not.toBe(first.targetId);
+  });
+});

--- a/src/cron/idempotency.ts
+++ b/src/cron/idempotency.ts
@@ -1,0 +1,65 @@
+import {
+  buildExplicitReactionActionKey,
+  buildObserverReactionActionKey,
+  executeIdempotentReactionAction,
+  fingerprintReactionAction,
+  type ReactionActionRecord,
+} from "../policy/reaction-actions.js";
+import { dbCreateCronJob, dbGetCronJob } from "./cron-db.js";
+import type { CronJob, CronJobInput } from "./types.js";
+
+export interface CronCreationIdempotency {
+  explicitKey?: string;
+  observer?: {
+    ruleId: string;
+    sourceTurnIds: string[];
+  };
+}
+
+export interface CronCreationResult {
+  created: boolean;
+  targetId: string;
+  job: CronJob | null;
+  reaction?: ReactionActionRecord;
+}
+
+/** Create a cron once, retaining the reaction ledger even after a one-shot job deletes itself. */
+export function createCronJobIdempotently(
+  input: CronJobInput,
+  idempotency?: CronCreationIdempotency,
+): CronCreationResult {
+  const actionType = "cron.add";
+  const actionFingerprint = fingerprintReactionAction(input);
+  const explicitKey = idempotency?.explicitKey;
+  const key =
+    explicitKey !== undefined
+      ? buildExplicitReactionActionKey(explicitKey)
+      : idempotency?.observer
+        ? buildObserverReactionActionKey({
+            ...idempotency.observer,
+            actionType,
+            actionFingerprint,
+          })
+        : null;
+
+  if (!key) {
+    const job = dbCreateCronJob(input);
+    return { created: true, targetId: job.id, job };
+  }
+
+  const outcome = executeIdempotentReactionAction({
+    ...key,
+    actionType,
+    actionFingerprint,
+    execute: () => {
+      const job = dbCreateCronJob(input);
+      return { targetType: "cron", targetId: job.id };
+    },
+  });
+  return {
+    created: outcome.created,
+    targetId: outcome.record.targetId,
+    job: dbGetCronJob(outcome.record.targetId),
+    reaction: outcome.record,
+  };
+}

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -28,6 +28,9 @@ export {
   dbUpdateJobState,
 } from "./cron-db.js";
 
+export { createCronJobIdempotently } from "./idempotency.js";
+export type { CronCreationIdempotency, CronCreationResult } from "./idempotency.js";
+
 // Schedule utilities
 export {
   calculateNextRun,

--- a/src/plugins/internal/ravi-system/skills/cron/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/cron/SKILL.md
@@ -73,6 +73,9 @@ Opções:
 - `--timeout <seconds|duration>` - Timeout para shell jobs, ex: `60`, `30s`, `10m`
 - `--env-file <path>` - Arquivo dotenv simples para shell jobs
 - `--on-error notify-session:<session>` - Notifica sessão só quando shell job falhar
+- `--idempotency-key <key>` - Reutiliza duravelmente a mesma criação em retries; a mesma key não pode representar outro job
+
+Quando `cron add` roda dentro de um turn de observer com source turn id, Ravi deriva a idempotência automaticamente de rule + source turn + ação normalizada. Isso impede que replay/retry crie follow-ups duplicados, inclusive depois que um one-shot `--delete-after` já foi removido. Fora desse contexto, produtores automatizados devem passar uma `--idempotency-key` estável.
 
 Depois de criar job que deve responder em um chat/sessão específica, sempre rode `ravi cron show <id>` e confira `agent`, `account`, `session`/`reply-session` antes de considerar pronto. Não confie no account herdado do contexto atual: se o cron entregar pelo account errado, o agent pode trabalhar e falhar no delivery com `chat not found`.
 

--- a/src/plugins/internal/ravi-system/skills/observers/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/observers/SKILL.md
@@ -46,10 +46,11 @@ ravi chats lists list --json                     # filas de leitura (se observer
 ravi observers list
 ravi observers show <binding-id>
 ravi observers refresh <session>
+ravi observers refresh <session> --reconcile full-reconcile
 
 ravi observers rules list
 ravi observers rules show <rule-id>
-ravi observers rules set <rule-id> <observer-agent> [--scope profile] [--source-profile observed-task] [--profile tasks]
+ravi observers rules set <rule-id> <observer-agent> [--scope profile] [--source-profile observed-task] [--profile tasks] [--selector <expression>]
 ravi observers rules validate
 ravi observers rules explain --session <session>
 
@@ -59,6 +60,24 @@ ravi observers profiles preview <profile-id> --event message.assistant
 ravi observers profiles validate [profile-id]
 ravi observers profiles init <profile-id>
 ```
+
+## Selectors Genéricos
+
+`--selector` usa um predicado restrito, sem JavaScript/eval, sobre `source.*`, `turn.*` e `event.*`. Operadores: `==`, `!=`, `startsWith`, `endsWith`, `includes`, `!`, `&&`, `||` e parênteses.
+
+Exemplo para observar somente turnos interativos, mesmo quando um cron executa dentro da sessão `main`:
+
+```bash
+ravi observers rules set proactive-followups proactive-followup-observer \
+  --scope global \
+  --selector 'turn.background == "false"'
+```
+
+Selectors de `source.*` são avaliados antes de criar o binding. Selectors com `turn.*` ou `event.*` são avaliados por evento e sobrevivem corretamente a debounce. Expressões inválidas falham fechadas. Use `--selector clear` para remover.
+
+`metadata.sourceExclusions` continua sendo lido para compatibilidade com regras antigas, mas novas regras devem preferir `--selector`.
+
+Reconciliação é explícita: `attach-missing` (padrão), `detach-disabled`, `refresh-profile` ou `full-reconcile`. Ela desativa bindings obsoletos sem apagar o histórico.
 
 ## Profiles
 

--- a/src/policy/predicate.test.ts
+++ b/src/policy/predicate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { compilePredicate, evaluatePredicate } from "./predicate.js";
+
+describe("policy predicate", () => {
+  it("evaluates multiple roots with boolean precedence", () => {
+    const compiled = compilePredicate(
+      `source.channel == "slack" && (turn.origin == "human" || event.type == "manual")`,
+      { allowedRoots: ["source", "turn", "event"] },
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect(compiled.predicate.roots).toEqual(["event", "source", "turn"]);
+    expect(
+      compiled.predicate.evaluate({
+        source: { channel: "slack" },
+        turn: { origin: "human" },
+        event: { type: "turn.complete" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects roots outside the consumer boundary", () => {
+    const result = compilePredicate(`secret.token == "x"`, { allowedRoots: ["source", "turn"] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("not allowed");
+  });
+
+  it("lets each consumer choose invalid-expression fail mode", () => {
+    expect(evaluatePredicate("invalid", {}, { failMode: "open" })).toBe(true);
+    expect(evaluatePredicate("invalid", {}, { failMode: "closed" })).toBe(false);
+  });
+
+  it("never executes arbitrary JavaScript", () => {
+    const result = compilePredicate(`source.constructor.constructor == "return process"`, {
+      allowedRoots: ["source"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.predicate.evaluate({ source: {} })).toBe(false);
+  });
+});

--- a/src/policy/predicate.ts
+++ b/src/policy/predicate.ts
@@ -1,0 +1,308 @@
+/**
+ * Small, side-effect-free predicate language shared by runtime policy consumers.
+ * It deliberately supports only string comparisons and boolean composition.
+ */
+
+export type PredicateComparisonOperator = "==" | "!=" | "startsWith" | "endsWith" | "includes";
+export type PredicateFailMode = "open" | "closed";
+
+type PredicateAst =
+  | { type: "comparison"; path: string; operator: PredicateComparisonOperator; expected: string }
+  | { type: "and"; left: PredicateAst; right: PredicateAst }
+  | { type: "or"; left: PredicateAst; right: PredicateAst }
+  | { type: "not"; expression: PredicateAst };
+
+type Token =
+  | { type: "path"; value: string; position: number }
+  | { type: "operator"; value: PredicateComparisonOperator; position: number }
+  | { type: "string"; value: string; position: number }
+  | { type: "and" | "or" | "not" | "lparen" | "rparen" | "eof"; position: number }
+  | { type: "word"; value: string; position: number };
+
+export interface PredicateCompileOptions {
+  allowedRoots?: Iterable<string>;
+  /** Consumer-specific text used in syntax errors, for example `data.<path>`. */
+  pathLabel?: string;
+}
+
+export interface CompiledPredicate {
+  expression: string;
+  paths: readonly string[];
+  roots: readonly string[];
+  evaluate(context: Record<string, unknown>): boolean;
+}
+
+export type PredicateCompileResult = { ok: true; predicate: CompiledPredicate } | { ok: false; error: string };
+
+const OPERATORS = new Set<string>(["==", "!=", "startsWith", "endsWith", "includes"]);
+const PATH_RE = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$/;
+
+function isOperator(value: string): value is PredicateComparisonOperator {
+  return OPERATORS.has(value);
+}
+
+function syntaxError(message: string, position: number): string {
+  return `${message} at character ${position}`;
+}
+
+function tokenize(input: string): Token[] | string {
+  const tokens: Token[] = [];
+  let index = 0;
+  while (index < input.length) {
+    const char = input[index];
+    if (!char) break;
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+    if (input.startsWith("&&", index)) {
+      tokens.push({ type: "and", position: index });
+      index += 2;
+      continue;
+    }
+    if (input.startsWith("||", index)) {
+      tokens.push({ type: "or", position: index });
+      index += 2;
+      continue;
+    }
+    if (input.startsWith("!=", index) || input.startsWith("==", index)) {
+      tokens.push({
+        type: "operator",
+        value: input.slice(index, index + 2) as PredicateComparisonOperator,
+        position: index,
+      });
+      index += 2;
+      continue;
+    }
+    if (char === "!") {
+      tokens.push({ type: "not", position: index++ });
+      continue;
+    }
+    if (char === "(") {
+      tokens.push({ type: "lparen", position: index++ });
+      continue;
+    }
+    if (char === ")") {
+      tokens.push({ type: "rparen", position: index++ });
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      const quote = char;
+      const position = index++;
+      let value = "";
+      let closed = false;
+      while (index < input.length) {
+        const next = input[index];
+        if (next === "\\") {
+          const escaped = input[index + 1];
+          if (escaped === undefined) return syntaxError("Unterminated escape sequence", index);
+          value += escaped;
+          index += 2;
+          continue;
+        }
+        if (next === quote) {
+          index += 1;
+          closed = true;
+          tokens.push({ type: "string", value, position });
+          break;
+        }
+        value += next;
+        index += 1;
+      }
+      if (!closed) return syntaxError("Unterminated quoted string", position);
+      continue;
+    }
+
+    const start = index;
+    while (
+      index < input.length &&
+      !/\s/.test(input[index] ?? "") &&
+      !["(", ")", "!", "=", "&", "|", '"', "'"].includes(input[index] ?? "")
+    ) {
+      index += 1;
+    }
+    if (index === start) return syntaxError(`Unexpected character '${char}'`, index);
+    const value = input.slice(start, index);
+    if (isOperator(value)) tokens.push({ type: "operator", value, position: start });
+    else if (PATH_RE.test(value)) tokens.push({ type: "path", value, position: start });
+    else tokens.push({ type: "word", value, position: start });
+  }
+  tokens.push({ type: "eof", position: input.length });
+  return tokens;
+}
+
+class PredicateParser {
+  private index = 0;
+
+  constructor(
+    private readonly tokens: Token[],
+    private readonly allowedRoots: Set<string> | undefined,
+    private readonly pathLabel: string,
+  ) {}
+
+  parse(): PredicateCompileResult {
+    const ast = this.parseOr();
+    if (typeof ast === "string") return { ok: false, error: ast };
+    const current = this.current();
+    if (current.type !== "eof") {
+      return { ok: false, error: syntaxError(`Unexpected token '${this.describe(current)}'`, current.position) };
+    }
+    const paths = [...collectPaths(ast)].sort();
+    return {
+      ok: true,
+      predicate: {
+        expression: "",
+        paths,
+        roots: [...new Set(paths.map((path) => path.split(".")[0]!))].sort(),
+        evaluate: (context) => evaluateAst(ast, context),
+      },
+    };
+  }
+
+  private parseOr(): PredicateAst | string {
+    let left = this.parseAnd();
+    if (typeof left === "string") return left;
+    while (this.match("or")) {
+      const right = this.parseAnd();
+      if (typeof right === "string") return right;
+      left = { type: "or", left, right };
+    }
+    return left;
+  }
+
+  private parseAnd(): PredicateAst | string {
+    let left = this.parseUnary();
+    if (typeof left === "string") return left;
+    while (this.match("and")) {
+      const right = this.parseUnary();
+      if (typeof right === "string") return right;
+      left = { type: "and", left, right };
+    }
+    return left;
+  }
+
+  private parseUnary(): PredicateAst | string {
+    if (this.match("not")) {
+      const expression = this.parseUnary();
+      return typeof expression === "string" ? expression : { type: "not", expression };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): PredicateAst | string {
+    if (!this.match("lparen")) return this.parseComparison();
+    const expression = this.parseOr();
+    if (typeof expression === "string") return expression;
+    if (!this.match("rparen")) return syntaxError("Expected ')'", this.current().position);
+    return expression;
+  }
+
+  private parseComparison(): PredicateAst | string {
+    const path = this.consume("path", `Expected ${this.pathLabel}`);
+    if (typeof path === "string") return path;
+    const root = path.value.split(".")[0]!;
+    if (this.allowedRoots && !this.allowedRoots.has(root)) {
+      return syntaxError(`Path root '${root}' is not allowed`, path.position);
+    }
+    const operator = this.consume("operator", "Expected comparison operator");
+    if (typeof operator === "string") return operator;
+    const expected = this.consume("string", "Expected quoted string value");
+    if (typeof expected === "string") return expected;
+    return { type: "comparison", path: path.value, operator: operator.value, expected: expected.value };
+  }
+
+  private match(type: Token["type"]): boolean {
+    if (this.current().type !== type) return false;
+    this.index += 1;
+    return true;
+  }
+
+  private consume<T extends Token["type"]>(type: T, message: string): Extract<Token, { type: T }> | string {
+    const token = this.current();
+    if (token.type !== type) return syntaxError(`${message}, got '${this.describe(token)}'`, token.position);
+    this.index += 1;
+    return token as Extract<Token, { type: T }>;
+  }
+
+  private current(): Token {
+    return this.tokens[this.index] ?? { type: "eof", position: 0 };
+  }
+
+  private describe(token: Token): string {
+    if ("value" in token) return token.value;
+    return ({ and: "&&", or: "||", not: "!", lparen: "(", rparen: ")", eof: "end of input" } as const)[token.type];
+  }
+}
+
+function collectPaths(ast: PredicateAst, result = new Set<string>()): Set<string> {
+  if (ast.type === "comparison") result.add(ast.path);
+  else if (ast.type === "not") collectPaths(ast.expression, result);
+  else {
+    collectPaths(ast.left, result);
+    collectPaths(ast.right, result);
+  }
+  return result;
+}
+
+function resolvePath(context: Record<string, unknown>, path: string): unknown {
+  let current: unknown = context;
+  for (const part of path.split(".")) {
+    if (!part || current === null || current === undefined || typeof current !== "object") return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, part)) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function evaluateAst(ast: PredicateAst, context: Record<string, unknown>): boolean {
+  if (ast.type === "and") return evaluateAst(ast.left, context) && evaluateAst(ast.right, context);
+  if (ast.type === "or") return evaluateAst(ast.left, context) || evaluateAst(ast.right, context);
+  if (ast.type === "not") return !evaluateAst(ast.expression, context);
+  const raw = resolvePath(context, ast.path);
+  if (raw === undefined) return false;
+  const value = String(raw);
+  switch (ast.operator) {
+    case "==":
+      return value === ast.expected;
+    case "!=":
+      return value !== ast.expected;
+    case "startsWith":
+      return value.startsWith(ast.expected);
+    case "endsWith":
+      return value.endsWith(ast.expected);
+    case "includes":
+      return value.includes(ast.expected);
+  }
+}
+
+export function compilePredicate(
+  expression: string | null | undefined,
+  options: PredicateCompileOptions = {},
+): PredicateCompileResult {
+  const normalized = expression?.trim() ?? "";
+  if (!normalized) {
+    return {
+      ok: true,
+      predicate: { expression: "", paths: [], roots: [], evaluate: () => true },
+    };
+  }
+  const tokens = tokenize(normalized);
+  if (typeof tokens === "string") return { ok: false, error: tokens };
+  const allowedRoots = options.allowedRoots ? new Set(options.allowedRoots) : undefined;
+  const parsed = new PredicateParser(tokens, allowedRoots, options.pathLabel ?? "<root>.<path>").parse();
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    predicate: { ...parsed.predicate, expression: normalized },
+  };
+}
+
+export function evaluatePredicate(
+  expression: string | null | undefined,
+  context: Record<string, unknown>,
+  options: PredicateCompileOptions & { failMode?: PredicateFailMode } = {},
+): boolean {
+  const compiled = compilePredicate(expression, options);
+  if (!compiled.ok) return options.failMode === "open";
+  return compiled.predicate.evaluate(context);
+}

--- a/src/policy/reaction-actions.test.ts
+++ b/src/policy/reaction-actions.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getDb } from "../router/router-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import {
+  buildExplicitReactionActionKey,
+  executeIdempotentReactionAction,
+  fingerprintReactionAction,
+} from "./reaction-actions.js";
+
+let stateDir: string | null = null;
+
+describe("durable reaction actions", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-reaction-action-test-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("executes once and returns the durable target on retries", () => {
+    const key = buildExplicitReactionActionKey("source-turn-1:cron.add");
+    const actionFingerprint = fingerprintReactionAction({ schedule: "tomorrow" });
+    let executions = 0;
+    const run = () =>
+      executeIdempotentReactionAction({
+        ...key,
+        actionType: "cron.add",
+        actionFingerprint,
+        execute: () => ({ targetType: "cron", targetId: `job-${++executions}` }),
+      });
+
+    const first = run();
+    const retry = run();
+
+    expect(first).toMatchObject({ created: true, record: { targetId: "job-1" } });
+    expect(retry).toMatchObject({ created: false, record: { targetId: "job-1" } });
+    expect(executions).toBe(1);
+  });
+
+  it("rolls the claim back when the action fails", () => {
+    const key = buildExplicitReactionActionKey("retry-after-failure");
+    const actionFingerprint = fingerprintReactionAction({ action: "cron.add" });
+    expect(() =>
+      executeIdempotentReactionAction({
+        ...key,
+        actionType: "cron.add",
+        actionFingerprint,
+        execute: () => {
+          throw new Error("temporary failure");
+        },
+      }),
+    ).toThrow("temporary failure");
+
+    expect(getDb().prepare("SELECT COUNT(*) AS count FROM reaction_actions").get() as { count: number }).toEqual({
+      count: 0,
+    });
+  });
+
+  it("rejects reuse of an explicit key for a different action", () => {
+    const key = buildExplicitReactionActionKey("operator-key");
+    executeIdempotentReactionAction({
+      ...key,
+      actionType: "cron.add",
+      actionFingerprint: fingerprintReactionAction({ message: "first" }),
+      execute: () => ({ targetType: "cron", targetId: "job-1" }),
+    });
+
+    expect(() =>
+      executeIdempotentReactionAction({
+        ...key,
+        actionType: "cron.add",
+        actionFingerprint: fingerprintReactionAction({ message: "different" }),
+        execute: () => ({ targetType: "cron", targetId: "job-2" }),
+      }),
+    ).toThrow("different reaction action");
+  });
+});

--- a/src/policy/reaction-actions.ts
+++ b/src/policy/reaction-actions.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import { getDb } from "../router/router-db.js";
+
+export type ReactionActionKeySource = "explicit" | "observer";
+
+export interface ReactionActionRecord {
+  keyHash: string;
+  keySource: ReactionActionKeySource;
+  actionType: string;
+  actionFingerprint: string;
+  ruleId?: string;
+  sourceTurnIds: string[];
+  targetType: string;
+  targetId: string;
+  createdAt: number;
+  completedAt: number;
+}
+
+interface ReactionActionRow {
+  idempotency_key_hash: string;
+  key_source: ReactionActionKeySource;
+  action_type: string;
+  action_fingerprint: string;
+  rule_id: string | null;
+  source_turn_ids_json: string;
+  target_type: string;
+  target_id: string;
+  created_at: number;
+  completed_at: number;
+}
+
+export interface ReactionActionKey {
+  keyHash: string;
+  keySource: ReactionActionKeySource;
+  ruleId?: string;
+  sourceTurnIds?: string[];
+}
+
+export interface ExecuteIdempotentReactionActionInput extends ReactionActionKey {
+  actionType: string;
+  actionFingerprint: string;
+  execute(): { targetType: string; targetId: string };
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+}
+
+function normalizeSourceTurnIds(values: Iterable<string> = []): string[] {
+  return [...new Set([...values].map((value) => value.trim()).filter(Boolean))].sort();
+}
+
+export function fingerprintReactionAction(action: unknown): string {
+  const serialized = JSON.stringify(canonicalize(action));
+  return sha256(serialized ?? "undefined");
+}
+
+export function buildExplicitReactionActionKey(value: string): ReactionActionKey {
+  const key = value.trim();
+  if (!key) throw new Error("Idempotency key must not be empty.");
+  return {
+    keyHash: sha256(`explicit\0${key}`),
+    keySource: "explicit",
+  };
+}
+
+export function buildObserverReactionActionKey(input: {
+  ruleId: string;
+  sourceTurnIds: Iterable<string>;
+  actionType: string;
+  actionFingerprint: string;
+}): ReactionActionKey {
+  const ruleId = input.ruleId.trim();
+  const sourceTurnIds = normalizeSourceTurnIds(input.sourceTurnIds);
+  if (!ruleId) throw new Error("Observer reaction rule id must not be empty.");
+  if (sourceTurnIds.length === 0) throw new Error("Observer reaction requires at least one source turn id.");
+  return {
+    keyHash: sha256(
+      ["observer", ruleId, sourceTurnIds.join(","), input.actionType, input.actionFingerprint].join("\0"),
+    ),
+    keySource: "observer",
+    ruleId,
+    sourceTurnIds,
+  };
+}
+
+function rowToReactionAction(row: ReactionActionRow): ReactionActionRecord {
+  let sourceTurnIds: string[] = [];
+  try {
+    const parsed = JSON.parse(row.source_turn_ids_json) as unknown;
+    if (Array.isArray(parsed))
+      sourceTurnIds = normalizeSourceTurnIds(parsed.filter((item): item is string => typeof item === "string"));
+  } catch {
+    sourceTurnIds = [];
+  }
+  return {
+    keyHash: row.idempotency_key_hash,
+    keySource: row.key_source,
+    actionType: row.action_type,
+    actionFingerprint: row.action_fingerprint,
+    ...(row.rule_id ? { ruleId: row.rule_id } : {}),
+    sourceTurnIds,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function getReactionAction(keyHash: string): ReactionActionRecord | null {
+  const row = getDb().prepare("SELECT * FROM reaction_actions WHERE idempotency_key_hash = ?").get(keyHash) as
+    | ReactionActionRow
+    | undefined;
+  return row ? rowToReactionAction(row) : null;
+}
+
+/**
+ * Execute a reaction exactly once with the action and ledger write in one
+ * SQLite transaction. The durable row intentionally survives target deletion.
+ */
+export function executeIdempotentReactionAction(input: ExecuteIdempotentReactionActionInput): {
+  created: boolean;
+  record: ReactionActionRecord;
+} {
+  const db = getDb();
+  let outcome: { created: boolean; record: ReactionActionRecord } | undefined;
+
+  db.transaction(() => {
+    const now = Date.now();
+    const claim = db
+      .prepare(
+        `INSERT OR IGNORE INTO reaction_actions (
+           idempotency_key_hash, key_source, action_type, action_fingerprint,
+           rule_id, source_turn_ids_json, target_type, target_id, created_at, completed_at
+         ) VALUES (?, ?, ?, ?, ?, ?, '', '', ?, 0)`,
+      )
+      .run(
+        input.keyHash,
+        input.keySource,
+        input.actionType,
+        input.actionFingerprint,
+        input.ruleId ?? null,
+        JSON.stringify(normalizeSourceTurnIds(input.sourceTurnIds)),
+        now,
+      );
+    if (claim.changes === 0) {
+      const existing = getReactionAction(input.keyHash);
+      if (!existing) throw new Error("Idempotent reaction claim disappeared.");
+      if (existing.actionType !== input.actionType || existing.actionFingerprint !== input.actionFingerprint) {
+        throw new Error("Idempotency key was already used for a different reaction action.");
+      }
+      outcome = { created: false, record: existing };
+      return;
+    }
+
+    const target = input.execute();
+    db.prepare(
+      `UPDATE reaction_actions
+       SET target_type = ?, target_id = ?, completed_at = ?
+       WHERE idempotency_key_hash = ?`,
+    ).run(target.targetType, target.targetId, Date.now(), input.keyHash);
+    const completed = getReactionAction(input.keyHash);
+    if (!completed) throw new Error("Completed reaction action disappeared.");
+    outcome = { created: true, record: completed };
+  })();
+
+  if (!outcome) throw new Error("Failed to persist reaction action.");
+  return outcome;
+}

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -2308,6 +2308,23 @@ function getDb(): Database {
 
     CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled ON cron_jobs(enabled);
     CREATE INDEX IF NOT EXISTS idx_cron_jobs_next_run ON cron_jobs(next_run_at);
+
+    -- Durable idempotency ledger for reactions whose target may later be deleted.
+    CREATE TABLE IF NOT EXISTS reaction_actions (
+      idempotency_key_hash TEXT PRIMARY KEY,
+      key_source TEXT NOT NULL CHECK(key_source IN ('explicit','observer')),
+      action_type TEXT NOT NULL,
+      action_fingerprint TEXT NOT NULL,
+      rule_id TEXT,
+      source_turn_ids_json TEXT NOT NULL DEFAULT '[]',
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_reaction_actions_source
+      ON reaction_actions(rule_id, action_type, created_at);
   `);
 
   // Migration: add reply_session to cron_jobs

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -135,7 +135,7 @@ describe("router context queries", () => {
     ).toEqual(["active", "expired-recent"]);
   });
 
-  it("creates trace indexes and shell trigger columns during schema bootstrap", () => {
+  it("creates trace indexes, shell trigger columns, and the reaction ledger during schema bootstrap", () => {
     const db = getDb();
     const sessionEventIndexes = new Set(
       (db.prepare("PRAGMA index_list(session_events)").all() as Array<{ name: string }>).map((row) => row.name),
@@ -145,6 +145,12 @@ describe("router context queries", () => {
     );
     const triggerColumns = new Set(
       (db.prepare("PRAGMA table_info(triggers)").all() as Array<{ name: string }>).map((row) => row.name),
+    );
+    const reactionColumns = new Set(
+      (db.prepare("PRAGMA table_info(reaction_actions)").all() as Array<{ name: string }>).map((row) => row.name),
+    );
+    const reactionIndexes = new Set(
+      (db.prepare("PRAGMA index_list(reaction_actions)").all() as Array<{ name: string }>).map((row) => row.name),
     );
 
     expect(sessionEventIndexes).toContain("idx_session_events_key_time_seq_id");
@@ -157,6 +163,21 @@ describe("router context queries", () => {
     expect(triggerColumns).toContain("shell_timeout_ms");
     expect(triggerColumns).toContain("shell_env_file");
     expect(triggerColumns).toContain("on_error");
+    expect(reactionColumns).toEqual(
+      new Set([
+        "idempotency_key_hash",
+        "key_source",
+        "action_type",
+        "action_fingerprint",
+        "rule_id",
+        "source_turn_ids_json",
+        "target_type",
+        "target_id",
+        "created_at",
+        "completed_at",
+      ]),
+    );
+    expect(reactionIndexes).toContain("idx_reaction_actions_source");
   });
 
   it("gets reading lists by exact primary-key id without falling back to name", () => {

--- a/src/runtime/compaction-announcement.test.ts
+++ b/src/runtime/compaction-announcement.test.ts
@@ -69,7 +69,7 @@ describe("classifyCompactionAnnouncement", () => {
       },
     });
     expect(result.externalAnnouncementsAllowed).toBe(false);
-    expect(result.origin).toBe("automation");
+    expect(result.origin).toBe("session-followup");
   });
 
   it("suppresses announcements when identity provenance is an automation source", () => {
@@ -77,7 +77,7 @@ describe("classifyCompactionAnnouncement", () => {
       source: { ...humanSource, identityProvenance: { source: "cron" } },
     });
     expect(result.externalAnnouncementsAllowed).toBe(false);
-    expect(result.origin).toBe("automation");
+    expect(result.origin).toBe("cron");
   });
 
   it("suppresses announcements for background sources that set suppressPresence", () => {
@@ -94,6 +94,6 @@ describe("classifyCompactionAnnouncement", () => {
     });
     // actorType=automation without an automationId is not a sufficient signal on its own.
     expect(result.externalAnnouncementsAllowed).toBe(true);
-    expect(result.origin).toBe("human");
+    expect(result.origin).toBe("unknown");
   });
 });

--- a/src/runtime/compaction-announcement.ts
+++ b/src/runtime/compaction-announcement.ts
@@ -1,5 +1,6 @@
 import type { RuntimeMessageTarget } from "./host-session.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { classifyTurnProvenance, type TurnOrigin, type TurnProvenance } from "./turn-provenance.js";
 
 /**
  * Best-effort classification of what kind of turn is effectively executing when
@@ -8,14 +9,7 @@ import type { RuntimeLaunchPrompt } from "./message-types.js";
  * observability (runtime status, `runtime.status` trace, live state, skill
  * visibility reset, logs) is never affected by this classification.
  */
-export type CompactionTurnOrigin =
-  | "human"
-  | "cron"
-  | "trigger"
-  | "session-followup"
-  | "heartbeat"
-  | "automation"
-  | "background";
+export type CompactionTurnOrigin = TurnOrigin;
 
 export interface CompactionAnnouncementSnapshot {
   /** Whether external compaction announcements may be emitted for the effective turn. */
@@ -35,29 +29,18 @@ type CompactionAnnouncementSource = Pick<
 
 export interface CompactionAnnouncementClassificationInput {
   /** Launch prompt of the turn effectively executing (not pending/after_response messages). */
-  prompt?: Pick<RuntimeLaunchPrompt, "_cron" | "_trigger" | "_sessionFollowup" | "_heartbeat">;
+  prompt?: Partial<RuntimeLaunchPrompt>;
   /** Resolved output source for the turn effectively executing. */
   source?: CompactionAnnouncementSource;
 }
 
-const AUTOMATION_PROVENANCE_SOURCES = new Set([
-  "cron",
-  "trigger",
-  "session-followup",
-  "sessionfollowup",
-  "heartbeat",
-  "routine",
-  "task",
-  "background",
-  "automation",
-  "daemon-restart",
-]);
-
-function readProvenanceSource(source: CompactionAnnouncementSource | undefined): string | undefined {
-  const provenance = source?.identityProvenance;
-  if (!provenance || typeof provenance !== "object") return undefined;
-  const value = (provenance as Record<string, unknown>).source;
-  return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
+export function compactionAnnouncementForTurn(provenance: TurnProvenance): CompactionAnnouncementSnapshot {
+  return {
+    externalAnnouncementsAllowed: !provenance.background,
+    automationOriginated: provenance.automationOriginated,
+    origin: provenance.origin,
+    reason: provenance.reason,
+  };
 }
 
 /**
@@ -74,37 +57,5 @@ function readProvenanceSource(source: CompactionAnnouncementSource | undefined):
 export function classifyCompactionAnnouncement(
   input: CompactionAnnouncementClassificationInput,
 ): CompactionAnnouncementSnapshot {
-  const { prompt, source } = input;
-
-  const suppress = (origin: CompactionTurnOrigin, reason: string): CompactionAnnouncementSnapshot => ({
-    externalAnnouncementsAllowed: false,
-    automationOriginated: true,
-    origin,
-    reason,
-  });
-
-  if (prompt?._cron) return suppress("cron", "prompt._cron");
-  if (prompt?._trigger) return suppress("trigger", "prompt._trigger");
-  if (prompt?._sessionFollowup) return suppress("session-followup", "prompt._sessionFollowup");
-  if (prompt?._heartbeat) return suppress("heartbeat", "prompt._heartbeat");
-
-  if (source?.actorType === "automation" && source.automationId) {
-    return suppress("automation", "source.actorType=automation");
-  }
-
-  const provenanceSource = readProvenanceSource(source);
-  if (provenanceSource && AUTOMATION_PROVENANCE_SOURCES.has(provenanceSource)) {
-    return suppress("automation", `identityProvenance.source=${provenanceSource}`);
-  }
-
-  if (source?.suppressPresence === true) {
-    return suppress("background", "source.suppressPresence");
-  }
-
-  return {
-    externalAnnouncementsAllowed: true,
-    automationOriginated: false,
-    origin: "human",
-    reason: "no automation signal",
-  };
+  return compactionAnnouncementForTurn(classifyTurnProvenance(input));
 }

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -25,7 +25,7 @@ import {
   classifyRuntimeContextWindowFailure,
   RUNTIME_CONTEXT_WINDOW_RECOVERY_REASON,
 } from "./context-window-recovery.js";
-import { classifyCompactionAnnouncement } from "./compaction-announcement.js";
+import { compactionAnnouncementForTurn } from "./compaction-announcement.js";
 import { classifyRuntimeCredentialFailure } from "./credential-classifier.js";
 import { mergeRuntimeCredentialSessionMetadata } from "./credential-resolver.js";
 import { refreshRuntimeCredential } from "./credential-refresh.js";
@@ -69,6 +69,7 @@ import type {
   RuntimeSessionHandle,
   RuntimeSkillVisibilitySnapshot,
 } from "./types.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 
 const log = logger.child("bot");
 
@@ -688,6 +689,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       turnId: input.turnId ?? streaming.currentTraceTurnId,
       preview: input.preview,
       payload: input.payload,
+      turn: streaming.currentTurnProvenance ?? classifyTurnProvenance({ source: streaming.currentSource }),
     });
     observationEvents.push(event);
     deliverObservationBatch([event], ["realtime"], "realtime");
@@ -862,15 +864,22 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     // Include _source on turn-ending events so any gateway daemon can stop typing.
     // In multi-daemon mode the daemon that processes the prompt may differ from
     // the daemon that received the inbound message (which set activeTargets locally).
-    const augmented =
-      (event.type === "result" || event.type === "silent") && streaming.currentSource
-        ? { ...event, _source: streaming.currentSource }
-        : event;
+    const augmented = {
+      ...event,
+      ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
+      ...((event.type === "result" || event.type === "silent") && streaming.currentSource
+        ? { _source: streaming.currentSource }
+        : {}),
+    };
     await safeEmit(`ravi.session.${sessionName}.${legacyEventTopicSuffix}`, augmented);
   };
 
   const emitRuntimeEvent = async (event: Record<string, unknown>) => {
-    const augmented = streaming.currentSource ? { ...event, _source: streaming.currentSource } : event;
+    const augmented = {
+      ...event,
+      ...(streaming.currentSource ? { _source: streaming.currentSource } : {}),
+      ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
+    };
     await safeEmit(`ravi.session.${sessionName}.runtime`, augmented);
   };
 
@@ -1329,9 +1338,9 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         // Snapshot whether compaction announcements may be externalized for the
         // turn effectively executing. Falls back to source-only classification
         // if a per-turn snapshot was not recorded (e.g. resumed stashed turn).
-        const compactionAnnouncement =
-          streaming.currentTurnCompactionAnnouncement ??
-          classifyCompactionAnnouncement({ source: streaming.currentSource });
+        const compactionAnnouncement = compactionAnnouncementForTurn(
+          streaming.currentTurnProvenance ?? classifyTurnProvenance({ source: streaming.currentSource }),
+        );
         if (status === "compacting" || compactionChanged) {
           log.info("Compaction status", {
             sessionName,
@@ -1487,6 +1496,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           sessionName,
           agentId: agent.id,
           metadata: event.metadata,
+          ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
         }).catch((err) => log.warn("Failed to emit tool start", { error: err }));
         updateRuntimeLiveState(sessionName, {
           activity: "thinking",
@@ -1661,6 +1671,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           sessionName,
           agentId: agent.id,
           metadata: event.metadata,
+          ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
         }).catch((err) => log.warn("Failed to emit tool end", { error: err }));
         updateRuntimeLiveState(sessionName, {
           activity: event.isError ? "blocked" : "thinking",

--- a/src/runtime/host-session.ts
+++ b/src/runtime/host-session.ts
@@ -1,6 +1,6 @@
 import type { DeliveryBarrier, DeliveryBarrierSource } from "../delivery-barriers.js";
 import type { SessionEntry } from "../router/index.js";
-import type { CompactionAnnouncementSnapshot } from "./compaction-announcement.js";
+import type { TurnProvenance } from "./turn-provenance.js";
 import type { RuntimeCredentialAttemptBinding } from "./credential-types.js";
 import type { MessageActorMetadata, RaviCommandPromptMetadata, RuntimeLaunchPrompt } from "./message-types.js";
 import type {
@@ -100,7 +100,7 @@ export interface RuntimeHostStreamingSession {
    * automation-originated turns compact silently while human/channel turns keep
    * announcements. Internal compaction observability is unaffected.
    */
-  currentTurnCompactionAnnouncement?: CompactionAnnouncementSnapshot;
+  currentTurnProvenance?: TurnProvenance;
   /** Tool safety classification - "safe" tools can be interrupted, "unsafe" cannot */
   currentToolSafety: "safe" | "unsafe" | null;
   /** Pending abort - set when abort is requested during an unsafe tool call */

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -101,6 +101,8 @@ export interface ObservationPromptMetadata {
   profileVersion?: string;
   permissionGrants?: string[];
   eventIds: string[];
+  /** Source trace turns used to derive durable reaction idempotency. */
+  sourceTurnIds?: string[];
 }
 
 export interface DaemonRestartResumePromptMetadata {

--- a/src/runtime/observation-plane.test.ts
+++ b/src/runtime/observation-plane.test.ts
@@ -13,8 +13,10 @@ import {
   ensureObserverBindingsForSession,
   explainObserverRulesForSession,
   getObservationDebounceMs,
+  reconcileObserverBindingsForSession,
   setObservationPromptPublisherForTests,
 } from "./observation-plane.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 
 let stateDir: string | null = null;
 const publishedPrompts: Array<{
@@ -78,6 +80,126 @@ describe("Observation Plane", () => {
     });
     expect(second.created).toHaveLength(0);
     expect(dbListObserverBindings({ sourceSessionKey: "source-session" })).toHaveLength(1);
+  });
+
+  it("defers turn selectors and excludes a cron running in the main session", async () => {
+    const session = getOrCreateSession("agent:worker:main", "worker", "/tmp/worker", { name: "main" });
+    const rule = dbUpsertObserverRule({
+      id: "interactive-followups",
+      scope: "global",
+      observerAgentId: "observer",
+      observerRole: "interactive-followups",
+      observerMode: "summarize",
+      eventTypes: ["turn.complete"],
+      selector: `turn.background == "false"`,
+    });
+    const attached = ensureObserverBindingsForSession({ sessionName: "main", session });
+
+    expect(rule.selector).toBe(`turn.background == "false"`);
+    expect(attached.bindings).toHaveLength(1);
+    expect(attached.skipped).toHaveLength(0);
+
+    const cronResult = await deliverObservationEvents({
+      sourceSessionName: "main",
+      sourceSession: session,
+      agentId: "worker",
+      events: [
+        createObservationEvent({
+          runId: "run-main-cron",
+          sequence: 1,
+          type: "turn.complete",
+          turn: classifyTurnProvenance({ prompt: { prompt: "cron", _cron: true, _jobId: "job-1" } }),
+        }),
+      ],
+    });
+    expect(cronResult.delivered).toHaveLength(0);
+    expect(publishedPrompts).toHaveLength(0);
+
+    const humanResult = await deliverObservationEvents({
+      sourceSessionName: "main",
+      sourceSession: session,
+      agentId: "worker",
+      events: [
+        createObservationEvent({
+          runId: "run-main-human",
+          sequence: 1,
+          type: "turn.complete",
+          turn: classifyTurnProvenance({ source: { actorType: "contact" } }),
+        }),
+      ],
+    });
+    expect(humanResult.delivered).toHaveLength(1);
+    expect(publishedPrompts).toHaveLength(1);
+  });
+
+  it("evaluates source-only selectors before creating a binding", () => {
+    const session = getOrCreateSession("source-selector", "worker", "/tmp/worker", { name: "source-selector" });
+    session.channel = "slack";
+    dbUpsertObserverRule({
+      id: "whatsapp-only",
+      scope: "global",
+      observerAgentId: "observer",
+      observerRole: "whatsapp-only",
+      selector: `source.channel == "whatsapp"`,
+    });
+
+    const result = ensureObserverBindingsForSession({ sessionName: "source-selector", session });
+    expect(result.bindings).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toBe("selector_mismatch");
+  });
+
+  it("keeps legacy sourceExclusions metadata as compatibility input", () => {
+    const session = getOrCreateSession("agent:worker:cron:legacy", "worker", "/tmp/worker", {
+      name: "legacy-cron",
+    });
+    dbUpsertObserverRule({
+      id: "legacy-exclusions",
+      observerAgentId: "observer",
+      observerRole: "legacy-exclusions",
+      metadata: { sourceExclusions: { sessionKeyFragments: [":cron:"] } },
+    });
+
+    const result = ensureObserverBindingsForSession({ sessionName: "legacy-cron", session });
+    expect(result.bindings).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toBe("excluded_source_session_key_fragment");
+  });
+
+  it("rejects invalid or out-of-bound observer selectors", () => {
+    expect(() =>
+      dbUpsertObserverRule({
+        id: "invalid-selector",
+        observerAgentId: "observer",
+        selector: `secret.token == "nope"`,
+      }),
+    ).toThrow("Invalid observer selector");
+  });
+
+  it("reconciles and disables durable bindings that no longer match", () => {
+    const session = getOrCreateSession("reconcile-source", "worker", "/tmp/worker", {
+      name: "reconcile-source",
+    });
+    session.channel = "slack";
+    dbUpsertObserverRule({
+      id: "reconcile-rule",
+      observerAgentId: "observer",
+      observerRole: "reconcile-role",
+      selector: `source.channel == "slack"`,
+    });
+    ensureObserverBindingsForSession({ sessionName: "reconcile-source", session });
+    dbUpsertObserverRule({
+      id: "reconcile-rule",
+      observerAgentId: "observer",
+      selector: `source.channel == "whatsapp"`,
+    });
+
+    const result = reconcileObserverBindingsForSession({
+      sessionName: "reconcile-source",
+      session,
+      mode: "full-reconcile",
+    });
+    expect(result.bindings).toHaveLength(0);
+    expect(result.disabled).toHaveLength(1);
+    expect(dbListObserverBindings({ sourceSessionKey: session.sessionKey })[0]?.enabled).toBe(false);
   });
 
   it("matches contact-tagged observer rules via session participants", () => {
@@ -281,6 +403,7 @@ describe("Observation Plane", () => {
           runId: "run-test",
           sequence: 2,
           type: "turn.complete",
+          turnId: "turn-deliver",
           payload: { responseChars: 10 },
         }),
       ],
@@ -290,9 +413,60 @@ describe("Observation Plane", () => {
     expect(publishedPrompts).toHaveLength(1);
     expect(publishedPrompts[0]?.sessionName).toMatch(/^obs:/);
     expect(publishedPrompts[0]?.payload._agentId).toBe("observer");
+    expect(publishedPrompts[0]?.payload._observation).toMatchObject({ sourceTurnIds: ["turn-deliver"] });
     expect(String(publishedPrompts[0]?.payload.prompt)).toContain("Turn Completed");
     expect(String(publishedPrompts[0]?.payload.prompt)).not.toContain('{"id"');
     expect(String(publishedPrompts[0]?.payload.prompt)).not.toContain("ignored by filter");
+  });
+
+  it("claims delivery ids durably and releases the claim when publishing fails", async () => {
+    const session = getOrCreateSession("dedupe-source", "worker", "/tmp/worker", { name: "dedupe-source" });
+    dbUpsertObserverRule({
+      id: "dedupe-rule",
+      observerAgentId: "observer",
+      observerRole: "dedupe-role",
+      observerMode: "summarize",
+      eventTypes: ["turn.complete"],
+    });
+    ensureObserverBindingsForSession({ sessionName: "dedupe-source", session });
+    const event = createObservationEvent({
+      runId: "run-dedupe",
+      sequence: 1,
+      type: "turn.complete",
+    });
+
+    let attempts = 0;
+    setObservationPromptPublisherForTests(async (sessionName, payload) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary publish failure");
+      publishedPrompts.push({ sessionName, payload });
+    });
+    await expect(
+      deliverObservationEvents({
+        sourceSessionName: "dedupe-source",
+        sourceSession: session,
+        agentId: "worker",
+        events: [event],
+      }),
+    ).rejects.toThrow("temporary publish failure");
+
+    const retry = await deliverObservationEvents({
+      sourceSessionName: "dedupe-source",
+      sourceSession: session,
+      agentId: "worker",
+      events: [event],
+    });
+    const duplicate = await deliverObservationEvents({
+      sourceSessionName: "dedupe-source",
+      sourceSession: session,
+      agentId: "worker",
+      events: [event],
+    });
+
+    expect(retry.delivered).toHaveLength(1);
+    expect(duplicate.delivered).toHaveLength(0);
+    expect(duplicate.skipped[0]?.reason).toBe("events_already_delivered");
+    expect(attempts).toBe(2);
   });
 
   it("uses rule-selected Markdown profiles and snapshots them on bindings", async () => {

--- a/src/runtime/observation-plane.ts
+++ b/src/runtime/observation-plane.ts
@@ -18,6 +18,8 @@ import {
 } from "./observation-profiles.js";
 import { DEFAULT_RUNTIME_PROVIDER_ID } from "./provider-registry.js";
 import type { RuntimeProviderId } from "./types.js";
+import { compilePredicate, type CompiledPredicate } from "../policy/predicate.js";
+import { classifyTurnProvenance, type TurnProvenance } from "./turn-provenance.js";
 
 const log = logger.child("runtime:observation-plane");
 
@@ -25,6 +27,7 @@ export type ObserverScope = "global" | "agent" | "session" | "task" | "profile" 
 export type ObserverMode = "observe" | "summarize" | "report" | "intervene";
 export type ObservationDeliveryPolicy = "realtime" | "debounce" | "end_of_turn" | "manual";
 export type ObserverTagTargetType = "agent" | "session" | "task" | "project" | "contact" | "profile" | "any";
+export type ObserverReconcileMode = "attach-missing" | "detach-disabled" | "refresh-profile" | "full-reconcile";
 
 const OBSERVER_SCOPES = new Set<ObserverScope>(["global", "agent", "session", "task", "profile", "project", "tag"]);
 const OBSERVER_MODES = new Set<ObserverMode>(["observe", "summarize", "report", "intervene"]);
@@ -64,6 +67,7 @@ export interface ObserverRule {
   tagSlug?: string;
   tagInherited: boolean;
   permissionGrants: string[];
+  selector?: string;
   metadata?: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
@@ -92,6 +96,8 @@ export interface ObserverRuleInput {
   tagSlug?: string;
   tagInherited?: boolean;
   permissionGrants?: string[];
+  /** Predicate over source.*, turn.* and event.*; invalid selectors fail closed. */
+  selector?: string | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -115,6 +121,7 @@ export interface ObserverBinding {
   deliveryPolicy: ObservationDeliveryPolicy;
   debounceMs?: number;
   permissionGrants: string[];
+  selector?: string;
   metadata?: Record<string, unknown>;
   enabled: boolean;
   createdAt: number;
@@ -129,6 +136,8 @@ export interface ObservationEvent {
   turnId?: string;
   preview?: string;
   payload?: Record<string, unknown>;
+  /** Snapshot of the turn cause; required for correct deferred/debounced selection. */
+  turn: TurnProvenance;
 }
 
 export interface ObservationSourceTag {
@@ -160,6 +169,12 @@ export interface ObservationSourceDescriptor {
   projectId?: string;
   projectSlug?: string;
   contactIds?: string[];
+  channel?: string;
+  accountId?: string;
+  chatId?: string;
+  threadId?: string;
+  chatType?: SessionEntry["chatType"];
+  actorType?: string;
   tags: ObservationSourceTag[];
 }
 
@@ -192,6 +207,7 @@ interface ObserverRuleRow {
   tag_slug: string | null;
   tag_inherited: number;
   permission_grants_json: string;
+  selector: string | null;
   metadata_json: string | null;
   created_at: number;
   updated_at: number;
@@ -217,6 +233,7 @@ interface ObserverBindingRow {
   delivery_policy: ObservationDeliveryPolicy;
   debounce_ms: number | null;
   permission_grants_json: string;
+  selector: string | null;
   metadata_json: string | null;
   enabled: number;
   created_at: number;
@@ -270,6 +287,7 @@ export function ensureObservationSchema(): void {
       tag_slug TEXT,
       tag_inherited INTEGER NOT NULL DEFAULT 0 CHECK(tag_inherited IN (0,1)),
       permission_grants_json TEXT NOT NULL,
+      selector TEXT,
       metadata_json TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
@@ -302,6 +320,7 @@ export function ensureObservationSchema(): void {
       delivery_policy TEXT NOT NULL CHECK(delivery_policy IN ('realtime','debounce','end_of_turn','manual')),
       debounce_ms INTEGER,
       permission_grants_json TEXT NOT NULL,
+      selector TEXT,
       metadata_json TEXT,
       enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0,1)),
       created_at INTEGER NOT NULL,
@@ -316,6 +335,13 @@ export function ensureObservationSchema(): void {
       ON observer_bindings(observer_session_name);
     CREATE INDEX IF NOT EXISTS idx_observer_bindings_rule
       ON observer_bindings(rule_id);
+
+    CREATE TABLE IF NOT EXISTS observer_delivery_events (
+      binding_id TEXT NOT NULL REFERENCES observer_bindings(id) ON DELETE CASCADE,
+      event_id TEXT NOT NULL,
+      delivered_at INTEGER NOT NULL,
+      PRIMARY KEY(binding_id, event_id)
+    );
   `);
   ensureObservationColumn("observer_rules", "observer_runtime_provider_id", "TEXT");
   ensureObservationColumn("observer_rules", "observer_model", "TEXT");
@@ -327,6 +353,8 @@ export function ensureObservationSchema(): void {
   ensureObservationColumn("observer_bindings", "observer_profile_source", "TEXT");
   ensureObservationColumn("observer_bindings", "observer_profile_snapshot_markdown", "TEXT");
   ensureObservationColumn("observer_bindings", "debounce_ms", "INTEGER");
+  ensureObservationColumn("observer_rules", "selector", "TEXT");
+  ensureObservationColumn("observer_bindings", "selector", "TEXT");
   schemaReady = true;
   schemaDbPath = dbPath;
 }
@@ -362,6 +390,88 @@ function cleanOptionalText(value: string | null | undefined): string | null {
 
 function resolveOptionalTextOverride(value: string | null | undefined, existing?: string): string | undefined {
   return cleanOptionalText(value === undefined ? existing : value) ?? undefined;
+}
+
+const OBSERVER_SELECTOR_ROOTS = ["source", "turn", "event"] as const;
+const observerSelectorCache = new Map<string, CompiledPredicate>();
+
+function compileObserverSelector(selector: string): CompiledPredicate {
+  const cached = observerSelectorCache.get(selector);
+  if (cached) return cached;
+  const result = compilePredicate(selector, {
+    allowedRoots: OBSERVER_SELECTOR_ROOTS,
+    pathLabel: "source.<path>, turn.<path> or event.<path>",
+  });
+  if (!result.ok) throw new Error(`Invalid observer selector: ${result.error}`);
+  observerSelectorCache.set(selector, result.predicate);
+  if (observerSelectorCache.size > 500) {
+    observerSelectorCache.delete(observerSelectorCache.keys().next().value ?? "");
+  }
+  return result.predicate;
+}
+
+function resolveSelectorOverride(value: string | null | undefined, existing?: string): string | undefined {
+  const selector = resolveOptionalTextOverride(value, existing);
+  if (selector) compileObserverSelector(selector);
+  return selector;
+}
+
+interface ObserverSourceExclusions {
+  agentIds: string[];
+  sessionKeys: string[];
+  sessionNames: string[];
+  sessionKeyFragments: string[];
+}
+
+function sourceExclusionList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function observerSourceExclusions(metadata?: Record<string, unknown>): ObserverSourceExclusions | null {
+  const value = metadata?.sourceExclusions;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  return {
+    agentIds: sourceExclusionList(raw.agentIds),
+    sessionKeys: sourceExclusionList(raw.sessionKeys),
+    sessionNames: sourceExclusionList(raw.sessionNames),
+    sessionKeyFragments: sourceExclusionList(raw.sessionKeyFragments),
+  };
+}
+
+function validateObserverSourceExclusions(metadata?: Record<string, unknown>): void {
+  const value = metadata?.sourceExclusions;
+  if (value === undefined) return;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Observer metadata.sourceExclusions must be an object.");
+  }
+  const raw = value as Record<string, unknown>;
+  for (const key of ["agentIds", "sessionKeys", "sessionNames", "sessionKeyFragments"] as const) {
+    const list = raw[key];
+    if (list === undefined) continue;
+    if (!Array.isArray(list) || list.some((item) => typeof item !== "string" || !item.trim())) {
+      throw new Error(`Observer metadata.sourceExclusions.${key} must be an array of non-empty strings.`);
+    }
+  }
+}
+
+function sourceExclusionReason(
+  metadata: Record<string, unknown> | undefined,
+  source: ObservationSourceDescriptor,
+): string | null {
+  const exclusions = observerSourceExclusions(metadata);
+  if (!exclusions) return null;
+  if (exclusions.agentIds.includes(source.agentId)) return "excluded_source_agent";
+  if (exclusions.sessionKeys.includes(source.sessionKey)) return "excluded_source_session_key";
+  if (exclusions.sessionNames.includes(source.sessionName)) return "excluded_source_session_name";
+  if (exclusions.sessionKeyFragments.some((fragment) => source.sessionKey.includes(fragment))) {
+    return "excluded_source_session_key_fragment";
+  }
+  return null;
 }
 
 function normalizeId(value: string, label: string): string {
@@ -517,6 +627,7 @@ function rowToRule(row: ObserverRuleRow): ObserverRule {
     ...(row.tag_slug ? { tagSlug: row.tag_slug } : {}),
     tagInherited: row.tag_inherited === 1,
     permissionGrants: parseJsonArray(row.permission_grants_json),
+    ...(row.selector ? { selector: row.selector } : {}),
     ...(parseJsonObject(row.metadata_json) ? { metadata: parseJsonObject(row.metadata_json) } : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -546,6 +657,7 @@ function rowToBinding(row: ObserverBindingRow): ObserverBinding {
     deliveryPolicy: row.delivery_policy,
     ...(row.debounce_ms !== null ? { debounceMs: row.debounce_ms } : {}),
     permissionGrants: parseJsonArray(row.permission_grants_json),
+    ...(row.selector ? { selector: row.selector } : {}),
     ...(parseJsonObject(row.metadata_json) ? { metadata: parseJsonObject(row.metadata_json) } : {}),
     enabled: row.enabled === 1,
     createdAt: row.created_at,
@@ -593,6 +705,9 @@ export function dbUpsertObserverRule(input: ObserverRuleInput): ObserverRule {
   const permissionGrants = normalizePermissionGrants(input.permissionGrants ?? existing?.permissionGrants);
   const tagTargetType = normalizeTagTargetType(input.tagTargetType ?? existing?.tagTargetType);
   const tagSlug = normalizeTagSlug(input.tagSlug ?? existing?.tagSlug);
+  const selector = resolveSelectorOverride(input.selector, existing?.selector);
+  const metadata = input.metadata ?? existing?.metadata;
+  validateObserverSourceExclusions(metadata);
 
   validateRuleSafety({
     scope,
@@ -616,9 +731,9 @@ export function dbUpsertObserverRule(input: ObserverRuleInput): ObserverRule {
           observer_runtime_provider_id, observer_model, observer_profile_id, observer_mode,
           event_types_json, delivery_policy, debounce_ms,
           source_agent_id, source_session, source_task_id, source_profile_id, source_project_id,
-          tag_target_type, tag_slug, tag_inherited, permission_grants_json, metadata_json,
+          tag_target_type, tag_slug, tag_inherited, permission_grants_json, selector, metadata_json,
           created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           enabled = excluded.enabled,
           scope = excluded.scope,
@@ -641,6 +756,7 @@ export function dbUpsertObserverRule(input: ObserverRuleInput): ObserverRule {
           tag_slug = excluded.tag_slug,
           tag_inherited = excluded.tag_inherited,
           permission_grants_json = excluded.permission_grants_json,
+          selector = excluded.selector,
           metadata_json = excluded.metadata_json,
           updated_at = excluded.updated_at
       `,
@@ -668,7 +784,8 @@ export function dbUpsertObserverRule(input: ObserverRuleInput): ObserverRule {
       tagSlug,
       (input.tagInherited ?? existing?.tagInherited) ? 1 : 0,
       stringifyJson(permissionGrants),
-      (input.metadata ?? existing?.metadata) ? stringifyJson(input.metadata ?? existing?.metadata) : null,
+      selector ?? null,
+      metadata ? stringifyJson(metadata) : null,
       existing?.createdAt ?? now,
       now,
     );
@@ -779,9 +896,9 @@ function upsertObserverBinding(input: {
           observer_runtime_provider_id, observer_model,
           observer_profile_id, observer_profile_version, observer_profile_source, observer_profile_snapshot_markdown,
           observer_role, observer_mode, rule_id,
-          event_types_json, delivery_policy, debounce_ms, permission_grants_json, metadata_json,
+          event_types_json, delivery_policy, debounce_ms, permission_grants_json, selector, metadata_json,
           enabled, created_at, updated_at, last_delivered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(source_session_key, observer_role) DO UPDATE SET
           source_session_name = excluded.source_session_name,
           source_agent_id = excluded.source_agent_id,
@@ -798,6 +915,7 @@ function upsertObserverBinding(input: {
           delivery_policy = excluded.delivery_policy,
           debounce_ms = excluded.debounce_ms,
           permission_grants_json = excluded.permission_grants_json,
+          selector = excluded.selector,
           metadata_json = excluded.metadata_json,
           enabled = excluded.enabled,
           updated_at = excluded.updated_at
@@ -823,6 +941,7 @@ function upsertObserverBinding(input: {
       input.rule.deliveryPolicy,
       input.rule.debounceMs ?? null,
       stringifyJson(input.rule.permissionGrants),
+      input.rule.selector ?? null,
       metadata ? stringifyJson(metadata) : null,
       input.rule.enabled ? 1 : 0,
       existing?.createdAt ?? now,
@@ -900,6 +1019,8 @@ export function buildObservationSourceDescriptor(input: {
   const workflow = task?.id ? dbGetTaskWorkflowSurface(task.id) : null;
   const project = workflow ? getProjectSurfaceByWorkflowRunId(workflow.workflowRunId) : null;
   const contactIds = resolveSessionContactIds(input.session);
+  const promptSource = input.prompt?.source;
+  const promptContext = input.prompt?.context;
   const tags = uniqueTags([
     ...collectTagsForTarget("session", sourceSessionName),
     ...(sourceSessionName !== input.session.sessionKey
@@ -924,6 +1045,28 @@ export function buildObservationSourceDescriptor(input: {
     ...(project?.projectId ? { projectId: project.projectId } : {}),
     ...(project?.projectSlug ? { projectSlug: project.projectSlug } : {}),
     ...(contactIds.length > 0 ? { contactIds } : {}),
+    ...((promptSource?.channel ?? input.session.channel ?? input.session.lastChannel)
+      ? { channel: promptSource?.channel ?? input.session.channel ?? input.session.lastChannel }
+      : {}),
+    ...((promptSource?.accountId ?? promptContext?.accountId ?? input.session.accountId ?? input.session.lastAccountId)
+      ? {
+          accountId:
+            promptSource?.accountId ??
+            promptContext?.accountId ??
+            input.session.accountId ??
+            input.session.lastAccountId,
+        }
+      : {}),
+    ...((promptSource?.chatId ?? promptContext?.chatId ?? input.session.lastTo)
+      ? { chatId: promptSource?.chatId ?? promptContext?.chatId ?? input.session.lastTo }
+      : {}),
+    ...((promptSource?.threadId ?? input.session.lastThreadId)
+      ? { threadId: promptSource?.threadId ?? input.session.lastThreadId }
+      : {}),
+    ...(input.session.chatType ? { chatType: input.session.chatType } : {}),
+    ...((promptContext?.actorType ?? promptSource?.actorType)
+      ? { actorType: promptContext?.actorType ?? promptSource?.actorType }
+      : {}),
     tags,
   };
 }
@@ -936,7 +1079,7 @@ function isObserverSessionName(sessionName: string): boolean {
   return sessionName.startsWith("obs:");
 }
 
-function matchRule(rule: ObserverRule, source: ObservationSourceDescriptor): ObserverRuleMatchResult {
+function matchLegacyRule(rule: ObserverRule, source: ObservationSourceDescriptor): ObserverRuleMatchResult {
   if (!rule.enabled) return { matched: false, reason: "disabled" };
   switch (rule.scope) {
     case "global":
@@ -1006,6 +1149,26 @@ function matchRule(rule: ObserverRule, source: ObservationSourceDescriptor): Obs
           }
         : { matched: false, reason: "tag_mismatch" };
     }
+  }
+}
+
+function matchRule(rule: ObserverRule, source: ObservationSourceDescriptor): ObserverRuleMatchResult {
+  const legacy = matchLegacyRule(rule, source);
+  if (!legacy.matched) return legacy;
+  const exclusionReason = sourceExclusionReason(rule.metadata, source);
+  if (exclusionReason) return { matched: false, reason: exclusionReason };
+  if (!rule.selector) return legacy;
+
+  try {
+    const selector = compileObserverSelector(rule.selector);
+    if (selector.roots.some((root) => root !== "source")) {
+      return { ...legacy, reason: `${legacy.reason}+selector_deferred` };
+    }
+    return selector.evaluate({ source })
+      ? { ...legacy, reason: `${legacy.reason}+selector` }
+      : { matched: false, reason: "selector_mismatch" };
+  } catch {
+    return { matched: false, reason: "invalid_selector" };
   }
 }
 
@@ -1082,17 +1245,105 @@ export function ensureObserverBindingsForSession(input: {
   return { source, bindings, created, skipped };
 }
 
+/** Reconcile durable bindings against the current rule/profile desired state. */
+export function reconcileObserverBindingsForSession(input: {
+  sessionName: string;
+  session: SessionEntry;
+  agent?: AgentConfig;
+  prompt?: RuntimeLaunchPrompt;
+  mode?: ObserverReconcileMode;
+}): ReturnType<typeof ensureObserverBindingsForSession> & {
+  mode: ObserverReconcileMode;
+  disabled: ObserverBinding[];
+  refreshedProfiles: ObserverBinding[];
+} {
+  const mode = input.mode ?? "attach-missing";
+  const result = ensureObserverBindingsForSession(input);
+  if (!result.source || mode === "attach-missing") {
+    return { ...result, mode, disabled: [], refreshedProfiles: [] };
+  }
+
+  const selectedIds = new Set(result.bindings.map((binding) => binding.id));
+  const disabled: ObserverBinding[] = [];
+  const refreshedProfiles: ObserverBinding[] = [];
+  const shouldDetach = mode === "detach-disabled" || mode === "full-reconcile";
+  const shouldRefreshProfiles = mode === "refresh-profile" || mode === "full-reconcile";
+
+  const existingBindings = dbListObserverBindings({ sourceSessionKey: result.source.sessionKey });
+  const db = getDb();
+  db.transaction(() => {
+    for (const binding of existingBindings) {
+      const selected = selectedIds.has(binding.id);
+      if (shouldDetach && !selected && binding.enabled) {
+        db.prepare("UPDATE observer_bindings SET enabled = 0, updated_at = ? WHERE id = ?").run(Date.now(), binding.id);
+        const updated = dbGetObserverBinding(binding.id);
+        if (updated) disabled.push(updated);
+        continue;
+      }
+      if (!shouldRefreshProfiles || !selected) continue;
+
+      const rule = dbGetObserverRule(binding.ruleId);
+      const profile = resolveObserverProfile(rule?.observerProfileId ?? binding.observerProfileId);
+      db.prepare(
+        `UPDATE observer_bindings
+         SET observer_profile_id = ?, observer_profile_version = ?, observer_profile_source = ?,
+             observer_profile_snapshot_markdown = ?, updated_at = ?
+         WHERE id = ?`,
+      ).run(
+        profile.id,
+        profile.version,
+        profile.source,
+        buildObserverProfileSnapshotMarkdown(profile),
+        Date.now(),
+        binding.id,
+      );
+      const updated = dbGetObserverBinding(binding.id);
+      if (updated) refreshedProfiles.push(updated);
+    }
+  })();
+
+  const reload = (binding: ObserverBinding): ObserverBinding => dbGetObserverBinding(binding.id) ?? binding;
+  return {
+    ...result,
+    bindings: result.bindings.map(reload),
+    created: result.created.map(reload),
+    mode,
+    disabled,
+    refreshedProfiles,
+  };
+}
+
 function bindingAllowsEvent(
   binding: ObserverBinding,
+  source: ObservationSourceDescriptor,
   event: ObservationEvent,
   deliveryPolicies?: Set<ObservationDeliveryPolicy>,
 ): boolean {
-  return (
+  const basicMatch =
     binding.enabled &&
     binding.deliveryPolicy !== "manual" &&
     (!deliveryPolicies || deliveryPolicies.has(binding.deliveryPolicy)) &&
-    binding.eventTypes.includes(event.type)
-  );
+    binding.eventTypes.includes(event.type);
+  if (!basicMatch) return false;
+  if (sourceExclusionReason(binding.metadata, source)) return false;
+  if (!binding.selector) return true;
+  try {
+    return compileObserverSelector(binding.selector).evaluate({
+      source,
+      turn: event.turn,
+      event: {
+        id: event.id,
+        type: event.type,
+        timestamp: event.timestamp,
+        turnId: event.turnId,
+        preview: event.preview,
+        payload: event.payload,
+      },
+    });
+  } catch {
+    // Persisted invalid selectors fail closed even if the database was edited manually.
+    return false;
+  }
 }
 
 function composeObservationPrompt(input: {
@@ -1112,6 +1363,19 @@ function composeObservationPrompt(input: {
     deliveryPolicy: input.binding.deliveryPolicy,
     runId: input.runId,
   });
+}
+
+function claimObservationEvents(bindingId: string, events: ObservationEvent[]): ObservationEvent[] {
+  const statement = getDb().prepare(
+    "INSERT OR IGNORE INTO observer_delivery_events (binding_id, event_id, delivered_at) VALUES (?, ?, ?)",
+  );
+  const now = Date.now();
+  return events.filter((event) => statement.run(bindingId, event.id, now).changes > 0);
+}
+
+function releaseObservationEventClaims(bindingId: string, events: ObservationEvent[]): void {
+  const statement = getDb().prepare("DELETE FROM observer_delivery_events WHERE binding_id = ? AND event_id = ?");
+  for (const event of events) statement.run(bindingId, event.id);
 }
 
 export async function deliverObservationEvents(input: {
@@ -1150,44 +1414,67 @@ export async function deliverObservationEvents(input: {
   const deliveryPolicies = input.deliveryPolicies ? new Set(input.deliveryPolicies) : undefined;
 
   for (const binding of bindings) {
-    const selected = input.events.filter((event) => bindingAllowsEvent(binding, event, deliveryPolicies));
+    const exclusionReason = sourceExclusionReason(binding.metadata, source);
+    if (exclusionReason) {
+      skipped.push({ bindingId: binding.id, reason: exclusionReason });
+      continue;
+    }
+    const selected = input.events.filter((event) => bindingAllowsEvent(binding, source, event, deliveryPolicies));
     if (selected.length === 0) {
-      skipped.push({ bindingId: binding.id, reason: "no_matching_events" });
+      skipped.push({
+        bindingId: binding.id,
+        reason: binding.selector ? "selector_or_event_mismatch" : "no_matching_events",
+      });
+      continue;
+    }
+
+    const claimed = claimObservationEvents(binding.id, selected);
+    if (claimed.length === 0) {
+      skipped.push({ bindingId: binding.id, reason: "events_already_delivered" });
       continue;
     }
 
     const prompt = composeObservationPrompt({
       binding,
       source,
-      events: selected,
+      events: claimed,
       runId: input.runId,
     });
-    await observationPromptPublisher(binding.observerSessionName, {
-      prompt,
-      _agentId: binding.observerAgentId,
-      ...(binding.observerRuntimeProviderId ? { _runtimeProviderId: binding.observerRuntimeProviderId } : {}),
-      ...(binding.observerModel ? { _runtimeModel: binding.observerModel } : {}),
-      _observation: {
-        sourceSessionKey: source.sessionKey,
-        sourceSessionName: source.sessionName,
-        bindingId: binding.id,
-        ruleId: binding.ruleId,
-        role: binding.observerRole,
-        mode: binding.observerMode,
-        ...(binding.observerProfileId ? { profileId: binding.observerProfileId } : {}),
-        ...(binding.observerProfileVersion ? { profileVersion: binding.observerProfileVersion } : {}),
-        ...(binding.permissionGrants.length > 0 ? { permissionGrants: binding.permissionGrants } : {}),
-        eventIds: selected.map((event) => event.id),
-      },
-      deliveryBarrier: "after_response",
-    });
+    const sourceTurnIds = [
+      ...new Set(claimed.map((event) => event.turnId).filter((id): id is string => Boolean(id))),
+    ].sort();
+    try {
+      await observationPromptPublisher(binding.observerSessionName, {
+        prompt,
+        _agentId: binding.observerAgentId,
+        ...(binding.observerRuntimeProviderId ? { _runtimeProviderId: binding.observerRuntimeProviderId } : {}),
+        ...(binding.observerModel ? { _runtimeModel: binding.observerModel } : {}),
+        _observation: {
+          sourceSessionKey: source.sessionKey,
+          sourceSessionName: source.sessionName,
+          bindingId: binding.id,
+          ruleId: binding.ruleId,
+          role: binding.observerRole,
+          mode: binding.observerMode,
+          ...(binding.observerProfileId ? { profileId: binding.observerProfileId } : {}),
+          ...(binding.observerProfileVersion ? { profileVersion: binding.observerProfileVersion } : {}),
+          ...(binding.permissionGrants.length > 0 ? { permissionGrants: binding.permissionGrants } : {}),
+          eventIds: claimed.map((event) => event.id),
+          ...(sourceTurnIds.length > 0 ? { sourceTurnIds } : {}),
+        },
+        deliveryBarrier: "after_response",
+      });
+    } catch (error) {
+      releaseObservationEventClaims(binding.id, claimed);
+      throw error;
+    }
     getDb()
       .prepare("UPDATE observer_bindings SET last_delivered_at = ?, updated_at = ? WHERE id = ?")
       .run(Date.now(), Date.now(), binding.id);
     delivered.push({
       bindingId: binding.id,
       observerSessionName: binding.observerSessionName,
-      eventCount: selected.length,
+      eventCount: claimed.length,
     });
   }
 
@@ -1215,6 +1502,16 @@ export function getObservationDebounceMs(input: {
   const delays = bindings
     .filter(
       (binding) =>
+        !sourceExclusionReason(binding.metadata, source) &&
+        (!binding.selector ||
+          (() => {
+            try {
+              const selector = compileObserverSelector(binding.selector);
+              return selector.roots.some((root) => root !== "source") || selector.evaluate({ source });
+            } catch {
+              return false;
+            }
+          })()) &&
         binding.deliveryPolicy === "debounce" &&
         input.eventTypes.some((eventType) => binding.eventTypes.includes(eventType)),
     )
@@ -1229,6 +1526,8 @@ export function validateObserverRules(): {
   const errors: Array<{ ruleId: string; message: string }> = [];
   for (const rule of dbListObserverRules()) {
     try {
+      if (rule.selector) compileObserverSelector(rule.selector);
+      validateObserverSourceExclusions(rule.metadata);
       validateRuleSafety({
         scope: rule.scope,
         mode: rule.observerMode,
@@ -1251,10 +1550,11 @@ export function validateObserverRules(): {
 }
 
 export function createObservationEvent(
-  input: Omit<ObservationEvent, "id" | "timestamp"> & {
+  input: Omit<ObservationEvent, "id" | "timestamp" | "turn"> & {
     runId: string;
     sequence: number;
     timestamp?: number;
+    turn?: TurnProvenance;
   },
 ): ObservationEvent {
   return {
@@ -1264,6 +1564,7 @@ export function createObservationEvent(
     ...(input.turnId ? { turnId: input.turnId } : {}),
     ...(input.preview ? { preview: input.preview } : {}),
     ...(input.payload ? { payload: input.payload } : {}),
+    turn: input.turn ?? classifyTurnProvenance(),
   };
 }
 

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -8,6 +8,7 @@ import {
 } from "../omni/session-stream.js";
 import { logger } from "../utils/logger.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
 
 const log = logger.child("runtime:prompt-subscription");
@@ -136,6 +137,7 @@ export class RuntimePromptSubscription {
                 taskBarrierTaskId: prompt.taskBarrierTaskId,
                 commands: prompt.commands,
                 observation: prompt._observation,
+                turnProvenance: classifyTurnProvenance({ prompt }),
                 thread: prompt._thread,
                 _agentId: prompt._agentId,
                 timestamp: new Date().toISOString(),

--- a/src/runtime/runtime-request-builder.ts
+++ b/src/runtime/runtime-request-builder.ts
@@ -9,7 +9,7 @@ import {
   summarizeRuntimeCapabilities,
 } from "../session-trace/runtime-trace.js";
 import type { TaskRuntimeResolution } from "../tasks/types.js";
-import { classifyCompactionAnnouncement } from "./compaction-announcement.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 import { resolveAgentSkills } from "./allowed-skills.js";
 import { createRuntimeMessageGenerator } from "./delivery-queue.js";
 import { getRuntimeToolAccessMode } from "./host-services.js";
@@ -333,6 +333,7 @@ export async function buildRuntimeStartRequest(
       pendingIds: input.deliverableMessages.map((message) => message.pendingId).filter((id): id is string => !!id),
       commands: input.deliverableMessages.flatMap((message) => message.commands ?? []),
       runtimeCredential: runtimeCredential ? serializeRuntimeCredentialAttemptBinding(runtimeCredential) : null,
+      turnProvenance: streamingSession.currentTurnProvenance ?? null,
     });
   };
   const messageGenerator = createRuntimeMessageGenerator({
@@ -345,7 +346,7 @@ export async function buildRuntimeStartRequest(
       if (turnSource) {
         streamingSession.currentSource = turnSource;
       }
-      streamingSession.currentTurnCompactionAnnouncement = classifyCompactionAnnouncement({
+      streamingSession.currentTurnProvenance = classifyTurnProvenance({
         prompt: turnPrompt,
         source: turnSource,
       });

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -738,6 +738,58 @@ describe("runtime request context authority", () => {
     expect(canWithCapabilities(runtimeContext.capabilities, "admin", "system", "*")).toBe(false);
   });
 
+  it("runs heartbeat and observer prompts under explicit automation principals", () => {
+    dbCreateAgent({ id: agent.id, cwd: agent.cwd });
+    getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
+
+    const heartbeat = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: "/tmp/provider-agent",
+      agent,
+      prompt: { prompt: "heartbeat", _heartbeat: true },
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+    }).runtimeContext;
+    expect(heartbeat.metadata).toMatchObject({
+      actorPrincipal: "automation:heartbeat",
+      agentIdentityCompartment: "automation:heartbeat",
+      turnProvenance: { origin: "heartbeat", background: true },
+      actor: { identityProvenance: { source: "heartbeat" } },
+    });
+
+    const observer = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: "/tmp/provider-agent",
+      agent,
+      prompt: {
+        prompt: "observe",
+        _observation: {
+          sourceSessionKey: "source-key",
+          sourceSessionName: "source",
+          bindingId: "binding-1",
+          ruleId: "rule-1",
+          role: "observer",
+          mode: "observe",
+          eventIds: ["event-1"],
+          sourceTurnIds: ["turn-source-1"],
+        },
+      },
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+    }).runtimeContext;
+    expect(observer.metadata).toMatchObject({
+      actorPrincipal: "automation:observer:binding-1",
+      agentIdentityCompartment: "automation:observer:binding-1",
+      turnProvenance: { origin: "observer", background: true },
+      actor: { identityProvenance: { source: "observer", bindingId: "binding-1", ruleId: "rule-1" } },
+      observation: { ruleId: "rule-1", sourceTurnIds: ["turn-source-1"] },
+    });
+  });
+
   it("runs session followup prompts as automation principals with their delivery surface", () => {
     dbCreateAgent({ id: agent.id, cwd: agent.cwd });
     getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });

--- a/src/runtime/runtime-request-context.ts
+++ b/src/runtime/runtime-request-context.ts
@@ -26,6 +26,7 @@ import {
   snapshotAgentCapabilities,
 } from "./runtime-context-store.js";
 import type { RuntimeCapabilities, RuntimeProviderId } from "./types.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 
 export interface RuntimeRequestContextOptions {
   dbSessionKey: string;
@@ -466,6 +467,7 @@ function buildRuntimeContextMetadata(options: {
       ? { runtimeThinking: options.runtimeResolution.options.thinking }
       : {}),
     runtimeModelSource: options.runtimeResolution.sources.model,
+    turnProvenance: classifyTurnProvenance({ prompt: options.prompt, source: options.resolvedSource }),
     ...(options.runtimeResolution.modelPresetId
       ? { runtimeModelPresetId: options.runtimeResolution.modelPresetId }
       : {}),
@@ -476,6 +478,7 @@ function buildRuntimeContextMetadata(options: {
     runtimeThinkingSource: options.runtimeResolution.sources.thinking,
     ...(options.approvalSource ? { approvalSource: options.approvalSource } : {}),
     ...(actorMetadata ? { actor: actorMetadata, actorMetadata } : {}),
+    ...(options.prompt._observation ? { observation: { ...options.prompt._observation } } : {}),
     ...(options.prompt._thread ? { raviThread: options.prompt._thread } : {}),
   };
 }
@@ -515,6 +518,12 @@ function resolveAutomationPromptPrincipal(
   source?: RuntimeMessageTarget,
   context?: RuntimeLaunchPrompt["context"],
 ): AuthorityPrincipal | null {
+  if (prompt._observation) {
+    return {
+      subjectType: "automation",
+      subjectId: `observer:${prompt._observation.bindingId}`,
+    };
+  }
   if (prompt._cron && prompt._jobId) {
     return { subjectType: "automation", subjectId: `cron:${prompt._jobId}` };
   }
@@ -530,6 +539,9 @@ function resolveAutomationPromptPrincipal(
       subjectId: "session-followup",
     };
   }
+  if (prompt._heartbeat) {
+    return { subjectType: "automation", subjectId: "heartbeat" };
+  }
   if (prompt._daemonRestartResume) {
     if (hasResolvedContactActor(source) || hasResolvedContactActor(context)) {
       return null;
@@ -544,9 +556,29 @@ function hasResolvedContactActor(metadata: { actorType?: string; contactId?: str
 }
 
 function buildAutomationIdentityProvenance(prompt: RuntimeLaunchPrompt): Record<string, unknown> | undefined {
+  if (prompt._observation) {
+    return {
+      source: "observer",
+      bindingId: prompt._observation.bindingId,
+      ruleId: prompt._observation.ruleId,
+    };
+  }
   if (prompt._cron && prompt._jobId) {
     return { source: "cron", jobId: prompt._jobId };
   }
+  if (prompt._trigger) {
+    return { source: "trigger", ...(prompt._triggerId ? { triggerId: prompt._triggerId } : {}) };
+  }
+  if (prompt._sessionFollowup) {
+    return {
+      source: "session-followup",
+      ...(prompt._sessionFollowupCadenceId ? { cadenceId: prompt._sessionFollowupCadenceId } : {}),
+      ...(prompt._sessionFollowupRunId ? { runId: prompt._sessionFollowupRunId } : {}),
+    };
+  }
+  if (prompt._heartbeat) return { source: "heartbeat" };
+  if (prompt.taskBarrierTaskId) return { source: "task", taskId: prompt.taskBarrierTaskId };
+  if (prompt._daemonRestartResume) return { source: "daemon-restart" };
   return undefined;
 }
 

--- a/src/runtime/session-pool.test.ts
+++ b/src/runtime/session-pool.test.ts
@@ -93,6 +93,9 @@ describe("runtime session pool", () => {
       }),
     ).toBe("background");
     expect(classifyRuntimeSessionStartLane("main", { prompt: "task", taskBarrierTaskId: "task-1" })).toBe("background");
+    expect(classifyRuntimeSessionStartLane("main", { prompt: "cron", _cron: true })).toBe("background");
+    expect(classifyRuntimeSessionStartLane("main", { prompt: "trigger", _trigger: true })).toBe("background");
+    expect(classifyRuntimeSessionStartLane("main", { prompt: "heartbeat", _heartbeat: true })).toBe("background");
     expect(
       classifyRuntimeSessionStartLane("main", {
         prompt: "system",

--- a/src/runtime/session-pool.ts
+++ b/src/runtime/session-pool.ts
@@ -1,7 +1,7 @@
 import { getSession, getSessionByName } from "../router/index.js";
 import type { RuntimeHostStreamingSession } from "./host-session.js";
-import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 
 export const RUNTIME_SESSION_POOL_MAX_ENV = "RAVI_RUNTIME_SESSION_POOL_MAX";
 export const LEGACY_RUNTIME_SESSION_POOL_MAX_ENV = "RAVI_STREAMING_POOL_MAX";
@@ -165,10 +165,7 @@ export function classifyRuntimeSessionStartLane(
   sessionName?: string | null,
   prompt?: RuntimeLaunchPrompt | null,
 ): RuntimeSessionStartLane {
-  if (prompt?._observation) {
-    return "background";
-  }
-  if (normalizePromptTaskBarrierTaskId(prompt?.taskBarrierTaskId)) {
+  if (classifyTurnProvenance({ prompt }).background) {
     return "background";
   }
   if (sessionName && isTaskSessionName(sessionName)) {

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { saveMessage } from "../db.js";
 import { nats } from "../nats.js";
 import { attachChatToSession } from "../router/sessions.js";
-import { classifyCompactionAnnouncement } from "./compaction-announcement.js";
+import { classifyTurnProvenance } from "./turn-provenance.js";
 import {
   getOrCreateSession,
   getSession,
@@ -445,7 +445,15 @@ describe("runtime session trace instrumentation", () => {
       delivery_barrier: "after_tool",
       task_barrier_task_id: "task-1",
       tool_access_mode: "restricted",
+      turn_provenance: {
+        origin: "task",
+        background: true,
+        automationOriginated: true,
+        automationId: "task:task-1",
+        reason: "prompt.taskBarrierTaskId",
+      },
     });
+    expect(streaming.currentTurnProvenance).toMatchObject({ origin: "task", background: true });
 
     const turn = getSessionTurn(streaming.currentTraceTurnId ?? "");
     expect(turn?.status).toBe("running");
@@ -895,7 +903,7 @@ describe("runtime session trace instrumentation", () => {
     attachSpeakingOutputChat();
     const streaming = makeStreamingSession({
       agentMode: "active",
-      currentTurnCompactionAnnouncement: classifyCompactionAnnouncement({ source }),
+      currentTurnProvenance: classifyTurnProvenance({ source }),
     });
     seedAdapterTrace(streaming);
 
@@ -928,7 +936,7 @@ describe("runtime session trace instrumentation", () => {
       attachSpeakingOutputChat();
       const streaming = makeStreamingSession({
         agentMode: "active",
-        currentTurnCompactionAnnouncement: classifyCompactionAnnouncement({
+        currentTurnProvenance: classifyTurnProvenance({
           prompt: scenario.prompt,
           source,
         }),

--- a/src/runtime/turn-provenance.test.ts
+++ b/src/runtime/turn-provenance.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { classifyTurnProvenance } from "./turn-provenance.js";
+
+describe("classifyTurnProvenance", () => {
+  it("keeps the producer cause when automation replies to a human surface", () => {
+    const result = classifyTurnProvenance({
+      prompt: {
+        prompt: "audit",
+        _cron: true,
+        _jobId: "job-1",
+        source: {
+          channel: "slack",
+          accountId: "main",
+          chatId: "C123",
+          actorType: "contact",
+          contactId: "contact-1",
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      origin: "cron",
+      background: true,
+      automationOriginated: true,
+      automationId: "cron:job-1",
+      reason: "prompt._cron",
+    });
+  });
+
+  it("classifies every built-in background producer", () => {
+    expect(classifyTurnProvenance({ prompt: { prompt: "", _trigger: true } }).origin).toBe("trigger");
+    expect(classifyTurnProvenance({ prompt: { prompt: "", _sessionFollowup: true } }).origin).toBe("session-followup");
+    expect(classifyTurnProvenance({ prompt: { prompt: "", _heartbeat: true } }).origin).toBe("heartbeat");
+    expect(
+      classifyTurnProvenance({
+        prompt: {
+          prompt: "",
+          _observation: {
+            sourceSessionKey: "source",
+            sourceSessionName: "source",
+            bindingId: "binding-1",
+            ruleId: "rule-1",
+            role: "observer",
+            mode: "observe",
+            eventIds: [],
+          },
+        },
+      }).origin,
+    ).toBe("observer");
+    expect(classifyTurnProvenance({ prompt: { prompt: "", taskBarrierTaskId: "task-1" } }).origin).toBe("task");
+    expect(
+      classifyTurnProvenance({
+        prompt: { prompt: "", _daemonRestartResume: { restartEpoch: "epoch-1" } },
+      }).origin,
+    ).toBe("daemon-restart");
+  });
+
+  it("distinguishes a human from an unknown interactive origin", () => {
+    expect(
+      classifyTurnProvenance({
+        source: { actorType: "contact" },
+      }),
+    ).toMatchObject({ origin: "human", background: false });
+    expect(classifyTurnProvenance()).toMatchObject({ origin: "unknown", background: false });
+  });
+
+  it("routes agent and system producers through background capacity", () => {
+    expect(classifyTurnProvenance({ source: { actorType: "agent" } })).toMatchObject({
+      origin: "agent",
+      background: true,
+      automationOriginated: true,
+    });
+    expect(classifyTurnProvenance({ source: { actorType: "system" } })).toMatchObject({
+      origin: "system",
+      background: true,
+      automationOriginated: true,
+    });
+  });
+
+  it("uses actor context when the resolved reply target has no actor metadata", () => {
+    expect(
+      classifyTurnProvenance({
+        prompt: {
+          prompt: "hello",
+          context: {
+            channelId: "slack",
+            channelName: "Slack",
+            accountId: "main",
+            chatId: "C123",
+            messageId: "m1",
+            senderId: "U123",
+            isGroup: true,
+            timestamp: 1,
+            actorType: "contact",
+            contactId: "contact-1",
+          },
+        },
+        source: { identityProvenance: { source: "slack" } },
+      }).origin,
+    ).toBe("human");
+  });
+
+  it("uses automation provenance when prompt markers are unavailable", () => {
+    expect(
+      classifyTurnProvenance({
+        source: {
+          actorType: "automation",
+          automationId: "routine:daily-brief",
+        },
+      }),
+    ).toMatchObject({ origin: "routine", background: true });
+    expect(
+      classifyTurnProvenance({
+        source: { identityProvenance: { source: "observer" } },
+      }).origin,
+    ).toBe("observer");
+  });
+});

--- a/src/runtime/turn-provenance.ts
+++ b/src/runtime/turn-provenance.ts
@@ -1,0 +1,172 @@
+import type { RuntimeMessageTarget } from "./host-session.js";
+import type { RuntimeLaunchPrompt } from "./message-types.js";
+
+/** Canonical cause of a runtime turn. Kept separate from actor authority and reply surface. */
+export type TurnOrigin =
+  | "human"
+  | "cron"
+  | "trigger"
+  | "session-followup"
+  | "heartbeat"
+  | "observer"
+  | "task"
+  | "routine"
+  | "daemon-restart"
+  | "automation"
+  | "agent"
+  | "system"
+  | "background"
+  | "unknown";
+
+export interface TurnProvenance {
+  origin: TurnOrigin;
+  /** True when the turn must use background runtime capacity and silent presence semantics. */
+  background: boolean;
+  /** True when an automated producer, rather than a human message, caused the turn. */
+  automationOriginated: boolean;
+  automationId?: string;
+  /** Stable, machine-readable explanation of the strongest signal used. */
+  reason: string;
+}
+
+type TurnProvenanceSource = Pick<
+  RuntimeMessageTarget,
+  "actorType" | "automationId" | "identityProvenance" | "suppressPresence"
+>;
+
+export interface TurnProvenanceInput {
+  prompt?: Partial<RuntimeLaunchPrompt> | null;
+  source?: TurnProvenanceSource | null;
+}
+
+const AUTOMATION_ORIGINS = new Set<TurnOrigin>([
+  "cron",
+  "trigger",
+  "session-followup",
+  "heartbeat",
+  "observer",
+  "task",
+  "routine",
+  "daemon-restart",
+  "automation",
+  "agent",
+  "system",
+  "background",
+]);
+
+function result(origin: TurnOrigin, reason: string, automationId?: string): TurnProvenance {
+  const background = origin !== "human" && origin !== "unknown";
+  return {
+    origin,
+    background,
+    automationOriginated: AUTOMATION_ORIGINS.has(origin),
+    ...(automationId ? { automationId } : {}),
+    reason,
+  };
+}
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function provenanceSource(source: TurnProvenanceSource | null | undefined): string | undefined {
+  const provenance = source?.identityProvenance;
+  if (!provenance || typeof provenance !== "object") return undefined;
+  return cleanString((provenance as Record<string, unknown>).source)?.toLowerCase();
+}
+
+function originFromProvenanceSource(value: string | undefined): TurnOrigin | undefined {
+  switch (value) {
+    case "cron":
+      return "cron";
+    case "trigger":
+      return "trigger";
+    case "session-followup":
+    case "sessionfollowup":
+      return "session-followup";
+    case "heartbeat":
+      return "heartbeat";
+    case "observer":
+    case "observation":
+      return "observer";
+    case "task":
+      return "task";
+    case "routine":
+      return "routine";
+    case "daemon-restart":
+      return "daemon-restart";
+    case "automation":
+      return "automation";
+    case "background":
+      return "background";
+    default:
+      return undefined;
+  }
+}
+
+function originFromAutomationId(automationId: string | undefined): TurnOrigin {
+  const prefix = automationId?.split(":", 1)[0]?.toLowerCase();
+  return originFromProvenanceSource(prefix) ?? "automation";
+}
+
+/**
+ * Resolve the cause of the effective turn. Prompt markers win over reply-surface
+ * metadata: a cron replying into Slack is still a cron turn.
+ */
+export function classifyTurnProvenance(input: TurnProvenanceInput = {}): TurnProvenance {
+  const prompt = input.prompt ?? undefined;
+  const promptSource = prompt?.source;
+  const promptContext = prompt?.context;
+  const source: TurnProvenanceSource = {
+    actorType: input.source?.actorType ?? promptContext?.actorType ?? promptSource?.actorType,
+    automationId: input.source?.automationId ?? promptContext?.automationId ?? promptSource?.automationId,
+    identityProvenance:
+      input.source?.identityProvenance ?? promptContext?.identityProvenance ?? promptSource?.identityProvenance,
+    suppressPresence: input.source?.suppressPresence ?? promptSource?.suppressPresence,
+  };
+
+  if (prompt?._observation) {
+    return result("observer", "prompt._observation", `observer:${prompt._observation.bindingId}`);
+  }
+  if (prompt?._cron) return result("cron", "prompt._cron", prompt._jobId ? `cron:${prompt._jobId}` : undefined);
+  if (prompt?._trigger) {
+    return result("trigger", "prompt._trigger", prompt._triggerId ? `trigger:${prompt._triggerId}` : undefined);
+  }
+  if (prompt?._sessionFollowup) {
+    return result(
+      "session-followup",
+      "prompt._sessionFollowup",
+      prompt._sessionFollowupCadenceId ? `session-followup:${prompt._sessionFollowupCadenceId}` : undefined,
+    );
+  }
+  if (prompt?._heartbeat) return result("heartbeat", "prompt._heartbeat", "heartbeat");
+  const taskId = cleanString(prompt?.taskBarrierTaskId);
+  if (taskId) return result("task", "prompt.taskBarrierTaskId", `task:${taskId}`);
+  if (prompt?._daemonRestartResume) {
+    return result("daemon-restart", "prompt._daemonRestartResume", "daemon-restart");
+  }
+
+  const automationId = cleanString(source?.automationId);
+  if (source?.actorType === "automation" && automationId) {
+    return result(originFromAutomationId(automationId), "source.actorType=automation", automationId);
+  }
+
+  const identitySource = provenanceSource(source);
+  const identityOrigin = originFromProvenanceSource(identitySource);
+  if (identityOrigin) {
+    return result(identityOrigin, `identityProvenance.source=${identitySource}`, automationId);
+  }
+
+  if (source?.suppressPresence === true) return result("background", "source.suppressPresence", automationId);
+  if (source?.actorType === "agent") return result("agent", "source.actorType=agent");
+  if (source?.actorType === "system") return result("system", "source.actorType=system");
+  if (source?.actorType === "contact") return result("human", "source.actorType=contact");
+
+  return result("unknown", "no origin signal");
+}
+
+export function isBackgroundTurn(input: TurnProvenanceInput = {}): boolean {
+  return classifyTurnProvenance(input).background;
+}

--- a/src/session-trace/runtime-trace.ts
+++ b/src/session-trace/runtime-trace.ts
@@ -1,5 +1,6 @@
 import type { DeliveryBarrier, DeliveryBarrierSource } from "../delivery-barriers.js";
 import type { RuntimeMessageTarget } from "../runtime/host-session.js";
+import type { TurnProvenance } from "../runtime/turn-provenance.js";
 import type {
   RuntimeCapabilities,
   RuntimeEffort,
@@ -71,6 +72,7 @@ export interface RuntimeTraceAdapterRequestInput extends RuntimeTraceIdentity {
   pendingIds?: string[];
   commands?: unknown[];
   runtimeCredential?: Record<string, unknown> | null;
+  turnProvenance?: TurnProvenance | null;
 }
 
 export interface RuntimeTraceTerminalTurnInput extends RuntimeTraceIdentity {
@@ -229,6 +231,7 @@ export function recordAdapterRequestTrace(input: RuntimeTraceAdapterRequestInput
       pending_ids: input.pendingIds ?? [],
       commands: input.commands ?? [],
       runtime_credential: input.runtimeCredential ?? null,
+      turn_provenance: input.turnProvenance ?? null,
     };
     const request = recordSessionBlob({
       kind: "adapter_request",

--- a/src/session-trace/session-trace.test.ts
+++ b/src/session-trace/session-trace.test.ts
@@ -108,6 +108,13 @@ describe("session trace query", () => {
       pluginNames: [],
       mcpServerNames: [],
       hasRemoteSpawn: false,
+      turnProvenance: {
+        origin: "cron",
+        background: true,
+        automationOriginated: true,
+        automationId: "cron:job-1",
+        reason: "prompt._cron",
+      },
     });
 
     expect(trace).not.toBeNull();
@@ -115,6 +122,7 @@ describe("session trace query", () => {
       model_source: "session_override",
       effort_source: "agent_default",
       thinking_source: "runtime_default",
+      turn_provenance: { origin: "cron", background: true, automationId: "cron:job-1" },
     });
   });
 });

--- a/src/triggers/__tests__/runner.test.ts
+++ b/src/triggers/__tests__/runner.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "bun:test";
-import { getTriggerEventDedupeKey } from "../runner.js";
+import {
+  getTriggerEventDedupeKey,
+  isTriggerOriginatedEvent,
+  planTriggerTopicRefresh,
+  shouldRetryTriggerTopic,
+} from "../runner.js";
+
+describe("trigger runner subscription refresh", () => {
+  it("retains unchanged topics and applies only the incremental diff", () => {
+    expect(planTriggerTopicRefresh(["topic.keep", "topic.remove"], ["topic.keep", "topic.add"])).toEqual({
+      keep: ["topic.keep"],
+      add: ["topic.add"],
+      remove: ["topic.remove"],
+    });
+  });
+
+  it("uses canonical provenance while retaining legacy anti-loop markers", () => {
+    expect(isTriggerOriginatedEvent("custom.topic", { _turnProvenance: { origin: "trigger" } })).toBe(true);
+    expect(isTriggerOriginatedEvent("custom.topic", { _turnProvenance: { origin: "human" } })).toBe(false);
+    expect(isTriggerOriginatedEvent("ravi.agent:main:trigger:abc.result", {})).toBe(true);
+    expect(isTriggerOriginatedEvent("custom.topic", { _trigger: true })).toBe(true);
+  });
+
+  it("does not let a delayed retry revive a topic removed from desired state", () => {
+    expect(shouldRetryTriggerTopic("topic.retry", true, new Set(["topic.retry"]), new Map())).toBe(true);
+    expect(shouldRetryTriggerTopic("topic.retry", true, new Set(), new Map())).toBe(false);
+    expect(shouldRetryTriggerTopic("topic.retry", true, new Set(["topic.retry"]), new Map([["topic.retry", {}]]))).toBe(
+      false,
+    );
+  });
+});
 
 describe("trigger runner event dedupe", () => {
   it("keys local inbox mail events by trigger, topic, and message identity", () => {

--- a/src/triggers/filter.ts
+++ b/src/triggers/filter.ts
@@ -1,384 +1,62 @@
-/**
- * Trigger Filter Evaluator
- *
- * Evaluates restricted boolean filter expressions against event data.
- * No eval, no new Function().
- *
- * Syntax:
- *   data.<path> <operator> "<value>"
- *   !<expression>
- *   <expression> && <expression>
- *   <expression> || <expression>
- *   (<expression>)
- *
- * Operators: ==, !=, startsWith, endsWith, includes
- */
-
+import { compilePredicate, type CompiledPredicate } from "../policy/predicate.js";
 import { logger } from "../utils/logger.js";
 
 const log = logger.child("triggers:filter");
+const FILTER_CACHE_MAX = 500;
+const filterCache = new Map<string, CompiledFilter>();
 
-type ComparisonOperator = "==" | "!=" | "startsWith" | "endsWith" | "includes";
+export interface CompiledFilter {
+  expression?: string;
+  valid: boolean;
+  error?: string;
+  evaluate(data: unknown): boolean;
+}
 
-type FilterAst =
-  | { type: "comparison"; path: string; operator: ComparisonOperator; expected: string }
-  | { type: "and"; left: FilterAst; right: FilterAst }
-  | { type: "or"; left: FilterAst; right: FilterAst }
-  | { type: "not"; expression: FilterAst };
+function buildFilter(filter: string | undefined): CompiledFilter {
+  const expression = filter?.trim();
+  const compiled = compilePredicate(expression, {
+    allowedRoots: ["data"],
+    pathLabel: "data.<path>",
+  });
+  if (!compiled.ok) {
+    return {
+      expression,
+      valid: false,
+      error: compiled.error,
+      // Historical trigger behavior is deliberately fail-open at runtime.
+      evaluate: () => true,
+    };
+  }
+  const predicate: CompiledPredicate = compiled.predicate;
+  return {
+    expression,
+    valid: true,
+    evaluate: (data) => predicate.evaluate({ data }),
+  };
+}
 
-type Token =
-  | { type: "path"; value: string; position: number }
-  | { type: "operator"; value: ComparisonOperator; position: number }
-  | { type: "string"; value: string; position: number }
-  | { type: "and"; position: number }
-  | { type: "or"; position: number }
-  | { type: "not"; position: number }
-  | { type: "lparen"; position: number }
-  | { type: "rparen"; position: number }
-  | { type: "word"; value: string; position: number }
-  | { type: "eof"; position: number };
-
-type ParseResult = { ok: true; ast: FilterAst } | { ok: false; error: string };
+/** Compile once when loading trigger configuration. */
+export function compileFilter(filter: string | undefined): CompiledFilter {
+  const key = filter?.trim() ?? "";
+  const cached = filterCache.get(key);
+  if (cached) return cached;
+  const compiled = buildFilter(filter);
+  filterCache.set(key, compiled);
+  if (filterCache.size > FILTER_CACHE_MAX) filterCache.delete(filterCache.keys().next().value ?? "");
+  return compiled;
+}
 
 export type FilterValidationResult = { ok: true } | { ok: false; error: string };
 
-const COMPARISON_OPERATORS = new Set<string>(["==", "!=", "startsWith", "endsWith", "includes"]);
-const PATH_RE = /^data\.[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
-
-function isComparisonOperator(value: string): value is ComparisonOperator {
-  return COMPARISON_OPERATORS.has(value);
-}
-
-function syntaxError(message: string, position: number): string {
-  return `${message} at character ${position}`;
-}
-
-function tokenize(input: string): Token[] | string {
-  const tokens: Token[] = [];
-  let index = 0;
-
-  while (index < input.length) {
-    const char = input[index];
-    if (!char) break;
-
-    if (/\s/.test(char)) {
-      index += 1;
-      continue;
-    }
-
-    if (input.startsWith("&&", index)) {
-      tokens.push({ type: "and", position: index });
-      index += 2;
-      continue;
-    }
-
-    if (input.startsWith("||", index)) {
-      tokens.push({ type: "or", position: index });
-      index += 2;
-      continue;
-    }
-
-    if (input.startsWith("!=", index)) {
-      tokens.push({ type: "operator", value: "!=", position: index });
-      index += 2;
-      continue;
-    }
-
-    if (input.startsWith("==", index)) {
-      tokens.push({ type: "operator", value: "==", position: index });
-      index += 2;
-      continue;
-    }
-
-    if (char === "!") {
-      tokens.push({ type: "not", position: index });
-      index += 1;
-      continue;
-    }
-
-    if (char === "(") {
-      tokens.push({ type: "lparen", position: index });
-      index += 1;
-      continue;
-    }
-
-    if (char === ")") {
-      tokens.push({ type: "rparen", position: index });
-      index += 1;
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      const quote = char;
-      const position = index;
-      index += 1;
-      let value = "";
-      let closed = false;
-      while (index < input.length) {
-        const next = input[index];
-        if (next === "\\") {
-          const escaped = input[index + 1];
-          if (escaped === undefined) {
-            return syntaxError("Unterminated escape sequence", index);
-          }
-          value += escaped;
-          index += 2;
-          continue;
-        }
-        if (next === quote) {
-          index += 1;
-          closed = true;
-          tokens.push({ type: "string", value, position });
-          break;
-        }
-        value += next;
-        index += 1;
-      }
-      if (!closed) {
-        return syntaxError("Unterminated quoted string", position);
-      }
-      continue;
-    }
-
-    const wordStart = index;
-    while (
-      index < input.length &&
-      !/\s/.test(input[index] ?? "") &&
-      !["(", ")", "!", "=", "&", "|", '"', "'"].includes(input[index] ?? "")
-    ) {
-      index += 1;
-    }
-
-    if (index === wordStart) {
-      return syntaxError(`Unexpected character '${char}'`, index);
-    }
-
-    const value = input.slice(wordStart, index);
-    if (isComparisonOperator(value)) {
-      tokens.push({ type: "operator", value, position: wordStart });
-    } else if (PATH_RE.test(value)) {
-      tokens.push({ type: "path", value, position: wordStart });
-    } else {
-      tokens.push({ type: "word", value, position: wordStart });
-    }
-  }
-
-  tokens.push({ type: "eof", position: input.length });
-  return tokens;
-}
-
-class FilterParser {
-  private index = 0;
-
-  constructor(private readonly tokens: Token[]) {}
-
-  parse(): ParseResult {
-    const ast = this.parseOr();
-    if (typeof ast === "string") return { ok: false, error: ast };
-
-    const current = this.current();
-    if (current.type !== "eof") {
-      return { ok: false, error: syntaxError(`Unexpected token '${this.describe(current)}'`, current.position) };
-    }
-
-    return { ok: true, ast };
-  }
-
-  private parseOr(): FilterAst | string {
-    let left = this.parseAnd();
-    if (typeof left === "string") return left;
-
-    while (this.match("or")) {
-      const right = this.parseAnd();
-      if (typeof right === "string") return right;
-      left = { type: "or", left, right };
-    }
-
-    return left;
-  }
-
-  private parseAnd(): FilterAst | string {
-    let left = this.parseUnary();
-    if (typeof left === "string") return left;
-
-    while (this.match("and")) {
-      const right = this.parseUnary();
-      if (typeof right === "string") return right;
-      left = { type: "and", left, right };
-    }
-
-    return left;
-  }
-
-  private parseUnary(): FilterAst | string {
-    if (this.match("not")) {
-      const expression = this.parseUnary();
-      if (typeof expression === "string") return expression;
-      return { type: "not", expression };
-    }
-
-    return this.parsePrimary();
-  }
-
-  private parsePrimary(): FilterAst | string {
-    if (this.match("lparen")) {
-      const expression = this.parseOr();
-      if (typeof expression === "string") return expression;
-      if (!this.match("rparen")) {
-        return syntaxError("Expected ')'", this.current().position);
-      }
-      return expression;
-    }
-
-    return this.parseComparison();
-  }
-
-  private parseComparison(): FilterAst | string {
-    const path = this.consume("path", "Expected data.<path>");
-    if (typeof path === "string") return path;
-
-    const operator = this.consume("operator", "Expected comparison operator");
-    if (typeof operator === "string") return operator;
-
-    const expected = this.consume("string", "Expected quoted string value");
-    if (typeof expected === "string") return expected;
-
-    return {
-      type: "comparison",
-      path: path.value,
-      operator: operator.value,
-      expected: expected.value,
-    };
-  }
-
-  private match(type: Token["type"]): boolean {
-    if (this.current().type !== type) return false;
-    this.index += 1;
-    return true;
-  }
-
-  private consume<T extends Token["type"]>(type: T, message: string): Extract<Token, { type: T }> | string {
-    const token = this.current();
-    if (token.type !== type) {
-      return syntaxError(`${message}, got '${this.describe(token)}'`, token.position);
-    }
-    this.index += 1;
-    return token as Extract<Token, { type: T }>;
-  }
-
-  private current(): Token {
-    return this.tokens[this.index] ?? this.tokens[this.tokens.length - 1] ?? { type: "eof", position: 0 };
-  }
-
-  private describe(token: Token): string {
-    switch (token.type) {
-      case "path":
-      case "operator":
-      case "string":
-      case "word":
-        return token.value;
-      case "and":
-        return "&&";
-      case "or":
-        return "||";
-      case "not":
-        return "!";
-      case "lparen":
-        return "(";
-      case "rparen":
-        return ")";
-      case "eof":
-        return "end of input";
-    }
-  }
-}
-
-function parseFilter(filter: string): ParseResult {
-  const tokens = tokenize(filter);
-  if (typeof tokens === "string") {
-    return { ok: false, error: tokens };
-  }
-  return new FilterParser(tokens).parse();
-}
-
-/**
- * Validate a filter expression before persisting it through CLI commands.
- */
 export function validateFilter(filter: string | undefined): FilterValidationResult {
-  if (!filter || filter.trim() === "") {
-    return { ok: true };
-  }
-
-  const parsed = parseFilter(filter.trim());
-  return parsed.ok ? { ok: true } : { ok: false, error: parsed.error };
+  const compiled = compileFilter(filter);
+  return compiled.valid ? { ok: true } : { ok: false, error: compiled.error ?? "Invalid filter" };
 }
 
-/**
- * Resolve a dot-notation path into an object.
- * e.g. "data.hook_event_name" with root { hook_event_name: "Stop" } -> "Stop"
- * The leading "data." is stripped before resolution.
- */
-function resolvePath(obj: unknown, path: string): unknown {
-  const parts = path.replace(/^data\./, "").split(".");
-  let current: unknown = obj;
-  for (const part of parts) {
-    if (!part) return undefined;
-    if (current === null || current === undefined) return undefined;
-    if (typeof current !== "object") return undefined;
-    current = (current as Record<string, unknown>)[part];
-  }
-  return current;
-}
-
-function evaluateAst(ast: FilterAst, data: unknown): boolean {
-  switch (ast.type) {
-    case "and":
-      return evaluateAst(ast.left, data) && evaluateAst(ast.right, data);
-    case "or":
-      return evaluateAst(ast.left, data) || evaluateAst(ast.right, data);
-    case "not":
-      return !evaluateAst(ast.expression, data);
-    case "comparison": {
-      const rawValue = resolvePath(data, ast.path);
-      if (rawValue === undefined) return false;
-
-      const value = String(rawValue);
-      switch (ast.operator) {
-        case "==":
-          return value === ast.expected;
-        case "!=":
-          return value !== ast.expected;
-        case "startsWith":
-          return value.startsWith(ast.expected);
-        case "endsWith":
-          return value.endsWith(ast.expected);
-        case "includes":
-          return value.includes(ast.expected);
-      }
-    }
-  }
-}
-
-/**
- * Evaluate a filter expression against event data.
- *
- * Returns true if:
- * - filter is undefined or empty (no filter = always fires)
- * - filter matches the data
- * - filter is invalid (fail open, logs warning)
- *
- * Returns false if the filter expression evaluates to false.
- */
 export function evaluateFilter(filter: string | undefined, data: unknown): boolean {
-  if (!filter || filter.trim() === "") {
-    return true;
+  const compiled = compileFilter(filter);
+  if (!compiled.valid) {
+    log.warn("Trigger filter: invalid syntax, failing open", { filter, error: compiled.error });
   }
-
-  const parsed = parseFilter(filter.trim());
-  if (!parsed.ok) {
-    log.warn("Trigger filter: invalid syntax, failing open", { filter, error: parsed.error });
-    return true;
-  }
-
-  return evaluateAst(parsed.ast, data);
+  return compiled.evaluate(data);
 }

--- a/src/triggers/runner.ts
+++ b/src/triggers/runner.ts
@@ -26,7 +26,7 @@ import {
 } from "../router/index.js";
 import { getAgent } from "../router/config.js";
 import { dbListTriggers, dbGetTrigger, dbUpdateTriggerState } from "./triggers-db.js";
-import { evaluateFilter } from "./filter.js";
+import { compileFilter, type CompiledFilter } from "./filter.js";
 import type { Trigger } from "./types.js";
 import { isBlockedTriggerTopic } from "./topic-policy.js";
 import { buildTriggerPrompt } from "./prompt.js";
@@ -39,12 +39,54 @@ const EVENT_DEDUPE_MAX = 2_000;
 /** Tracks a topic subscription stream for teardown */
 type TopicSub = ReturnType<typeof nats.subscribe>;
 
+interface PreparedTrigger {
+  trigger: Trigger;
+  filter: CompiledFilter;
+}
+
+interface TopicSubscription {
+  stream: TopicSub;
+  triggers: PreparedTrigger[];
+}
+
+export function planTriggerTopicRefresh(
+  currentTopics: Iterable<string>,
+  desiredTopics: Iterable<string>,
+): { keep: string[]; add: string[]; remove: string[] } {
+  const current = new Set(currentTopics);
+  const desired = new Set(desiredTopics);
+  return {
+    keep: [...desired].filter((topic) => current.has(topic)).sort(),
+    add: [...desired].filter((topic) => !current.has(topic)).sort(),
+    remove: [...current].filter((topic) => !desired.has(topic)).sort(),
+  };
+}
+
+export function isTriggerOriginatedEvent(topic: string, data: unknown): boolean {
+  if (topic.includes(":trigger:")) return true;
+  if (!data || typeof data !== "object") return false;
+  const record = data as Record<string, unknown>;
+  const origin = (record._turnProvenance as { origin?: unknown } | undefined)?.origin;
+  return origin === "trigger" || record._trigger === true;
+}
+
+export function shouldRetryTriggerTopic(
+  topic: string,
+  running: boolean,
+  desiredTopics: ReadonlySet<string>,
+  subscriptions: ReadonlyMap<string, unknown>,
+): boolean {
+  return running && desiredTopics.has(topic) && !subscriptions.has(topic);
+}
+
 /**
  * TriggerRunner - manages event-driven trigger subscriptions
  */
 export class TriggerRunner {
   /** Topic streams (NOT including refresh/test — those are long-lived) */
-  private topicSubs: TopicSub[] = [];
+  private topicSubs = new Map<string, TopicSubscription>();
+  /** Last desired topic set, used to prevent delayed retries from reviving removed subscriptions. */
+  private desiredTopics = new Set<string>();
   private running = false;
   private recentEventFires = new Map<string, number>();
   private recentEventFireOps = 0;
@@ -83,14 +125,15 @@ export class TriggerRunner {
    * Tear down all topic subscriptions.
    */
   private teardownSubscriptions(): void {
-    for (const sub of this.topicSubs) {
+    for (const subscription of this.topicSubs.values()) {
       try {
-        sub.return?.(undefined);
+        subscription.stream.return?.(undefined);
       } catch {
         // ignore close errors
       }
     }
-    this.topicSubs = [];
+    this.topicSubs.clear();
+    this.desiredTopics.clear();
   }
 
   // Mutex to prevent concurrent setupSubscriptions calls
@@ -119,39 +162,78 @@ export class TriggerRunner {
   }
 
   private async _doSetupSubscriptions(): Promise<void> {
-    // Tear down existing
-    this.teardownSubscriptions();
-
     const triggers = dbListTriggers({ enabledOnly: true });
 
     // Group by topic to share subscriptions
-    const byTopic = new Map<string, Trigger[]>();
+    const byTopic = new Map<string, PreparedTrigger[]>();
     for (const t of triggers) {
+      if (isBlockedTriggerTopic(t.topic)) {
+        log.warn("Skipping trigger on internal topic (anti-loop)", { topic: t.topic, triggerId: t.id });
+        continue;
+      }
       const list = byTopic.get(t.topic) || [];
-      list.push(t);
+      const filter = compileFilter(t.filter);
+      if (!filter.valid) {
+        log.warn("Loaded invalid trigger filter; preserving legacy fail-open behavior", {
+          triggerId: t.id,
+          filter: t.filter,
+          error: filter.error,
+        });
+      }
+      list.push({ trigger: t, filter });
       byTopic.set(t.topic, list);
     }
 
-    for (const [topic, trigs] of byTopic) {
-      if (isBlockedTriggerTopic(topic)) {
-        log.warn("Skipping trigger on internal topic (anti-loop)", { topic });
-        continue;
+    this.desiredTopics = new Set(byTopic.keys());
+    const plan = planTriggerTopicRefresh(this.topicSubs.keys(), this.desiredTopics);
+    for (const topic of plan.keep) {
+      const existing = this.topicSubs.get(topic);
+      const desired = byTopic.get(topic);
+      if (!existing || !desired) continue;
+      const previousById = new Map(existing.triggers.map((item) => [item.trigger.id, item.trigger]));
+      for (const item of desired) {
+        const previous = previousById.get(item.trigger.id);
+        if (previous?.lastFiredAt && (!item.trigger.lastFiredAt || previous.lastFiredAt > item.trigger.lastFiredAt)) {
+          item.trigger.lastFiredAt = previous.lastFiredAt;
+        }
       }
-      this.subscribeToTopic(topic, trigs);
+      // The loop reads this mutable snapshot, so config changes do not churn
+      // a healthy NATS subscription for the same topic.
+      existing.triggers = desired;
+    }
+
+    for (const topic of plan.add) {
+      const desired = byTopic.get(topic);
+      if (desired) this.subscribeToTopic(topic, desired);
+    }
+
+    for (const topic of plan.remove) {
+      const subscription = this.topicSubs.get(topic);
+      if (!subscription) continue;
+      this.topicSubs.delete(topic);
+      try {
+        subscription.stream.return?.(undefined);
+      } catch {
+        // Ignore close failures; the subscription is no longer reachable.
+      }
     }
 
     log.info("Subscriptions set up", {
       topics: byTopic.size,
       triggers: triggers.length,
+      addedTopics: plan.add.length,
+      retainedTopics: plan.keep.length,
+      removedTopics: plan.remove.length,
     });
   }
 
   /**
    * Subscribe to a NATS topic and fire matching triggers.
    */
-  private subscribeToTopic(topic: string, triggers: Trigger[]): void {
+  private subscribeToTopic(topic: string, triggers: PreparedTrigger[]): void {
     const stream = nats.subscribe(topic);
-    this.topicSubs.push(stream);
+    const subscription: TopicSubscription = { stream, triggers };
+    this.topicSubs.set(topic, subscription);
 
     // Run subscription loop in background
     (async () => {
@@ -161,12 +243,13 @@ export class TriggerRunner {
 
           // Skip events from trigger sessions (prevents self-fire loops)
           // Trigger sessions use pattern: ravi.agent:{id}:trigger:{triggerId}.*
-          if (event.topic.includes(":trigger:")) continue;
-          // Also skip events explicitly tagged as trigger-originated
+          // Prefer canonical turn provenance; retain legacy topic/marker checks
+          // for producers that have not adopted it yet.
           const eventData = event.data as Record<string, unknown> | undefined;
-          if (eventData?._trigger) continue;
+          if (isTriggerOriginatedEvent(event.topic, eventData)) continue;
 
-          for (const trigger of triggers) {
+          for (const prepared of subscription.triggers) {
+            const trigger = prepared.trigger;
             // Cooldown check
             if (trigger.lastFiredAt && Date.now() - trigger.lastFiredAt < trigger.cooldownMs) {
               log.debug("Trigger cooldown active, skipping", {
@@ -177,7 +260,7 @@ export class TriggerRunner {
             }
 
             // Filter check: evaluate trigger's filter expression against event data
-            if (!evaluateFilter(trigger.filter, event.data)) {
+            if (!prepared.filter.evaluate(event.data)) {
               log.debug("Trigger filter did not match, skipping", {
                 triggerId: trigger.id,
                 triggerName: trigger.name,
@@ -212,13 +295,14 @@ export class TriggerRunner {
         }
       } catch (err) {
         // Stream closed is expected during teardown
-        if (!this.running) return;
+        if (!this.running || this.topicSubs.get(topic) !== subscription) return;
 
         log.error("Topic subscription error", { topic, error: err });
+        this.topicSubs.delete(topic);
         // Retry after delay
         setTimeout(() => {
-          if (this.running) {
-            this.subscribeToTopic(topic, triggers);
+          if (shouldRetryTriggerTopic(topic, this.running, this.desiredTopics, this.topicSubs)) {
+            this.subscribeToTopic(topic, subscription.triggers);
           }
         }, 5000);
       }

--- a/src/triggers/triggers.test.ts
+++ b/src/triggers/triggers.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { compileFilter } from "./filter.js";
+import { isTriggerOriginatedEvent, planTriggerTopicRefresh, shouldRetryTriggerTopic } from "./runner.js";
 import { findTriggerTopicCatalogEntry } from "./topic-catalog.js";
 import { dbCreateTrigger, dbGetTrigger, dbUpdateTrigger } from "./triggers-db.js";
 
@@ -78,5 +80,29 @@ describe("triggers native automation support", () => {
     expect(updated?.shellTimeoutMs).toBeUndefined();
     expect(updated?.shellEnvFile).toBeUndefined();
     expect(updated?.onError).toBeUndefined();
+  });
+
+  it("compiles and caches boolean filters while preserving invalid-filter fail-open behavior", () => {
+    const expression = `data.provider == "slack" && data.actionId startsWith "ticket_"`;
+    const compiled = compileFilter(expression);
+
+    expect(compiled.valid).toBe(true);
+    expect(compileFilter(expression)).toBe(compiled);
+    expect(compiled.evaluate({ provider: "slack", actionId: "ticket_claim" })).toBe(true);
+    expect(compiled.evaluate({ provider: "slack", actionId: "other" })).toBe(false);
+
+    const invalid = compileFilter("this is not a predicate");
+    expect(invalid.valid).toBe(false);
+    expect(invalid.evaluate({ provider: "slack" })).toBe(true);
+  });
+
+  it("refreshes topic subscriptions incrementally without reviving removed or trigger-originated work", () => {
+    expect(planTriggerTopicRefresh(["topic.keep", "topic.remove"], ["topic.keep", "topic.add"])).toEqual({
+      keep: ["topic.keep"],
+      add: ["topic.add"],
+      remove: ["topic.remove"],
+    });
+    expect(shouldRetryTriggerTopic("topic.remove", true, new Set(), new Map())).toBe(false);
+    expect(isTriggerOriginatedEvent("custom.topic", { _turnProvenance: { origin: "trigger" } })).toBe(true);
   });
 });


### PR DESCRIPTION
## Objective

Give runtime consumers one canonical turn-cause snapshot and make proactive observer reactions safe to retry without duplicating scheduled work.

## Problem

Turn origin was inferred independently by compaction, pool scheduling, observers, traces, and triggers. Observer exclusions were ad hoc, binding reconciliation was incomplete, and a retried observer turn could recreate the same cron after a one-shot job disappeared.

## Solution

- Classify turn provenance once and propagate it through runtime context, events, traces, compaction, pool lanes, observers, and trigger anti-loop checks.
- Add a shared predicate compiler, observer selectors over source, turn, and event roots, legacy sourceExclusions compatibility, and desired-state binding reconciliation.
- Refresh trigger topics incrementally with cached predicates and stale-retry protection.
- Persist observer delivery claims and reaction-action keys; cron creation automatically derives durable idempotency from observer rule and source-turn metadata, with an explicit CLI override.
- Update public CLI contracts, generated SDK artifacts, specs, tests, and packaged Ravi skills.

## Practical impact

Observers can target new sessions generically, ignore automated turns such as cron executions, and create proactive follow-up crons exactly once even across retries or deletion of completed one-shot jobs. Trigger refreshes also avoid unnecessary unsubscribe and resubscribe churn.

## What does NOT change

Trigger filter syntax and its legacy fail-open behavior remain compatible. Existing observer metadata.sourceExclusions continues to work, direct cron creation remains non-idempotent unless observer context or an explicit key is present, and the observer and trigger runners remain separate runtime components.

## Validation

- bun run build
- bun run typecheck
- bun run lint
- bun run test
- bun run test:sdk
- 73 focused policy, provenance, observer, trigger, and cron-idempotency tests
- focused trace, compaction, session-pool, SDK, CLI, and automation-principal tests

The new runtime-context automation-principal case passes in isolation. The standalone runtime-request-context file retains the same six pre-existing baseline failures reproduced on dev.

## Risks

Incorrect provenance could route work to the wrong capacity lane, selectors could suppress intended observations, and the durable ledgers add rows over time. Compatibility fallbacks, fail-closed observer selectors, additive schema changes, and focused retry and reconciliation tests reduce those risks.

## Rollback

Revert the commits in this PR and redeploy. The added SQLite tables and columns are additive and may remain unused safely; no destructive data migration or mandatory cleanup is required for rollback.