### PR TITLE
fix(sdk): make Swift codegen collision-safe and refresh contracts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "44d943d302e2d246"
+    "version": "fdc8765bea4b81b6"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -1792,6 +1792,45 @@
                     "key": {
                       "type": "string"
                     },
+                    "sessionOverrides": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "effort": {
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh",
+                              "max",
+                              "ultra"
+                            ],
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "sessionName": {
+                            "type": "string"
+                          },
+                          "thinking": {
+                            "enum": [
+                              "off",
+                              "normal",
+                              "verbose"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "sessionName"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "value": {}
                   },
                   "required": [
@@ -1799,7 +1838,8 @@
                     "changed",
                     "agentId",
                     "key",
-                    "value"
+                    "value",
+                    "sessionOverrides"
                   ],
                   "type": "object"
                 }
@@ -1825,7 +1865,7 @@
             "bearerAuth": []
           }
         ],
-        "summary": "Set agent property",
+        "summary": "Set agent property and report active session runtime overrides",
         "tags": [
           "agents"
         ]
@@ -16726,26 +16766,27 @@
         ]
       }
     },
-    "/api/v1/chats/lists/recompute": {
+    "/api/v1/chats/lists/preview": {
       "post": {
-        "operationId": "chats.lists.recompute",
+        "operationId": "chats.lists.preview",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "additionalProperties": false,
                 "properties": {
-                  "list": {
-                    "description": "List id or name",
+                  "listId": {
+                    "description": "Canonical reading-list id (crl_<24 hex>)",
+                    "pattern": "^crl_[0-9a-f]{24}$",
                     "type": "string"
                   },
                   "owner": {
-                    "description": "Owner scope when resolving list by name",
+                    "description": "Optional owner assertion for the canonical list id",
                     "type": "string"
                   }
                 },
                 "required": [
-                  "list"
+                  "listId"
                 ],
                 "type": "object"
               }
@@ -16758,39 +16799,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$defs": {
-                    "__schema0": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "items": {
-                            "$ref": "#/$defs/__schema0"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "additionalProperties": {
-                            "$ref": "#/$defs/__schema0"
-                          },
-                          "propertyNames": {
-                            "type": "string"
-                          },
-                          "type": "object"
-                        }
-                      ]
-                    }
-                  },
                   "additionalProperties": false,
                   "properties": {
                     "list": {
@@ -16808,15 +16816,6 @@
                         "id": {
                           "type": "string"
                         },
-                        "metadata": {
-                          "additionalProperties": {
-                            "$ref": "#/$defs/__schema0"
-                          },
-                          "propertyNames": {
-                            "type": "string"
-                          },
-                          "type": "object"
-                        },
                         "mode": {
                           "type": "string"
                         },
@@ -16829,14 +16828,335 @@
                         "ownerType": {
                           "type": "string"
                         },
-                        "selector": {
-                          "additionalProperties": {
-                            "$ref": "#/$defs/__schema0"
+                        "updatedAt": {
+                          "type": "number"
+                        },
+                        "visibility": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "ownerType",
+                        "ownerId",
+                        "visibility",
+                        "mode",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    },
+                    "preview": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "current": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "preserved": {
+                              "type": "number"
+                            },
+                            "selector": {
+                              "type": "number"
+                            },
+                            "total": {
+                              "type": "number"
+                            }
                           },
-                          "propertyNames": {
-                            "type": "string"
-                          },
+                          "required": [
+                            "total",
+                            "selector",
+                            "preserved"
+                          ],
                           "type": "object"
+                        },
+                        "diff": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "added": {
+                                  "type": "number"
+                                },
+                                "eligible": {
+                                  "type": "number"
+                                },
+                                "kept": {
+                                  "type": "number"
+                                },
+                                "preserved": {
+                                  "type": "number"
+                                },
+                                "removed": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "added",
+                                "removed",
+                                "kept",
+                                "preserved",
+                                "eligible"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "dryRun": {
+                          "const": true,
+                          "type": "boolean"
+                        },
+                        "list": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "archivedAt": {
+                              "type": "number"
+                            },
+                            "createdAt": {
+                              "type": "number"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "mode": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ownerId": {
+                              "type": "string"
+                            },
+                            "ownerType": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "number"
+                            },
+                            "visibility": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "ownerType",
+                            "ownerId",
+                            "visibility",
+                            "mode",
+                            "createdAt",
+                            "updatedAt"
+                          ],
+                          "type": "object"
+                        },
+                        "validation": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "canApply": {
+                              "type": "boolean"
+                            },
+                            "conditions": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "negative": {
+                                  "type": "number"
+                                },
+                                "positive": {
+                                  "type": "number"
+                                },
+                                "supported": {
+                                  "type": "number"
+                                },
+                                "total": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "total",
+                                "supported",
+                                "positive",
+                                "negative"
+                              ],
+                              "type": "object"
+                            },
+                            "issues": {
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "severity": {
+                                    "enum": [
+                                      "error",
+                                      "warning"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "severity",
+                                  "message"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "match": {
+                              "enum": [
+                                "all",
+                                "any"
+                              ],
+                              "type": "string"
+                            },
+                            "riskLevel": {
+                              "enum": [
+                                "low",
+                                "high"
+                              ],
+                              "type": "string"
+                            },
+                            "scope": {
+                              "enum": [
+                                "contact",
+                                "chat"
+                              ],
+                              "type": "string"
+                            },
+                            "valid": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "valid",
+                            "canApply",
+                            "riskLevel",
+                            "scope",
+                            "match",
+                            "conditions",
+                            "issues"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "list",
+                        "dryRun",
+                        "validation",
+                        "current",
+                        "diff"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "list",
+                    "preview"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Validate a dynamic selector and preview membership diff without writes",
+        "tags": [
+          "chats"
+        ]
+      }
+    },
+    "/api/v1/chats/lists/recompute": {
+      "post": {
+        "operationId": "chats.lists.recompute",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "listId": {
+                    "description": "Canonical reading-list id (crl_<24 hex>)",
+                    "pattern": "^crl_[0-9a-f]{24}$",
+                    "type": "string"
+                  },
+                  "owner": {
+                    "description": "Optional owner assertion for the canonical list id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "listId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "list": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "archivedAt": {
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ownerId": {
+                          "type": "string"
+                        },
+                        "ownerType": {
+                          "type": "string"
                         },
                         "updatedAt": {
                           "type": "number"
@@ -16863,29 +17183,11 @@
                         "added": {
                           "type": "number"
                         },
-                        "addedChatIds": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
                         "eligible": {
                           "type": "number"
                         },
-                        "eligibleChatIds": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
                         "kept": {
                           "type": "number"
-                        },
-                        "keptChatIds": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
                         },
                         "list": {
                           "additionalProperties": false,
@@ -16902,15 +17204,6 @@
                             "id": {
                               "type": "string"
                             },
-                            "metadata": {
-                              "additionalProperties": {
-                                "$ref": "#/$defs/__schema0"
-                              },
-                              "propertyNames": {
-                                "type": "string"
-                              },
-                              "type": "object"
-                            },
                             "mode": {
                               "type": "string"
                             },
@@ -16922,15 +17215,6 @@
                             },
                             "ownerType": {
                               "type": "string"
-                            },
-                            "selector": {
-                              "additionalProperties": {
-                                "$ref": "#/$defs/__schema0"
-                              },
-                              "propertyNames": {
-                                "type": "string"
-                              },
-                              "type": "object"
                             },
                             "updatedAt": {
                               "type": "number"
@@ -16954,39 +17238,12 @@
                         "preserved": {
                           "type": "number"
                         },
-                        "preservedChatIds": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
                         "removed": {
                           "type": "number"
-                        },
-                        "removedChatIds": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "additionalProperties": {
-                            "$ref": "#/$defs/__schema0"
-                          },
-                          "propertyNames": {
-                            "type": "string"
-                          },
-                          "type": "object"
                         }
                       },
                       "required": [
                         "list",
-                        "selector",
-                        "eligibleChatIds",
-                        "addedChatIds",
-                        "removedChatIds",
-                        "keptChatIds",
-                        "preservedChatIds",
                         "added",
                         "removed",
                         "kept",
@@ -17102,6 +17359,239 @@
           }
         ],
         "summary": "Remove a chat from a reading list without deleting cursor history",
+        "tags": [
+          "chats"
+        ]
+      }
+    },
+    "/api/v1/chats/lists/show": {
+      "post": {
+        "operationId": "chats.lists.show",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "listId": {
+                    "description": "Canonical reading-list id (crl_<24 hex>)",
+                    "pattern": "^crl_[0-9a-f]{24}$",
+                    "type": "string"
+                  },
+                  "owner": {
+                    "description": "Optional owner assertion for the canonical list id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "listId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "current": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "preserved": {
+                          "type": "number"
+                        },
+                        "selector": {
+                          "type": "number"
+                        },
+                        "total": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "total",
+                        "selector",
+                        "preserved"
+                      ],
+                      "type": "object"
+                    },
+                    "list": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "archivedAt": {
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ownerId": {
+                          "type": "string"
+                        },
+                        "ownerType": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "number"
+                        },
+                        "visibility": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "ownerType",
+                        "ownerId",
+                        "visibility",
+                        "mode",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "type": "object"
+                    },
+                    "validation": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "canApply": {
+                          "type": "boolean"
+                        },
+                        "conditions": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "negative": {
+                              "type": "number"
+                            },
+                            "positive": {
+                              "type": "number"
+                            },
+                            "supported": {
+                              "type": "number"
+                            },
+                            "total": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "total",
+                            "supported",
+                            "positive",
+                            "negative"
+                          ],
+                          "type": "object"
+                        },
+                        "issues": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "code": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "severity": {
+                                "enum": [
+                                  "error",
+                                  "warning"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "severity",
+                              "message"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "match": {
+                          "enum": [
+                            "all",
+                            "any"
+                          ],
+                          "type": "string"
+                        },
+                        "riskLevel": {
+                          "enum": [
+                            "low",
+                            "high"
+                          ],
+                          "type": "string"
+                        },
+                        "scope": {
+                          "enum": [
+                            "contact",
+                            "chat"
+                          ],
+                          "type": "string"
+                        },
+                        "valid": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "valid",
+                        "canApply",
+                        "riskLevel",
+                        "scope",
+                        "match",
+                        "conditions",
+                        "issues"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "list",
+                    "validation",
+                    "current"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Show one reading list and explain whether its selector is safe",
         "tags": [
           "chats"
         ]
@@ -31833,6 +32323,10 @@
                   },
                   "exec": {
                     "description": "Alias for --shell",
+                    "type": "string"
+                  },
+                  "idempotencyKey": {
+                    "description": "Durable create idempotency key",
                     "type": "string"
                   },
                   "isolated": {
@@ -52004,6 +52498,10 @@
               "schema": {
                 "additionalProperties": false,
                 "properties": {
+                  "reconcile": {
+                    "description": "attach-missing|detach-disabled|refresh-profile|full-reconcile",
+                    "type": "string"
+                  },
                   "session": {
                     "description": "Source session name or key",
                     "type": "string"
@@ -52600,6 +53098,10 @@
                   },
                   "scope": {
                     "description": "global|agent|session|task|profile|project|tag",
+                    "type": "string"
+                  },
+                  "selector": {
+                    "description": "Predicate over source.*, turn.* and event.*; use 'clear' to remove",
                     "type": "string"
                   },
                   "sourceAgent": {
@@ -61847,7 +62349,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "out": {
-                    "description": "Write spec JSON to this path",
+                    "description": "Write spec JSON to this path (default: docs/openapi.json)",
                     "type": "string"
                   },
                   "stdout": {
@@ -65185,9 +65687,142 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {},
-                  "properties": {},
-                  "type": "object"
+                  "anyOf": [
+                    {
+                      "additionalProperties": {},
+                      "properties": {
+                        "count": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "messages": {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "role": {
+                                    "enum": [
+                                      "user",
+                                      "assistant"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "time": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "role",
+                                  "text",
+                                  "time"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "content": {
+                                    "type": "string"
+                                  },
+                                  "createdAt": {
+                                    "type": "number"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "source": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "role",
+                                  "content",
+                                  "createdAt",
+                                  "source"
+                                ],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        "session": {
+                          "additionalProperties": {},
+                          "properties": {
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "sessionKey": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "sessionKey",
+                            "label",
+                            "agentId"
+                          ],
+                          "type": "object"
+                        },
+                        "totalMessages": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "transcript": {
+                          "additionalProperties": {},
+                          "properties": {
+                            "available": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "available"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "session",
+                        "transcript",
+                        "messages"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": {},
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        },
+                        "messageId": {
+                          "type": "string"
+                        },
+                        "meta": {},
+                        "ok": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "ok"
+                      ],
+                      "type": "object"
+                    }
+                  ]
                 }
               }
             },
@@ -66005,7 +66640,98 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": {},
-                  "properties": {},
+                  "properties": {
+                    "action": {
+                      "const": "send",
+                      "type": "string"
+                    },
+                    "createdSession": {
+                      "type": "boolean"
+                    },
+                    "delivery": {
+                      "additionalProperties": {},
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "mode": {
+                      "enum": [
+                        "fire-and-forget",
+                        "wait"
+                      ],
+                      "type": "string"
+                    },
+                    "promptLength": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "published": {
+                      "type": "boolean"
+                    },
+                    "response": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "length": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "length",
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    "session": {
+                      "additionalProperties": {},
+                      "properties": {
+                        "agentId": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "sessionKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "label",
+                        "agentId"
+                      ],
+                      "type": "object"
+                    },
+                    "thread": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "properties": {},
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "action",
+                    "mode",
+                    "published",
+                    "createdSession",
+                    "session",
+                    "promptLength",
+                    "delivery",
+                    "thread"
+                  ],
                   "type": "object"
                 }
               }
@@ -66625,6 +67351,471 @@
         },
         "security": [],
         "summary": "Set session model override",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/api/v1/sessions/set-provider": {
+      "post": {
+        "operationId": "sessions.set-provider",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "nameOrKey": {
+                    "description": "Session name or key",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "nameOrKey",
+                  "provider"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "action": {
+                      "const": "set-provider",
+                      "type": "string"
+                    },
+                    "after": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "agentId": {
+                              "type": "string"
+                            },
+                            "effectiveModel": {
+                              "type": "string"
+                            },
+                            "effectiveProvider": {
+                              "type": "string"
+                            },
+                            "effortOverride": {
+                              "enum": [
+                                "none",
+                                "minimal",
+                                "low",
+                                "medium",
+                                "high",
+                                "xhigh",
+                                "max",
+                                "ultra"
+                              ],
+                              "type": "string"
+                            },
+                            "ephemeral": {
+                              "type": "boolean"
+                            },
+                            "expiresAt": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "modelOverride": {
+                              "type": "string"
+                            },
+                            "modelPresetId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "modelPresetVersion": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "modelSource": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "runtimeOptions": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "effort": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "enum": [
+                                        "session_override",
+                                        "agent_default",
+                                        "runtime_default"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "enum": [
+                                        "none",
+                                        "minimal",
+                                        "low",
+                                        "medium",
+                                        "high",
+                                        "xhigh",
+                                        "max",
+                                        "ultra"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "model": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "thinking": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "model",
+                                "effort",
+                                "thinking"
+                              ],
+                              "type": "object"
+                            },
+                            "sessionKey": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "sessionKey",
+                            "label",
+                            "agentId",
+                            "effectiveProvider",
+                            "effectiveModel",
+                            "modelSource",
+                            "modelPresetId",
+                            "modelPresetVersion",
+                            "ephemeral",
+                            "expiresAt",
+                            "runtimeOptions"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "appliesOn": {
+                      "const": "next-turn-runtime-restart",
+                      "type": "string"
+                    },
+                    "before": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "agentId": {
+                          "type": "string"
+                        },
+                        "effectiveModel": {
+                          "type": "string"
+                        },
+                        "effectiveProvider": {
+                          "type": "string"
+                        },
+                        "effortOverride": {
+                          "enum": [
+                            "none",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh",
+                            "max",
+                            "ultra"
+                          ],
+                          "type": "string"
+                        },
+                        "ephemeral": {
+                          "type": "boolean"
+                        },
+                        "expiresAt": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "modelOverride": {
+                          "type": "string"
+                        },
+                        "modelPresetId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "modelPresetVersion": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "modelSource": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "runtimeOptions": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "effort": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "enum": [
+                                    "session_override",
+                                    "agent_default",
+                                    "runtime_default"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max",
+                                    "ultra"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "model": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "thinking": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "model",
+                            "effort",
+                            "thinking"
+                          ],
+                          "type": "object"
+                        },
+                        "sessionKey": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "label",
+                        "agentId",
+                        "effectiveProvider",
+                        "effectiveModel",
+                        "modelSource",
+                        "modelPresetId",
+                        "modelPresetVersion",
+                        "ephemeral",
+                        "expiresAt",
+                        "runtimeOptions"
+                      ],
+                      "type": "object"
+                    },
+                    "changed": {
+                      "type": "boolean"
+                    },
+                    "effectiveProvider": {
+                      "type": "string"
+                    },
+                    "runtimeProviderOverride": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sessionKey": {
+                      "type": "string"
+                    },
+                    "sessionName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "action",
+                    "changed",
+                    "sessionKey",
+                    "sessionName",
+                    "before",
+                    "after",
+                    "runtimeProviderOverride",
+                    "effectiveProvider",
+                    "appliesOn"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Set session runtime provider override",
         "tags": [
           "sessions"
         ]
@@ -70611,6 +71802,14 @@
                     "description": "Slack channel/conversation ID",
                     "type": "string"
                   },
+                  "connection": {
+                    "description": "Ravi channel config; SDK-safe alias for --channel",
+                    "type": "string"
+                  },
+                  "ephemeralUser": {
+                    "description": "Send as an ephemeral message visible only to this Slack user",
+                    "type": "string"
+                  },
                   "execute": {
                     "description": "Perform the mutation; default is dry-run",
                     "type": "boolean"
@@ -73524,6 +74723,10 @@
                     "description": "Slack channel/conversation ID",
                     "type": "string"
                   },
+                  "connection": {
+                    "description": "Ravi channel config; SDK-safe alias for --channel",
+                    "type": "string"
+                  },
                   "execute": {
                     "description": "Perform the mutation; default is dry-run",
                     "type": "boolean"
@@ -74844,6 +76047,10 @@
                     "description": "Slack channel/conversation ID",
                     "type": "string"
                   },
+                  "ephemeralUser": {
+                    "description": "Send as an ephemeral message visible only to this Slack user",
+                    "type": "string"
+                  },
                   "execute": {
                     "description": "Perform the mutation; default is dry-run",
                     "type": "boolean"
@@ -74986,6 +76193,494 @@
           }
         ],
         "summary": "Send a Slack message; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/modals-open": {
+      "post": {
+        "operationId": "slack.modals-open",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Ravi channel config",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to a Block Kit view JSON file",
+                    "type": "string"
+                  },
+                  "triggerId": {
+                    "description": "Slack interaction trigger_id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "triggerId",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Open a Slack modal from an interaction trigger_id; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/modals-push": {
+      "post": {
+        "operationId": "slack.modals-push",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Ravi channel config",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to a Block Kit view JSON file",
+                    "type": "string"
+                  },
+                  "triggerId": {
+                    "description": "Slack interaction trigger_id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "triggerId",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Push a Slack modal view onto an existing modal stack; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/modals-update": {
+      "post": {
+        "operationId": "slack.modals-update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Ravi channel config",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "externalId": {
+                    "description": "Treat <view> as an external_id instead of a view_id",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to a Block Kit view JSON file",
+                    "type": "string"
+                  },
+                  "hash": {
+                    "description": "Slack view.hash for optimistic concurrency control",
+                    "type": "string"
+                  },
+                  "view": {
+                    "description": "Slack view_id, or external_id when --external-id is set",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "view",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update a Slack modal view; dry-run unless --execute is set",
         "tags": [
           "slack"
         ]
@@ -75273,6 +76968,632 @@
           }
         ],
         "summary": "Show Slack channels and Ravi route/session ownership",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/work-objects-present-details": {
+      "post": {
+        "operationId": "slack.work-objects-present-details",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Ravi channel config",
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Ravi channel config; SDK-safe alias for --channel",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to Slack native Work Object detail metadata JSON",
+                    "type": "string"
+                  },
+                  "triggerId": {
+                    "description": "Slack entity_details_requested trigger_id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "triggerId",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Present Slack native Work Object flexpane details; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/work-objects-send": {
+      "post": {
+        "operationId": "slack.work-objects-send",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Slack channel/conversation ID",
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Ravi channel config; SDK-safe alias for --channel",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to Slack native Work Object message JSON",
+                    "type": "string"
+                  },
+                  "text": {
+                    "description": "Top-level fallback text for notifications/accessibility",
+                    "type": "string"
+                  },
+                  "threadTs": {
+                    "description": "Send inside a Slack thread",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "channel",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Send Slack native Work Object metadata with chat.postMessage; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/work-objects-unfurl": {
+      "post": {
+        "operationId": "slack.work-objects-unfurl",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "channel": {
+                    "description": "Slack channel/conversation ID containing the URL message",
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Ravi channel config; SDK-safe alias for --channel",
+                    "type": "string"
+                  },
+                  "execute": {
+                    "description": "Perform the mutation; default is dry-run",
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "description": "Path to Slack native Work Object metadata JSON",
+                    "type": "string"
+                  },
+                  "ts": {
+                    "description": "Slack message timestamp containing the URL",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "URL in the message to unfurl",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "channel",
+                  "ts",
+                  "url",
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "connection": {
+                      "type": "string"
+                    },
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    },
+                    "raw": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "request": {
+                      "additionalProperties": {
+                        "$ref": "#/$defs/__schema0"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider",
+                    "connection",
+                    "source",
+                    "dryRun",
+                    "method",
+                    "request"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Attach Slack native Work Object metadata with chat.unfurl; dry-run unless --execute is set",
+        "tags": [
+          "slack"
+        ]
+      }
+    },
+    "/api/v1/slack/work-objects-validate": {
+      "post": {
+        "operationId": "slack.work-objects-validate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "file": {
+                    "description": "Path to Slack native Work Object metadata JSON",
+                    "type": "string"
+                  },
+                  "target": {
+                    "default": "message",
+                    "description": "Validation target: message or detail",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$defs": {
+                    "__schema0": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/__schema0"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "dryRun": {
+                      "type": "boolean"
+                    },
+                    "item": {
+                      "$ref": "#/$defs/__schema0"
+                    },
+                    "ok": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "outputFile": {
+                      "type": "string"
+                    },
+                    "provider": {
+                      "const": "slack",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "provider"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Validate Slack native Work Object metadata JSON",
         "tags": [
           "slack"
         ]
@@ -88505,6 +90826,2931 @@
           "workflows"
         ]
       }
+    },
+    "/api/v1/yt/analytics-countries": {
+      "post": {
+        "operationId": "yt.analytics-countries",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Rows, 1-200 (default: 10)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "countries": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "country": {
+                            "type": "string"
+                          },
+                          "subscribersGained": {
+                            "type": "number"
+                          },
+                          "views": {
+                            "type": "number"
+                          },
+                          "watchTimeMinutes": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "country",
+                          "views",
+                          "watchTimeMinutes",
+                          "subscribersGained"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "countries"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Break down recent views and watch time by country",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-demographics": {
+      "post": {
+        "operationId": "yt.analytics-demographics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "demographics": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "ageGroup": {
+                            "type": "string"
+                          },
+                          "gender": {
+                            "type": "string"
+                          },
+                          "viewerPercentage": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "ageGroup",
+                          "gender",
+                          "viewerPercentage"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "demographics"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Break down viewer percentage by age group and gender",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-devices": {
+      "post": {
+        "operationId": "yt.analytics-devices",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "devices": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "device": {
+                            "type": "string"
+                          },
+                          "views": {
+                            "type": "number"
+                          },
+                          "watchTimeMinutes": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "views",
+                          "watchTimeMinutes"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "devices"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Break down recent views and watch time by device type",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-overview": {
+      "post": {
+        "operationId": "yt.analytics-overview",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "overview": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "avgViewDurationSec": {
+                          "type": "number"
+                        },
+                        "comments": {
+                          "type": "number"
+                        },
+                        "dislikes": {
+                          "type": "number"
+                        },
+                        "likes": {
+                          "type": "number"
+                        },
+                        "netSubscribers": {
+                          "type": "number"
+                        },
+                        "shares": {
+                          "type": "number"
+                        },
+                        "subscribersGained": {
+                          "type": "number"
+                        },
+                        "subscribersLost": {
+                          "type": "number"
+                        },
+                        "views": {
+                          "type": "number"
+                        },
+                        "watchTimeMinutes": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "views",
+                        "watchTimeMinutes",
+                        "avgViewDurationSec",
+                        "subscribersGained",
+                        "subscribersLost",
+                        "netSubscribers",
+                        "likes",
+                        "dislikes",
+                        "comments",
+                        "shares"
+                      ],
+                      "type": "object"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "overview"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Return aggregate channel engagement metrics for a recent period",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-series": {
+      "post": {
+        "operationId": "yt.analytics-series",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "metric": {
+                    "description": "views|estimatedMinutesWatched|averageViewDuration|subscribersGained|likes|comments|shares (default: views)",
+                    "enum": [
+                      "views",
+                      "estimatedMinutesWatched",
+                      "averageViewDuration",
+                      "subscribersGained",
+                      "likes",
+                      "comments",
+                      "shares"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "metric": {
+                      "type": "string"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "metric",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Return a daily time series for one approved YouTube Analytics metric",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-top": {
+      "post": {
+        "operationId": "yt.analytics-top",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Rows, 1-200 (default: 10)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "period": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "videos": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "avgViewDurationSec": {
+                            "type": "number"
+                          },
+                          "comments": {
+                            "type": "number"
+                          },
+                          "likes": {
+                            "type": "number"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "videoId": {
+                            "type": "string"
+                          },
+                          "views": {
+                            "type": "number"
+                          },
+                          "watchTimeMinutes": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "videoId",
+                          "title",
+                          "views",
+                          "watchTimeMinutes",
+                          "avgViewDurationSec",
+                          "likes",
+                          "comments"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "videos"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Rank channel videos by views for a recent period",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/analytics-traffic": {
+      "post": {
+        "operationId": "yt.analytics-traffic",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "days": {
+                    "description": "Recent days, 1-365 (default: 28)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "period": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "source": {
+                            "type": "string"
+                          },
+                          "views": {
+                            "type": "number"
+                          },
+                          "watchTimeMinutes": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "source",
+                          "views",
+                          "watchTimeMinutes"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "period",
+                    "sources"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Break down recent views and watch time by traffic-source type",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/caption-download": {
+      "post": {
+        "operationId": "yt.caption-download",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "captionId": {
+                    "description": "Caption track ID from `ravi yt captions`",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "format": {
+                    "description": "srt|vtt|ttml (default: srt)",
+                    "enum": [
+                      "srt",
+                      "vtt",
+                      "ttml"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Optional ISO 639-1 translation language",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "captionId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "captionId": {
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "format": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "captionId",
+                    "format",
+                    "content"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Download one caption track as text",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/captions": {
+      "post": {
+        "operationId": "yt.captions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "videoId": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "videoId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "captions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "captionId": {
+                            "type": "string"
+                          },
+                          "isAutoSynced": {
+                            "type": "boolean"
+                          },
+                          "isDraft": {
+                            "type": "boolean"
+                          },
+                          "language": {
+                            "type": "string"
+                          },
+                          "lastUpdated": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "trackKind": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "captionId",
+                          "language",
+                          "name",
+                          "trackKind",
+                          "isAutoSynced",
+                          "isDraft",
+                          "status",
+                          "lastUpdated"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    },
+                    "videoId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "videoId",
+                    "captions",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List caption tracks for one video",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/comments": {
+      "post": {
+        "operationId": "yt.comments",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-100 (default: 20)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  },
+                  "videoId": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "videoId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "comments": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "author": {
+                            "type": "string"
+                          },
+                          "authorChannelUrl": {
+                            "type": "string"
+                          },
+                          "commentId": {
+                            "type": "string"
+                          },
+                          "likeCount": {
+                            "type": "number"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "replyCount": {
+                            "type": "number"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "threadId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "threadId",
+                          "commentId",
+                          "author",
+                          "authorChannelUrl",
+                          "text",
+                          "likeCount",
+                          "publishedAt",
+                          "replyCount"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    },
+                    "videoId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "videoId",
+                    "comments",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List top-level comment threads for a video",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/health": {
+      "post": {
+        "operationId": "yt.health",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "app": {
+                      "const": "youtube",
+                      "type": "string"
+                    },
+                    "authenticated": {
+                      "const": false,
+                      "type": "boolean"
+                    },
+                    "connection": {
+                      "type": "string"
+                    },
+                    "credentialConfigured": {
+                      "type": "boolean"
+                    },
+                    "credentialStatus": {
+                      "type": "string"
+                    },
+                    "externalCheckPerformed": {
+                      "const": false,
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "ready": {
+                      "type": "boolean"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "app",
+                    "connection",
+                    "ready",
+                    "credentialConfigured",
+                    "credentialStatus",
+                    "authenticated",
+                    "externalCheckPerformed",
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Inspect YouTube credential metadata without resolving a secret or calling Google",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/info": {
+      "post": {
+        "operationId": "yt.info",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "channel": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "channelId": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "subscriberCount": {
+                          "type": "number"
+                        },
+                        "thumbnail": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "uploadsPlaylistId": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "videoCount": {
+                          "type": "number"
+                        },
+                        "viewCount": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "channelId",
+                        "title",
+                        "description",
+                        "subscriberCount",
+                        "videoCount",
+                        "viewCount",
+                        "thumbnail",
+                        "uploadsPlaylistId",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "channel"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Return metadata and lifetime counters for the authenticated channel",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlist": {
+      "post": {
+        "operationId": "yt.playlist",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-50 (default: 25)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  },
+                  "playlistId": {
+                    "description": "YouTube playlist ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "playlistId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "playlistId": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    },
+                    "videos": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "commentCount": {
+                            "type": "number"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "duration": {
+                            "type": "string"
+                          },
+                          "likeCount": {
+                            "type": "number"
+                          },
+                          "playlistItemId": {
+                            "type": "string"
+                          },
+                          "privacyStatus": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "thumbnail": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "videoId": {
+                            "type": "string"
+                          },
+                          "viewCount": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "videoId",
+                          "title",
+                          "description",
+                          "publishedAt",
+                          "thumbnail",
+                          "viewCount",
+                          "likeCount",
+                          "commentCount",
+                          "duration",
+                          "privacyStatus",
+                          "url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "playlistId",
+                    "videos",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List videos and playlist-item IDs from one playlist",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlist-add": {
+      "post": {
+        "operationId": "yt.playlist-add",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "playlistId": {
+                    "description": "Target YouTube playlist ID",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "videoId": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "playlistId",
+                  "videoId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "item": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "playlistId": {
+                          "type": "string"
+                        },
+                        "playlistItemId": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "videoId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "playlistItemId",
+                        "playlistId",
+                        "videoId",
+                        "title"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "item"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Add one video to a YouTube playlist",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlist-create": {
+      "post": {
+        "operationId": "yt.playlist-create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "Playlist description",
+                    "type": "string"
+                  },
+                  "privacy": {
+                    "description": "public|private|unlisted (default: private)",
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Playlist title",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "playlist": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "itemCount": {
+                          "type": "number"
+                        },
+                        "playlistId": {
+                          "type": "string"
+                        },
+                        "privacyStatus": {
+                          "type": "string"
+                        },
+                        "publishedAt": {
+                          "type": "string"
+                        },
+                        "thumbnail": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "playlistId",
+                        "title",
+                        "description",
+                        "thumbnail",
+                        "itemCount",
+                        "publishedAt",
+                        "privacyStatus",
+                        "url"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "playlist"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Create a YouTube playlist",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlist-delete": {
+      "post": {
+        "operationId": "yt.playlist-delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "playlistId": {
+                    "description": "Owned YouTube playlist ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "playlistId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "deleted": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "deleted"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Permanently delete a YouTube playlist without deleting its videos",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlist-remove": {
+      "post": {
+        "operationId": "yt.playlist-remove",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "playlistItemId": {
+                    "description": "Playlist item ID, not video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "playlistItemId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "removed": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "removed"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Remove one playlist item without deleting the video",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/playlists": {
+      "post": {
+        "operationId": "yt.playlists",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-50 (default: 25)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "playlists": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "itemCount": {
+                            "type": "number"
+                          },
+                          "playlistId": {
+                            "type": "string"
+                          },
+                          "privacyStatus": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "thumbnail": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "playlistId",
+                          "title",
+                          "description",
+                          "thumbnail",
+                          "itemCount",
+                          "publishedAt",
+                          "privacyStatus",
+                          "url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "playlists",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List playlists owned by the authenticated channel",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/reply": {
+      "post": {
+        "operationId": "yt.reply",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "commentId": {
+                    "description": "Top-level comment ID from `ravi yt comments`",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "text": {
+                    "description": "Exact approved reply text",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "commentId",
+                  "text"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "replyId": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "replyId"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Publish a reply to a top-level YouTube comment",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/search": {
+      "post": {
+        "operationId": "yt.search",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-50 (default: 10)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  },
+                  "query": {
+                    "description": "Search text",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "query": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    },
+                    "videos": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "commentCount": {
+                            "type": "number"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "duration": {
+                            "type": "string"
+                          },
+                          "likeCount": {
+                            "type": "number"
+                          },
+                          "playlistItemId": {
+                            "type": "string"
+                          },
+                          "privacyStatus": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "thumbnail": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "videoId": {
+                            "type": "string"
+                          },
+                          "viewCount": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "videoId",
+                          "title",
+                          "description",
+                          "publishedAt",
+                          "thumbnail",
+                          "viewCount",
+                          "likeCount",
+                          "commentCount",
+                          "duration",
+                          "privacyStatus",
+                          "url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "videos",
+                    "totalResults",
+                    "query"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Search videos in the authenticated channel",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/stats": {
+      "post": {
+        "operationId": "yt.stats",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "stats": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "commentCount": {
+                          "type": "number"
+                        },
+                        "daysSincePublish": {
+                          "type": "number"
+                        },
+                        "likeCount": {
+                          "type": "number"
+                        },
+                        "publishedAt": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "videoId": {
+                          "type": "string"
+                        },
+                        "viewCount": {
+                          "type": "number"
+                        },
+                        "viewsPerDay": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "videoId",
+                        "title",
+                        "viewCount",
+                        "likeCount",
+                        "commentCount",
+                        "publishedAt",
+                        "daysSincePublish",
+                        "viewsPerDay"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "stats"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Calculate lifetime video counters, age and average views per day",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/subscriptions": {
+      "post": {
+        "operationId": "yt.subscriptions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-50 (default: 25)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "subscriptions": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "channelId": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "subscriptionId": {
+                            "type": "string"
+                          },
+                          "thumbnail": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "totalItemCount": {
+                            "type": "number"
+                          },
+                          "url": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "subscriptionId",
+                          "channelId",
+                          "title",
+                          "description",
+                          "thumbnail",
+                          "publishedAt",
+                          "totalItemCount",
+                          "url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "subscriptions",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List channels followed by the authenticated channel",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/unanswered": {
+      "post": {
+        "operationId": "yt.unanswered",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Threads inspected, 1-100 (default: 50)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  },
+                  "videoId": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "videoId"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "comments": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "author": {
+                            "type": "string"
+                          },
+                          "authorChannelUrl": {
+                            "type": "string"
+                          },
+                          "commentId": {
+                            "type": "string"
+                          },
+                          "likeCount": {
+                            "type": "number"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "replyCount": {
+                            "type": "number"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "threadId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "threadId",
+                          "commentId",
+                          "author",
+                          "authorChannelUrl",
+                          "text",
+                          "likeCount",
+                          "publishedAt",
+                          "replyCount"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalUnanswered": {
+                      "type": "number"
+                    },
+                    "videoId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "videoId",
+                    "comments",
+                    "totalUnanswered"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List recent comment threads with zero replies",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/video": {
+      "post": {
+        "operationId": "yt.video",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "video": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "commentCount": {
+                          "type": "number"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "duration": {
+                          "type": "string"
+                        },
+                        "likeCount": {
+                          "type": "number"
+                        },
+                        "playlistItemId": {
+                          "type": "string"
+                        },
+                        "privacyStatus": {
+                          "type": "string"
+                        },
+                        "publishedAt": {
+                          "type": "string"
+                        },
+                        "thumbnail": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "videoId": {
+                          "type": "string"
+                        },
+                        "viewCount": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "videoId",
+                        "title",
+                        "description",
+                        "publishedAt",
+                        "thumbnail",
+                        "viewCount",
+                        "likeCount",
+                        "commentCount",
+                        "duration",
+                        "privacyStatus",
+                        "url"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "video"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Get one video by YouTube video ID",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/video-categories": {
+      "post": {
+        "operationId": "yt.video-categories",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "region": {
+                    "description": "ISO 3166-1 alpha-2 region (default: BR)",
+                    "pattern": "^[A-Za-z]{2}$",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "categories": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "assignable": {
+                            "type": "boolean"
+                          },
+                          "categoryId": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "categoryId",
+                          "title",
+                          "assignable"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "region": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "region",
+                    "categories",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List assignable YouTube video categories for a region",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/video-delete": {
+      "post": {
+        "operationId": "yt.video-delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Owned YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "deleted": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "deleted"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Permanently delete an owned YouTube video",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/video-update": {
+      "post": {
+        "operationId": "yt.video-update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "category": {
+                    "description": "Replacement category ID",
+                    "type": "string"
+                  },
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "Replacement description",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "Owned YouTube video ID",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "privacy": {
+                    "description": "public|private|unlisted",
+                    "enum": [
+                      "public",
+                      "private",
+                      "unlisted"
+                    ],
+                    "type": "string"
+                  },
+                  "tags": {
+                    "description": "Replacement comma-separated tag list",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Replacement title",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "video": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "commentCount": {
+                          "type": "number"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "duration": {
+                          "type": "string"
+                        },
+                        "likeCount": {
+                          "type": "number"
+                        },
+                        "playlistItemId": {
+                          "type": "string"
+                        },
+                        "privacyStatus": {
+                          "type": "string"
+                        },
+                        "publishedAt": {
+                          "type": "string"
+                        },
+                        "thumbnail": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "videoId": {
+                          "type": "string"
+                        },
+                        "viewCount": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "videoId",
+                        "title",
+                        "description",
+                        "publishedAt",
+                        "thumbnail",
+                        "viewCount",
+                        "likeCount",
+                        "commentCount",
+                        "duration",
+                        "privacyStatus",
+                        "url"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "video"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Update selected metadata on an owned YouTube video",
+        "tags": [
+          "yt"
+        ]
+      }
+    },
+    "/api/v1/yt/videos": {
+      "post": {
+        "operationId": "yt.videos",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "connection": {
+                    "description": "Credential connection (default: default)",
+                    "type": "string"
+                  },
+                  "limit": {
+                    "description": "Page size, 1-50 (default: 10)",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "page": {
+                    "description": "Provider page token from nextPageToken",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "nextPageToken": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "totalResults": {
+                      "type": "number"
+                    },
+                    "videos": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "commentCount": {
+                            "type": "number"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "duration": {
+                            "type": "string"
+                          },
+                          "likeCount": {
+                            "type": "number"
+                          },
+                          "playlistItemId": {
+                            "type": "string"
+                          },
+                          "privacyStatus": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "thumbnail": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "videoId": {
+                            "type": "string"
+                          },
+                          "viewCount": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "videoId",
+                          "title",
+                          "description",
+                          "publishedAt",
+                          "thumbnail",
+                          "viewCount",
+                          "likeCount",
+                          "commentCount",
+                          "duration",
+                          "privacyStatus",
+                          "url"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "videos",
+                    "totalResults"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "List videos from the authenticated channel uploads playlist",
+        "tags": [
+          "yt"
+        ]
+      }
     }
   },
   "servers": [
@@ -88773,6 +94019,10 @@
     },
     {
       "name": "workflows"
+    },
+    {
+      "description": "Operate YouTube Data API v3 and YouTube Analytics API v2 through Ravi credentials",
+      "name": "yt"
     }
   ]
 }

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -49316,7 +49316,7 @@ export const SdkOpenapiEmitInputSchema = {
   "additionalProperties": false,
   "properties": {
     "out": {
-      "description": "Write spec JSON to this path",
+      "description": "Write spec JSON to this path (default: docs/openapi.json)",
       "type": "string"
     },
     "stdout": {

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:2ab4adf7588d6ed03844f0672cd4c420f1330fa60da1e2532e0aca498d16a18f";
+export const REGISTRY_HASH = "sha256:5a7761fa7bc22992d1f8ff60bc07571166533154d12a566813c9e657cc429ea2";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "599f41fa4e59";
+export const GIT_SHA = "333c8e66f098";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviClient.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviClient.generated.swift
@@ -39,6 +39,10 @@ public final class RaviClient {
     CalendarsNamespace(transport: transport)
   }
 
+  public var channels: ChannelsNamespace {
+    ChannelsNamespace(transport: transport)
+  }
+
   public var chats: ChatsNamespace {
     ChatsNamespace(transport: transport)
   }
@@ -65,6 +69,10 @@ public final class RaviClient {
 
   public var costs: CostsNamespace {
     CostsNamespace(transport: transport)
+  }
+
+  public var credentials: CredentialsNamespace {
+    CredentialsNamespace(transport: transport)
   }
 
   public var crm: CrmNamespace {
@@ -195,6 +203,10 @@ public final class RaviClient {
     SkillsNamespace(transport: transport)
   }
 
+  public var slack: SlackNamespace {
+    SlackNamespace(transport: transport)
+  }
+
   public var specs: SpecsNamespace {
     SpecsNamespace(transport: transport)
   }
@@ -253,6 +265,10 @@ public final class RaviClient {
 
   public var workflows: WorkflowsNamespace {
     WorkflowsNamespace(transport: transport)
+  }
+
+  public var yt: YtNamespace {
+    YtNamespace(transport: transport)
   }
 
 }
@@ -742,6 +758,68 @@ public struct CalendarsEventsNamespace: Sendable {
   }
 }
 
+public struct ChannelsNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func create(_ name: String, _ options: ChannelsCreateOptions = .init()) async throws -> ChannelsCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["name"] = try RaviJSON.fromEncodable(name)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["channels"], command: "create", body: requestBody, as: ChannelsCreateReturn.self)
+  }
+
+  public func list(_ options: ChannelsListOptions = .init()) async throws -> ChannelsListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["channels"], command: "list", body: requestBody, as: ChannelsListReturn.self)
+  }
+
+  public func probe() async throws -> ChannelsProbeReturn {
+    let requestBody: [String: RaviJSON] = [:]
+    return try await transport.call(groupSegments: ["channels"], command: "probe", body: requestBody, as: ChannelsProbeReturn.self)
+  }
+
+  public func restart(_ options: ChannelsRestartOptions = .init()) async throws -> ChannelsRestartReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["channels"], command: "restart", body: requestBody, as: ChannelsRestartReturn.self)
+  }
+
+  public func set(_ name: String, _ key: String, _ value: String) async throws -> ChannelsSetReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["name"] = try RaviJSON.fromEncodable(name)
+    requestBody["key"] = try RaviJSON.fromEncodable(key)
+    requestBody["value"] = try RaviJSON.fromEncodable(value)
+    return try await transport.call(groupSegments: ["channels"], command: "set", body: requestBody, as: ChannelsSetReturn.self)
+  }
+
+  public func show(_ name: String) async throws -> ChannelsShowReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["name"] = try RaviJSON.fromEncodable(name)
+    return try await transport.call(groupSegments: ["channels"], command: "show", body: requestBody, as: ChannelsShowReturn.self)
+  }
+
+  public func start(_ options: ChannelsStartOptions = .init()) async throws -> ChannelsStartReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["channels"], command: "start", body: requestBody, as: ChannelsStartReturn.self)
+  }
+
+  public func status() async throws -> ChannelsStatusReturn {
+    let requestBody: [String: RaviJSON] = [:]
+    return try await transport.call(groupSegments: ["channels"], command: "status", body: requestBody, as: ChannelsStatusReturn.self)
+  }
+
+  public func stop() async throws -> ChannelsStopReturn {
+    let requestBody: [String: RaviJSON] = [:]
+    return try await transport.call(groupSegments: ["channels"], command: "stop", body: requestBody, as: ChannelsStopReturn.self)
+  }
+}
+
 public struct ChatsNamespace: Sendable {
   private let transport: any RaviTransport
 
@@ -824,9 +902,16 @@ public struct ChatsListsNamespace: Sendable {
     return try await transport.call(groupSegments: ["chats","lists"], command: "members", body: requestBody, as: ChatsListsMembersReturn.self)
   }
 
-  public func recompute(_ list: String, _ options: ChatsListsRecomputeOptions = .init()) async throws -> ChatsListsRecomputeReturn {
+  public func preview(_ listId: String, _ options: ChatsListsPreviewOptions = .init()) async throws -> ChatsListsPreviewReturn {
     var requestBody: [String: RaviJSON] = [:]
-    requestBody["list"] = try RaviJSON.fromEncodable(list)
+    requestBody["listId"] = try RaviJSON.fromEncodable(listId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["chats","lists"], command: "preview", body: requestBody, as: ChatsListsPreviewReturn.self)
+  }
+
+  public func recompute(_ listId: String, _ options: ChatsListsRecomputeOptions = .init()) async throws -> ChatsListsRecomputeReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["listId"] = try RaviJSON.fromEncodable(listId)
     try options.encodeBody(into: &requestBody)
     return try await transport.call(groupSegments: ["chats","lists"], command: "recompute", body: requestBody, as: ChatsListsRecomputeReturn.self)
   }
@@ -837,6 +922,13 @@ public struct ChatsListsNamespace: Sendable {
     requestBody["chat"] = try RaviJSON.fromEncodable(chat)
     try options.encodeBody(into: &requestBody)
     return try await transport.call(groupSegments: ["chats","lists"], command: "remove", body: requestBody, as: ChatsListsRemoveReturn.self)
+  }
+
+  public func show(_ listId: String, _ options: ChatsListsShowOptions = .init()) async throws -> ChatsListsShowReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["listId"] = try RaviJSON.fromEncodable(listId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["chats","lists"], command: "show", body: requestBody, as: ChatsListsShowReturn.self)
   }
 }
 
@@ -1356,6 +1448,68 @@ public struct CostsNamespace: Sendable {
     var requestBody: [String: RaviJSON] = [:]
     try options.encodeBody(into: &requestBody)
     return try await transport.call(groupSegments: ["costs"], command: "top-sessions", body: requestBody, as: CostsTopSessionsReturn.self)
+  }
+}
+
+public struct CredentialsNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public var connections: CredentialsConnectionsNamespace {
+    CredentialsConnectionsNamespace(transport: transport)
+  }
+
+  public var policies: CredentialsPoliciesNamespace {
+    CredentialsPoliciesNamespace(transport: transport)
+  }
+}
+
+public struct CredentialsConnectionsNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func disable(_ options: CredentialsConnectionsDisableOptions = .init()) async throws -> CredentialsConnectionsDisableReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["credentials","connections"], command: "disable", body: requestBody, as: CredentialsConnectionsDisableReturn.self)
+  }
+
+  public func enable(_ options: CredentialsConnectionsEnableOptions = .init()) async throws -> CredentialsConnectionsEnableReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["credentials","connections"], command: "enable", body: requestBody, as: CredentialsConnectionsEnableReturn.self)
+  }
+
+  public func list(_ options: CredentialsConnectionsListOptions = .init()) async throws -> CredentialsConnectionsListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["credentials","connections"], command: "list", body: requestBody, as: CredentialsConnectionsListReturn.self)
+  }
+
+  public func show(_ options: CredentialsConnectionsShowOptions = .init()) async throws -> CredentialsConnectionsShowReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["credentials","connections"], command: "show", body: requestBody, as: CredentialsConnectionsShowReturn.self)
+  }
+}
+
+public struct CredentialsPoliciesNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func explain(_ options: CredentialsPoliciesExplainOptions = .init()) async throws -> CredentialsPoliciesExplainReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["credentials","policies"], command: "explain", body: requestBody, as: CredentialsPoliciesExplainReturn.self)
   }
 }
 
@@ -2920,9 +3074,10 @@ public struct ObserversNamespace: Sendable {
     return try await transport.call(groupSegments: ["observers"], command: "list", body: requestBody, as: ObserversListReturn.self)
   }
 
-  public func refresh(_ session: String) async throws -> ObserversRefreshReturn {
+  public func refresh(_ session: String, _ options: ObserversRefreshOptions = .init()) async throws -> ObserversRefreshReturn {
     var requestBody: [String: RaviJSON] = [:]
     requestBody["session"] = try RaviJSON.fromEncodable(session)
+    try options.encodeBody(into: &requestBody)
     return try await transport.call(groupSegments: ["observers"], command: "refresh", body: requestBody, as: ObserversRefreshReturn.self)
   }
 
@@ -3617,6 +3772,10 @@ public struct RuntimeNamespace: Sendable {
   public var credentials: RuntimeCredentialsNamespace {
     RuntimeCredentialsNamespace(transport: transport)
   }
+
+  public var presets: RuntimePresetsNamespace {
+    RuntimePresetsNamespace(transport: transport)
+  }
 }
 
 public struct RuntimeCredentialsNamespace: Sendable {
@@ -3689,6 +3848,70 @@ public struct RuntimeCredentialsNamespace: Sendable {
       requestBody["id"] = try RaviJSON.fromEncodable(id)
     }
     return try await transport.call(groupSegments: ["runtime","credentials"], command: "status", body: requestBody, as: RuntimeCredentialsStatusReturn.self)
+  }
+}
+
+public struct RuntimePresetsNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func create(_ id: String, _ options: RuntimePresetsCreateOptions = .init()) async throws -> RuntimePresetsCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "create", body: requestBody, as: RuntimePresetsCreateReturn.self)
+  }
+
+  public func delete(_ id: String, _ options: RuntimePresetsDeleteOptions = .init()) async throws -> RuntimePresetsDeleteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "delete", body: requestBody, as: RuntimePresetsDeleteReturn.self)
+  }
+
+  public func disable(_ id: String, _ options: RuntimePresetsDisableOptions = .init()) async throws -> RuntimePresetsDisableReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "disable", body: requestBody, as: RuntimePresetsDisableReturn.self)
+  }
+
+  public func enable(_ id: String, _ options: RuntimePresetsEnableOptions = .init()) async throws -> RuntimePresetsEnableReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "enable", body: requestBody, as: RuntimePresetsEnableReturn.self)
+  }
+
+  public func impact(_ id: String, _ options: RuntimePresetsImpactOptions = .init()) async throws -> RuntimePresetsImpactReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "impact", body: requestBody, as: RuntimePresetsImpactReturn.self)
+  }
+
+  public func list(_ options: RuntimePresetsListOptions = .init()) async throws -> RuntimePresetsListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "list", body: requestBody, as: RuntimePresetsListReturn.self)
+  }
+
+  public func set(_ id: String, _ field: String, _ value: String, _ options: RuntimePresetsSetOptions = .init()) async throws -> RuntimePresetsSetReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    requestBody["field"] = try RaviJSON.fromEncodable(field)
+    requestBody["value"] = try RaviJSON.fromEncodable(value)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "set", body: requestBody, as: RuntimePresetsSetReturn.self)
+  }
+
+  public func show(_ id: String) async throws -> RuntimePresetsShowReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    return try await transport.call(groupSegments: ["runtime","presets"], command: "show", body: requestBody, as: RuntimePresetsShowReturn.self)
   }
 }
 
@@ -4017,11 +4240,25 @@ public struct SessionsNamespace: Sendable {
     return try await transport.call(groupSegments: ["sessions"], command: "set-display", body: requestBody, as: SessionsSetDisplayReturn.self)
   }
 
+  public func setEffort(_ nameOrKey: String, _ level: String) async throws -> SessionsSetEffortReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["nameOrKey"] = try RaviJSON.fromEncodable(nameOrKey)
+    requestBody["level"] = try RaviJSON.fromEncodable(level)
+    return try await transport.call(groupSegments: ["sessions"], command: "set-effort", body: requestBody, as: SessionsSetEffortReturn.self)
+  }
+
   public func setModel(_ nameOrKey: String, _ model: String) async throws -> SessionsSetModelReturn {
     var requestBody: [String: RaviJSON] = [:]
     requestBody["nameOrKey"] = try RaviJSON.fromEncodable(nameOrKey)
     requestBody["model"] = try RaviJSON.fromEncodable(model)
     return try await transport.call(groupSegments: ["sessions"], command: "set-model", body: requestBody, as: SessionsSetModelReturn.self)
+  }
+
+  public func setProvider(_ nameOrKey: String, _ provider: String) async throws -> SessionsSetProviderReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["nameOrKey"] = try RaviJSON.fromEncodable(nameOrKey)
+    requestBody["provider"] = try RaviJSON.fromEncodable(provider)
+    return try await transport.call(groupSegments: ["sessions"], command: "set-provider", body: requestBody, as: SessionsSetProviderReturn.self)
   }
 
   public func setThinking(_ nameOrKey: String, _ level: String) async throws -> SessionsSetThinkingReturn {
@@ -4300,6 +4537,26 @@ public struct SkillsNamespace: Sendable {
     self.transport = transport
   }
 
+  public func grant(_ agent: String, _ skill: String, _ options: SkillsGrantOptions = .init()) async throws -> SkillsGrantReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["agent"] = try RaviJSON.fromEncodable(agent)
+    requestBody["skill"] = try RaviJSON.fromEncodable(skill)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["skills"], command: "grant", body: requestBody, as: SkillsGrantReturn.self)
+  }
+
+  public func grantBatch(_ options: SkillsGrantBatchOptions = .init()) async throws -> SkillsGrantBatchReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["skills"], command: "grant-batch", body: requestBody, as: SkillsGrantBatchReturn.self)
+  }
+
+  public func inspect(_ agent: String) async throws -> SkillsInspectReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["agent"] = try RaviJSON.fromEncodable(agent)
+    return try await transport.call(groupSegments: ["skills"], command: "inspect", body: requestBody, as: SkillsInspectReturn.self)
+  }
+
   public func install(_ name: String? = nil, _ options: SkillsInstallOptions = .init()) async throws -> SkillsInstallReturn {
     var requestBody: [String: RaviJSON] = [:]
     if let name {
@@ -4315,6 +4572,19 @@ public struct SkillsNamespace: Sendable {
     return try await transport.call(groupSegments: ["skills"], command: "list", body: requestBody, as: SkillsListReturn.self)
   }
 
+  public func revoke(_ agent: String, _ skill: String) async throws -> SkillsRevokeReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["agent"] = try RaviJSON.fromEncodable(agent)
+    requestBody["skill"] = try RaviJSON.fromEncodable(skill)
+    return try await transport.call(groupSegments: ["skills"], command: "revoke", body: requestBody, as: SkillsRevokeReturn.self)
+  }
+
+  public func revokeBatch(_ options: SkillsRevokeBatchOptions = .init()) async throws -> SkillsRevokeBatchReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["skills"], command: "revoke-batch", body: requestBody, as: SkillsRevokeBatchReturn.self)
+  }
+
   public func show(_ name: String, _ options: SkillsShowOptions = .init()) async throws -> SkillsShowReturn {
     var requestBody: [String: RaviJSON] = [:]
     requestBody["name"] = try RaviJSON.fromEncodable(name)
@@ -4325,6 +4595,286 @@ public struct SkillsNamespace: Sendable {
   public func sync() async throws -> SkillsSyncReturn {
     let requestBody: [String: RaviJSON] = [:]
     return try await transport.call(groupSegments: ["skills"], command: "sync", body: requestBody, as: SkillsSyncReturn.self)
+  }
+
+  public func who(_ skill: String? = nil, _ options: SkillsWhoOptions = .init()) async throws -> SkillsWhoReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    if let skill {
+      requestBody["skill"] = try RaviJSON.fromEncodable(skill)
+    }
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["skills"], command: "who", body: requestBody, as: SkillsWhoReturn.self)
+  }
+}
+
+public struct SlackNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func blocksSend(_ channel: String, _ file: String, _ options: SlackBlocksSendOptions = .init()) async throws -> SlackBlocksSendReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "blocks-send", body: requestBody, as: SlackBlocksSendReturn.self)
+  }
+
+  public func blocksShowcase(_ channel: String, _ options: SlackBlocksShowcaseOptions = .init()) async throws -> SlackBlocksShowcaseReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "blocks-showcase", body: requestBody, as: SlackBlocksShowcaseReturn.self)
+  }
+
+  public func blocksUpdate(_ channel: String, _ ts: String, _ file: String, _ options: SlackBlocksUpdateOptions = .init()) async throws -> SlackBlocksUpdateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["ts"] = try RaviJSON.fromEncodable(ts)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "blocks-update", body: requestBody, as: SlackBlocksUpdateReturn.self)
+  }
+
+  public func blocksValidate(_ file: String, _ options: SlackBlocksValidateOptions = .init()) async throws -> SlackBlocksValidateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "blocks-validate", body: requestBody, as: SlackBlocksValidateReturn.self)
+  }
+
+  public func canvasAccessDelete(_ canvas: String, _ options: SlackCanvasAccessDeleteOptions = .init()) async throws -> SlackCanvasAccessDeleteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-access-delete", body: requestBody, as: SlackCanvasAccessDeleteReturn.self)
+  }
+
+  public func canvasAccessSet(_ canvas: String, _ access: String, _ options: SlackCanvasAccessSetOptions = .init()) async throws -> SlackCanvasAccessSetReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    requestBody["access"] = try RaviJSON.fromEncodable(access)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-access-set", body: requestBody, as: SlackCanvasAccessSetReturn.self)
+  }
+
+  public func canvasArtifactPublish(_ artifactOrFile: String, _ options: SlackCanvasArtifactPublishOptions = .init()) async throws -> SlackCanvasArtifactPublishReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["artifactOrFile"] = try RaviJSON.fromEncodable(artifactOrFile)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-artifact-publish", body: requestBody, as: SlackCanvasArtifactPublishReturn.self)
+  }
+
+  public func canvasArtifactStatus(_ artifact: String) async throws -> SlackCanvasArtifactStatusReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["artifact"] = try RaviJSON.fromEncodable(artifact)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-artifact-status", body: requestBody, as: SlackCanvasArtifactStatusReturn.self)
+  }
+
+  public func canvasChannelCreate(_ channel: String, _ options: SlackCanvasChannelCreateOptions = .init()) async throws -> SlackCanvasChannelCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-channel-create", body: requestBody, as: SlackCanvasChannelCreateReturn.self)
+  }
+
+  public func canvasChannelShowcase(_ channel: String, _ options: SlackCanvasChannelShowcaseOptions = .init()) async throws -> SlackCanvasChannelShowcaseReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-channel-showcase", body: requestBody, as: SlackCanvasChannelShowcaseReturn.self)
+  }
+
+  public func canvasCreate(_ options: SlackCanvasCreateOptions = .init()) async throws -> SlackCanvasCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-create", body: requestBody, as: SlackCanvasCreateReturn.self)
+  }
+
+  public func canvasDelete(_ canvas: String, _ options: SlackCanvasDeleteOptions = .init()) async throws -> SlackCanvasDeleteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-delete", body: requestBody, as: SlackCanvasDeleteReturn.self)
+  }
+
+  public func canvasEdit(_ canvas: String, _ operation: String, _ options: SlackCanvasEditOptions = .init()) async throws -> SlackCanvasEditReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    requestBody["operation"] = try RaviJSON.fromEncodable(operation)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-edit", body: requestBody, as: SlackCanvasEditReturn.self)
+  }
+
+  public func canvasSectionsLookup(_ canvas: String, _ options: SlackCanvasSectionsLookupOptions = .init()) async throws -> SlackCanvasSectionsLookupReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-sections-lookup", body: requestBody, as: SlackCanvasSectionsLookupReturn.self)
+  }
+
+  public func canvasShowcase(_ canvas: String, _ options: SlackCanvasShowcaseOptions = .init()) async throws -> SlackCanvasShowcaseReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["canvas"] = try RaviJSON.fromEncodable(canvas)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "canvas-showcase", body: requestBody, as: SlackCanvasShowcaseReturn.self)
+  }
+
+  public func channelsCreate(_ name: String, _ options: SlackChannelsCreateOptions = .init()) async throws -> SlackChannelsCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["name"] = try RaviJSON.fromEncodable(name)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-create", body: requestBody, as: SlackChannelsCreateReturn.self)
+  }
+
+  public func channelsHistory(_ channel: String, _ options: SlackChannelsHistoryOptions = .init()) async throws -> SlackChannelsHistoryReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-history", body: requestBody, as: SlackChannelsHistoryReturn.self)
+  }
+
+  public func channelsInfo(_ channel: String) async throws -> SlackChannelsInfoReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-info", body: requestBody, as: SlackChannelsInfoReturn.self)
+  }
+
+  public func channelsInvite(_ channel: String, _ users: String, _ options: SlackChannelsInviteOptions = .init()) async throws -> SlackChannelsInviteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["users"] = try RaviJSON.fromEncodable(users)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-invite", body: requestBody, as: SlackChannelsInviteReturn.self)
+  }
+
+  public func channelsList(_ options: SlackChannelsListOptions = .init()) async throws -> SlackChannelsListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-list", body: requestBody, as: SlackChannelsListReturn.self)
+  }
+
+  public func channelsRename(_ channel: String, _ name: String, _ options: SlackChannelsRenameOptions = .init()) async throws -> SlackChannelsRenameReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["name"] = try RaviJSON.fromEncodable(name)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "channels-rename", body: requestBody, as: SlackChannelsRenameReturn.self)
+  }
+
+  public func filesList(_ options: SlackFilesListOptions = .init()) async throws -> SlackFilesListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "files-list", body: requestBody, as: SlackFilesListReturn.self)
+  }
+
+  public func interactionsRespond(_ responseUrlId: String, _ file: String, _ options: SlackInteractionsRespondOptions = .init()) async throws -> SlackInteractionsRespondReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["responseUrlId"] = try RaviJSON.fromEncodable(responseUrlId)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "interactions-respond", body: requestBody, as: SlackInteractionsRespondReturn.self)
+  }
+
+  public func membersList(_ channel: String, _ options: SlackMembersListOptions = .init()) async throws -> SlackMembersListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "members-list", body: requestBody, as: SlackMembersListReturn.self)
+  }
+
+  public func messagesInspect(_ channel: String, _ ts: String) async throws -> SlackMessagesInspectReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["ts"] = try RaviJSON.fromEncodable(ts)
+    return try await transport.call(groupSegments: ["slack"], command: "messages-inspect", body: requestBody, as: SlackMessagesInspectReturn.self)
+  }
+
+  public func messagesReplay(_ channel: String, _ ts: String, _ options: SlackMessagesReplayOptions = .init()) async throws -> SlackMessagesReplayReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["ts"] = try RaviJSON.fromEncodable(ts)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "messages-replay", body: requestBody, as: SlackMessagesReplayReturn.self)
+  }
+
+  public func messagesSend(_ channel: String, _ text: String, _ options: SlackMessagesSendOptions = .init()) async throws -> SlackMessagesSendReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["text"] = try RaviJSON.fromEncodable(text)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "messages-send", body: requestBody, as: SlackMessagesSendReturn.self)
+  }
+
+  public func modalsOpen(_ triggerId: String, _ file: String, _ options: SlackModalsOpenOptions = .init()) async throws -> SlackModalsOpenReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["triggerId"] = try RaviJSON.fromEncodable(triggerId)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "modals-open", body: requestBody, as: SlackModalsOpenReturn.self)
+  }
+
+  public func modalsPush(_ triggerId: String, _ file: String, _ options: SlackModalsPushOptions = .init()) async throws -> SlackModalsPushReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["triggerId"] = try RaviJSON.fromEncodable(triggerId)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "modals-push", body: requestBody, as: SlackModalsPushReturn.self)
+  }
+
+  public func modalsUpdate(_ view: String, _ file: String, _ options: SlackModalsUpdateOptions = .init()) async throws -> SlackModalsUpdateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["view"] = try RaviJSON.fromEncodable(view)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "modals-update", body: requestBody, as: SlackModalsUpdateReturn.self)
+  }
+
+  public func permissionsList(_ options: SlackPermissionsListOptions = .init()) async throws -> SlackPermissionsListReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "permissions-list", body: requestBody, as: SlackPermissionsListReturn.self)
+  }
+
+  public func topology(_ options: SlackTopologyOptions = .init()) async throws -> SlackTopologyReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "topology", body: requestBody, as: SlackTopologyReturn.self)
+  }
+
+  public func workObjectsPresentDetails(_ triggerId: String, _ file: String, _ options: SlackWorkObjectsPresentDetailsOptions = .init()) async throws -> SlackWorkObjectsPresentDetailsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["triggerId"] = try RaviJSON.fromEncodable(triggerId)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "work-objects-present-details", body: requestBody, as: SlackWorkObjectsPresentDetailsReturn.self)
+  }
+
+  public func workObjectsSend(_ channel: String, _ file: String, _ options: SlackWorkObjectsSendOptions = .init()) async throws -> SlackWorkObjectsSendReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "work-objects-send", body: requestBody, as: SlackWorkObjectsSendReturn.self)
+  }
+
+  public func workObjectsUnfurl(_ channel: String, _ ts: String, _ url: String, _ file: String, _ options: SlackWorkObjectsUnfurlOptions = .init()) async throws -> SlackWorkObjectsUnfurlReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["channel"] = try RaviJSON.fromEncodable(channel)
+    requestBody["ts"] = try RaviJSON.fromEncodable(ts)
+    requestBody["url"] = try RaviJSON.fromEncodable(url)
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "work-objects-unfurl", body: requestBody, as: SlackWorkObjectsUnfurlReturn.self)
+  }
+
+  public func workObjectsValidate(_ file: String, _ options: SlackWorkObjectsValidateOptions = .init()) async throws -> SlackWorkObjectsValidateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["file"] = try RaviJSON.fromEncodable(file)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["slack"], command: "work-objects-validate", body: requestBody, as: SlackWorkObjectsValidateReturn.self)
   }
 }
 
@@ -5360,5 +5910,198 @@ public struct WorkflowsSpecsNamespace: Sendable {
     var requestBody: [String: RaviJSON] = [:]
     requestBody["specId"] = try RaviJSON.fromEncodable(specId)
     return try await transport.call(groupSegments: ["workflows","specs"], command: "show", body: requestBody, as: WorkflowsSpecsShowReturn.self)
+  }
+}
+
+public struct YtNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func analyticsCountries(_ options: YtAnalyticsCountriesOptions = .init()) async throws -> YtAnalyticsCountriesReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-countries", body: requestBody, as: YtAnalyticsCountriesReturn.self)
+  }
+
+  public func analyticsDemographics(_ options: YtAnalyticsDemographicsOptions = .init()) async throws -> YtAnalyticsDemographicsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-demographics", body: requestBody, as: YtAnalyticsDemographicsReturn.self)
+  }
+
+  public func analyticsDevices(_ options: YtAnalyticsDevicesOptions = .init()) async throws -> YtAnalyticsDevicesReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-devices", body: requestBody, as: YtAnalyticsDevicesReturn.self)
+  }
+
+  public func analyticsOverview(_ options: YtAnalyticsOverviewOptions = .init()) async throws -> YtAnalyticsOverviewReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-overview", body: requestBody, as: YtAnalyticsOverviewReturn.self)
+  }
+
+  public func analyticsSeries(_ options: YtAnalyticsSeriesOptions = .init()) async throws -> YtAnalyticsSeriesReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-series", body: requestBody, as: YtAnalyticsSeriesReturn.self)
+  }
+
+  public func analyticsTop(_ options: YtAnalyticsTopOptions = .init()) async throws -> YtAnalyticsTopReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-top", body: requestBody, as: YtAnalyticsTopReturn.self)
+  }
+
+  public func analyticsTraffic(_ options: YtAnalyticsTrafficOptions = .init()) async throws -> YtAnalyticsTrafficReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "analytics-traffic", body: requestBody, as: YtAnalyticsTrafficReturn.self)
+  }
+
+  public func captionDownload(_ captionId: String, _ options: YtCaptionDownloadOptions = .init()) async throws -> YtCaptionDownloadReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["captionId"] = try RaviJSON.fromEncodable(captionId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "caption-download", body: requestBody, as: YtCaptionDownloadReturn.self)
+  }
+
+  public func captions(_ videoId: String, _ options: YtCaptionsOptions = .init()) async throws -> YtCaptionsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["videoId"] = try RaviJSON.fromEncodable(videoId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "captions", body: requestBody, as: YtCaptionsReturn.self)
+  }
+
+  public func comments(_ videoId: String, _ options: YtCommentsOptions = .init()) async throws -> YtCommentsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["videoId"] = try RaviJSON.fromEncodable(videoId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "comments", body: requestBody, as: YtCommentsReturn.self)
+  }
+
+  public func health(_ options: YtHealthOptions = .init()) async throws -> YtHealthReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "health", body: requestBody, as: YtHealthReturn.self)
+  }
+
+  public func info(_ options: YtInfoOptions = .init()) async throws -> YtInfoReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "info", body: requestBody, as: YtInfoReturn.self)
+  }
+
+  public func playlist(_ playlistId: String, _ options: YtPlaylistOptions = .init()) async throws -> YtPlaylistReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["playlistId"] = try RaviJSON.fromEncodable(playlistId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlist", body: requestBody, as: YtPlaylistReturn.self)
+  }
+
+  public func playlistAdd(_ playlistId: String, _ videoId: String, _ options: YtPlaylistAddOptions = .init()) async throws -> YtPlaylistAddReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["playlistId"] = try RaviJSON.fromEncodable(playlistId)
+    requestBody["videoId"] = try RaviJSON.fromEncodable(videoId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlist-add", body: requestBody, as: YtPlaylistAddReturn.self)
+  }
+
+  public func playlistCreate(_ title: String, _ options: YtPlaylistCreateOptions = .init()) async throws -> YtPlaylistCreateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["title"] = try RaviJSON.fromEncodable(title)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlist-create", body: requestBody, as: YtPlaylistCreateReturn.self)
+  }
+
+  public func playlistDelete(_ playlistId: String, _ options: YtPlaylistDeleteOptions = .init()) async throws -> YtPlaylistDeleteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["playlistId"] = try RaviJSON.fromEncodable(playlistId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlist-delete", body: requestBody, as: YtPlaylistDeleteReturn.self)
+  }
+
+  public func playlistRemove(_ playlistItemId: String, _ options: YtPlaylistRemoveOptions = .init()) async throws -> YtPlaylistRemoveReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["playlistItemId"] = try RaviJSON.fromEncodable(playlistItemId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlist-remove", body: requestBody, as: YtPlaylistRemoveReturn.self)
+  }
+
+  public func playlists(_ options: YtPlaylistsOptions = .init()) async throws -> YtPlaylistsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "playlists", body: requestBody, as: YtPlaylistsReturn.self)
+  }
+
+  public func reply(_ commentId: String, _ text: String, _ options: YtReplyOptions = .init()) async throws -> YtReplyReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["commentId"] = try RaviJSON.fromEncodable(commentId)
+    requestBody["text"] = try RaviJSON.fromEncodable(text)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "reply", body: requestBody, as: YtReplyReturn.self)
+  }
+
+  public func search(_ query: String, _ options: YtSearchOptions = .init()) async throws -> YtSearchReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["query"] = try RaviJSON.fromEncodable(query)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "search", body: requestBody, as: YtSearchReturn.self)
+  }
+
+  public func stats(_ id: String, _ options: YtStatsOptions = .init()) async throws -> YtStatsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "stats", body: requestBody, as: YtStatsReturn.self)
+  }
+
+  public func subscriptions(_ options: YtSubscriptionsOptions = .init()) async throws -> YtSubscriptionsReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "subscriptions", body: requestBody, as: YtSubscriptionsReturn.self)
+  }
+
+  public func unanswered(_ videoId: String, _ options: YtUnansweredOptions = .init()) async throws -> YtUnansweredReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["videoId"] = try RaviJSON.fromEncodable(videoId)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "unanswered", body: requestBody, as: YtUnansweredReturn.self)
+  }
+
+  public func video(_ id: String, _ options: YtVideoOptions = .init()) async throws -> YtVideoReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "video", body: requestBody, as: YtVideoReturn.self)
+  }
+
+  public func videoCategories(_ options: YtVideoCategoriesOptions = .init()) async throws -> YtVideoCategoriesReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "video-categories", body: requestBody, as: YtVideoCategoriesReturn.self)
+  }
+
+  public func videoDelete(_ id: String, _ options: YtVideoDeleteOptions = .init()) async throws -> YtVideoDeleteReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "video-delete", body: requestBody, as: YtVideoDeleteReturn.self)
+  }
+
+  public func videoUpdate(_ id: String, _ options: YtVideoUpdateOptions = .init()) async throws -> YtVideoUpdateReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["id"] = try RaviJSON.fromEncodable(id)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "video-update", body: requestBody, as: YtVideoUpdateReturn.self)
+  }
+
+  public func videos(_ options: YtVideosOptions = .init()) async throws -> YtVideosReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["yt"], command: "videos", body: requestBody, as: YtVideosReturn.self)
   }
 }

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -630,6 +630,10 @@ public enum RaviSchemas {
         "description": "Runtime model selector",
         "type": "string"
       },
+      "modelPreset": {
+        "description": "Reference a runtime model preset (mutually exclusive with --model)",
+        "type": "string"
+      },
       "provider": {
         "description": "Runtime provider id",
         "type": "string"
@@ -1407,6 +1411,45 @@ public enum RaviSchemas {
       "key": {
         "type": "string"
       },
+      "sessionOverrides": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "effort": {
+              "enum": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max",
+                "ultra"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "sessionName": {
+              "type": "string"
+            },
+            "thinking": {
+              "enum": [
+                "off",
+                "normal",
+                "verbose"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "sessionName"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
       "value": {}
     },
     "required": [
@@ -1414,7 +1457,8 @@ public enum RaviSchemas {
       "changed",
       "agentId",
       "key",
-      "value"
+      "value",
+      "sessionOverrides"
     ],
     "type": "object"
   }
@@ -12488,6 +12532,1625 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let ChannelsCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "credentialConnection": {
+        "description": "Credential Manager connection id",
+        "type": "string"
+      },
+      "name": {
+        "description": "Channel config name",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Channel provider, e.g. slack",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsCreateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "changedCount": {
+        "type": "number"
+      },
+      "channel": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "credentialConnection": {
+            "type": "string"
+          },
+          "defaults": {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "deletedAt": {
+            "type": "number"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "provider",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "channel",
+      "changedCount"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "limit": {
+        "description": "Page size (default: 50, max: 500)",
+        "type": "string"
+      },
+      "offset": {
+        "description": "Number of matching channels to skip (default: 0)",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Filter by provider, e.g. slack",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsListReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "channels": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "createdAt": {
+              "type": "number"
+            },
+            "credentialConnection": {
+              "type": "string"
+            },
+            "defaults": {
+              "additionalProperties": {
+                "$ref": "#/$defs/__schema0"
+              },
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "deletedAt": {
+              "type": "number"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "provider",
+            "createdAt",
+            "updatedAt"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "items": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "createdAt": {
+              "type": "number"
+            },
+            "credentialConnection": {
+              "type": "string"
+            },
+            "defaults": {
+              "additionalProperties": {
+                "$ref": "#/$defs/__schema0"
+              },
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "deletedAt": {
+              "type": "number"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "provider",
+            "createdAt",
+            "updatedAt"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCommand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextOffset": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "limit",
+          "offset",
+          "returned",
+          "total"
+        ],
+        "type": "object"
+      },
+      "total": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "total",
+      "pagination",
+      "channels",
+      "items"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsProbeInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsProbeReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "adapters": {
+        "items": {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "outbound": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "pid": {
+        "type": "number"
+      },
+      "running": {
+        "type": "boolean"
+      },
+      "startedAt": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "running",
+      "startedAt",
+      "pid",
+      "outbound",
+      "adapters"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsRestartInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "build": {
+        "description": "Use dist bundle from source repo",
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsRestartReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "pm2Status": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "reason": {
+        "type": "string"
+      },
+      "runnerEnv": {
+        "additionalProperties": false,
+        "properties": {
+          "consumeOutbound": {
+            "type": "string"
+          },
+          "slackSocketMode": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "slackSocketMode",
+          "consumeOutbound"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "additionalProperties": false,
+        "properties": {
+          "channels": {
+            "additionalProperties": false,
+            "properties": {
+              "cpu": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managed": {
+                "type": "boolean"
+              },
+              "memoryBytes": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "memoryMb": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "pid": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pmId": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "running": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "managed",
+              "running",
+              "status",
+              "pid",
+              "pmId",
+              "cpu",
+              "memoryBytes",
+              "memoryMb"
+            ],
+            "type": "object"
+          },
+          "pm2Available": {
+            "type": "boolean"
+          },
+          "processName": {
+            "type": "string"
+          },
+          "processes": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "managed": {
+                  "type": "boolean"
+                },
+                "memoryBytes": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "memoryMb": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "pid": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pmId": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "managed",
+                "running",
+                "status",
+                "pid",
+                "pmId",
+                "cpu",
+                "memoryBytes",
+                "memoryMb"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pm2Available",
+          "processName",
+          "channels",
+          "processes"
+        ],
+        "type": "object"
+      },
+      "target": {
+        "additionalProperties": false,
+        "properties": {
+          "bundlePath": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "sourceProjectRoot": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundlePath",
+          "cwd"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsSetInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "key": {
+        "description": "Property key: provider|enabled|credentialConnection|defaults",
+        "type": "string"
+      },
+      "name": {
+        "description": "Channel config name",
+        "type": "string"
+      },
+      "value": {
+        "description": "Property value, or '-' to clear nullable fields",
+        "type": "string"
+      }
+    },
+    "required": [
+      "key",
+      "name",
+      "value"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsSetReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "changedCount": {
+        "type": "number"
+      },
+      "channel": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "credentialConnection": {
+            "type": "string"
+          },
+          "defaults": {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "deletedAt": {
+            "type": "number"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "provider",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "channel",
+      "changedCount"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsShowInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "description": "Channel config name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsShowReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "createdAt": {
+        "type": "number"
+      },
+      "credentialConnection": {
+        "type": "string"
+      },
+      "defaults": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "deletedAt": {
+        "type": "number"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "name": {
+        "type": "string"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "updatedAt": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "name",
+      "provider",
+      "createdAt",
+      "updatedAt"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStartInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "build": {
+        "description": "Use dist bundle from source repo",
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStartReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "pm2Status": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "reason": {
+        "type": "string"
+      },
+      "runnerEnv": {
+        "additionalProperties": false,
+        "properties": {
+          "consumeOutbound": {
+            "type": "string"
+          },
+          "slackSocketMode": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "slackSocketMode",
+          "consumeOutbound"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "additionalProperties": false,
+        "properties": {
+          "channels": {
+            "additionalProperties": false,
+            "properties": {
+              "cpu": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managed": {
+                "type": "boolean"
+              },
+              "memoryBytes": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "memoryMb": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "pid": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pmId": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "running": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "managed",
+              "running",
+              "status",
+              "pid",
+              "pmId",
+              "cpu",
+              "memoryBytes",
+              "memoryMb"
+            ],
+            "type": "object"
+          },
+          "pm2Available": {
+            "type": "boolean"
+          },
+          "processName": {
+            "type": "string"
+          },
+          "processes": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "managed": {
+                  "type": "boolean"
+                },
+                "memoryBytes": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "memoryMb": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "pid": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pmId": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "managed",
+                "running",
+                "status",
+                "pid",
+                "pmId",
+                "cpu",
+                "memoryBytes",
+                "memoryMb"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pm2Available",
+          "processName",
+          "channels",
+          "processes"
+        ],
+        "type": "object"
+      },
+      "target": {
+        "additionalProperties": false,
+        "properties": {
+          "bundlePath": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "sourceProjectRoot": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundlePath",
+          "cwd"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStatusInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStatusReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channels": {
+        "additionalProperties": false,
+        "properties": {
+          "cpu": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "managed": {
+            "type": "boolean"
+          },
+          "memoryBytes": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "memoryMb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "pid": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pmId": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "running": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "managed",
+          "running",
+          "status",
+          "pid",
+          "pmId",
+          "cpu",
+          "memoryBytes",
+          "memoryMb"
+        ],
+        "type": "object"
+      },
+      "pm2Available": {
+        "type": "boolean"
+      },
+      "processName": {
+        "type": "string"
+      },
+      "processes": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "cpu": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "managed": {
+              "type": "boolean"
+            },
+            "memoryBytes": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "memoryMb": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "pid": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pmId": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "running": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "managed",
+            "running",
+            "status",
+            "pid",
+            "pmId",
+            "cpu",
+            "memoryBytes",
+            "memoryMb"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "pm2Available",
+      "processName",
+      "channels",
+      "processes"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStopInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsStopReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "pm2Status": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "reason": {
+        "type": "string"
+      },
+      "runnerEnv": {
+        "additionalProperties": false,
+        "properties": {
+          "consumeOutbound": {
+            "type": "string"
+          },
+          "slackSocketMode": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "slackSocketMode",
+          "consumeOutbound"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "additionalProperties": false,
+        "properties": {
+          "channels": {
+            "additionalProperties": false,
+            "properties": {
+              "cpu": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managed": {
+                "type": "boolean"
+              },
+              "memoryBytes": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "memoryMb": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "pid": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pmId": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "running": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "managed",
+              "running",
+              "status",
+              "pid",
+              "pmId",
+              "cpu",
+              "memoryBytes",
+              "memoryMb"
+            ],
+            "type": "object"
+          },
+          "pm2Available": {
+            "type": "boolean"
+          },
+          "processName": {
+            "type": "string"
+          },
+          "processes": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "managed": {
+                  "type": "boolean"
+                },
+                "memoryBytes": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "memoryMb": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "pid": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pmId": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "managed",
+                "running",
+                "status",
+                "pid",
+                "pmId",
+                "cpu",
+                "memoryBytes",
+                "memoryMb"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pm2Available",
+          "processName",
+          "channels",
+          "processes"
+        ],
+        "type": "object"
+      },
+      "target": {
+        "additionalProperties": false,
+        "properties": {
+          "bundlePath": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "sourceProjectRoot": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundlePath",
+          "cwd"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let ChatsBackfillProviderTimestampsInputSchema = #"""
   {
     "additionalProperties": false,
@@ -12854,61 +14517,29 @@ public enum RaviSchemas {
   }
   """#
 
-  public static let ChatsListsRecomputeInputSchema = #"""
+  public static let ChatsListsPreviewInputSchema = #"""
   {
     "additionalProperties": false,
     "properties": {
-      "list": {
-        "description": "List id or name",
+      "listId": {
+        "description": "Canonical reading-list id (crl_<24 hex>)",
+        "pattern": "^crl_[0-9a-f]{24}$",
         "type": "string"
       },
       "owner": {
-        "description": "Owner scope when resolving list by name",
+        "description": "Optional owner assertion for the canonical list id",
         "type": "string"
       }
     },
     "required": [
-      "list"
+      "listId"
     ],
     "type": "object"
   }
   """#
 
-  public static let ChatsListsRecomputeReturnSchema = #"""
+  public static let ChatsListsPreviewReturnSchema = #"""
   {
-    "$defs": {
-      "__schema0": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "number"
-          },
-          {
-            "type": "boolean"
-          },
-          {
-            "type": "null"
-          },
-          {
-            "items": {
-              "$ref": "#/$defs/__schema0"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": {
-              "$ref": "#/$defs/__schema0"
-            },
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": "object"
-          }
-        ]
-      }
-    },
     "additionalProperties": false,
     "properties": {
       "list": {
@@ -12926,15 +14557,6 @@ public enum RaviSchemas {
           "id": {
             "type": "string"
           },
-          "metadata": {
-            "additionalProperties": {
-              "$ref": "#/$defs/__schema0"
-            },
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": "object"
-          },
           "mode": {
             "type": "string"
           },
@@ -12947,14 +14569,299 @@ public enum RaviSchemas {
           "ownerType": {
             "type": "string"
           },
-          "selector": {
-            "additionalProperties": {
-              "$ref": "#/$defs/__schema0"
+          "updatedAt": {
+            "type": "number"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerType",
+          "ownerId",
+          "visibility",
+          "mode",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "preview": {
+        "additionalProperties": false,
+        "properties": {
+          "current": {
+            "additionalProperties": false,
+            "properties": {
+              "preserved": {
+                "type": "number"
+              },
+              "selector": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
             },
-            "propertyNames": {
-              "type": "string"
-            },
+            "required": [
+              "total",
+              "selector",
+              "preserved"
+            ],
             "type": "object"
+          },
+          "diff": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "added": {
+                    "type": "number"
+                  },
+                  "eligible": {
+                    "type": "number"
+                  },
+                  "kept": {
+                    "type": "number"
+                  },
+                  "preserved": {
+                    "type": "number"
+                  },
+                  "removed": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "added",
+                  "removed",
+                  "kept",
+                  "preserved",
+                  "eligible"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "dryRun": {
+            "const": true,
+            "type": "boolean"
+          },
+          "list": {
+            "additionalProperties": false,
+            "properties": {
+              "archivedAt": {
+                "type": "number"
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "ownerType": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "number"
+              },
+              "visibility": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "ownerType",
+              "ownerId",
+              "visibility",
+              "mode",
+              "createdAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          },
+          "validation": {
+            "additionalProperties": false,
+            "properties": {
+              "canApply": {
+                "type": "boolean"
+              },
+              "conditions": {
+                "additionalProperties": false,
+                "properties": {
+                  "negative": {
+                    "type": "number"
+                  },
+                  "positive": {
+                    "type": "number"
+                  },
+                  "supported": {
+                    "type": "number"
+                  },
+                  "total": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "total",
+                  "supported",
+                  "positive",
+                  "negative"
+                ],
+                "type": "object"
+              },
+              "issues": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "severity": {
+                      "enum": [
+                        "error",
+                        "warning"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "severity",
+                    "message"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "match": {
+                "enum": [
+                  "all",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "riskLevel": {
+                "enum": [
+                  "low",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "scope": {
+                "enum": [
+                  "contact",
+                  "chat"
+                ],
+                "type": "string"
+              },
+              "valid": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "valid",
+              "canApply",
+              "riskLevel",
+              "scope",
+              "match",
+              "conditions",
+              "issues"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "list",
+          "dryRun",
+          "validation",
+          "current",
+          "diff"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "list",
+      "preview"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChatsListsRecomputeInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "listId": {
+        "description": "Canonical reading-list id (crl_<24 hex>)",
+        "pattern": "^crl_[0-9a-f]{24}$",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Optional owner assertion for the canonical list id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "listId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChatsListsRecomputeReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "list": {
+        "additionalProperties": false,
+        "properties": {
+          "archivedAt": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "ownerType": {
+            "type": "string"
           },
           "updatedAt": {
             "type": "number"
@@ -12981,29 +14888,11 @@ public enum RaviSchemas {
           "added": {
             "type": "number"
           },
-          "addedChatIds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "eligible": {
             "type": "number"
           },
-          "eligibleChatIds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "kept": {
             "type": "number"
-          },
-          "keptChatIds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "list": {
             "additionalProperties": false,
@@ -13020,15 +14909,6 @@ public enum RaviSchemas {
               "id": {
                 "type": "string"
               },
-              "metadata": {
-                "additionalProperties": {
-                  "$ref": "#/$defs/__schema0"
-                },
-                "propertyNames": {
-                  "type": "string"
-                },
-                "type": "object"
-              },
               "mode": {
                 "type": "string"
               },
@@ -13040,15 +14920,6 @@ public enum RaviSchemas {
               },
               "ownerType": {
                 "type": "string"
-              },
-              "selector": {
-                "additionalProperties": {
-                  "$ref": "#/$defs/__schema0"
-                },
-                "propertyNames": {
-                  "type": "string"
-                },
-                "type": "object"
               },
               "updatedAt": {
                 "type": "number"
@@ -13072,39 +14943,12 @@ public enum RaviSchemas {
           "preserved": {
             "type": "number"
           },
-          "preservedChatIds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "removed": {
             "type": "number"
-          },
-          "removedChatIds": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "selector": {
-            "additionalProperties": {
-              "$ref": "#/$defs/__schema0"
-            },
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": "object"
           }
         },
         "required": [
           "list",
-          "selector",
-          "eligibleChatIds",
-          "addedChatIds",
-          "removedChatIds",
-          "keptChatIds",
-          "preservedChatIds",
           "added",
           "removed",
           "kept",
@@ -13159,6 +15003,203 @@ public enum RaviSchemas {
   {
     "additionalProperties": {},
     "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let ChatsListsShowInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "listId": {
+        "description": "Canonical reading-list id (crl_<24 hex>)",
+        "pattern": "^crl_[0-9a-f]{24}$",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Optional owner assertion for the canonical list id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "listId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChatsListsShowReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "current": {
+        "additionalProperties": false,
+        "properties": {
+          "preserved": {
+            "type": "number"
+          },
+          "selector": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "total",
+          "selector",
+          "preserved"
+        ],
+        "type": "object"
+      },
+      "list": {
+        "additionalProperties": false,
+        "properties": {
+          "archivedAt": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "ownerType": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerType",
+          "ownerId",
+          "visibility",
+          "mode",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "validation": {
+        "additionalProperties": false,
+        "properties": {
+          "canApply": {
+            "type": "boolean"
+          },
+          "conditions": {
+            "additionalProperties": false,
+            "properties": {
+              "negative": {
+                "type": "number"
+              },
+              "positive": {
+                "type": "number"
+              },
+              "supported": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "total",
+              "supported",
+              "positive",
+              "negative"
+            ],
+            "type": "object"
+          },
+          "issues": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "severity": {
+                  "enum": [
+                    "error",
+                    "warning"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "severity",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "match": {
+            "enum": [
+              "all",
+              "any"
+            ],
+            "type": "string"
+          },
+          "riskLevel": {
+            "enum": [
+              "low",
+              "high"
+            ],
+            "type": "string"
+          },
+          "scope": {
+            "enum": [
+              "contact",
+              "chat"
+            ],
+            "type": "string"
+          },
+          "valid": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "valid",
+          "canApply",
+          "riskLevel",
+          "scope",
+          "match",
+          "conditions",
+          "issues"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "list",
+      "validation",
+      "current"
+    ],
     "type": "object"
   }
   """#
@@ -21104,6 +23145,537 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let CredentialsConnectionsDisableInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Connection id",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Provider id",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsDisableReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "backend": {
+                "enum": [
+                  "keychain",
+                  "vault"
+                ],
+                "type": "string"
+              },
+              "connection": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "id": {
+                "type": "string"
+              },
+              "label": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "provider": {
+                "type": "string"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "disabled"
+                ],
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "provider",
+              "connection",
+              "label",
+              "backend",
+              "secretRef",
+              "scopes",
+              "status",
+              "createdAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "connection"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsEnableInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Connection id",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Provider id",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsEnableReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "backend": {
+                "enum": [
+                  "keychain",
+                  "vault"
+                ],
+                "type": "string"
+              },
+              "connection": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "id": {
+                "type": "string"
+              },
+              "label": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "provider": {
+                "type": "string"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "disabled"
+                ],
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "provider",
+              "connection",
+              "label",
+              "backend",
+              "secretRef",
+              "scopes",
+              "status",
+              "createdAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "connection"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "all": {
+        "description": "Include disabled connections",
+        "type": "boolean"
+      },
+      "limit": {
+        "default": "50",
+        "description": "Page size",
+        "type": "string"
+      },
+      "offset": {
+        "default": "0",
+        "description": "Offset",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Filter by provider, e.g. slack",
+        "type": "string"
+      },
+      "status": {
+        "description": "Filter by status: active or disabled",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsListReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "items": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "backend": {
+              "enum": [
+                "keychain",
+                "vault"
+              ],
+              "type": "string"
+            },
+            "connection": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "number"
+            },
+            "id": {
+              "type": "string"
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secretRef": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "active",
+                "disabled"
+              ],
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "provider",
+            "connection",
+            "label",
+            "backend",
+            "secretRef",
+            "scopes",
+            "status",
+            "createdAt",
+            "updatedAt"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCommand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextOffset": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "limit",
+          "offset",
+          "returned",
+          "total"
+        ],
+        "type": "object"
+      },
+      "total": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "total",
+      "pagination",
+      "items"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsShowInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Connection id, e.g. main",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Provider id, e.g. slack",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsConnectionsShowReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "additionalProperties": false,
+        "properties": {
+          "backend": {
+            "enum": [
+              "keychain",
+              "vault"
+            ],
+            "type": "string"
+          },
+          "connection": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "secretRef": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "disabled"
+            ],
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "connection",
+          "label",
+          "backend",
+          "secretRef",
+          "scopes",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "connection"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsPoliciesExplainInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "description": "Provider action, e.g. messages.send",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Connection id",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Provider id",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let CredentialsPoliciesExplainReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "approval": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "required",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "connection": {
+        "type": "string"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "requiredCapabilities": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "provider",
+      "connection",
+      "action",
+      "requiredCapabilities",
+      "approval"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let CrmAccountInputSchema = #"""
   {
     "additionalProperties": false,
@@ -24057,6 +26629,10 @@ public enum RaviSchemas {
         "description": "Alias for --shell",
         "type": "string"
       },
+      "idempotencyKey": {
+        "description": "Durable create idempotency key",
+        "type": "string"
+      },
       "isolated": {
         "description": "Run in isolated session",
         "type": "boolean"
@@ -24941,7 +27517,20 @@ public enum RaviSchemas {
       },
       "self": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "org_id": {
+            "type": "string"
+          },
+          "principal_type": {
+            "type": "string"
+          },
+          "service_user_id": {
+            "type": "string"
+          },
+          "service_user_name": {
+            "type": "string"
+          }
+        },
         "type": "object"
       }
     },
@@ -24976,7 +27565,214 @@ public enum RaviSchemas {
     "properties": {
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       },
       "status": {
@@ -25019,7 +27815,36 @@ public enum RaviSchemas {
       "attachments": {
         "items": {
           "additionalProperties": {},
-          "properties": {},
+          "properties": {
+            "attachmentId": {
+              "type": "string"
+            },
+            "contentType": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attachmentId",
+            "name",
+            "source",
+            "url"
+          ],
           "type": "object"
         },
         "type": "array"
@@ -25045,11 +27870,11 @@ public enum RaviSchemas {
     "additionalProperties": false,
     "properties": {
       "advancedMode": {
-        "description": "analyze|create|improve|batch|manage",
+        "description": "Legacy: analyze|create|improve|batch|manage",
         "type": "string"
       },
       "asUser": {
-        "description": "create_as_user_id",
+        "description": "create_as_user_id (impersonate user)",
         "type": "string"
       },
       "attachmentUrl": {
@@ -25067,6 +27892,14 @@ public enum RaviSchemas {
         "description": "Child playbook ID",
         "type": "string"
       },
+      "devinId": {
+        "description": "Idempotent session creation key",
+        "type": "string"
+      },
+      "devinMode": {
+        "description": "Agent mode: normal|fast|lite|ultra",
+        "type": "string"
+      },
       "knowledge": {
         "description": "Knowledge note IDs",
         "items": {
@@ -25082,6 +27915,15 @@ public enum RaviSchemas {
         "default": true,
         "description": "Intentionally omit max_acu_limit",
         "type": "boolean"
+      },
+      "noResumable": {
+        "default": true,
+        "description": "Disposable session, do not preserve VM state",
+        "type": "boolean"
+      },
+      "platform": {
+        "description": "VM platform override (org-specific)",
+        "type": "string"
       },
       "playbook": {
         "description": "Playbook ID",
@@ -25110,8 +27952,12 @@ public enum RaviSchemas {
         },
         "type": "array"
       },
+      "resumable": {
+        "description": "Preserve VM state for resume (default: true)",
+        "type": "boolean"
+      },
       "secret": {
-        "description": "Secret IDs",
+        "description": "Secret IDs (org-level secret references)",
         "items": {
           "type": "string"
         },
@@ -25123,6 +27969,17 @@ public enum RaviSchemas {
           "type": "string"
         },
         "type": "array"
+      },
+      "sessionSecret": {
+        "description": "Inline session secrets (key=value); sensitive by default",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "structuredOutputRequired": {
+        "description": "Require structured output before turn ends",
+        "type": "boolean"
       },
       "structuredOutputSchema": {
         "description": "JSON schema for structured output",
@@ -25152,6 +28009,16 @@ public enum RaviSchemas {
   {
     "additionalProperties": {},
     "properties": {
+      "devinMode": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "maxAcuLimit": {
         "anyOf": [
           {
@@ -25165,9 +28032,236 @@ public enum RaviSchemas {
       "maxAcuLimitSource": {
         "type": "string"
       },
+      "platform": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resumable": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       },
       "status": {
@@ -25211,12 +28305,248 @@ public enum RaviSchemas {
     "properties": {
       "insights": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "analysis": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "properties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "numDevinMessages": {
+            "type": "number"
+          },
+          "numUserMessages": {
+            "type": "number"
+          },
+          "sessionSize": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
         "type": "object"
       },
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       },
       "summary": {
@@ -25338,7 +28668,214 @@ public enum RaviSchemas {
       "sessions": {
         "items": {
           "additionalProperties": {},
-          "properties": {},
+          "properties": {
+            "acusConsumed": {
+              "type": "number"
+            },
+            "devinId": {
+              "type": "string"
+            },
+            "devinMode": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "effectiveCreateAsUserId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "isArchived": {
+              "type": "boolean"
+            },
+            "lastSyncedAt": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "maxAcuLimit": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "maxAcuLimitSource": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "origin": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "originId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "originType": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "platform": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "projectId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "proxRunId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "resumable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "serviceUserId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "statusDetail": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "taskId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "updatedAt": {
+              "type": "number"
+            },
+            "url": {
+              "type": "string"
+            },
+            "userId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "devinId",
+            "title",
+            "status",
+            "statusDetail",
+            "url",
+            "tags",
+            "updatedAt"
+          ],
           "type": "object"
         },
         "type": "array"
@@ -25391,7 +28928,26 @@ public enum RaviSchemas {
       "messages": {
         "items": {
           "additionalProperties": {},
-          "properties": {},
+          "properties": {
+            "createdAt": {
+              "type": "number"
+            },
+            "eventId": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "eventId",
+            "createdAt",
+            "source",
+            "message"
+          ],
           "type": "object"
         },
         "type": "array"
@@ -25440,7 +28996,214 @@ public enum RaviSchemas {
     "properties": {
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       },
       "status": {
@@ -25482,7 +29245,214 @@ public enum RaviSchemas {
     "properties": {
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       }
     },
@@ -25547,7 +29517,214 @@ public enum RaviSchemas {
       },
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       }
     },
@@ -25591,7 +29768,214 @@ public enum RaviSchemas {
       },
       "session": {
         "additionalProperties": {},
-        "properties": {},
+        "properties": {
+          "acusConsumed": {
+            "type": "number"
+          },
+          "devinId": {
+            "type": "string"
+          },
+          "devinMode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveCreateAsUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxAcuLimitSource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "originType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "projectId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "proxRunId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resumable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceUserId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "devinId",
+          "title",
+          "status",
+          "statusDetail",
+          "url",
+          "tags",
+          "updatedAt"
+        ],
         "type": "object"
       },
       "status": {
@@ -38604,6 +42988,10 @@ public enum RaviSchemas {
   {
     "additionalProperties": false,
     "properties": {
+      "reconcile": {
+        "description": "attach-missing|detach-disabled|refresh-profile|full-reconcile",
+        "type": "string"
+      },
       "session": {
         "description": "Source session name or key",
         "type": "string"
@@ -38984,6 +43372,10 @@ public enum RaviSchemas {
       },
       "scope": {
         "description": "global|agent|session|task|profile|project|tag",
+        "type": "string"
+      },
+      "selector": {
+        "description": "Predicate over source.*, turn.* and event.*; use 'clear' to remove",
         "type": "string"
       },
       "sourceAgent": {
@@ -44656,6 +49048,924 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let RuntimePresetsCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "description": {
+        "description": "Human-readable description",
+        "type": "string"
+      },
+      "disabled": {
+        "description": "Create in the disabled state",
+        "type": "boolean"
+      },
+      "id": {
+        "description": "Stable preset id/slug",
+        "type": "string"
+      },
+      "model": {
+        "description": "Model selector",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Runtime provider id (immutable)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsCreateReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "enum": [
+          "create",
+          "set-model",
+          "enable",
+          "disable",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "dryRun",
+      "preset"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsDeleteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "dryRun": {
+        "description": "Preview without persisting",
+        "type": "boolean"
+      },
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsDeleteReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "enum": [
+          "create",
+          "set-model",
+          "enable",
+          "disable",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "dryRun",
+      "preset"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsDisableInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "dryRun": {
+        "description": "Preview without persisting or bumping the version",
+        "type": "boolean"
+      },
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsDisableReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "enum": [
+          "create",
+          "set-model",
+          "enable",
+          "disable",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "dryRun",
+      "preset"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsEnableInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "dryRun": {
+        "description": "Preview without persisting or bumping the version",
+        "type": "boolean"
+      },
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsEnableReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "enum": [
+          "create",
+          "set-model",
+          "enable",
+          "disable",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "dryRun",
+      "preset"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsImpactInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size (default: 50, max: 500)",
+        "type": "string"
+      },
+      "offset": {
+        "description": "Number of agents to skip (default: 0)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsImpactReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agents": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "effectiveModel": {
+              "type": "string"
+            },
+            "modelSource": {
+              "const": "agent_preset",
+              "type": "string"
+            },
+            "name": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "provider": {
+              "type": "string"
+            },
+            "shadowingSessions": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "agentId",
+            "name",
+            "provider",
+            "effectiveModel",
+            "modelSource",
+            "shadowingSessions"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "correctionCommand": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "limit": {
+        "type": "number"
+      },
+      "model": {
+        "type": "string"
+      },
+      "offset": {
+        "type": "number"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCommand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextOffset": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "limit",
+          "offset",
+          "returned",
+          "total",
+          "hasMore",
+          "nextOffset",
+          "nextCommand"
+        ],
+        "type": "object"
+      },
+      "presetId": {
+        "type": "string"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "referenced": {
+        "type": "boolean"
+      },
+      "referencingAgentsTotal": {
+        "type": "number"
+      },
+      "shadowingSessionsTotal": {
+        "type": "number"
+      },
+      "version": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "presetId",
+      "version",
+      "provider",
+      "model",
+      "enabled",
+      "referencingAgentsTotal",
+      "shadowingSessionsTotal",
+      "agents",
+      "limit",
+      "offset",
+      "referenced",
+      "correctionCommand",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "disabled": {
+        "description": "Only disabled presets",
+        "type": "boolean"
+      },
+      "enabled": {
+        "description": "Only enabled presets",
+        "type": "boolean"
+      },
+      "limit": {
+        "description": "Page size (default: 50, max: 500)",
+        "type": "string"
+      },
+      "offset": {
+        "description": "Number of presets to skip (default: 0)",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Filter by provider",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsListReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCommand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextOffset": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "offset": {
+            "type": "number"
+          },
+          "returned": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "limit",
+          "offset",
+          "returned",
+          "total",
+          "hasMore",
+          "nextOffset",
+          "nextCommand"
+        ],
+        "type": "object"
+      },
+      "presets": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "createdAt": {
+              "type": "number"
+            },
+            "description": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "number"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "provider",
+            "model",
+            "description",
+            "enabled",
+            "version",
+            "createdAt",
+            "updatedAt"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "total": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "total",
+      "pagination",
+      "presets"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsSetInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "dryRun": {
+        "description": "Preview without persisting or bumping the version",
+        "type": "boolean"
+      },
+      "field": {
+        "description": "Field to set (model)",
+        "type": "string"
+      },
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      },
+      "value": {
+        "description": "New value",
+        "type": "string"
+      }
+    },
+    "required": [
+      "field",
+      "id",
+      "value"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsSetReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "enum": [
+          "create",
+          "set-model",
+          "enable",
+          "disable",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "dryRun",
+      "preset"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsShowInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "description": "Preset id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let RuntimePresetsShowReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "preset": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "provider",
+          "model",
+          "description",
+          "enabled",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "referencingAgentsTotal": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "preset",
+      "referencingAgentsTotal"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let SdkClientCheckInputSchema = #"""
   {
     "additionalProperties": false,
@@ -44827,7 +50137,7 @@ public enum RaviSchemas {
     "additionalProperties": false,
     "properties": {
       "out": {
-        "description": "Write spec JSON to this path",
+        "description": "Write spec JSON to this path (default: docs/openapi.json)",
         "type": "string"
       },
       "stdout": {
@@ -46652,7 +51962,7 @@ public enum RaviSchemas {
     "additionalProperties": false,
     "properties": {
       "action": {
-        "description": "get|set|create|pause|resume|complete|clear|account",
+        "description": "get|set|create|pause|resume|block|complete|clear|account",
         "type": "string"
       },
       "budget": {
@@ -46669,6 +51979,10 @@ public enum RaviSchemas {
       },
       "project": {
         "description": "Optional project id link for set/create",
+        "type": "string"
+      },
+      "reason": {
+        "description": "Concrete reason for blocking",
         "type": "string"
       },
       "seconds": {
@@ -46694,8 +52008,139 @@ public enum RaviSchemas {
 
   public static let SessionsGoalReturnSchema = #"""
   {
-    "additionalProperties": {},
-    "properties": {},
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "goal": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "blockedReason": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "goalId": {
+                "type": "string"
+              },
+              "objective": {
+                "type": "string"
+              },
+              "projectId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sessionKey": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "active",
+                  "paused",
+                  "budget_limited",
+                  "blocked",
+                  "complete"
+                ],
+                "type": "string"
+              },
+              "taskId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "timeUsedSeconds": {
+                "type": "number"
+              },
+              "tokenBudget": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tokensUsed": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "sessionKey",
+              "goalId",
+              "objective",
+              "status",
+              "tokenBudget",
+              "tokensUsed",
+              "timeUsedSeconds",
+              "taskId",
+              "projectId",
+              "blockedReason",
+              "createdAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "session": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "sessionKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionKey",
+          "agentId",
+          "label"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "session",
+      "goal"
+    ],
     "type": "object"
   }
   """#
@@ -46997,9 +52442,142 @@ public enum RaviSchemas {
 
   public static let SessionsReadReturnSchema = #"""
   {
-    "additionalProperties": {},
-    "properties": {},
-    "type": "object"
+    "anyOf": [
+      {
+        "additionalProperties": {},
+        "properties": {
+          "count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "messages": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "user",
+                        "assistant"
+                      ],
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "time": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role",
+                    "text",
+                    "time"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "role",
+                    "content",
+                    "createdAt",
+                    "source"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "session": {
+            "additionalProperties": {},
+            "properties": {
+              "agentId": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "sessionKey": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionKey",
+              "label",
+              "agentId"
+            ],
+            "type": "object"
+          },
+          "totalMessages": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transcript": {
+            "additionalProperties": {},
+            "properties": {
+              "available": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "available"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "session",
+          "transcript",
+          "messages"
+        ],
+        "type": "object"
+      },
+      {
+        "additionalProperties": {},
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "meta": {},
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "type": "object"
+      }
+    ]
   }
   """#
 
@@ -47487,7 +53065,98 @@ public enum RaviSchemas {
   public static let SessionsSendReturnSchema = #"""
   {
     "additionalProperties": {},
-    "properties": {},
+    "properties": {
+      "action": {
+        "const": "send",
+        "type": "string"
+      },
+      "createdSession": {
+        "type": "boolean"
+      },
+      "delivery": {
+        "additionalProperties": {},
+        "properties": {},
+        "type": "object"
+      },
+      "mode": {
+        "enum": [
+          "fire-and-forget",
+          "wait"
+        ],
+        "type": "string"
+      },
+      "promptLength": {
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "published": {
+        "type": "boolean"
+      },
+      "response": {
+        "additionalProperties": false,
+        "properties": {
+          "length": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "length",
+          "text"
+        ],
+        "type": "object"
+      },
+      "session": {
+        "additionalProperties": {},
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sessionKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionKey",
+          "label",
+          "agentId"
+        ],
+        "type": "object"
+      },
+      "thread": {
+        "anyOf": [
+          {
+            "additionalProperties": {},
+            "properties": {},
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "action",
+      "mode",
+      "published",
+      "createdSession",
+      "session",
+      "promptLength",
+      "delivery",
+      "thread"
+    ],
     "type": "object"
   }
   """#
@@ -47521,6 +53190,474 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let SessionsSetEffortInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "level": {
+        "description": "Reasoning effort (none|minimal|low|medium|high|xhigh|max|ultra) or 'clear'",
+        "type": "string"
+      },
+      "nameOrKey": {
+        "description": "Session name or key",
+        "type": "string"
+      }
+    },
+    "required": [
+      "level",
+      "nameOrKey"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsSetEffortReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "const": "set-effort",
+        "type": "string"
+      },
+      "after": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "agentId": {
+                "type": "string"
+              },
+              "effectiveModel": {
+                "type": "string"
+              },
+              "effectiveProvider": {
+                "type": "string"
+              },
+              "effortOverride": {
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "type": "string"
+              },
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expiresAt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "modelOverride": {
+                "type": "string"
+              },
+              "modelPresetId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modelPresetVersion": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modelSource": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "runtimeOptions": {
+                "additionalProperties": false,
+                "properties": {
+                  "effort": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "enum": [
+                          "session_override",
+                          "agent_default",
+                          "runtime_default"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max",
+                          "ultra"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "model": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "thinking": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "model",
+                  "effort",
+                  "thinking"
+                ],
+                "type": "object"
+              },
+              "sessionKey": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionKey",
+              "label",
+              "agentId",
+              "effectiveProvider",
+              "effectiveModel",
+              "modelSource",
+              "modelPresetId",
+              "modelPresetVersion",
+              "ephemeral",
+              "expiresAt",
+              "runtimeOptions"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "appliesOn": {
+        "const": "next-turn-runtime-restart",
+        "type": "string"
+      },
+      "before": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "effectiveModel": {
+            "type": "string"
+          },
+          "effectiveProvider": {
+            "type": "string"
+          },
+          "effortOverride": {
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              "ultra"
+            ],
+            "type": "string"
+          },
+          "ephemeral": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "modelOverride": {
+            "type": "string"
+          },
+          "modelPresetId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelPresetVersion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelSource": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "runtimeOptions": {
+            "additionalProperties": false,
+            "properties": {
+              "effort": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "enum": [
+                      "session_override",
+                      "agent_default",
+                      "runtime_default"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "enum": [
+                      "none",
+                      "minimal",
+                      "low",
+                      "medium",
+                      "high",
+                      "xhigh",
+                      "max",
+                      "ultra"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "model": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "thinking": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "model",
+              "effort",
+              "thinking"
+            ],
+            "type": "object"
+          },
+          "sessionKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionKey",
+          "label",
+          "agentId",
+          "effectiveProvider",
+          "effectiveModel",
+          "modelSource",
+          "modelPresetId",
+          "modelPresetVersion",
+          "ephemeral",
+          "expiresAt",
+          "runtimeOptions"
+        ],
+        "type": "object"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "effectiveEffort": {
+        "enum": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+          "ultra"
+        ],
+        "type": "string"
+      },
+      "effectiveEffortSource": {
+        "enum": [
+          "session_override",
+          "agent_default",
+          "runtime_default"
+        ],
+        "type": "string"
+      },
+      "effortOverride": {
+        "anyOf": [
+          {
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              "ultra"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "sessionKey": {
+        "type": "string"
+      },
+      "sessionName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "sessionKey",
+      "sessionName",
+      "before",
+      "after",
+      "effortOverride",
+      "effectiveEffort",
+      "effectiveEffortSource",
+      "appliesOn"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let SessionsSetModelInputSchema = #"""
   {
     "additionalProperties": false,
@@ -47546,6 +53683,445 @@ public enum RaviSchemas {
   {
     "additionalProperties": {},
     "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsSetProviderInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nameOrKey": {
+        "description": "Session name or key",
+        "type": "string"
+      },
+      "provider": {
+        "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+        "type": "string"
+      }
+    },
+    "required": [
+      "nameOrKey",
+      "provider"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsSetProviderReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "action": {
+        "const": "set-provider",
+        "type": "string"
+      },
+      "after": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "agentId": {
+                "type": "string"
+              },
+              "effectiveModel": {
+                "type": "string"
+              },
+              "effectiveProvider": {
+                "type": "string"
+              },
+              "effortOverride": {
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "type": "string"
+              },
+              "ephemeral": {
+                "type": "boolean"
+              },
+              "expiresAt": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "modelOverride": {
+                "type": "string"
+              },
+              "modelPresetId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modelPresetVersion": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modelSource": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "runtimeOptions": {
+                "additionalProperties": false,
+                "properties": {
+                  "effort": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "enum": [
+                          "session_override",
+                          "agent_default",
+                          "runtime_default"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "enum": [
+                          "none",
+                          "minimal",
+                          "low",
+                          "medium",
+                          "high",
+                          "xhigh",
+                          "max",
+                          "ultra"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "model": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "thinking": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "model",
+                  "effort",
+                  "thinking"
+                ],
+                "type": "object"
+              },
+              "sessionKey": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionKey",
+              "label",
+              "agentId",
+              "effectiveProvider",
+              "effectiveModel",
+              "modelSource",
+              "modelPresetId",
+              "modelPresetVersion",
+              "ephemeral",
+              "expiresAt",
+              "runtimeOptions"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "appliesOn": {
+        "const": "next-turn-runtime-restart",
+        "type": "string"
+      },
+      "before": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "effectiveModel": {
+            "type": "string"
+          },
+          "effectiveProvider": {
+            "type": "string"
+          },
+          "effortOverride": {
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              "ultra"
+            ],
+            "type": "string"
+          },
+          "ephemeral": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "modelOverride": {
+            "type": "string"
+          },
+          "modelPresetId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelPresetVersion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelSource": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "runtimeOptions": {
+            "additionalProperties": false,
+            "properties": {
+              "effort": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "enum": [
+                      "session_override",
+                      "agent_default",
+                      "runtime_default"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "enum": [
+                      "none",
+                      "minimal",
+                      "low",
+                      "medium",
+                      "high",
+                      "xhigh",
+                      "max",
+                      "ultra"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "model": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "thinking": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "model",
+              "effort",
+              "thinking"
+            ],
+            "type": "object"
+          },
+          "sessionKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionKey",
+          "label",
+          "agentId",
+          "effectiveProvider",
+          "effectiveModel",
+          "modelSource",
+          "modelPresetId",
+          "modelPresetVersion",
+          "ephemeral",
+          "expiresAt",
+          "runtimeOptions"
+        ],
+        "type": "object"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "effectiveProvider": {
+        "type": "string"
+      },
+      "runtimeProviderOverride": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "sessionKey": {
+        "type": "string"
+      },
+      "sessionName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "action",
+      "changed",
+      "sessionKey",
+      "sessionName",
+      "before",
+      "after",
+      "runtimeProviderOverride",
+      "effectiveProvider",
+      "appliesOn"
+    ],
     "type": "object"
   }
   """#
@@ -49833,6 +56409,259 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let SkillsGrantInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "Agent id (immutable)",
+        "type": "string"
+      },
+      "note": {
+        "description": "Optional operator note",
+        "type": "string"
+      },
+      "skill": {
+        "description": "Skill name (matches SKILL.md name)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "agent",
+      "skill"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsGrantReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentId": {
+        "type": "string"
+      },
+      "grant": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "grantedAt": {
+            "type": "number"
+          },
+          "note": {
+            "type": "string"
+          },
+          "skillName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentId",
+          "skillName",
+          "grantedAt"
+        ],
+        "type": "object"
+      },
+      "skillName": {
+        "type": "string"
+      },
+      "success": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "agentId",
+      "skillName"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsGrantBatchInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "Target a single agent (mutually exclusive with --all-agents)",
+        "type": "string"
+      },
+      "allAgents": {
+        "description": "Target every agent in the fleet",
+        "type": "boolean"
+      },
+      "allSkills": {
+        "description": "Target every catalog + installed skill",
+        "type": "boolean"
+      },
+      "dryRun": {
+        "description": "Preview counts without writing any grant",
+        "type": "boolean"
+      },
+      "note": {
+        "description": "Optional operator note stamped on every grant",
+        "type": "string"
+      },
+      "skill": {
+        "description": "Target a single skill (mutually exclusive with --all-skills)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsGrantBatchReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentsTargeted": {
+        "type": "number"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "errors": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            },
+            "skillName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentId",
+            "skillName",
+            "error"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "op": {
+        "enum": [
+          "grant",
+          "revoke"
+        ],
+        "type": "string"
+      },
+      "pairsAffected": {
+        "type": "number"
+      },
+      "pairsSkipped": {
+        "type": "number"
+      },
+      "sampleAgents": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "sampleSkills": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "skillsTargeted": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "op",
+      "dryRun",
+      "agentsTargeted",
+      "skillsTargeted",
+      "pairsAffected",
+      "pairsSkipped",
+      "errors",
+      "sampleAgents",
+      "sampleSkills"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsInspectInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "Agent id (immutable)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "agent"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsInspectReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentId": {
+        "type": "string"
+      },
+      "allowlist": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "hasConfiguration": {
+        "type": "boolean"
+      },
+      "provenance": {
+        "additionalProperties": false,
+        "properties": {
+          "baseline": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fromCapabilities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fromGrants": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "baseline",
+          "fromCapabilities",
+          "fromGrants"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "agentId",
+      "hasConfiguration",
+      "allowlist",
+      "provenance"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let SkillsInstallInputSchema = #"""
   {
     "additionalProperties": false,
@@ -50109,6 +56938,179 @@ public enum RaviSchemas {
   }
   """#
 
+  public static let SkillsRevokeInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "Agent id (immutable)",
+        "type": "string"
+      },
+      "skill": {
+        "description": "Skill name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "agent",
+      "skill"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsRevokeReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentId": {
+        "type": "string"
+      },
+      "grant": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "type": "string"
+          },
+          "grantedAt": {
+            "type": "number"
+          },
+          "note": {
+            "type": "string"
+          },
+          "skillName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentId",
+          "skillName",
+          "grantedAt"
+        ],
+        "type": "object"
+      },
+      "skillName": {
+        "type": "string"
+      },
+      "success": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "agentId",
+      "skillName"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsRevokeBatchInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "Target a single agent (mutually exclusive with --all-agents)",
+        "type": "string"
+      },
+      "allAgents": {
+        "description": "Target every agent in the fleet",
+        "type": "boolean"
+      },
+      "allSkills": {
+        "description": "Target every catalog + installed skill",
+        "type": "boolean"
+      },
+      "dryRun": {
+        "description": "Preview counts without removing any grant",
+        "type": "boolean"
+      },
+      "skill": {
+        "description": "Target a single skill (mutually exclusive with --all-skills)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsRevokeBatchReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentsTargeted": {
+        "type": "number"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "errors": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            },
+            "skillName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentId",
+            "skillName",
+            "error"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "op": {
+        "enum": [
+          "grant",
+          "revoke"
+        ],
+        "type": "string"
+      },
+      "pairsAffected": {
+        "type": "number"
+      },
+      "pairsSkipped": {
+        "type": "number"
+      },
+      "sampleAgents": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "sampleSkills": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "skillsTargeted": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "op",
+      "dryRun",
+      "agentsTargeted",
+      "skillsTargeted",
+      "pairsAffected",
+      "pairsSkipped",
+      "errors",
+      "sampleAgents",
+      "sampleSkills"
+    ],
+    "type": "object"
+  }
+  """#
+
   public static let SkillsShowInputSchema = #"""
   {
     "additionalProperties": false,
@@ -50225,6 +57227,4582 @@ public enum RaviSchemas {
       "success",
       "codexSynced",
       "total"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsWhoInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "description": "List grants for a specific agent instead",
+        "type": "string"
+      },
+      "skill": {
+        "description": "Skill name to look up",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SkillsWhoReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "grants": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "grantedAt": {
+              "type": "number"
+            },
+            "note": {
+              "type": "string"
+            },
+            "skillName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentId",
+            "skillName",
+            "grantedAt"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "skillName": {
+        "type": "string"
+      },
+      "total": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "total",
+      "grants"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksSendInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Ravi channel config; SDK-safe alias for --channel",
+        "type": "string"
+      },
+      "ephemeralUser": {
+        "description": "Send as an ephemeral message visible only to this Slack user",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a Block Kit message JSON file",
+        "type": "string"
+      },
+      "text": {
+        "description": "Top-level fallback text for notifications/accessibility",
+        "type": "string"
+      },
+      "threadTs": {
+        "description": "Send inside a Slack thread",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "file"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksSendReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksShowcaseInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "threadTs": {
+        "description": "Send inside a Slack thread",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksShowcaseReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksUpdateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a Block Kit message JSON file",
+        "type": "string"
+      },
+      "text": {
+        "description": "Top-level fallback text for notifications/accessibility",
+        "type": "string"
+      },
+      "ts": {
+        "description": "Slack message timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "file",
+      "ts"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksUpdateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksValidateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "file": {
+        "description": "Path to a Block Kit JSON file",
+        "type": "string"
+      },
+      "target": {
+        "description": "Validation target: blocks, message or view",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackBlocksValidateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasAccessDeleteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "channels": {
+        "description": "Comma-separated Slack channel IDs",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "users": {
+        "description": "Comma-separated Slack user IDs",
+        "type": "string"
+      }
+    },
+    "required": [
+      "canvas"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasAccessDeleteReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasAccessSetInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "access": {
+        "description": "read|write|owner",
+        "type": "string"
+      },
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "channels": {
+        "description": "Comma-separated Slack channel IDs",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "users": {
+        "description": "Comma-separated Slack user IDs",
+        "type": "string"
+      }
+    },
+    "required": [
+      "access",
+      "canvas"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasAccessSetReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasArtifactPublishInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "artifactOrFile": {
+        "description": "Ravi artifact id or local Markdown file path",
+        "type": "string"
+      },
+      "canvas": {
+        "description": "Publish into an existing Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "skipRefresh": {
+        "description": "Do not refresh the artifact from its source file before publishing",
+        "type": "boolean"
+      },
+      "slackChannel": {
+        "description": "Create/reuse a channel canvas for this Slack channel",
+        "type": "string"
+      },
+      "title": {
+        "description": "Canvas title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "artifactOrFile"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasArtifactPublishReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasArtifactStatusInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "artifact": {
+        "description": "Ravi artifact id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "artifact"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasArtifactStatusReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "item": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "ok": {
+        "const": true,
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "item"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasChannelCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "artifact": {
+        "description": "Read initial canvas markdown from a Ravi artifact",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "ensure": {
+        "description": "Return existing channel canvas when it already exists",
+        "type": "boolean"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "markdown": {
+        "description": "Initial canvas markdown",
+        "type": "string"
+      },
+      "markdownFile": {
+        "description": "Read initial canvas markdown from a file",
+        "type": "string"
+      },
+      "skipRefresh": {
+        "description": "Do not refresh the artifact from its source file before publishing",
+        "type": "boolean"
+      },
+      "title": {
+        "description": "Canvas title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasChannelCreateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasChannelShowcaseInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "title": {
+        "description": "Canvas title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasChannelShowcaseReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "artifact": {
+        "description": "Read initial canvas markdown from a Ravi artifact",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "markdown": {
+        "description": "Initial canvas markdown",
+        "type": "string"
+      },
+      "markdownFile": {
+        "description": "Read initial canvas markdown from a file",
+        "type": "string"
+      },
+      "skipRefresh": {
+        "description": "Do not refresh the artifact from its source file before publishing",
+        "type": "boolean"
+      },
+      "slackChannel": {
+        "description": "Optional Slack channel tab target",
+        "type": "string"
+      },
+      "title": {
+        "description": "Canvas title",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasCreateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasDeleteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "canvas"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasDeleteReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasEditInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "artifact": {
+        "description": "Read markdown content from a Ravi artifact",
+        "type": "string"
+      },
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "markdown": {
+        "description": "Markdown content for insert/replace operations",
+        "type": "string"
+      },
+      "markdownFile": {
+        "description": "Read markdown content from a file",
+        "type": "string"
+      },
+      "operation": {
+        "description": "insert_after|insert_before|insert_at_start|insert_at_end|replace|delete|rename",
+        "type": "string"
+      },
+      "sectionId": {
+        "description": "Slack canvas section ID",
+        "type": "string"
+      },
+      "skipRefresh": {
+        "description": "Do not refresh the artifact from its source file before publishing",
+        "type": "boolean"
+      },
+      "title": {
+        "description": "New title for rename operation",
+        "type": "string"
+      }
+    },
+    "required": [
+      "canvas",
+      "operation"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasEditReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasSectionsLookupInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "containsText": {
+        "description": "Text that matching sections must contain",
+        "type": "string"
+      },
+      "sectionTypes": {
+        "default": "any_header",
+        "description": "Comma-separated section types, e.g. h1,h2,h3,any_header",
+        "type": "string"
+      }
+    },
+    "required": [
+      "canvas"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasSectionsLookupReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "limit",
+          "cursor",
+          "nextCursor",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "items",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasShowcaseInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "canvas": {
+        "description": "Slack canvas ID",
+        "type": "string"
+      },
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "slackChannel": {
+        "description": "Slack channel/conversation ID for the showcase context",
+        "type": "string"
+      },
+      "title": {
+        "description": "Canvas title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "canvas"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackCanvasShowcaseReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "name": {
+        "description": "New Slack channel name",
+        "type": "string"
+      },
+      "private": {
+        "description": "Create a private channel",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsCreateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsHistoryInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "cursor": {
+        "description": "Slack pagination cursor",
+        "type": "string"
+      },
+      "inclusive": {
+        "description": "Include boundary timestamps",
+        "type": "boolean"
+      },
+      "latest": {
+        "description": "Latest Slack timestamp",
+        "type": "string"
+      },
+      "limit": {
+        "default": "20",
+        "description": "Page size",
+        "type": "string"
+      },
+      "oldest": {
+        "description": "Oldest Slack timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsHistoryReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "limit",
+          "cursor",
+          "nextCursor",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "items",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsInfoInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsInfoReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsInviteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Ravi channel config; SDK-safe alias for --channel",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "users": {
+        "description": "Comma-separated Slack user IDs",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "users"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsInviteReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "cursor": {
+        "description": "Slack pagination cursor",
+        "type": "string"
+      },
+      "includeArchived": {
+        "description": "Include archived conversations",
+        "type": "boolean"
+      },
+      "limit": {
+        "default": "100",
+        "description": "Page size",
+        "type": "string"
+      },
+      "types": {
+        "default": "public_channel,private_channel,im,mpim",
+        "description": "Slack conversation types",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsListReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "limit",
+          "cursor",
+          "nextCursor",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "items",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsRenameInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "name": {
+        "description": "New Slack channel name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "name"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackChannelsRenameReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackFilesListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "cursor": {
+        "description": "Slack pagination cursor",
+        "type": "string"
+      },
+      "limit": {
+        "default": "20",
+        "description": "Page size",
+        "type": "string"
+      },
+      "slackChannel": {
+        "description": "Restrict to a Slack channel/conversation ID",
+        "type": "string"
+      },
+      "user": {
+        "description": "Restrict to a Slack user ID",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SlackFilesListReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "limit",
+          "cursor",
+          "nextCursor",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "items",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackInteractionsRespondInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a JSON response payload",
+        "type": "string"
+      },
+      "responseUrlId": {
+        "description": "Opaque Slack interaction response URL handle",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file",
+      "responseUrlId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackInteractionsRespondReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMembersListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "cursor": {
+        "description": "Slack pagination cursor",
+        "type": "string"
+      },
+      "limit": {
+        "default": "100",
+        "description": "Page size",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMembersListReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "pagination": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "limit",
+          "cursor",
+          "nextCursor",
+          "hasMore"
+        ],
+        "type": "object"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "items",
+      "pagination"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesInspectInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "ts": {
+        "description": "Slack message timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "ts"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesInspectReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesReplayInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the replay; default is dry-run",
+        "type": "boolean"
+      },
+      "force": {
+        "description": "Replay even when the message is already in Ravi",
+        "type": "boolean"
+      },
+      "ts": {
+        "description": "Slack message timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "ts"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesReplayReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesSendInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "ephemeralUser": {
+        "description": "Send as an ephemeral message visible only to this Slack user",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "text": {
+        "description": "Message text",
+        "type": "string"
+      },
+      "threadTs": {
+        "description": "Send inside a Slack thread",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "text"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackMessagesSendReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsOpenInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a Block Kit view JSON file",
+        "type": "string"
+      },
+      "triggerId": {
+        "description": "Slack interaction trigger_id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file",
+      "triggerId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsOpenReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsPushInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a Block Kit view JSON file",
+        "type": "string"
+      },
+      "triggerId": {
+        "description": "Slack interaction trigger_id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file",
+      "triggerId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsPushReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsUpdateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "externalId": {
+        "description": "Treat <view> as an external_id instead of a view_id",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to a Block Kit view JSON file",
+        "type": "string"
+      },
+      "hash": {
+        "description": "Slack view.hash for optimistic concurrency control",
+        "type": "string"
+      },
+      "view": {
+        "description": "Slack view_id, or external_id when --external-id is set",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file",
+      "view"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackModalsUpdateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackPermissionsListInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SlackPermissionsListReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackTopologyInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "cursor": {
+        "description": "Slack pagination cursor",
+        "type": "string"
+      },
+      "includeArchived": {
+        "description": "Include archived conversations",
+        "type": "boolean"
+      },
+      "limit": {
+        "default": "200",
+        "description": "Conversation page size",
+        "type": "string"
+      },
+      "types": {
+        "default": "public_channel,private_channel",
+        "description": "Slack conversation types",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SlackTopologyReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "accountId": {
+        "type": "string"
+      },
+      "capabilities": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "channels": {
+        "items": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "type": "array"
+      },
+      "connection": {
+        "type": "string"
+      },
+      "ok": {
+        "const": true,
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "source": {
+        "type": "string"
+      },
+      "ungroupedChannelIds": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "accountId",
+      "channels",
+      "ungroupedChannelIds",
+      "capabilities"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsPresentDetailsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Ravi channel config",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Ravi channel config; SDK-safe alias for --channel",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to Slack native Work Object detail metadata JSON",
+        "type": "string"
+      },
+      "triggerId": {
+        "description": "Slack entity_details_requested trigger_id",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file",
+      "triggerId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsPresentDetailsReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsSendInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Ravi channel config; SDK-safe alias for --channel",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to Slack native Work Object message JSON",
+        "type": "string"
+      },
+      "text": {
+        "description": "Top-level fallback text for notifications/accessibility",
+        "type": "string"
+      },
+      "threadTs": {
+        "description": "Send inside a Slack thread",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "file"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsSendReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsUnfurlInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "description": "Slack channel/conversation ID containing the URL message",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Ravi channel config; SDK-safe alias for --channel",
+        "type": "string"
+      },
+      "execute": {
+        "description": "Perform the mutation; default is dry-run",
+        "type": "boolean"
+      },
+      "file": {
+        "description": "Path to Slack native Work Object metadata JSON",
+        "type": "string"
+      },
+      "ts": {
+        "description": "Slack message timestamp containing the URL",
+        "type": "string"
+      },
+      "url": {
+        "description": "URL in the message to unfurl",
+        "type": "string"
+      }
+    },
+    "required": [
+      "channel",
+      "file",
+      "ts",
+      "url"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsUnfurlReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "type": "string"
+      },
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "method": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      },
+      "raw": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "request": {
+        "additionalProperties": {
+          "$ref": "#/$defs/__schema0"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "source": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider",
+      "connection",
+      "source",
+      "dryRun",
+      "method",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsValidateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "file": {
+        "description": "Path to Slack native Work Object metadata JSON",
+        "type": "string"
+      },
+      "target": {
+        "default": "message",
+        "description": "Validation target: message or detail",
+        "type": "string"
+      }
+    },
+    "required": [
+      "file"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SlackWorkObjectsValidateReturnSchema = #"""
+  {
+    "$defs": {
+      "__schema0": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": {
+              "$ref": "#/$defs/__schema0"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "dryRun": {
+        "type": "boolean"
+      },
+      "item": {
+        "$ref": "#/$defs/__schema0"
+      },
+      "ok": {
+        "const": true,
+        "type": "boolean"
+      },
+      "outputFile": {
+        "type": "string"
+      },
+      "provider": {
+        "const": "slack",
+        "type": "string"
+      }
+    },
+    "required": [
+      "ok",
+      "provider"
     ],
     "type": "object"
   }
@@ -53834,7 +65412,7 @@ public enum RaviSchemas {
         "type": "array"
       },
       "effort": {
-        "description": "Runtime effort: low|medium|high|xhigh",
+        "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
         "type": "string"
       },
       "input": {
@@ -54243,7 +65821,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "effort": {
-        "description": "Runtime effort: low|medium|high|xhigh",
+        "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
         "type": "string"
       },
       "model": {
@@ -56486,6 +68064,14 @@ public enum RaviSchemas {
         "description": "Cooldown between fires (e.g., 5s, 30s, 1m)",
         "type": "string"
       },
+      "envFile": {
+        "description": "Env file loaded for shell triggers",
+        "type": "string"
+      },
+      "exec": {
+        "description": "Alias for --shell",
+        "type": "string"
+      },
       "filter": {
         "description": "Filter expression (e.g. 'data.cwd == \"/path/to/workspace\"')",
         "type": "string"
@@ -56498,12 +68084,24 @@ public enum RaviSchemas {
         "description": "Trigger name",
         "type": "string"
       },
+      "onError": {
+        "description": "Error action, e.g. notify-session:<session>",
+        "type": "string"
+      },
       "replySession": {
         "description": "Override the session used for outbound delivery (defaults to caller session)",
         "type": "string"
       },
       "session": {
         "description": "Session: main or isolated (default: isolated)",
+        "type": "string"
+      },
+      "shell": {
+        "description": "Run a shell command directly without invoking an agent",
+        "type": "string"
+      },
+      "timeout": {
+        "description": "Shell timeout, e.g. 60 or 5m",
         "type": "string"
       },
       "topic": {
@@ -56860,7 +68458,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "key": {
-        "description": "Property: name, message, topic, agent, account, session, cooldown, filter, replySession",
+        "description": "Property: name, message, shell, exec, timeout, env-file, on-error, topic, agent, account, session, cooldown, filter, replySession",
         "type": "string"
       },
       "value": {
@@ -59974,6 +71572,2203 @@ public enum RaviSchemas {
   {
     "additionalProperties": {},
     "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsCountriesInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Rows, 1-200 (default: 10)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsCountriesReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "countries": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "country": {
+              "type": "string"
+            },
+            "subscribersGained": {
+              "type": "number"
+            },
+            "views": {
+              "type": "number"
+            },
+            "watchTimeMinutes": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "country",
+            "views",
+            "watchTimeMinutes",
+            "subscribersGained"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "countries"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsDemographicsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsDemographicsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "demographics": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "ageGroup": {
+              "type": "string"
+            },
+            "gender": {
+              "type": "string"
+            },
+            "viewerPercentage": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "ageGroup",
+            "gender",
+            "viewerPercentage"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "demographics"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsDevicesInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsDevicesReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "devices": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "device": {
+              "type": "string"
+            },
+            "views": {
+              "type": "number"
+            },
+            "watchTimeMinutes": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "device",
+            "views",
+            "watchTimeMinutes"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "devices"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsOverviewInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsOverviewReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "overview": {
+        "additionalProperties": false,
+        "properties": {
+          "avgViewDurationSec": {
+            "type": "number"
+          },
+          "comments": {
+            "type": "number"
+          },
+          "dislikes": {
+            "type": "number"
+          },
+          "likes": {
+            "type": "number"
+          },
+          "netSubscribers": {
+            "type": "number"
+          },
+          "shares": {
+            "type": "number"
+          },
+          "subscribersGained": {
+            "type": "number"
+          },
+          "subscribersLost": {
+            "type": "number"
+          },
+          "views": {
+            "type": "number"
+          },
+          "watchTimeMinutes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "views",
+          "watchTimeMinutes",
+          "avgViewDurationSec",
+          "subscribersGained",
+          "subscribersLost",
+          "netSubscribers",
+          "likes",
+          "dislikes",
+          "comments",
+          "shares"
+        ],
+        "type": "object"
+      },
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "overview"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsSeriesInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "metric": {
+        "description": "views|estimatedMinutesWatched|averageViewDuration|subscribersGained|likes|comments|shares (default: views)",
+        "enum": [
+          "views",
+          "estimatedMinutesWatched",
+          "averageViewDuration",
+          "subscribersGained",
+          "likes",
+          "comments",
+          "shares"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsSeriesReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "data": {
+        "items": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "metric": {
+        "type": "string"
+      },
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "metric",
+      "data"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsTopInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Rows, 1-200 (default: 10)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsTopReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "period": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "videos": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "avgViewDurationSec": {
+              "type": "number"
+            },
+            "comments": {
+              "type": "number"
+            },
+            "likes": {
+              "type": "number"
+            },
+            "title": {
+              "type": "string"
+            },
+            "videoId": {
+              "type": "string"
+            },
+            "views": {
+              "type": "number"
+            },
+            "watchTimeMinutes": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "videoId",
+            "title",
+            "views",
+            "watchTimeMinutes",
+            "avgViewDurationSec",
+            "likes",
+            "comments"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "videos"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsTrafficInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "days": {
+        "description": "Recent days, 1-365 (default: 28)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtAnalyticsTrafficReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "period": {
+        "type": "string"
+      },
+      "sources": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "views": {
+              "type": "number"
+            },
+            "watchTimeMinutes": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "source",
+            "views",
+            "watchTimeMinutes"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "period",
+      "sources"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCaptionDownloadInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "captionId": {
+        "description": "Caption track ID from `ravi yt captions`",
+        "minLength": 1,
+        "type": "string"
+      },
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "format": {
+        "description": "srt|vtt|ttml (default: srt)",
+        "enum": [
+          "srt",
+          "vtt",
+          "ttml"
+        ],
+        "type": "string"
+      },
+      "language": {
+        "description": "Optional ISO 639-1 translation language",
+        "type": "string"
+      }
+    },
+    "required": [
+      "captionId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCaptionDownloadReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "captionId": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      },
+      "format": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "captionId",
+      "format",
+      "content"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCaptionsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "videoId": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "videoId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCaptionsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "captions": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "captionId": {
+              "type": "string"
+            },
+            "isAutoSynced": {
+              "type": "boolean"
+            },
+            "isDraft": {
+              "type": "boolean"
+            },
+            "language": {
+              "type": "string"
+            },
+            "lastUpdated": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "trackKind": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "captionId",
+            "language",
+            "name",
+            "trackKind",
+            "isAutoSynced",
+            "isDraft",
+            "status",
+            "lastUpdated"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      },
+      "videoId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "success",
+      "videoId",
+      "captions",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCommentsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-100 (default: 20)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      },
+      "videoId": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "videoId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtCommentsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "comments": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "author": {
+              "type": "string"
+            },
+            "authorChannelUrl": {
+              "type": "string"
+            },
+            "commentId": {
+              "type": "string"
+            },
+            "likeCount": {
+              "type": "number"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "replyCount": {
+              "type": "number"
+            },
+            "text": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "threadId",
+            "commentId",
+            "author",
+            "authorChannelUrl",
+            "text",
+            "likeCount",
+            "publishedAt",
+            "replyCount"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "nextPageToken": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      },
+      "videoId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "success",
+      "videoId",
+      "comments",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtHealthInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtHealthReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "app": {
+        "const": "youtube",
+        "type": "string"
+      },
+      "authenticated": {
+        "const": false,
+        "type": "boolean"
+      },
+      "connection": {
+        "type": "string"
+      },
+      "credentialConfigured": {
+        "type": "boolean"
+      },
+      "credentialStatus": {
+        "type": "string"
+      },
+      "externalCheckPerformed": {
+        "const": false,
+        "type": "boolean"
+      },
+      "message": {
+        "type": "string"
+      },
+      "ready": {
+        "type": "boolean"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "app",
+      "connection",
+      "ready",
+      "credentialConfigured",
+      "credentialStatus",
+      "authenticated",
+      "externalCheckPerformed",
+      "message"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtInfoInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtInfoReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "additionalProperties": false,
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "subscriberCount": {
+            "type": "number"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "uploadsPlaylistId": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoCount": {
+            "type": "number"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "channelId",
+          "title",
+          "description",
+          "subscriberCount",
+          "videoCount",
+          "viewCount",
+          "thumbnail",
+          "uploadsPlaylistId",
+          "url"
+        ],
+        "type": "object"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "channel"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-50 (default: 25)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      },
+      "playlistId": {
+        "description": "YouTube playlist ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "playlistId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nextPageToken": {
+        "type": "string"
+      },
+      "playlistId": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      },
+      "videos": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "commentCount": {
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "likeCount": {
+              "type": "number"
+            },
+            "playlistItemId": {
+              "type": "string"
+            },
+            "privacyStatus": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "videoId": {
+              "type": "string"
+            },
+            "viewCount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "videoId",
+            "title",
+            "description",
+            "publishedAt",
+            "thumbnail",
+            "viewCount",
+            "likeCount",
+            "commentCount",
+            "duration",
+            "privacyStatus",
+            "url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "success",
+      "playlistId",
+      "videos",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistAddInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "playlistId": {
+        "description": "Target YouTube playlist ID",
+        "minLength": 1,
+        "type": "string"
+      },
+      "videoId": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "playlistId",
+      "videoId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistAddReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "item": {
+        "additionalProperties": false,
+        "properties": {
+          "playlistId": {
+            "type": "string"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "playlistItemId",
+          "playlistId",
+          "videoId",
+          "title"
+        ],
+        "type": "object"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "item"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistCreateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "description": {
+        "description": "Playlist description",
+        "type": "string"
+      },
+      "privacy": {
+        "description": "public|private|unlisted (default: private)",
+        "enum": [
+          "public",
+          "private",
+          "unlisted"
+        ],
+        "type": "string"
+      },
+      "title": {
+        "description": "Playlist title",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "title"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistCreateReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "playlist": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "itemCount": {
+            "type": "number"
+          },
+          "playlistId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "playlistId",
+          "title",
+          "description",
+          "thumbnail",
+          "itemCount",
+          "publishedAt",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "playlist"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistDeleteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "playlistId": {
+        "description": "Owned YouTube playlist ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "playlistId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistDeleteReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "deleted": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "deleted"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistRemoveInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "playlistItemId": {
+        "description": "Playlist item ID, not video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "playlistItemId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistRemoveReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "removed": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "removed"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-50 (default: 25)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtPlaylistsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nextPageToken": {
+        "type": "string"
+      },
+      "playlists": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "itemCount": {
+              "type": "number"
+            },
+            "playlistId": {
+              "type": "string"
+            },
+            "privacyStatus": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "playlistId",
+            "title",
+            "description",
+            "thumbnail",
+            "itemCount",
+            "publishedAt",
+            "privacyStatus",
+            "url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "success",
+      "playlists",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtReplyInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "commentId": {
+        "description": "Top-level comment ID from `ravi yt comments`",
+        "minLength": 1,
+        "type": "string"
+      },
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "text": {
+        "description": "Exact approved reply text",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "commentId",
+      "text"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtReplyReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "replyId": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "replyId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtSearchInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-50 (default: 10)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      },
+      "query": {
+        "description": "Search text",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "query"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtSearchReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nextPageToken": {
+        "type": "string"
+      },
+      "query": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      },
+      "videos": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "commentCount": {
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "likeCount": {
+              "type": "number"
+            },
+            "playlistItemId": {
+              "type": "string"
+            },
+            "privacyStatus": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "videoId": {
+              "type": "string"
+            },
+            "viewCount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "videoId",
+            "title",
+            "description",
+            "publishedAt",
+            "thumbnail",
+            "viewCount",
+            "likeCount",
+            "commentCount",
+            "duration",
+            "privacyStatus",
+            "url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "success",
+      "videos",
+      "totalResults",
+      "query"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtStatsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "id": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtStatsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "stats": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "daysSincePublish": {
+            "type": "number"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          },
+          "viewsPerDay": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "publishedAt",
+          "daysSincePublish",
+          "viewsPerDay"
+        ],
+        "type": "object"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "stats"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtSubscriptionsInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-50 (default: 25)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtSubscriptionsReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nextPageToken": {
+        "type": "string"
+      },
+      "subscriptions": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "channelId": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "subscriptionId": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "totalItemCount": {
+              "type": "number"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "subscriptionId",
+            "channelId",
+            "title",
+            "description",
+            "thumbnail",
+            "publishedAt",
+            "totalItemCount",
+            "url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "success",
+      "subscriptions",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtUnansweredInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Threads inspected, 1-100 (default: 50)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      },
+      "videoId": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "videoId"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtUnansweredReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "comments": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "author": {
+              "type": "string"
+            },
+            "authorChannelUrl": {
+              "type": "string"
+            },
+            "commentId": {
+              "type": "string"
+            },
+            "likeCount": {
+              "type": "number"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "replyCount": {
+              "type": "number"
+            },
+            "text": {
+              "type": "string"
+            },
+            "threadId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "threadId",
+            "commentId",
+            "author",
+            "authorChannelUrl",
+            "text",
+            "likeCount",
+            "publishedAt",
+            "replyCount"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "nextPageToken": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalUnanswered": {
+        "type": "number"
+      },
+      "videoId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "success",
+      "videoId",
+      "comments",
+      "totalUnanswered"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "id": {
+        "description": "YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "video": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "duration",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "success",
+      "video"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoCategoriesInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "region": {
+        "description": "ISO 3166-1 alpha-2 region (default: BR)",
+        "pattern": "^[A-Za-z]{2}$",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoCategoriesReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "categories": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "assignable": {
+              "type": "boolean"
+            },
+            "categoryId": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "categoryId",
+            "title",
+            "assignable"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "region": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "success",
+      "region",
+      "categories",
+      "totalResults"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoDeleteInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "id": {
+        "description": "Owned YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoDeleteReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "deleted": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "success",
+      "deleted"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoUpdateInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "category": {
+        "description": "Replacement category ID",
+        "type": "string"
+      },
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "description": {
+        "description": "Replacement description",
+        "type": "string"
+      },
+      "id": {
+        "description": "Owned YouTube video ID",
+        "minLength": 1,
+        "type": "string"
+      },
+      "privacy": {
+        "description": "public|private|unlisted",
+        "enum": [
+          "public",
+          "private",
+          "unlisted"
+        ],
+        "type": "string"
+      },
+      "tags": {
+        "description": "Replacement comma-separated tag list",
+        "type": "string"
+      },
+      "title": {
+        "description": "Replacement title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideoUpdateReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "video": {
+        "additionalProperties": false,
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "number"
+          },
+          "playlistItemId": {
+            "type": "string"
+          },
+          "privacyStatus": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "viewCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "videoId",
+          "title",
+          "description",
+          "publishedAt",
+          "thumbnail",
+          "viewCount",
+          "likeCount",
+          "commentCount",
+          "duration",
+          "privacyStatus",
+          "url"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "success",
+      "video"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideosInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "connection": {
+        "description": "Credential connection (default: default)",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Page size, 1-50 (default: 10)",
+        "pattern": "^\\d+$",
+        "type": "string"
+      },
+      "page": {
+        "description": "Provider page token from nextPageToken",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let YtVideosReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "nextPageToken": {
+        "type": "string"
+      },
+      "success": {
+        "const": true,
+        "type": "boolean"
+      },
+      "totalResults": {
+        "type": "number"
+      },
+      "videos": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "commentCount": {
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "likeCount": {
+              "type": "number"
+            },
+            "playlistItemId": {
+              "type": "string"
+            },
+            "privacyStatus": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "videoId": {
+              "type": "string"
+            },
+            "viewCount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "videoId",
+            "title",
+            "description",
+            "publishedAt",
+            "thumbnail",
+            "viewCount",
+            "likeCount",
+            "commentCount",
+            "duration",
+            "privacyStatus",
+            "url"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "success",
+      "videos",
+      "totalResults"
+    ],
     "type": "object"
   }
   """#

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -115,17 +115,20 @@ public struct AdaptersShowReturn: Codable, Sendable {
 public struct AgentsCreateOptions: Codable, Sendable {
   public var allowRuntimeMismatch: Bool?
   public var model: String?
+  public var modelPreset: String?
   public var provider: String?
 
-  public init(allowRuntimeMismatch: Bool? = nil, model: String? = nil, provider: String? = nil) {
+  public init(allowRuntimeMismatch: Bool? = nil, model: String? = nil, modelPreset: String? = nil, provider: String? = nil) {
     self.allowRuntimeMismatch = allowRuntimeMismatch
     self.model = model
+    self.modelPreset = modelPreset
     self.provider = provider
   }
 
   enum CodingKeys: String, CodingKey {
     case allowRuntimeMismatch = "allowRuntimeMismatch"
     case model = "model"
+    case modelPreset = "modelPreset"
     case provider = "provider"
   }
 
@@ -135,6 +138,9 @@ public struct AgentsCreateOptions: Codable, Sendable {
     }
     if let value = self.model {
       body["model"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.modelPreset {
+      body["modelPreset"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.provider {
       body["provider"] = try RaviJSON.fromEncodable(value)
@@ -411,14 +417,16 @@ public struct AgentsSetReturn: Codable, Sendable {
   public var agentId: String
   public var changed: Bool
   public var key: String
+  public var sessionOverrides: [RaviJSON]
   public var value: RaviJSON
 
-  public init(action: String, agent: [String: RaviJSON]? = nil, agentId: String, changed: Bool, key: String, value: RaviJSON) {
+  public init(action: String, agent: [String: RaviJSON]? = nil, agentId: String, changed: Bool, key: String, sessionOverrides: [RaviJSON], value: RaviJSON) {
     self.action = action
     self.agent = agent
     self.agentId = agentId
     self.changed = changed
     self.key = key
+    self.sessionOverrides = sessionOverrides
     self.value = value
   }
 
@@ -428,6 +436,7 @@ public struct AgentsSetReturn: Codable, Sendable {
     case agentId = "agentId"
     case changed = "changed"
     case key = "key"
+    case sessionOverrides = "sessionOverrides"
     case value = "value"
   }
 }
@@ -3132,6 +3141,321 @@ public struct CalendarsShowReturn: Codable, Sendable {
   }
 }
 
+public struct ChannelsCreateOptions: Codable, Sendable {
+  public var credentialConnection: String?
+  public var provider: String?
+
+  public init(credentialConnection: String? = nil, provider: String? = nil) {
+    self.credentialConnection = credentialConnection
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case credentialConnection = "credentialConnection"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.credentialConnection {
+      body["credentialConnection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChannelsCreateReturn: Codable, Sendable {
+  public var changedCount: Double
+  public var channel: RaviJSON
+  public var status: String
+
+  public init(changedCount: Double, channel: RaviJSON, status: String) {
+    self.changedCount = changedCount
+    self.channel = channel
+    self.status = status
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case changedCount = "changedCount"
+    case channel = "channel"
+    case status = "status"
+  }
+}
+
+public struct ChannelsListOptions: Codable, Sendable {
+  public var limit: String?
+  public var offset: String?
+  public var provider: String?
+
+  public init(limit: String? = nil, offset: String? = nil, provider: String? = nil) {
+    self.limit = limit
+    self.offset = offset
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case limit = "limit"
+    case offset = "offset"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.offset {
+      body["offset"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChannelsListReturn: Codable, Sendable {
+  public var channels: [RaviJSON]
+  public var items: [RaviJSON]
+  public var pagination: RaviJSON
+  public var total: Double
+
+  public init(channels: [RaviJSON], items: [RaviJSON], pagination: RaviJSON, total: Double) {
+    self.channels = channels
+    self.items = items
+    self.pagination = pagination
+    self.total = total
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channels = "channels"
+    case items = "items"
+    case pagination = "pagination"
+    case total = "total"
+  }
+}
+
+public struct ChannelsProbeReturn: Codable, Sendable {
+  public var adapters: [[String: RaviJSON]]
+  public var outbound: [String: RaviJSON]
+  public var pid: Double
+  public var running: Bool
+  public var startedAt: RaviJSON
+
+  public init(adapters: [[String: RaviJSON]], outbound: [String: RaviJSON], pid: Double, running: Bool, startedAt: RaviJSON) {
+    self.adapters = adapters
+    self.outbound = outbound
+    self.pid = pid
+    self.running = running
+    self.startedAt = startedAt
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case adapters = "adapters"
+    case outbound = "outbound"
+    case pid = "pid"
+    case running = "running"
+    case startedAt = "startedAt"
+  }
+}
+
+public struct ChannelsRestartOptions: Codable, Sendable {
+  public var build: Bool?
+
+  public init(build: Bool? = nil) {
+    self.build = build
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case build = "build"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.build {
+      body["build"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChannelsRestartReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var pm2Status: RaviJSON?
+  public var reason: String?
+  public var runnerEnv: RaviJSON?
+  public var status: RaviJSON?
+  public var target: RaviJSON?
+
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+    self.action = action
+    self.changed = changed
+    self.pm2Status = pm2Status
+    self.reason = reason
+    self.runnerEnv = runnerEnv
+    self.status = status
+    self.target = target
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case pm2Status = "pm2Status"
+    case reason = "reason"
+    case runnerEnv = "runnerEnv"
+    case status = "status"
+    case target = "target"
+  }
+}
+
+public struct ChannelsSetReturn: Codable, Sendable {
+  public var changedCount: Double
+  public var channel: RaviJSON
+  public var status: String
+
+  public init(changedCount: Double, channel: RaviJSON, status: String) {
+    self.changedCount = changedCount
+    self.channel = channel
+    self.status = status
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case changedCount = "changedCount"
+    case channel = "channel"
+    case status = "status"
+  }
+}
+
+public struct ChannelsShowReturn: Codable, Sendable {
+  public var createdAt: Double
+  public var credentialConnection: String?
+  public var defaults: [String: RaviJSON]?
+  public var deletedAt: Double?
+  public var enabled: Bool?
+  public var name: String
+  public var provider: String
+  public var updatedAt: Double
+
+  public init(createdAt: Double, credentialConnection: String? = nil, defaults: [String: RaviJSON]? = nil, deletedAt: Double? = nil, enabled: Bool? = nil, name: String, provider: String, updatedAt: Double) {
+    self.createdAt = createdAt
+    self.credentialConnection = credentialConnection
+    self.defaults = defaults
+    self.deletedAt = deletedAt
+    self.enabled = enabled
+    self.name = name
+    self.provider = provider
+    self.updatedAt = updatedAt
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case createdAt = "createdAt"
+    case credentialConnection = "credentialConnection"
+    case defaults = "defaults"
+    case deletedAt = "deletedAt"
+    case enabled = "enabled"
+    case name = "name"
+    case provider = "provider"
+    case updatedAt = "updatedAt"
+  }
+}
+
+public struct ChannelsStartOptions: Codable, Sendable {
+  public var build: Bool?
+
+  public init(build: Bool? = nil) {
+    self.build = build
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case build = "build"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.build {
+      body["build"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChannelsStartReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var pm2Status: RaviJSON?
+  public var reason: String?
+  public var runnerEnv: RaviJSON?
+  public var status: RaviJSON?
+  public var target: RaviJSON?
+
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+    self.action = action
+    self.changed = changed
+    self.pm2Status = pm2Status
+    self.reason = reason
+    self.runnerEnv = runnerEnv
+    self.status = status
+    self.target = target
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case pm2Status = "pm2Status"
+    case reason = "reason"
+    case runnerEnv = "runnerEnv"
+    case status = "status"
+    case target = "target"
+  }
+}
+
+public struct ChannelsStatusReturn: Codable, Sendable {
+  public var channels: RaviJSON
+  public var pm2Available: Bool
+  public var processName: String
+  public var processes: [RaviJSON]
+
+  public init(channels: RaviJSON, pm2Available: Bool, processName: String, processes: [RaviJSON]) {
+    self.channels = channels
+    self.pm2Available = pm2Available
+    self.processName = processName
+    self.processes = processes
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channels = "channels"
+    case pm2Available = "pm2Available"
+    case processName = "processName"
+    case processes = "processes"
+  }
+}
+
+public struct ChannelsStopReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var pm2Status: RaviJSON?
+  public var reason: String?
+  public var runnerEnv: RaviJSON?
+  public var status: RaviJSON?
+  public var target: RaviJSON?
+
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+    self.action = action
+    self.changed = changed
+    self.pm2Status = pm2Status
+    self.reason = reason
+    self.runnerEnv = runnerEnv
+    self.status = status
+    self.target = target
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case pm2Status = "pm2Status"
+    case reason = "reason"
+    case runnerEnv = "runnerEnv"
+    case status = "status"
+    case target = "target"
+  }
+}
+
 public struct ChatsBackfillProviderTimestampsOptions: Codable, Sendable {
   public var apply: Bool?
   public var dryRun: Bool?
@@ -3514,6 +3838,39 @@ public struct ChatsListsMembersOptions: Codable, Sendable {
 
 public typealias ChatsListsMembersReturn = [String: RaviJSON]
 
+public struct ChatsListsPreviewOptions: Codable, Sendable {
+  public var owner: String?
+
+  public init(owner: String? = nil) {
+    self.owner = owner
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case owner = "owner"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.owner {
+      body["owner"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChatsListsPreviewReturn: Codable, Sendable {
+  public var list: RaviJSON
+  public var preview: RaviJSON
+
+  public init(list: RaviJSON, preview: RaviJSON) {
+    self.list = list
+    self.preview = preview
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case list = "list"
+    case preview = "preview"
+  }
+}
+
 public struct ChatsListsRecomputeOptions: Codable, Sendable {
   public var owner: String?
 
@@ -3578,6 +3935,42 @@ public struct ChatsListsRemoveOptions: Codable, Sendable {
 }
 
 public typealias ChatsListsRemoveReturn = [String: RaviJSON]
+
+public struct ChatsListsShowOptions: Codable, Sendable {
+  public var owner: String?
+
+  public init(owner: String? = nil) {
+    self.owner = owner
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case owner = "owner"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.owner {
+      body["owner"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct ChatsListsShowReturn: Codable, Sendable {
+  public var current: RaviJSON
+  public var list: RaviJSON
+  public var validation: RaviJSON
+
+  public init(current: RaviJSON, list: RaviJSON, validation: RaviJSON) {
+    self.current = current
+    self.list = list
+    self.validation = validation
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case current = "current"
+    case list = "list"
+    case validation = "validation"
+  }
+}
 
 public struct ChatsReadOptions: Codable, Sendable {
   public var channel: String?
@@ -5767,6 +6160,228 @@ public struct CostsTopSessionsReturn: Codable, Sendable {
   }
 }
 
+public struct CredentialsConnectionsDisableOptions: Codable, Sendable {
+  public var connection: String?
+  public var provider: String?
+
+  public init(connection: String? = nil, provider: String? = nil) {
+    self.connection = connection
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct CredentialsConnectionsDisableReturn: Codable, Sendable {
+  public var connection: RaviJSON
+
+  public init(connection: RaviJSON) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+}
+
+public struct CredentialsConnectionsEnableOptions: Codable, Sendable {
+  public var connection: String?
+  public var provider: String?
+
+  public init(connection: String? = nil, provider: String? = nil) {
+    self.connection = connection
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct CredentialsConnectionsEnableReturn: Codable, Sendable {
+  public var connection: RaviJSON
+
+  public init(connection: RaviJSON) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+}
+
+public struct CredentialsConnectionsListOptions: Codable, Sendable {
+  public var all: Bool?
+  public var limit: String?
+  public var offset: String?
+  public var provider: String?
+  public var status: String?
+
+  public init(all: Bool? = nil, limit: String? = nil, offset: String? = nil, provider: String? = nil, status: String? = nil) {
+    self.all = all
+    self.limit = limit
+    self.offset = offset
+    self.provider = provider
+    self.status = status
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case all = "all"
+    case limit = "limit"
+    case offset = "offset"
+    case provider = "provider"
+    case status = "status"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.all {
+      body["all"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.offset {
+      body["offset"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.status {
+      body["status"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct CredentialsConnectionsListReturn: Codable, Sendable {
+  public var items: [RaviJSON]
+  public var pagination: RaviJSON
+  public var total: Double
+
+  public init(items: [RaviJSON], pagination: RaviJSON, total: Double) {
+    self.items = items
+    self.pagination = pagination
+    self.total = total
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case items = "items"
+    case pagination = "pagination"
+    case total = "total"
+  }
+}
+
+public struct CredentialsConnectionsShowOptions: Codable, Sendable {
+  public var connection: String?
+  public var provider: String?
+
+  public init(connection: String? = nil, provider: String? = nil) {
+    self.connection = connection
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct CredentialsConnectionsShowReturn: Codable, Sendable {
+  public var connection: RaviJSON
+
+  public init(connection: RaviJSON) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+}
+
+public struct CredentialsPoliciesExplainOptions: Codable, Sendable {
+  public var action: String?
+  public var connection: String?
+  public var provider: String?
+
+  public init(action: String? = nil, connection: String? = nil, provider: String? = nil) {
+    self.action = action
+    self.connection = connection
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case connection = "connection"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.action {
+      body["action"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct CredentialsPoliciesExplainReturn: Codable, Sendable {
+  public var action: String
+  public var approval: RaviJSON
+  public var connection: String
+  public var provider: String
+  public var requiredCapabilities: [String]
+
+  public init(action: String, approval: RaviJSON, connection: String, provider: String, requiredCapabilities: [String]) {
+    self.action = action
+    self.approval = approval
+    self.connection = connection
+    self.provider = provider
+    self.requiredCapabilities = requiredCapabilities
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case approval = "approval"
+    case connection = "connection"
+    case provider = "provider"
+    case requiredCapabilities = "requiredCapabilities"
+  }
+}
+
 public struct CrmAccountReturn: Codable, Sendable {
   public var crm: [String: RaviJSON]
   public var target: String
@@ -7644,6 +8259,7 @@ public struct CronAddOptions: Codable, Sendable {
   public var envFile: String?
   public var every: String?
   public var exec: String?
+  public var idempotencyKey: String?
   public var isolated: Bool?
   public var message: String?
   public var onError: String?
@@ -7651,7 +8267,7 @@ public struct CronAddOptions: Codable, Sendable {
   public var timeout: String?
   public var tz: String?
 
-  public init(account: String? = nil, agent: String? = nil, at: String? = nil, cron: String? = nil, deleteAfter: Bool? = nil, description: String? = nil, envFile: String? = nil, every: String? = nil, exec: String? = nil, isolated: Bool? = nil, message: String? = nil, onError: String? = nil, shell: String? = nil, timeout: String? = nil, tz: String? = nil) {
+  public init(account: String? = nil, agent: String? = nil, at: String? = nil, cron: String? = nil, deleteAfter: Bool? = nil, description: String? = nil, envFile: String? = nil, every: String? = nil, exec: String? = nil, idempotencyKey: String? = nil, isolated: Bool? = nil, message: String? = nil, onError: String? = nil, shell: String? = nil, timeout: String? = nil, tz: String? = nil) {
     self.account = account
     self.agent = agent
     self.at = at
@@ -7661,6 +8277,7 @@ public struct CronAddOptions: Codable, Sendable {
     self.envFile = envFile
     self.every = every
     self.exec = exec
+    self.idempotencyKey = idempotencyKey
     self.isolated = isolated
     self.message = message
     self.onError = onError
@@ -7679,6 +8296,7 @@ public struct CronAddOptions: Codable, Sendable {
     case envFile = "envFile"
     case every = "every"
     case exec = "exec"
+    case idempotencyKey = "idempotencyKey"
     case isolated = "isolated"
     case message = "message"
     case onError = "onError"
@@ -7714,6 +8332,9 @@ public struct CronAddOptions: Codable, Sendable {
     }
     if let value = self.exec {
       body["exec"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.idempotencyKey {
+      body["idempotencyKey"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.isolated {
       body["isolated"] = try RaviJSON.fromEncodable(value)
@@ -8187,9 +8808,9 @@ public struct DevinAuthCheckReturn: Codable, Sendable {
   public var baseUrl: String
   public var configuredOrgId: String?
   public var ok: Bool
-  public var self_: [String: RaviJSON]
+  public var self_: RaviJSON
 
-  public init(baseUrl: String, configuredOrgId: String? = nil, ok: Bool, self_: [String: RaviJSON]) {
+  public init(baseUrl: String, configuredOrgId: String? = nil, ok: Bool, self_: RaviJSON) {
     self.baseUrl = baseUrl
     self.configuredOrgId = configuredOrgId
     self.ok = ok
@@ -8205,10 +8826,10 @@ public struct DevinAuthCheckReturn: Codable, Sendable {
 }
 
 public struct DevinSessionsArchiveReturn: Codable, Sendable {
-  public var session: [String: RaviJSON]
+  public var session: RaviJSON
   public var status: String
 
-  public init(session: [String: RaviJSON], status: String) {
+  public init(session: RaviJSON, status: String) {
     self.session = session
     self.status = status
   }
@@ -8238,11 +8859,11 @@ public struct DevinSessionsAttachmentsOptions: Codable, Sendable {
 }
 
 public struct DevinSessionsAttachmentsReturn: Codable, Sendable {
-  public var attachments: [[String: RaviJSON]]
+  public var attachments: [RaviJSON]
   public var devinId: String
   public var total: Double
 
-  public init(attachments: [[String: RaviJSON]], devinId: String, total: Double) {
+  public init(attachments: [RaviJSON], devinId: String, total: Double) {
     self.attachments = attachments
     self.devinId = devinId
     self.total = total
@@ -8261,39 +8882,53 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
   public var attachmentUrl: [String]?
   public var bypassApproval: Bool?
   public var childPlaybook: String?
+  public var devinId: String?
+  public var devinMode: String?
   public var knowledge: [String]?
   public var maxAcu: String?
   public var noMaxAcuLimit: Bool?
+  public var noResumable: Bool?
+  public var platform: String?
   public var playbook: String?
   public var project: String?
   public var prompt: String?
   public var promptFile: String?
   public var proxRun: String?
   public var repo: [String]?
+  public var resumable: Bool?
   public var secret: [String]?
   public var sessionLink: [String]?
+  public var sessionSecret: [String]?
+  public var structuredOutputRequired: Bool?
   public var structuredOutputSchema: String?
   public var tag: [String]?
   public var task: String?
   public var title: String?
 
-  public init(advancedMode: String? = nil, asUser: String? = nil, attachmentUrl: [String]? = nil, bypassApproval: Bool? = nil, childPlaybook: String? = nil, knowledge: [String]? = nil, maxAcu: String? = nil, noMaxAcuLimit: Bool? = nil, playbook: String? = nil, project: String? = nil, prompt: String? = nil, promptFile: String? = nil, proxRun: String? = nil, repo: [String]? = nil, secret: [String]? = nil, sessionLink: [String]? = nil, structuredOutputSchema: String? = nil, tag: [String]? = nil, task: String? = nil, title: String? = nil) {
+  public init(advancedMode: String? = nil, asUser: String? = nil, attachmentUrl: [String]? = nil, bypassApproval: Bool? = nil, childPlaybook: String? = nil, devinId: String? = nil, devinMode: String? = nil, knowledge: [String]? = nil, maxAcu: String? = nil, noMaxAcuLimit: Bool? = nil, noResumable: Bool? = nil, platform: String? = nil, playbook: String? = nil, project: String? = nil, prompt: String? = nil, promptFile: String? = nil, proxRun: String? = nil, repo: [String]? = nil, resumable: Bool? = nil, secret: [String]? = nil, sessionLink: [String]? = nil, sessionSecret: [String]? = nil, structuredOutputRequired: Bool? = nil, structuredOutputSchema: String? = nil, tag: [String]? = nil, task: String? = nil, title: String? = nil) {
     self.advancedMode = advancedMode
     self.asUser = asUser
     self.attachmentUrl = attachmentUrl
     self.bypassApproval = bypassApproval
     self.childPlaybook = childPlaybook
+    self.devinId = devinId
+    self.devinMode = devinMode
     self.knowledge = knowledge
     self.maxAcu = maxAcu
     self.noMaxAcuLimit = noMaxAcuLimit
+    self.noResumable = noResumable
+    self.platform = platform
     self.playbook = playbook
     self.project = project
     self.prompt = prompt
     self.promptFile = promptFile
     self.proxRun = proxRun
     self.repo = repo
+    self.resumable = resumable
     self.secret = secret
     self.sessionLink = sessionLink
+    self.sessionSecret = sessionSecret
+    self.structuredOutputRequired = structuredOutputRequired
     self.structuredOutputSchema = structuredOutputSchema
     self.tag = tag
     self.task = task
@@ -8306,17 +8941,24 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
     case attachmentUrl = "attachmentUrl"
     case bypassApproval = "bypassApproval"
     case childPlaybook = "childPlaybook"
+    case devinId = "devinId"
+    case devinMode = "devinMode"
     case knowledge = "knowledge"
     case maxAcu = "maxAcu"
     case noMaxAcuLimit = "noMaxAcuLimit"
+    case noResumable = "noResumable"
+    case platform = "platform"
     case playbook = "playbook"
     case project = "project"
     case prompt = "prompt"
     case promptFile = "promptFile"
     case proxRun = "proxRun"
     case repo = "repo"
+    case resumable = "resumable"
     case secret = "secret"
     case sessionLink = "sessionLink"
+    case sessionSecret = "sessionSecret"
+    case structuredOutputRequired = "structuredOutputRequired"
     case structuredOutputSchema = "structuredOutputSchema"
     case tag = "tag"
     case task = "task"
@@ -8339,6 +8981,12 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
     if let value = self.childPlaybook {
       body["childPlaybook"] = try RaviJSON.fromEncodable(value)
     }
+    if let value = self.devinId {
+      body["devinId"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.devinMode {
+      body["devinMode"] = try RaviJSON.fromEncodable(value)
+    }
     if let value = self.knowledge {
       body["knowledge"] = try RaviJSON.fromEncodable(value)
     }
@@ -8347,6 +8995,12 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
     }
     if let value = self.noMaxAcuLimit {
       body["noMaxAcuLimit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.noResumable {
+      body["noResumable"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.platform {
+      body["platform"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.playbook {
       body["playbook"] = try RaviJSON.fromEncodable(value)
@@ -8366,11 +9020,20 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
     if let value = self.repo {
       body["repo"] = try RaviJSON.fromEncodable(value)
     }
+    if let value = self.resumable {
+      body["resumable"] = try RaviJSON.fromEncodable(value)
+    }
     if let value = self.secret {
       body["secret"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.sessionLink {
       body["sessionLink"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.sessionSecret {
+      body["sessionSecret"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.structuredOutputRequired {
+      body["structuredOutputRequired"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.structuredOutputSchema {
       body["structuredOutputSchema"] = try RaviJSON.fromEncodable(value)
@@ -8388,21 +9051,30 @@ public struct DevinSessionsCreateOptions: Codable, Sendable {
 }
 
 public struct DevinSessionsCreateReturn: Codable, Sendable {
+  public var devinMode: RaviJSON?
   public var maxAcuLimit: RaviJSON
   public var maxAcuLimitSource: String
-  public var session: [String: RaviJSON]
+  public var platform: RaviJSON?
+  public var resumable: RaviJSON?
+  public var session: RaviJSON
   public var status: String
 
-  public init(maxAcuLimit: RaviJSON, maxAcuLimitSource: String, session: [String: RaviJSON], status: String) {
+  public init(devinMode: RaviJSON? = nil, maxAcuLimit: RaviJSON, maxAcuLimitSource: String, platform: RaviJSON? = nil, resumable: RaviJSON? = nil, session: RaviJSON, status: String) {
+    self.devinMode = devinMode
     self.maxAcuLimit = maxAcuLimit
     self.maxAcuLimitSource = maxAcuLimitSource
+    self.platform = platform
+    self.resumable = resumable
     self.session = session
     self.status = status
   }
 
   enum CodingKeys: String, CodingKey {
+    case devinMode = "devinMode"
     case maxAcuLimit = "maxAcuLimit"
     case maxAcuLimitSource = "maxAcuLimitSource"
+    case platform = "platform"
+    case resumable = "resumable"
     case session = "session"
     case status = "status"
   }
@@ -8427,11 +9099,11 @@ public struct DevinSessionsInsightsOptions: Codable, Sendable {
 }
 
 public struct DevinSessionsInsightsReturn: Codable, Sendable {
-  public var insights: [String: RaviJSON]
-  public var session: [String: RaviJSON]
+  public var insights: RaviJSON
+  public var session: RaviJSON
   public var summary: RaviJSON
 
-  public init(insights: [String: RaviJSON], session: [String: RaviJSON], summary: RaviJSON) {
+  public init(insights: RaviJSON, session: RaviJSON, summary: RaviJSON) {
     self.insights = insights
     self.session = session
     self.summary = summary
@@ -8490,11 +9162,11 @@ public struct DevinSessionsListReturn: Codable, Sendable {
   public var hasNextPage: Bool?
   public var items: [[String: RaviJSON]]
   public var pagination: RaviJSON
-  public var sessions: [[String: RaviJSON]]
+  public var sessions: [RaviJSON]
   public var source: String
   public var total: Double
 
-  public init(hasNextPage: Bool? = nil, items: [[String: RaviJSON]], pagination: RaviJSON, sessions: [[String: RaviJSON]], source: String, total: Double) {
+  public init(hasNextPage: Bool? = nil, items: [[String: RaviJSON]], pagination: RaviJSON, sessions: [RaviJSON], source: String, total: Double) {
     self.hasNextPage = hasNextPage
     self.items = items
     self.pagination = pagination
@@ -8533,10 +9205,10 @@ public struct DevinSessionsMessagesOptions: Codable, Sendable {
 
 public struct DevinSessionsMessagesReturn: Codable, Sendable {
   public var devinId: String
-  public var messages: [[String: RaviJSON]]
+  public var messages: [RaviJSON]
   public var total: Double
 
-  public init(devinId: String, messages: [[String: RaviJSON]], total: Double) {
+  public init(devinId: String, messages: [RaviJSON], total: Double) {
     self.devinId = devinId
     self.messages = messages
     self.total = total
@@ -8568,10 +9240,10 @@ public struct DevinSessionsSendOptions: Codable, Sendable {
 }
 
 public struct DevinSessionsSendReturn: Codable, Sendable {
-  public var session: [String: RaviJSON]
+  public var session: RaviJSON
   public var status: String
 
-  public init(session: [String: RaviJSON], status: String) {
+  public init(session: RaviJSON, status: String) {
     self.session = session
     self.status = status
   }
@@ -8601,9 +9273,9 @@ public struct DevinSessionsShowOptions: Codable, Sendable {
 }
 
 public struct DevinSessionsShowReturn: Codable, Sendable {
-  public var session: [String: RaviJSON]
+  public var session: RaviJSON
 
-  public init(session: [String: RaviJSON]) {
+  public init(session: RaviJSON) {
     self.session = session
   }
 
@@ -8641,9 +9313,9 @@ public struct DevinSessionsSyncReturn: Codable, Sendable {
   public var attachments: Double
   public var insights: RaviJSON
   public var messages: Double
-  public var session: [String: RaviJSON]
+  public var session: RaviJSON
 
-  public init(artifacts: [String], attachments: Double, insights: RaviJSON, messages: Double, session: [String: RaviJSON]) {
+  public init(artifacts: [String], attachments: Double, insights: RaviJSON, messages: Double, session: RaviJSON) {
     self.artifacts = artifacts
     self.attachments = attachments
     self.insights = insights
@@ -8680,10 +9352,10 @@ public struct DevinSessionsTerminateOptions: Codable, Sendable {
 
 public struct DevinSessionsTerminateReturn: Codable, Sendable {
   public var archive: Bool
-  public var session: [String: RaviJSON]
+  public var session: RaviJSON
   public var status: String
 
-  public init(archive: Bool, session: [String: RaviJSON], status: String) {
+  public init(archive: Bool, session: RaviJSON, status: String) {
     self.archive = archive
     self.session = session
     self.status = status
@@ -9477,7 +10149,7 @@ public struct ImageAtlasSplitOptions: Codable, Sendable {
 
 public struct ImageAtlasSplitReturn: Codable, Sendable {
   public var artifactId: String
-  public var artifactId: String
+  public var artifact_id: String
   public var crops: [[String: RaviJSON]]
   public var manifestPath: String
   public var outputDir: String
@@ -9485,9 +10157,9 @@ public struct ImageAtlasSplitReturn: Codable, Sendable {
   public var sent: [[String: RaviJSON]]
   public var success: Bool
 
-  public init(artifactId: String, artifactId: String, crops: [[String: RaviJSON]], manifestPath: String, outputDir: String, parentArtifactId: RaviJSON, sent: [[String: RaviJSON]], success: Bool) {
+  public init(artifactId: String, artifact_id: String, crops: [[String: RaviJSON]], manifestPath: String, outputDir: String, parentArtifactId: RaviJSON, sent: [[String: RaviJSON]], success: Bool) {
     self.artifactId = artifactId
-    self.artifactId = artifactId
+    self.artifact_id = artifact_id
     self.crops = crops
     self.manifestPath = manifestPath
     self.outputDir = outputDir
@@ -9498,7 +10170,7 @@ public struct ImageAtlasSplitReturn: Codable, Sendable {
 
   enum CodingKeys: String, CodingKey {
     case artifactId = "artifactId"
-    case artifactId = "artifact_id"
+    case artifact_id = "artifact_id"
     case crops = "crops"
     case manifestPath = "manifestPath"
     case outputDir = "outputDir"
@@ -12079,6 +12751,24 @@ public struct ObserversProfilesValidateReturn: Codable, Sendable {
   }
 }
 
+public struct ObserversRefreshOptions: Codable, Sendable {
+  public var reconcile: String?
+
+  public init(reconcile: String? = nil) {
+    self.reconcile = reconcile
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case reconcile = "reconcile"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.reconcile {
+      body["reconcile"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
 public struct ObserversRefreshReturn: Codable, Sendable {
   public var bindings: [[String: RaviJSON]]
   public var created: [[String: RaviJSON]]
@@ -12224,6 +12914,7 @@ public struct ObserversRulesSetOptions: Codable, Sendable {
   public var provider: String?
   public var role: String?
   public var scope: String?
+  public var selector: String?
   public var sourceAgent: String?
   public var sourceProfile: String?
   public var sourceProject: String?
@@ -12233,7 +12924,7 @@ public struct ObserversRulesSetOptions: Codable, Sendable {
   public var tagInherited: Bool?
   public var tagTarget: String?
 
-  public init(delivery: String? = nil, disabled: Bool? = nil, events: String? = nil, meta: String? = nil, mode: String? = nil, model: String? = nil, permissions: String? = nil, priority: String? = nil, profile: String? = nil, provider: String? = nil, role: String? = nil, scope: String? = nil, sourceAgent: String? = nil, sourceProfile: String? = nil, sourceProject: String? = nil, sourceSession: String? = nil, sourceTask: String? = nil, tag: String? = nil, tagInherited: Bool? = nil, tagTarget: String? = nil) {
+  public init(delivery: String? = nil, disabled: Bool? = nil, events: String? = nil, meta: String? = nil, mode: String? = nil, model: String? = nil, permissions: String? = nil, priority: String? = nil, profile: String? = nil, provider: String? = nil, role: String? = nil, scope: String? = nil, selector: String? = nil, sourceAgent: String? = nil, sourceProfile: String? = nil, sourceProject: String? = nil, sourceSession: String? = nil, sourceTask: String? = nil, tag: String? = nil, tagInherited: Bool? = nil, tagTarget: String? = nil) {
     self.delivery = delivery
     self.disabled = disabled
     self.events = events
@@ -12246,6 +12937,7 @@ public struct ObserversRulesSetOptions: Codable, Sendable {
     self.provider = provider
     self.role = role
     self.scope = scope
+    self.selector = selector
     self.sourceAgent = sourceAgent
     self.sourceProfile = sourceProfile
     self.sourceProject = sourceProject
@@ -12269,6 +12961,7 @@ public struct ObserversRulesSetOptions: Codable, Sendable {
     case provider = "provider"
     case role = "role"
     case scope = "scope"
+    case selector = "selector"
     case sourceAgent = "sourceAgent"
     case sourceProfile = "sourceProfile"
     case sourceProject = "sourceProject"
@@ -12315,6 +13008,9 @@ public struct ObserversRulesSetOptions: Codable, Sendable {
     }
     if let value = self.scope {
       body["scope"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.selector {
+      body["selector"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.sourceAgent {
       body["sourceAgent"] = try RaviJSON.fromEncodable(value)
@@ -15551,6 +16247,366 @@ public struct RuntimeCredentialsStatusReturn: Codable, Sendable {
   }
 }
 
+public struct RuntimePresetsCreateOptions: Codable, Sendable {
+  public var description: String?
+  public var disabled: Bool?
+  public var model: String?
+  public var provider: String?
+
+  public init(description: String? = nil, disabled: Bool? = nil, model: String? = nil, provider: String? = nil) {
+    self.description = description
+    self.disabled = disabled
+    self.model = model
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case description = "description"
+    case disabled = "disabled"
+    case model = "model"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.description {
+      body["description"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.disabled {
+      body["disabled"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.model {
+      body["model"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsCreateReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var dryRun: Bool
+  public var preset: RaviJSON
+
+  public init(action: String, changed: Bool, dryRun: Bool, preset: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.dryRun = dryRun
+    self.preset = preset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case dryRun = "dryRun"
+    case preset = "preset"
+  }
+}
+
+public struct RuntimePresetsDeleteOptions: Codable, Sendable {
+  public var dryRun: Bool?
+
+  public init(dryRun: Bool? = nil) {
+    self.dryRun = dryRun
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case dryRun = "dryRun"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsDeleteReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var dryRun: Bool
+  public var preset: RaviJSON
+
+  public init(action: String, changed: Bool, dryRun: Bool, preset: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.dryRun = dryRun
+    self.preset = preset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case dryRun = "dryRun"
+    case preset = "preset"
+  }
+}
+
+public struct RuntimePresetsDisableOptions: Codable, Sendable {
+  public var dryRun: Bool?
+
+  public init(dryRun: Bool? = nil) {
+    self.dryRun = dryRun
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case dryRun = "dryRun"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsDisableReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var dryRun: Bool
+  public var preset: RaviJSON
+
+  public init(action: String, changed: Bool, dryRun: Bool, preset: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.dryRun = dryRun
+    self.preset = preset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case dryRun = "dryRun"
+    case preset = "preset"
+  }
+}
+
+public struct RuntimePresetsEnableOptions: Codable, Sendable {
+  public var dryRun: Bool?
+
+  public init(dryRun: Bool? = nil) {
+    self.dryRun = dryRun
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case dryRun = "dryRun"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsEnableReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var dryRun: Bool
+  public var preset: RaviJSON
+
+  public init(action: String, changed: Bool, dryRun: Bool, preset: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.dryRun = dryRun
+    self.preset = preset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case dryRun = "dryRun"
+    case preset = "preset"
+  }
+}
+
+public struct RuntimePresetsImpactOptions: Codable, Sendable {
+  public var limit: String?
+  public var offset: String?
+
+  public init(limit: String? = nil, offset: String? = nil) {
+    self.limit = limit
+    self.offset = offset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case limit = "limit"
+    case offset = "offset"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.offset {
+      body["offset"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsImpactReturn: Codable, Sendable {
+  public var agents: [RaviJSON]
+  public var correctionCommand: RaviJSON
+  public var enabled: Bool
+  public var limit: Double
+  public var model: String
+  public var offset: Double
+  public var pagination: RaviJSON
+  public var presetId: String
+  public var provider: String
+  public var referenced: Bool
+  public var referencingAgentsTotal: Double
+  public var shadowingSessionsTotal: Double
+  public var version: Double
+
+  public init(agents: [RaviJSON], correctionCommand: RaviJSON, enabled: Bool, limit: Double, model: String, offset: Double, pagination: RaviJSON, presetId: String, provider: String, referenced: Bool, referencingAgentsTotal: Double, shadowingSessionsTotal: Double, version: Double) {
+    self.agents = agents
+    self.correctionCommand = correctionCommand
+    self.enabled = enabled
+    self.limit = limit
+    self.model = model
+    self.offset = offset
+    self.pagination = pagination
+    self.presetId = presetId
+    self.provider = provider
+    self.referenced = referenced
+    self.referencingAgentsTotal = referencingAgentsTotal
+    self.shadowingSessionsTotal = shadowingSessionsTotal
+    self.version = version
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agents = "agents"
+    case correctionCommand = "correctionCommand"
+    case enabled = "enabled"
+    case limit = "limit"
+    case model = "model"
+    case offset = "offset"
+    case pagination = "pagination"
+    case presetId = "presetId"
+    case provider = "provider"
+    case referenced = "referenced"
+    case referencingAgentsTotal = "referencingAgentsTotal"
+    case shadowingSessionsTotal = "shadowingSessionsTotal"
+    case version = "version"
+  }
+}
+
+public struct RuntimePresetsListOptions: Codable, Sendable {
+  public var disabled: Bool?
+  public var enabled: Bool?
+  public var limit: String?
+  public var offset: String?
+  public var provider: String?
+
+  public init(disabled: Bool? = nil, enabled: Bool? = nil, limit: String? = nil, offset: String? = nil, provider: String? = nil) {
+    self.disabled = disabled
+    self.enabled = enabled
+    self.limit = limit
+    self.offset = offset
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case disabled = "disabled"
+    case enabled = "enabled"
+    case limit = "limit"
+    case offset = "offset"
+    case provider = "provider"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.disabled {
+      body["disabled"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.enabled {
+      body["enabled"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.offset {
+      body["offset"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.provider {
+      body["provider"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsListReturn: Codable, Sendable {
+  public var pagination: RaviJSON
+  public var presets: [RaviJSON]
+  public var total: Double
+
+  public init(pagination: RaviJSON, presets: [RaviJSON], total: Double) {
+    self.pagination = pagination
+    self.presets = presets
+    self.total = total
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case pagination = "pagination"
+    case presets = "presets"
+    case total = "total"
+  }
+}
+
+public struct RuntimePresetsSetOptions: Codable, Sendable {
+  public var dryRun: Bool?
+
+  public init(dryRun: Bool? = nil) {
+    self.dryRun = dryRun
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case dryRun = "dryRun"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct RuntimePresetsSetReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var dryRun: Bool
+  public var preset: RaviJSON
+
+  public init(action: String, changed: Bool, dryRun: Bool, preset: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.dryRun = dryRun
+    self.preset = preset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case dryRun = "dryRun"
+    case preset = "preset"
+  }
+}
+
+public struct RuntimePresetsShowReturn: Codable, Sendable {
+  public var preset: RaviJSON
+  public var referencingAgentsTotal: Double
+
+  public init(preset: RaviJSON, referencingAgentsTotal: Double) {
+    self.preset = preset
+    self.referencingAgentsTotal = referencingAgentsTotal
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case preset = "preset"
+    case referencingAgentsTotal = "referencingAgentsTotal"
+  }
+}
+
 public struct SdkClientCheckOptions: Codable, Sendable {
   public var out: String?
   public var version: String?
@@ -16583,13 +17639,15 @@ public struct SessionsFollowupsUpdateReturn: Codable, Sendable {
 public struct SessionsGoalOptions: Codable, Sendable {
   public var budget: String?
   public var project: String?
+  public var reason: String?
   public var seconds: String?
   public var task: String?
   public var tokens: String?
 
-  public init(budget: String? = nil, project: String? = nil, seconds: String? = nil, task: String? = nil, tokens: String? = nil) {
+  public init(budget: String? = nil, project: String? = nil, reason: String? = nil, seconds: String? = nil, task: String? = nil, tokens: String? = nil) {
     self.budget = budget
     self.project = project
+    self.reason = reason
     self.seconds = seconds
     self.task = task
     self.tokens = tokens
@@ -16598,6 +17656,7 @@ public struct SessionsGoalOptions: Codable, Sendable {
   enum CodingKeys: String, CodingKey {
     case budget = "budget"
     case project = "project"
+    case reason = "reason"
     case seconds = "seconds"
     case task = "task"
     case tokens = "tokens"
@@ -16609,6 +17668,9 @@ public struct SessionsGoalOptions: Codable, Sendable {
     }
     if let value = self.project {
       body["project"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.reason {
+      body["reason"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.seconds {
       body["seconds"] = try RaviJSON.fromEncodable(value)
@@ -16622,7 +17684,26 @@ public struct SessionsGoalOptions: Codable, Sendable {
   }
 }
 
-public typealias SessionsGoalReturn = [String: RaviJSON]
+public struct SessionsGoalReturn: Codable, Sendable {
+  public var action: String
+  public var changed: Bool
+  public var goal: RaviJSON
+  public var session: RaviJSON
+
+  public init(action: String, changed: Bool, goal: RaviJSON, session: RaviJSON) {
+    self.action = action
+    self.changed = changed
+    self.goal = goal
+    self.session = session
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case changed = "changed"
+    case goal = "goal"
+    case session = "session"
+  }
+}
 
 public typealias SessionsInfoReturn = [String: RaviJSON]
 
@@ -16832,7 +17913,7 @@ public struct SessionsReadOptions: Codable, Sendable {
   }
 }
 
-public typealias SessionsReadReturn = [String: RaviJSON]
+public typealias SessionsReadReturn = RaviJSON
 
 public typealias SessionsRenameReturn = [String: RaviJSON]
 
@@ -17261,11 +18342,120 @@ public struct SessionsSendOptions: Codable, Sendable {
   }
 }
 
-public typealias SessionsSendReturn = [String: RaviJSON]
+public struct SessionsSendReturn: Codable, Sendable {
+  public var action: String
+  public var createdSession: Bool
+  public var delivery: [String: RaviJSON]
+  public var mode: String
+  public var promptLength: Int
+  public var published: Bool
+  public var response: RaviJSON?
+  public var session: RaviJSON
+  public var thread: RaviJSON
+
+  public init(action: String, createdSession: Bool, delivery: [String: RaviJSON], mode: String, promptLength: Int, published: Bool, response: RaviJSON? = nil, session: RaviJSON, thread: RaviJSON) {
+    self.action = action
+    self.createdSession = createdSession
+    self.delivery = delivery
+    self.mode = mode
+    self.promptLength = promptLength
+    self.published = published
+    self.response = response
+    self.session = session
+    self.thread = thread
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case createdSession = "createdSession"
+    case delivery = "delivery"
+    case mode = "mode"
+    case promptLength = "promptLength"
+    case published = "published"
+    case response = "response"
+    case session = "session"
+    case thread = "thread"
+  }
+}
 
 public typealias SessionsSetDisplayReturn = [String: RaviJSON]
 
+public struct SessionsSetEffortReturn: Codable, Sendable {
+  public var action: String
+  public var after: RaviJSON
+  public var appliesOn: String
+  public var before: RaviJSON
+  public var changed: Bool
+  public var effectiveEffort: String
+  public var effectiveEffortSource: String
+  public var effortOverride: RaviJSON
+  public var sessionKey: String
+  public var sessionName: RaviJSON
+
+  public init(action: String, after: RaviJSON, appliesOn: String, before: RaviJSON, changed: Bool, effectiveEffort: String, effectiveEffortSource: String, effortOverride: RaviJSON, sessionKey: String, sessionName: RaviJSON) {
+    self.action = action
+    self.after = after
+    self.appliesOn = appliesOn
+    self.before = before
+    self.changed = changed
+    self.effectiveEffort = effectiveEffort
+    self.effectiveEffortSource = effectiveEffortSource
+    self.effortOverride = effortOverride
+    self.sessionKey = sessionKey
+    self.sessionName = sessionName
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case after = "after"
+    case appliesOn = "appliesOn"
+    case before = "before"
+    case changed = "changed"
+    case effectiveEffort = "effectiveEffort"
+    case effectiveEffortSource = "effectiveEffortSource"
+    case effortOverride = "effortOverride"
+    case sessionKey = "sessionKey"
+    case sessionName = "sessionName"
+  }
+}
+
 public typealias SessionsSetModelReturn = [String: RaviJSON]
+
+public struct SessionsSetProviderReturn: Codable, Sendable {
+  public var action: String
+  public var after: RaviJSON
+  public var appliesOn: String
+  public var before: RaviJSON
+  public var changed: Bool
+  public var effectiveProvider: String
+  public var runtimeProviderOverride: RaviJSON
+  public var sessionKey: String
+  public var sessionName: RaviJSON
+
+  public init(action: String, after: RaviJSON, appliesOn: String, before: RaviJSON, changed: Bool, effectiveProvider: String, runtimeProviderOverride: RaviJSON, sessionKey: String, sessionName: RaviJSON) {
+    self.action = action
+    self.after = after
+    self.appliesOn = appliesOn
+    self.before = before
+    self.changed = changed
+    self.effectiveProvider = effectiveProvider
+    self.runtimeProviderOverride = runtimeProviderOverride
+    self.sessionKey = sessionKey
+    self.sessionName = sessionName
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case action = "action"
+    case after = "after"
+    case appliesOn = "appliesOn"
+    case before = "before"
+    case changed = "changed"
+    case effectiveProvider = "effectiveProvider"
+    case runtimeProviderOverride = "runtimeProviderOverride"
+    case sessionKey = "sessionKey"
+    case sessionName = "sessionName"
+  }
+}
 
 public typealias SessionsSetThinkingReturn = [String: RaviJSON]
 
@@ -17711,6 +18901,150 @@ public struct SkillGatesShowReturn: Codable, Sendable {
   }
 }
 
+public struct SkillsGrantOptions: Codable, Sendable {
+  public var note: String?
+
+  public init(note: String? = nil) {
+    self.note = note
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case note = "note"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.note {
+      body["note"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SkillsGrantReturn: Codable, Sendable {
+  public var agentId: String
+  public var grant: RaviJSON?
+  public var skillName: String
+  public var success: Bool
+
+  public init(agentId: String, grant: RaviJSON? = nil, skillName: String, success: Bool) {
+    self.agentId = agentId
+    self.grant = grant
+    self.skillName = skillName
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentId = "agentId"
+    case grant = "grant"
+    case skillName = "skillName"
+    case success = "success"
+  }
+}
+
+public struct SkillsGrantBatchOptions: Codable, Sendable {
+  public var agent: String?
+  public var allAgents: Bool?
+  public var allSkills: Bool?
+  public var dryRun: Bool?
+  public var note: String?
+  public var skill: String?
+
+  public init(agent: String? = nil, allAgents: Bool? = nil, allSkills: Bool? = nil, dryRun: Bool? = nil, note: String? = nil, skill: String? = nil) {
+    self.agent = agent
+    self.allAgents = allAgents
+    self.allSkills = allSkills
+    self.dryRun = dryRun
+    self.note = note
+    self.skill = skill
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agent = "agent"
+    case allAgents = "allAgents"
+    case allSkills = "allSkills"
+    case dryRun = "dryRun"
+    case note = "note"
+    case skill = "skill"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.agent {
+      body["agent"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.allAgents {
+      body["allAgents"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.allSkills {
+      body["allSkills"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.note {
+      body["note"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skill {
+      body["skill"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SkillsGrantBatchReturn: Codable, Sendable {
+  public var agentsTargeted: Double
+  public var dryRun: Bool
+  public var errors: [RaviJSON]
+  public var op: String
+  public var pairsAffected: Double
+  public var pairsSkipped: Double
+  public var sampleAgents: [String]
+  public var sampleSkills: [String]
+  public var skillsTargeted: Double
+
+  public init(agentsTargeted: Double, dryRun: Bool, errors: [RaviJSON], op: String, pairsAffected: Double, pairsSkipped: Double, sampleAgents: [String], sampleSkills: [String], skillsTargeted: Double) {
+    self.agentsTargeted = agentsTargeted
+    self.dryRun = dryRun
+    self.errors = errors
+    self.op = op
+    self.pairsAffected = pairsAffected
+    self.pairsSkipped = pairsSkipped
+    self.sampleAgents = sampleAgents
+    self.sampleSkills = sampleSkills
+    self.skillsTargeted = skillsTargeted
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentsTargeted = "agentsTargeted"
+    case dryRun = "dryRun"
+    case errors = "errors"
+    case op = "op"
+    case pairsAffected = "pairsAffected"
+    case pairsSkipped = "pairsSkipped"
+    case sampleAgents = "sampleAgents"
+    case sampleSkills = "sampleSkills"
+    case skillsTargeted = "skillsTargeted"
+  }
+}
+
+public struct SkillsInspectReturn: Codable, Sendable {
+  public var agentId: String
+  public var allowlist: [String]
+  public var hasConfiguration: Bool
+  public var provenance: RaviJSON
+
+  public init(agentId: String, allowlist: [String], hasConfiguration: Bool, provenance: RaviJSON) {
+    self.agentId = agentId
+    self.allowlist = allowlist
+    self.hasConfiguration = hasConfiguration
+    self.provenance = provenance
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentId = "agentId"
+    case allowlist = "allowlist"
+    case hasConfiguration = "hasConfiguration"
+    case provenance = "provenance"
+  }
+}
+
 public struct SkillsInstallOptions: Codable, Sendable {
   public var all: Bool?
   public var overwrite: Bool?
@@ -17852,6 +19186,105 @@ public struct SkillsListReturn: Codable, Sendable {
   }
 }
 
+public struct SkillsRevokeReturn: Codable, Sendable {
+  public var agentId: String
+  public var grant: RaviJSON?
+  public var skillName: String
+  public var success: Bool
+
+  public init(agentId: String, grant: RaviJSON? = nil, skillName: String, success: Bool) {
+    self.agentId = agentId
+    self.grant = grant
+    self.skillName = skillName
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentId = "agentId"
+    case grant = "grant"
+    case skillName = "skillName"
+    case success = "success"
+  }
+}
+
+public struct SkillsRevokeBatchOptions: Codable, Sendable {
+  public var agent: String?
+  public var allAgents: Bool?
+  public var allSkills: Bool?
+  public var dryRun: Bool?
+  public var skill: String?
+
+  public init(agent: String? = nil, allAgents: Bool? = nil, allSkills: Bool? = nil, dryRun: Bool? = nil, skill: String? = nil) {
+    self.agent = agent
+    self.allAgents = allAgents
+    self.allSkills = allSkills
+    self.dryRun = dryRun
+    self.skill = skill
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agent = "agent"
+    case allAgents = "allAgents"
+    case allSkills = "allSkills"
+    case dryRun = "dryRun"
+    case skill = "skill"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.agent {
+      body["agent"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.allAgents {
+      body["allAgents"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.allSkills {
+      body["allSkills"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.dryRun {
+      body["dryRun"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skill {
+      body["skill"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SkillsRevokeBatchReturn: Codable, Sendable {
+  public var agentsTargeted: Double
+  public var dryRun: Bool
+  public var errors: [RaviJSON]
+  public var op: String
+  public var pairsAffected: Double
+  public var pairsSkipped: Double
+  public var sampleAgents: [String]
+  public var sampleSkills: [String]
+  public var skillsTargeted: Double
+
+  public init(agentsTargeted: Double, dryRun: Bool, errors: [RaviJSON], op: String, pairsAffected: Double, pairsSkipped: Double, sampleAgents: [String], sampleSkills: [String], skillsTargeted: Double) {
+    self.agentsTargeted = agentsTargeted
+    self.dryRun = dryRun
+    self.errors = errors
+    self.op = op
+    self.pairsAffected = pairsAffected
+    self.pairsSkipped = pairsSkipped
+    self.sampleAgents = sampleAgents
+    self.sampleSkills = sampleSkills
+    self.skillsTargeted = skillsTargeted
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentsTargeted = "agentsTargeted"
+    case dryRun = "dryRun"
+    case errors = "errors"
+    case op = "op"
+    case pairsAffected = "pairsAffected"
+    case pairsSkipped = "pairsSkipped"
+    case sampleAgents = "sampleAgents"
+    case sampleSkills = "sampleSkills"
+    case skillsTargeted = "skillsTargeted"
+  }
+}
+
 public struct SkillsShowOptions: Codable, Sendable {
   public var installed: Bool?
   public var source: String?
@@ -17903,6 +19336,2313 @@ public struct SkillsSyncReturn: Codable, Sendable {
     case codexSynced = "codexSynced"
     case success = "success"
     case total = "total"
+  }
+}
+
+public struct SkillsWhoOptions: Codable, Sendable {
+  public var agent: String?
+
+  public init(agent: String? = nil) {
+    self.agent = agent
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agent = "agent"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.agent {
+      body["agent"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SkillsWhoReturn: Codable, Sendable {
+  public var grants: [RaviJSON]
+  public var skillName: String?
+  public var total: Double
+
+  public init(grants: [RaviJSON], skillName: String? = nil, total: Double) {
+    self.grants = grants
+    self.skillName = skillName
+    self.total = total
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case grants = "grants"
+    case skillName = "skillName"
+    case total = "total"
+  }
+}
+
+public struct SlackBlocksSendOptions: Codable, Sendable {
+  public var connection: String?
+  public var ephemeralUser: String?
+  public var execute: Bool?
+  public var text: String?
+  public var threadTs: String?
+
+  public init(connection: String? = nil, ephemeralUser: String? = nil, execute: Bool? = nil, text: String? = nil, threadTs: String? = nil) {
+    self.connection = connection
+    self.ephemeralUser = ephemeralUser
+    self.execute = execute
+    self.text = text
+    self.threadTs = threadTs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case ephemeralUser = "ephemeralUser"
+    case execute = "execute"
+    case text = "text"
+    case threadTs = "threadTs"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.ephemeralUser {
+      body["ephemeralUser"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.text {
+      body["text"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.threadTs {
+      body["threadTs"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackBlocksSendReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackBlocksShowcaseOptions: Codable, Sendable {
+  public var execute: Bool?
+  public var threadTs: String?
+
+  public init(execute: Bool? = nil, threadTs: String? = nil) {
+    self.execute = execute
+    self.threadTs = threadTs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case execute = "execute"
+    case threadTs = "threadTs"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.threadTs {
+      body["threadTs"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackBlocksShowcaseReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackBlocksUpdateOptions: Codable, Sendable {
+  public var execute: Bool?
+  public var text: String?
+
+  public init(execute: Bool? = nil, text: String? = nil) {
+    self.execute = execute
+    self.text = text
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case execute = "execute"
+    case text = "text"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.text {
+      body["text"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackBlocksUpdateReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackBlocksValidateOptions: Codable, Sendable {
+  public var channel: String?
+  public var target: String?
+
+  public init(channel: String? = nil, target: String? = nil) {
+    self.channel = channel
+    self.target = target
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case target = "target"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.target {
+      body["target"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackBlocksValidateReturn: Codable, Sendable {
+  public var connection: String
+  public var item: RaviJSON?
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, item: RaviJSON? = nil, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.item = item
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case item = "item"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasAccessDeleteOptions: Codable, Sendable {
+  public var channel: String?
+  public var channels: String?
+  public var execute: Bool?
+  public var users: String?
+
+  public init(channel: String? = nil, channels: String? = nil, execute: Bool? = nil, users: String? = nil) {
+    self.channel = channel
+    self.channels = channels
+    self.execute = execute
+    self.users = users
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case channels = "channels"
+    case execute = "execute"
+    case users = "users"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.channels {
+      body["channels"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.users {
+      body["users"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasAccessDeleteReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasAccessSetOptions: Codable, Sendable {
+  public var channel: String?
+  public var channels: String?
+  public var execute: Bool?
+  public var users: String?
+
+  public init(channel: String? = nil, channels: String? = nil, execute: Bool? = nil, users: String? = nil) {
+    self.channel = channel
+    self.channels = channels
+    self.execute = execute
+    self.users = users
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case channels = "channels"
+    case execute = "execute"
+    case users = "users"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.channels {
+      body["channels"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.users {
+      body["users"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasAccessSetReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasArtifactPublishOptions: Codable, Sendable {
+  public var canvas: String?
+  public var channel: String?
+  public var execute: Bool?
+  public var skipRefresh: Bool?
+  public var slackChannel: String?
+  public var title: String?
+
+  public init(canvas: String? = nil, channel: String? = nil, execute: Bool? = nil, skipRefresh: Bool? = nil, slackChannel: String? = nil, title: String? = nil) {
+    self.canvas = canvas
+    self.channel = channel
+    self.execute = execute
+    self.skipRefresh = skipRefresh
+    self.slackChannel = slackChannel
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case canvas = "canvas"
+    case channel = "channel"
+    case execute = "execute"
+    case skipRefresh = "skipRefresh"
+    case slackChannel = "slackChannel"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.canvas {
+      body["canvas"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skipRefresh {
+      body["skipRefresh"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.slackChannel {
+      body["slackChannel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasArtifactPublishReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasArtifactStatusReturn: Codable, Sendable {
+  public var item: [String: RaviJSON]
+  public var ok: Bool
+  public var provider: String
+
+  public init(item: [String: RaviJSON], ok: Bool, provider: String) {
+    self.item = item
+    self.ok = ok
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case item = "item"
+    case ok = "ok"
+    case provider = "provider"
+  }
+}
+
+public struct SlackCanvasChannelCreateOptions: Codable, Sendable {
+  public var artifact: String?
+  public var ensure: Bool?
+  public var execute: Bool?
+  public var markdown: String?
+  public var markdownFile: String?
+  public var skipRefresh: Bool?
+  public var title: String?
+
+  public init(artifact: String? = nil, ensure: Bool? = nil, execute: Bool? = nil, markdown: String? = nil, markdownFile: String? = nil, skipRefresh: Bool? = nil, title: String? = nil) {
+    self.artifact = artifact
+    self.ensure = ensure
+    self.execute = execute
+    self.markdown = markdown
+    self.markdownFile = markdownFile
+    self.skipRefresh = skipRefresh
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case artifact = "artifact"
+    case ensure = "ensure"
+    case execute = "execute"
+    case markdown = "markdown"
+    case markdownFile = "markdownFile"
+    case skipRefresh = "skipRefresh"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.artifact {
+      body["artifact"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.ensure {
+      body["ensure"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdown {
+      body["markdown"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdownFile {
+      body["markdownFile"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skipRefresh {
+      body["skipRefresh"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasChannelCreateReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasChannelShowcaseOptions: Codable, Sendable {
+  public var execute: Bool?
+  public var title: String?
+
+  public init(execute: Bool? = nil, title: String? = nil) {
+    self.execute = execute
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case execute = "execute"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasChannelShowcaseReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasCreateOptions: Codable, Sendable {
+  public var artifact: String?
+  public var channel: String?
+  public var execute: Bool?
+  public var markdown: String?
+  public var markdownFile: String?
+  public var skipRefresh: Bool?
+  public var slackChannel: String?
+  public var title: String?
+
+  public init(artifact: String? = nil, channel: String? = nil, execute: Bool? = nil, markdown: String? = nil, markdownFile: String? = nil, skipRefresh: Bool? = nil, slackChannel: String? = nil, title: String? = nil) {
+    self.artifact = artifact
+    self.channel = channel
+    self.execute = execute
+    self.markdown = markdown
+    self.markdownFile = markdownFile
+    self.skipRefresh = skipRefresh
+    self.slackChannel = slackChannel
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case artifact = "artifact"
+    case channel = "channel"
+    case execute = "execute"
+    case markdown = "markdown"
+    case markdownFile = "markdownFile"
+    case skipRefresh = "skipRefresh"
+    case slackChannel = "slackChannel"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.artifact {
+      body["artifact"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdown {
+      body["markdown"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdownFile {
+      body["markdownFile"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skipRefresh {
+      body["skipRefresh"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.slackChannel {
+      body["slackChannel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasCreateReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasDeleteOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+
+  public init(channel: String? = nil, execute: Bool? = nil) {
+    self.channel = channel
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasDeleteReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasEditOptions: Codable, Sendable {
+  public var artifact: String?
+  public var channel: String?
+  public var execute: Bool?
+  public var markdown: String?
+  public var markdownFile: String?
+  public var sectionId: String?
+  public var skipRefresh: Bool?
+  public var title: String?
+
+  public init(artifact: String? = nil, channel: String? = nil, execute: Bool? = nil, markdown: String? = nil, markdownFile: String? = nil, sectionId: String? = nil, skipRefresh: Bool? = nil, title: String? = nil) {
+    self.artifact = artifact
+    self.channel = channel
+    self.execute = execute
+    self.markdown = markdown
+    self.markdownFile = markdownFile
+    self.sectionId = sectionId
+    self.skipRefresh = skipRefresh
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case artifact = "artifact"
+    case channel = "channel"
+    case execute = "execute"
+    case markdown = "markdown"
+    case markdownFile = "markdownFile"
+    case sectionId = "sectionId"
+    case skipRefresh = "skipRefresh"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.artifact {
+      body["artifact"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdown {
+      body["markdown"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.markdownFile {
+      body["markdownFile"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.sectionId {
+      body["sectionId"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.skipRefresh {
+      body["skipRefresh"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasEditReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasSectionsLookupOptions: Codable, Sendable {
+  public var channel: String?
+  public var containsText: String?
+  public var sectionTypes: String?
+
+  public init(channel: String? = nil, containsText: String? = nil, sectionTypes: String? = nil) {
+    self.channel = channel
+    self.containsText = containsText
+    self.sectionTypes = sectionTypes
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case containsText = "containsText"
+    case sectionTypes = "sectionTypes"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.containsText {
+      body["containsText"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.sectionTypes {
+      body["sectionTypes"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasSectionsLookupReturn: Codable, Sendable {
+  public var connection: String
+  public var items: [RaviJSON]
+  public var ok: Bool
+  public var pagination: RaviJSON
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, items: [RaviJSON], ok: Bool, pagination: RaviJSON, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.items = items
+    self.ok = ok
+    self.pagination = pagination
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case items = "items"
+    case ok = "ok"
+    case pagination = "pagination"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackCanvasShowcaseOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+  public var slackChannel: String?
+  public var title: String?
+
+  public init(channel: String? = nil, execute: Bool? = nil, slackChannel: String? = nil, title: String? = nil) {
+    self.channel = channel
+    self.execute = execute
+    self.slackChannel = slackChannel
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+    case slackChannel = "slackChannel"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.slackChannel {
+      body["slackChannel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackCanvasShowcaseReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsCreateOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+  public var private_: Bool?
+
+  public init(channel: String? = nil, execute: Bool? = nil, private_: Bool? = nil) {
+    self.channel = channel
+    self.execute = execute
+    self.private_ = private_
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+    case private_ = "private"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.private_ {
+      body["private"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackChannelsCreateReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsHistoryOptions: Codable, Sendable {
+  public var cursor: String?
+  public var inclusive: Bool?
+  public var latest: String?
+  public var limit: String?
+  public var oldest: String?
+
+  public init(cursor: String? = nil, inclusive: Bool? = nil, latest: String? = nil, limit: String? = nil, oldest: String? = nil) {
+    self.cursor = cursor
+    self.inclusive = inclusive
+    self.latest = latest
+    self.limit = limit
+    self.oldest = oldest
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case cursor = "cursor"
+    case inclusive = "inclusive"
+    case latest = "latest"
+    case limit = "limit"
+    case oldest = "oldest"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.cursor {
+      body["cursor"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.inclusive {
+      body["inclusive"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.latest {
+      body["latest"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.oldest {
+      body["oldest"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackChannelsHistoryReturn: Codable, Sendable {
+  public var connection: String
+  public var items: [RaviJSON]
+  public var ok: Bool
+  public var pagination: RaviJSON
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, items: [RaviJSON], ok: Bool, pagination: RaviJSON, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.items = items
+    self.ok = ok
+    self.pagination = pagination
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case items = "items"
+    case ok = "ok"
+    case pagination = "pagination"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsInfoReturn: Codable, Sendable {
+  public var connection: String
+  public var item: RaviJSON?
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, item: RaviJSON? = nil, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.item = item
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case item = "item"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsInviteOptions: Codable, Sendable {
+  public var connection: String?
+  public var execute: Bool?
+
+  public init(connection: String? = nil, execute: Bool? = nil) {
+    self.connection = connection
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackChannelsInviteReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsListOptions: Codable, Sendable {
+  public var channel: String?
+  public var cursor: String?
+  public var includeArchived: Bool?
+  public var limit: String?
+  public var types: String?
+
+  public init(channel: String? = nil, cursor: String? = nil, includeArchived: Bool? = nil, limit: String? = nil, types: String? = nil) {
+    self.channel = channel
+    self.cursor = cursor
+    self.includeArchived = includeArchived
+    self.limit = limit
+    self.types = types
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case cursor = "cursor"
+    case includeArchived = "includeArchived"
+    case limit = "limit"
+    case types = "types"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.cursor {
+      body["cursor"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.includeArchived {
+      body["includeArchived"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.types {
+      body["types"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackChannelsListReturn: Codable, Sendable {
+  public var connection: String
+  public var items: [RaviJSON]
+  public var ok: Bool
+  public var pagination: RaviJSON
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, items: [RaviJSON], ok: Bool, pagination: RaviJSON, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.items = items
+    self.ok = ok
+    self.pagination = pagination
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case items = "items"
+    case ok = "ok"
+    case pagination = "pagination"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackChannelsRenameOptions: Codable, Sendable {
+  public var execute: Bool?
+
+  public init(execute: Bool? = nil) {
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackChannelsRenameReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackFilesListOptions: Codable, Sendable {
+  public var channel: String?
+  public var cursor: String?
+  public var limit: String?
+  public var slackChannel: String?
+  public var user: String?
+
+  public init(channel: String? = nil, cursor: String? = nil, limit: String? = nil, slackChannel: String? = nil, user: String? = nil) {
+    self.channel = channel
+    self.cursor = cursor
+    self.limit = limit
+    self.slackChannel = slackChannel
+    self.user = user
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case cursor = "cursor"
+    case limit = "limit"
+    case slackChannel = "slackChannel"
+    case user = "user"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.cursor {
+      body["cursor"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.slackChannel {
+      body["slackChannel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.user {
+      body["user"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackFilesListReturn: Codable, Sendable {
+  public var connection: String
+  public var items: [RaviJSON]
+  public var ok: Bool
+  public var pagination: RaviJSON
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, items: [RaviJSON], ok: Bool, pagination: RaviJSON, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.items = items
+    self.ok = ok
+    self.pagination = pagination
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case items = "items"
+    case ok = "ok"
+    case pagination = "pagination"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackInteractionsRespondOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+
+  public init(channel: String? = nil, execute: Bool? = nil) {
+    self.channel = channel
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackInteractionsRespondReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackMembersListOptions: Codable, Sendable {
+  public var cursor: String?
+  public var limit: String?
+
+  public init(cursor: String? = nil, limit: String? = nil) {
+    self.cursor = cursor
+    self.limit = limit
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case cursor = "cursor"
+    case limit = "limit"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.cursor {
+      body["cursor"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackMembersListReturn: Codable, Sendable {
+  public var connection: String
+  public var items: [RaviJSON]
+  public var ok: Bool
+  public var pagination: RaviJSON
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, items: [RaviJSON], ok: Bool, pagination: RaviJSON, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.items = items
+    self.ok = ok
+    self.pagination = pagination
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case items = "items"
+    case ok = "ok"
+    case pagination = "pagination"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackMessagesInspectReturn: Codable, Sendable {
+  public var connection: String
+  public var item: RaviJSON?
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, item: RaviJSON? = nil, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.item = item
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case item = "item"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackMessagesReplayOptions: Codable, Sendable {
+  public var execute: Bool?
+  public var force: Bool?
+
+  public init(execute: Bool? = nil, force: Bool? = nil) {
+    self.execute = execute
+    self.force = force
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case execute = "execute"
+    case force = "force"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.force {
+      body["force"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackMessagesReplayReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackMessagesSendOptions: Codable, Sendable {
+  public var ephemeralUser: String?
+  public var execute: Bool?
+  public var threadTs: String?
+
+  public init(ephemeralUser: String? = nil, execute: Bool? = nil, threadTs: String? = nil) {
+    self.ephemeralUser = ephemeralUser
+    self.execute = execute
+    self.threadTs = threadTs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case ephemeralUser = "ephemeralUser"
+    case execute = "execute"
+    case threadTs = "threadTs"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.ephemeralUser {
+      body["ephemeralUser"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.threadTs {
+      body["threadTs"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackMessagesSendReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackModalsOpenOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+
+  public init(channel: String? = nil, execute: Bool? = nil) {
+    self.channel = channel
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackModalsOpenReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackModalsPushOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+
+  public init(channel: String? = nil, execute: Bool? = nil) {
+    self.channel = channel
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackModalsPushReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackModalsUpdateOptions: Codable, Sendable {
+  public var channel: String?
+  public var execute: Bool?
+  public var externalId: Bool?
+  public var hash: String?
+
+  public init(channel: String? = nil, execute: Bool? = nil, externalId: Bool? = nil, hash: String? = nil) {
+    self.channel = channel
+    self.execute = execute
+    self.externalId = externalId
+    self.hash = hash
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case execute = "execute"
+    case externalId = "externalId"
+    case hash = "hash"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.externalId {
+      body["externalId"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.hash {
+      body["hash"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackModalsUpdateReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackPermissionsListOptions: Codable, Sendable {
+  public var channel: String?
+
+  public init(channel: String? = nil) {
+    self.channel = channel
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackPermissionsListReturn: Codable, Sendable {
+  public var connection: String
+  public var item: RaviJSON?
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var source: String
+
+  public init(connection: String, item: RaviJSON? = nil, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, source: String) {
+    self.connection = connection
+    self.item = item
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case item = "item"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case source = "source"
+  }
+}
+
+public struct SlackTopologyOptions: Codable, Sendable {
+  public var channel: String?
+  public var cursor: String?
+  public var includeArchived: Bool?
+  public var limit: String?
+  public var types: String?
+
+  public init(channel: String? = nil, cursor: String? = nil, includeArchived: Bool? = nil, limit: String? = nil, types: String? = nil) {
+    self.channel = channel
+    self.cursor = cursor
+    self.includeArchived = includeArchived
+    self.limit = limit
+    self.types = types
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case cursor = "cursor"
+    case includeArchived = "includeArchived"
+    case limit = "limit"
+    case types = "types"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.cursor {
+      body["cursor"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.includeArchived {
+      body["includeArchived"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.types {
+      body["types"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackTopologyReturn: Codable, Sendable {
+  public var accountId: String
+  public var capabilities: [String: RaviJSON]
+  public var channels: [RaviJSON]
+  public var connection: String
+  public var ok: Bool
+  public var provider: String
+  public var source: String
+  public var ungroupedChannelIds: [String]
+
+  public init(accountId: String, capabilities: [String: RaviJSON], channels: [RaviJSON], connection: String, ok: Bool, provider: String, source: String, ungroupedChannelIds: [String]) {
+    self.accountId = accountId
+    self.capabilities = capabilities
+    self.channels = channels
+    self.connection = connection
+    self.ok = ok
+    self.provider = provider
+    self.source = source
+    self.ungroupedChannelIds = ungroupedChannelIds
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case accountId = "accountId"
+    case capabilities = "capabilities"
+    case channels = "channels"
+    case connection = "connection"
+    case ok = "ok"
+    case provider = "provider"
+    case source = "source"
+    case ungroupedChannelIds = "ungroupedChannelIds"
+  }
+}
+
+public struct SlackWorkObjectsPresentDetailsOptions: Codable, Sendable {
+  public var channel: String?
+  public var connection: String?
+  public var execute: Bool?
+
+  public init(channel: String? = nil, connection: String? = nil, execute: Bool? = nil) {
+    self.channel = channel
+    self.connection = connection
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case connection = "connection"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.channel {
+      body["channel"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackWorkObjectsPresentDetailsReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackWorkObjectsSendOptions: Codable, Sendable {
+  public var connection: String?
+  public var execute: Bool?
+  public var text: String?
+  public var threadTs: String?
+
+  public init(connection: String? = nil, execute: Bool? = nil, text: String? = nil, threadTs: String? = nil) {
+    self.connection = connection
+    self.execute = execute
+    self.text = text
+    self.threadTs = threadTs
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case execute = "execute"
+    case text = "text"
+    case threadTs = "threadTs"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.text {
+      body["text"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.threadTs {
+      body["threadTs"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackWorkObjectsSendReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackWorkObjectsUnfurlOptions: Codable, Sendable {
+  public var connection: String?
+  public var execute: Bool?
+
+  public init(connection: String? = nil, execute: Bool? = nil) {
+    self.connection = connection
+    self.execute = execute
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case execute = "execute"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.execute {
+      body["execute"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackWorkObjectsUnfurlReturn: Codable, Sendable {
+  public var connection: String
+  public var dryRun: Bool
+  public var item: RaviJSON?
+  public var method: String
+  public var ok: Bool
+  public var provider: String
+  public var raw: [String: RaviJSON]?
+  public var request: [String: RaviJSON]
+  public var source: String
+
+  public init(connection: String, dryRun: Bool, item: RaviJSON? = nil, method: String, ok: Bool, provider: String, raw: [String: RaviJSON]? = nil, request: [String: RaviJSON], source: String) {
+    self.connection = connection
+    self.dryRun = dryRun
+    self.item = item
+    self.method = method
+    self.ok = ok
+    self.provider = provider
+    self.raw = raw
+    self.request = request
+    self.source = source
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case dryRun = "dryRun"
+    case item = "item"
+    case method = "method"
+    case ok = "ok"
+    case provider = "provider"
+    case raw = "raw"
+    case request = "request"
+    case source = "source"
+  }
+}
+
+public struct SlackWorkObjectsValidateOptions: Codable, Sendable {
+  public var target: String?
+
+  public init(target: String? = nil) {
+    self.target = target
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case target = "target"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.target {
+      body["target"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SlackWorkObjectsValidateReturn: Codable, Sendable {
+  public var dryRun: Bool?
+  public var item: RaviJSON?
+  public var ok: Bool
+  public var outputFile: String?
+  public var provider: String
+
+  public init(dryRun: Bool? = nil, item: RaviJSON? = nil, ok: Bool, outputFile: String? = nil, provider: String) {
+    self.dryRun = dryRun
+    self.item = item
+    self.ok = ok
+    self.outputFile = outputFile
+    self.provider = provider
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case dryRun = "dryRun"
+    case item = "item"
+    case ok = "ok"
+    case outputFile = "outputFile"
+    case provider = "provider"
   }
 }
 
@@ -21457,20 +25197,30 @@ public struct TriggersAddOptions: Codable, Sendable {
   public var account: String?
   public var agent: String?
   public var cooldown: String?
+  public var envFile: String?
+  public var exec: String?
   public var filter: String?
   public var message: String?
+  public var onError: String?
   public var replySession: String?
   public var session: String?
+  public var shell: String?
+  public var timeout: String?
   public var topic: String?
 
-  public init(account: String? = nil, agent: String? = nil, cooldown: String? = nil, filter: String? = nil, message: String? = nil, replySession: String? = nil, session: String? = nil, topic: String? = nil) {
+  public init(account: String? = nil, agent: String? = nil, cooldown: String? = nil, envFile: String? = nil, exec: String? = nil, filter: String? = nil, message: String? = nil, onError: String? = nil, replySession: String? = nil, session: String? = nil, shell: String? = nil, timeout: String? = nil, topic: String? = nil) {
     self.account = account
     self.agent = agent
     self.cooldown = cooldown
+    self.envFile = envFile
+    self.exec = exec
     self.filter = filter
     self.message = message
+    self.onError = onError
     self.replySession = replySession
     self.session = session
+    self.shell = shell
+    self.timeout = timeout
     self.topic = topic
   }
 
@@ -21478,10 +25228,15 @@ public struct TriggersAddOptions: Codable, Sendable {
     case account = "account"
     case agent = "agent"
     case cooldown = "cooldown"
+    case envFile = "envFile"
+    case exec = "exec"
     case filter = "filter"
     case message = "message"
+    case onError = "onError"
     case replySession = "replySession"
     case session = "session"
+    case shell = "shell"
+    case timeout = "timeout"
     case topic = "topic"
   }
 
@@ -21495,17 +25250,32 @@ public struct TriggersAddOptions: Codable, Sendable {
     if let value = self.cooldown {
       body["cooldown"] = try RaviJSON.fromEncodable(value)
     }
+    if let value = self.envFile {
+      body["envFile"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.exec {
+      body["exec"] = try RaviJSON.fromEncodable(value)
+    }
     if let value = self.filter {
       body["filter"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.message {
       body["message"] = try RaviJSON.fromEncodable(value)
     }
+    if let value = self.onError {
+      body["onError"] = try RaviJSON.fromEncodable(value)
+    }
     if let value = self.replySession {
       body["replySession"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.session {
       body["session"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.shell {
+      body["shell"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.timeout {
+      body["timeout"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.topic {
       body["topic"] = try RaviJSON.fromEncodable(value)
@@ -22924,3 +26694,1248 @@ public struct WorkflowsSpecsListReturn: Codable, Sendable {
 }
 
 public typealias WorkflowsSpecsShowReturn = [String: RaviJSON]
+
+public struct YtAnalyticsCountriesOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+  public var limit: String?
+
+  public init(connection: String? = nil, days: String? = nil, limit: String? = nil) {
+    self.connection = connection
+    self.days = days
+    self.limit = limit
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+    case limit = "limit"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsCountriesReturn: Codable, Sendable {
+  public var countries: [RaviJSON]
+  public var period: String
+  public var success: Bool
+
+  public init(countries: [RaviJSON], period: String, success: Bool) {
+    self.countries = countries
+    self.period = period
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case countries = "countries"
+    case period = "period"
+    case success = "success"
+  }
+}
+
+public struct YtAnalyticsDemographicsOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+
+  public init(connection: String? = nil, days: String? = nil) {
+    self.connection = connection
+    self.days = days
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsDemographicsReturn: Codable, Sendable {
+  public var demographics: [RaviJSON]
+  public var period: String
+  public var success: Bool
+
+  public init(demographics: [RaviJSON], period: String, success: Bool) {
+    self.demographics = demographics
+    self.period = period
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case demographics = "demographics"
+    case period = "period"
+    case success = "success"
+  }
+}
+
+public struct YtAnalyticsDevicesOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+
+  public init(connection: String? = nil, days: String? = nil) {
+    self.connection = connection
+    self.days = days
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsDevicesReturn: Codable, Sendable {
+  public var devices: [RaviJSON]
+  public var period: String
+  public var success: Bool
+
+  public init(devices: [RaviJSON], period: String, success: Bool) {
+    self.devices = devices
+    self.period = period
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case devices = "devices"
+    case period = "period"
+    case success = "success"
+  }
+}
+
+public struct YtAnalyticsOverviewOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+
+  public init(connection: String? = nil, days: String? = nil) {
+    self.connection = connection
+    self.days = days
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsOverviewReturn: Codable, Sendable {
+  public var overview: RaviJSON
+  public var period: String
+  public var success: Bool
+
+  public init(overview: RaviJSON, period: String, success: Bool) {
+    self.overview = overview
+    self.period = period
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case overview = "overview"
+    case period = "period"
+    case success = "success"
+  }
+}
+
+public struct YtAnalyticsSeriesOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+  public var metric: String?
+
+  public init(connection: String? = nil, days: String? = nil, metric: String? = nil) {
+    self.connection = connection
+    self.days = days
+    self.metric = metric
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+    case metric = "metric"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.metric {
+      body["metric"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsSeriesReturn: Codable, Sendable {
+  public var data: [[String: RaviJSON]]
+  public var metric: String
+  public var period: String
+  public var success: Bool
+
+  public init(data: [[String: RaviJSON]], metric: String, period: String, success: Bool) {
+    self.data = data
+    self.metric = metric
+    self.period = period
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case data = "data"
+    case metric = "metric"
+    case period = "period"
+    case success = "success"
+  }
+}
+
+public struct YtAnalyticsTopOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+  public var limit: String?
+
+  public init(connection: String? = nil, days: String? = nil, limit: String? = nil) {
+    self.connection = connection
+    self.days = days
+    self.limit = limit
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+    case limit = "limit"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsTopReturn: Codable, Sendable {
+  public var period: String
+  public var success: Bool
+  public var videos: [RaviJSON]
+
+  public init(period: String, success: Bool, videos: [RaviJSON]) {
+    self.period = period
+    self.success = success
+    self.videos = videos
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case period = "period"
+    case success = "success"
+    case videos = "videos"
+  }
+}
+
+public struct YtAnalyticsTrafficOptions: Codable, Sendable {
+  public var connection: String?
+  public var days: String?
+
+  public init(connection: String? = nil, days: String? = nil) {
+    self.connection = connection
+    self.days = days
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case days = "days"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.days {
+      body["days"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtAnalyticsTrafficReturn: Codable, Sendable {
+  public var period: String
+  public var sources: [RaviJSON]
+  public var success: Bool
+
+  public init(period: String, sources: [RaviJSON], success: Bool) {
+    self.period = period
+    self.sources = sources
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case period = "period"
+    case sources = "sources"
+    case success = "success"
+  }
+}
+
+public struct YtCaptionDownloadOptions: Codable, Sendable {
+  public var connection: String?
+  public var format: String?
+  public var language: String?
+
+  public init(connection: String? = nil, format: String? = nil, language: String? = nil) {
+    self.connection = connection
+    self.format = format
+    self.language = language
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case format = "format"
+    case language = "language"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.format {
+      body["format"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.language {
+      body["language"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtCaptionDownloadReturn: Codable, Sendable {
+  public var captionId: String
+  public var content: String
+  public var format: String
+  public var success: Bool
+
+  public init(captionId: String, content: String, format: String, success: Bool) {
+    self.captionId = captionId
+    self.content = content
+    self.format = format
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case captionId = "captionId"
+    case content = "content"
+    case format = "format"
+    case success = "success"
+  }
+}
+
+public struct YtCaptionsOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtCaptionsReturn: Codable, Sendable {
+  public var captions: [RaviJSON]
+  public var success: Bool
+  public var totalResults: Double
+  public var videoId: String
+
+  public init(captions: [RaviJSON], success: Bool, totalResults: Double, videoId: String) {
+    self.captions = captions
+    self.success = success
+    self.totalResults = totalResults
+    self.videoId = videoId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case captions = "captions"
+    case success = "success"
+    case totalResults = "totalResults"
+    case videoId = "videoId"
+  }
+}
+
+public struct YtCommentsOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtCommentsReturn: Codable, Sendable {
+  public var comments: [RaviJSON]
+  public var nextPageToken: String?
+  public var success: Bool
+  public var totalResults: Double
+  public var videoId: String
+
+  public init(comments: [RaviJSON], nextPageToken: String? = nil, success: Bool, totalResults: Double, videoId: String) {
+    self.comments = comments
+    self.nextPageToken = nextPageToken
+    self.success = success
+    self.totalResults = totalResults
+    self.videoId = videoId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case comments = "comments"
+    case nextPageToken = "nextPageToken"
+    case success = "success"
+    case totalResults = "totalResults"
+    case videoId = "videoId"
+  }
+}
+
+public struct YtHealthOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtHealthReturn: Codable, Sendable {
+  public var app: String
+  public var authenticated: Bool
+  public var connection: String
+  public var credentialConfigured: Bool
+  public var credentialStatus: String
+  public var externalCheckPerformed: Bool
+  public var message: String
+  public var ready: Bool
+  public var success: Bool
+
+  public init(app: String, authenticated: Bool, connection: String, credentialConfigured: Bool, credentialStatus: String, externalCheckPerformed: Bool, message: String, ready: Bool, success: Bool) {
+    self.app = app
+    self.authenticated = authenticated
+    self.connection = connection
+    self.credentialConfigured = credentialConfigured
+    self.credentialStatus = credentialStatus
+    self.externalCheckPerformed = externalCheckPerformed
+    self.message = message
+    self.ready = ready
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case app = "app"
+    case authenticated = "authenticated"
+    case connection = "connection"
+    case credentialConfigured = "credentialConfigured"
+    case credentialStatus = "credentialStatus"
+    case externalCheckPerformed = "externalCheckPerformed"
+    case message = "message"
+    case ready = "ready"
+    case success = "success"
+  }
+}
+
+public struct YtInfoOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtInfoReturn: Codable, Sendable {
+  public var channel: RaviJSON
+  public var success: Bool
+
+  public init(channel: RaviJSON, success: Bool) {
+    self.channel = channel
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case channel = "channel"
+    case success = "success"
+  }
+}
+
+public struct YtPlaylistOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistReturn: Codable, Sendable {
+  public var nextPageToken: String?
+  public var playlistId: String
+  public var success: Bool
+  public var totalResults: Double
+  public var videos: [RaviJSON]
+
+  public init(nextPageToken: String? = nil, playlistId: String, success: Bool, totalResults: Double, videos: [RaviJSON]) {
+    self.nextPageToken = nextPageToken
+    self.playlistId = playlistId
+    self.success = success
+    self.totalResults = totalResults
+    self.videos = videos
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case nextPageToken = "nextPageToken"
+    case playlistId = "playlistId"
+    case success = "success"
+    case totalResults = "totalResults"
+    case videos = "videos"
+  }
+}
+
+public struct YtPlaylistAddOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistAddReturn: Codable, Sendable {
+  public var item: RaviJSON
+  public var success: Bool
+
+  public init(item: RaviJSON, success: Bool) {
+    self.item = item
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case item = "item"
+    case success = "success"
+  }
+}
+
+public struct YtPlaylistCreateOptions: Codable, Sendable {
+  public var connection: String?
+  public var description: String?
+  public var privacy: String?
+
+  public init(connection: String? = nil, description: String? = nil, privacy: String? = nil) {
+    self.connection = connection
+    self.description = description
+    self.privacy = privacy
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case description = "description"
+    case privacy = "privacy"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.description {
+      body["description"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.privacy {
+      body["privacy"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistCreateReturn: Codable, Sendable {
+  public var playlist: RaviJSON
+  public var success: Bool
+
+  public init(playlist: RaviJSON, success: Bool) {
+    self.playlist = playlist
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case playlist = "playlist"
+    case success = "success"
+  }
+}
+
+public struct YtPlaylistDeleteOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistDeleteReturn: Codable, Sendable {
+  public var deleted: String
+  public var success: Bool
+
+  public init(deleted: String, success: Bool) {
+    self.deleted = deleted
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case deleted = "deleted"
+    case success = "success"
+  }
+}
+
+public struct YtPlaylistRemoveOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistRemoveReturn: Codable, Sendable {
+  public var removed: String
+  public var success: Bool
+
+  public init(removed: String, success: Bool) {
+    self.removed = removed
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case removed = "removed"
+    case success = "success"
+  }
+}
+
+public struct YtPlaylistsOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtPlaylistsReturn: Codable, Sendable {
+  public var nextPageToken: String?
+  public var playlists: [RaviJSON]
+  public var success: Bool
+  public var totalResults: Double
+
+  public init(nextPageToken: String? = nil, playlists: [RaviJSON], success: Bool, totalResults: Double) {
+    self.nextPageToken = nextPageToken
+    self.playlists = playlists
+    self.success = success
+    self.totalResults = totalResults
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case nextPageToken = "nextPageToken"
+    case playlists = "playlists"
+    case success = "success"
+    case totalResults = "totalResults"
+  }
+}
+
+public struct YtReplyOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtReplyReturn: Codable, Sendable {
+  public var replyId: String
+  public var success: Bool
+
+  public init(replyId: String, success: Bool) {
+    self.replyId = replyId
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case replyId = "replyId"
+    case success = "success"
+  }
+}
+
+public struct YtSearchOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtSearchReturn: Codable, Sendable {
+  public var nextPageToken: String?
+  public var query: String
+  public var success: Bool
+  public var totalResults: Double
+  public var videos: [RaviJSON]
+
+  public init(nextPageToken: String? = nil, query: String, success: Bool, totalResults: Double, videos: [RaviJSON]) {
+    self.nextPageToken = nextPageToken
+    self.query = query
+    self.success = success
+    self.totalResults = totalResults
+    self.videos = videos
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case nextPageToken = "nextPageToken"
+    case query = "query"
+    case success = "success"
+    case totalResults = "totalResults"
+    case videos = "videos"
+  }
+}
+
+public struct YtStatsOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtStatsReturn: Codable, Sendable {
+  public var stats: RaviJSON
+  public var success: Bool
+
+  public init(stats: RaviJSON, success: Bool) {
+    self.stats = stats
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case stats = "stats"
+    case success = "success"
+  }
+}
+
+public struct YtSubscriptionsOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtSubscriptionsReturn: Codable, Sendable {
+  public var nextPageToken: String?
+  public var subscriptions: [RaviJSON]
+  public var success: Bool
+  public var totalResults: Double
+
+  public init(nextPageToken: String? = nil, subscriptions: [RaviJSON], success: Bool, totalResults: Double) {
+    self.nextPageToken = nextPageToken
+    self.subscriptions = subscriptions
+    self.success = success
+    self.totalResults = totalResults
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case nextPageToken = "nextPageToken"
+    case subscriptions = "subscriptions"
+    case success = "success"
+    case totalResults = "totalResults"
+  }
+}
+
+public struct YtUnansweredOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtUnansweredReturn: Codable, Sendable {
+  public var comments: [RaviJSON]
+  public var nextPageToken: String?
+  public var success: Bool
+  public var totalUnanswered: Double
+  public var videoId: String
+
+  public init(comments: [RaviJSON], nextPageToken: String? = nil, success: Bool, totalUnanswered: Double, videoId: String) {
+    self.comments = comments
+    self.nextPageToken = nextPageToken
+    self.success = success
+    self.totalUnanswered = totalUnanswered
+    self.videoId = videoId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case comments = "comments"
+    case nextPageToken = "nextPageToken"
+    case success = "success"
+    case totalUnanswered = "totalUnanswered"
+    case videoId = "videoId"
+  }
+}
+
+public struct YtVideoOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtVideoReturn: Codable, Sendable {
+  public var success: Bool
+  public var video: RaviJSON
+
+  public init(success: Bool, video: RaviJSON) {
+    self.success = success
+    self.video = video
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case success = "success"
+    case video = "video"
+  }
+}
+
+public struct YtVideoCategoriesOptions: Codable, Sendable {
+  public var connection: String?
+  public var region: String?
+
+  public init(connection: String? = nil, region: String? = nil) {
+    self.connection = connection
+    self.region = region
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case region = "region"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.region {
+      body["region"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtVideoCategoriesReturn: Codable, Sendable {
+  public var categories: [RaviJSON]
+  public var region: String
+  public var success: Bool
+  public var totalResults: Double
+
+  public init(categories: [RaviJSON], region: String, success: Bool, totalResults: Double) {
+    self.categories = categories
+    self.region = region
+    self.success = success
+    self.totalResults = totalResults
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case categories = "categories"
+    case region = "region"
+    case success = "success"
+    case totalResults = "totalResults"
+  }
+}
+
+public struct YtVideoDeleteOptions: Codable, Sendable {
+  public var connection: String?
+
+  public init(connection: String? = nil) {
+    self.connection = connection
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtVideoDeleteReturn: Codable, Sendable {
+  public var deleted: String
+  public var success: Bool
+
+  public init(deleted: String, success: Bool) {
+    self.deleted = deleted
+    self.success = success
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case deleted = "deleted"
+    case success = "success"
+  }
+}
+
+public struct YtVideoUpdateOptions: Codable, Sendable {
+  public var category: String?
+  public var connection: String?
+  public var description: String?
+  public var privacy: String?
+  public var tags: String?
+  public var title: String?
+
+  public init(category: String? = nil, connection: String? = nil, description: String? = nil, privacy: String? = nil, tags: String? = nil, title: String? = nil) {
+    self.category = category
+    self.connection = connection
+    self.description = description
+    self.privacy = privacy
+    self.tags = tags
+    self.title = title
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case category = "category"
+    case connection = "connection"
+    case description = "description"
+    case privacy = "privacy"
+    case tags = "tags"
+    case title = "title"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.category {
+      body["category"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.description {
+      body["description"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.privacy {
+      body["privacy"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.tags {
+      body["tags"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.title {
+      body["title"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtVideoUpdateReturn: Codable, Sendable {
+  public var success: Bool
+  public var video: RaviJSON
+
+  public init(success: Bool, video: RaviJSON) {
+    self.success = success
+    self.video = video
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case success = "success"
+    case video = "video"
+  }
+}
+
+public struct YtVideosOptions: Codable, Sendable {
+  public var connection: String?
+  public var limit: String?
+  public var page: String?
+
+  public init(connection: String? = nil, limit: String? = nil, page: String? = nil) {
+    self.connection = connection
+    self.limit = limit
+    self.page = page
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case connection = "connection"
+    case limit = "limit"
+    case page = "page"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.connection {
+      body["connection"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.limit {
+      body["limit"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.page {
+      body["page"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct YtVideosReturn: Codable, Sendable {
+  public var nextPageToken: String?
+  public var success: Bool
+  public var totalResults: Double
+  public var videos: [RaviJSON]
+
+  public init(nextPageToken: String? = nil, success: Bool, totalResults: Double, videos: [RaviJSON]) {
+    self.nextPageToken = nextPageToken
+    self.success = success
+    self.totalResults = totalResults
+    self.videos = videos
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case nextPageToken = "nextPageToken"
+    case success = "success"
+    case totalResults = "totalResults"
+    case videos = "videos"
+  }
+}

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:b3209181e1236fe4eb5d6a1757a7c7c53f0c6dae6084954735abab90d5c3aaaf"
-public let RAVI_GIT_SHA = "428bb57dbcb5"
+public let RAVI_REGISTRY_HASH = "sha256:5a7761fa7bc22992d1f8ff60bc07571166533154d12a566813c9e657cc429ea2"
+public let RAVI_GIT_SHA = "333c8e66f098"

--- a/src/cli/commands/sdk.test.ts
+++ b/src/cli/commands/sdk.test.ts
@@ -70,6 +70,23 @@ describe("SdkOpenApiCommands.emit", () => {
     }
   });
 
+  it("writes to the canonical docs snapshot when --out is omitted", () => {
+    const dir = makeTmpDir("emit-default");
+    const originalCwd = process.cwd();
+    const capture = captureConsole();
+    try {
+      process.chdir(dir);
+      const result = new SdkOpenApiCommands().emit() as { status: string; path: string };
+      const target = join(process.cwd(), "docs", "openapi.json");
+      expect(result).toMatchObject({ status: "written", path: target });
+      expect(JSON.parse(readFileSync(target, "utf8")).openapi).toBe("3.1.0");
+    } finally {
+      process.chdir(originalCwd);
+      capture.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("prints to stdout when --stdout is provided", () => {
     const stdout = captureStdout();
     let result: { status: string } | undefined;

--- a/src/cli/commands/sdk.ts
+++ b/src/cli/commands/sdk.ts
@@ -29,6 +29,7 @@ function writeFileSafe(target: string, body: string): string {
 const DEFAULT_CLIENT_OUT_DIR = "packages/ravi-os-sdk/src";
 const DEFAULT_TYPESCRIPT_SDK_VERSION = "0.2.1";
 const DEFAULT_SWIFT_SDK_VERSION = "0.1.0";
+const DEFAULT_OPENAPI_SNAPSHOT_PATH = "docs/openapi.json";
 const GENERATED_FILES = ["client.ts", "schemas.ts", "types.ts", "version.ts", "streaming.generated.ts"] as const;
 const DEFAULT_SWIFT_OUT_DIR = "packages/ravi-os-swift-sdk/Sources/RaviSDK";
 const GENERATED_SWIFT_FILES = [
@@ -151,7 +152,11 @@ export class SdkOpenApiCommands {
   @CommandAccess({ kind: "read", resource: "sdk.openapi", action: "emit", risk: "low" })
   @Returns(openApiEmitReturnSchema)
   emit(
-    @Option({ flags: "--out <path>", description: "Write spec JSON to this path" }) out?: string,
+    @Option({
+      flags: "--out <path>",
+      description: `Write spec JSON to this path (default: ${DEFAULT_OPENAPI_SNAPSHOT_PATH})`,
+    })
+    out?: string,
     @Option({ flags: "--stdout", description: "Print spec JSON to stdout" }) toStdout?: boolean,
     @Option({ flags: "--json", description: "Print the result payload as JSON" }) asJson?: boolean,
   ) {
@@ -166,7 +171,7 @@ export class SdkOpenApiCommands {
         return { status: "stdout", bytes: json.length };
       }
 
-      const target = out?.trim() ? out : "openapi.json";
+      const target = out?.trim() ? out : DEFAULT_OPENAPI_SNAPSHOT_PATH;
       const absolute = writeFileSafe(target, `${json}\n`);
       const payload = { status: "written" as const, path: absolute, bytes: json.length };
       if (asJson) {

--- a/src/sdk/swift-codegen/codegen.test.ts
+++ b/src/sdk/swift-codegen/codegen.test.ts
@@ -60,6 +60,46 @@ class CrmAccountCommands {
   }
 }
 
+@Group({ name: "image", description: "Image ops", scope: "open" })
+class ImageCommands {
+  @Command({ name: "split", description: "Split an image atlas" })
+  @Returns(
+    z.object({
+      artifactId: z.string(),
+      artifact_id: z.string(),
+      "artifact-id": z.string(),
+    }),
+  )
+  split() {
+    return { artifactId: "canonical", artifact_id: "snake", "artifact-id": "kebab" };
+  }
+}
+
+@Group({ name: "collisions", description: "Swift identifier collisions", scope: "open" })
+class CollisionCommands {
+  @Command({ name: "arguments", description: "Exercise colliding argument names" })
+  arguments(
+    @Arg("artifactId") _canonical: string,
+    @Arg("artifact_id") _snake: string,
+    @Arg("artifact-id") _kebab: string,
+  ) {
+    return {};
+  }
+
+  @Command({ name: "option-fields", description: "Exercise colliding option field names" })
+  optionFields(
+    @Option({ flags: "--artifact-id <id>" }) _canonical?: string,
+    @Option({ flags: "--artifact-ID <id>" }) _alternate?: string,
+  ) {
+    return {};
+  }
+
+  @Command({ name: "reserved-argument", description: "Exercise the reserved options parameter" })
+  reservedArgument(@Arg("options") _wireOptions: string, @Option({ flags: "--force" }) _force?: boolean) {
+    return {};
+  }
+}
+
 const FIXED_VERSION = {
   sdkVersion: "9.9.9",
   registryHash: "sha256:fixed",
@@ -131,6 +171,54 @@ describe("swift-codegen :: emitAllSwift", () => {
     expect(output.types).toContain("public struct ArtifactsShowReturn: Codable, Sendable");
     expect(output.types).toContain("public var id: String");
     expect(output.types).toContain("public var links: [RaviJSON]");
+  });
+
+  it("disambiguates property names that normalize to the same Swift identifier", () => {
+    const registry = buildRegistry([ImageCommands]);
+    const output = emitAllSwift(registry, { version: FIXED_VERSION });
+
+    expect(output.types).toContain("public var artifactId: String");
+    expect(output.types).toContain("public var artifact_id: String");
+    expect(output.types).toContain("public var artifact_id_2: String");
+    expect(output.types).toContain(`case artifactId = "artifactId"`);
+    expect(output.types).toContain(`case artifact_id = "artifact_id"`);
+    expect(output.types).toContain(`case artifact_id_2 = "artifact-id"`);
+  });
+
+  it("disambiguates colliding positional argument names without changing their wire keys", () => {
+    const registry = buildRegistry([CollisionCommands]);
+    const output = emitAllSwift(registry, { version: FIXED_VERSION });
+
+    expect(output.client).toContain(
+      "public func arguments(_ artifactId: String, _ artifact_id: String, _ artifact_id_2: String)",
+    );
+    expect(output.client).toContain(`requestBody["artifactId"] = try RaviJSON.fromEncodable(artifactId)`);
+    expect(output.client).toContain(`requestBody["artifact_id"] = try RaviJSON.fromEncodable(artifact_id)`);
+    expect(output.client).toContain(`requestBody["artifact-id"] = try RaviJSON.fromEncodable(artifact_id_2)`);
+  });
+
+  it("disambiguates colliding option struct fields without changing their coding keys", () => {
+    const registry = buildRegistry([CollisionCommands]);
+    const output = emitAllSwift(registry, { version: FIXED_VERSION });
+
+    expect(output.types).toContain("public struct CollisionsOptionFieldsOptions: Codable, Sendable");
+    expect(output.types).toContain("public var artifactId: String?");
+    expect(output.types).toContain("public var artifact_ID: String?");
+    expect(output.types).toContain(`case artifactId = "artifactId"`);
+    expect(output.types).toContain(`case artifact_ID = "artifact-ID"`);
+    expect(output.types).toContain(`body["artifactId"] = try RaviJSON.fromEncodable(value)`);
+    expect(output.types).toContain(`body["artifact-ID"] = try RaviJSON.fromEncodable(value)`);
+  });
+
+  it("keeps the generated options bag distinct from an argument named options", () => {
+    const registry = buildRegistry([CollisionCommands]);
+    const output = emitAllSwift(registry, { version: FIXED_VERSION });
+
+    expect(output.client).toContain(
+      "public func reservedArgument(_ options_2: String, _ options: CollisionsReservedArgumentOptions = .init())",
+    );
+    expect(output.client).toContain(`requestBody["options"] = try RaviJSON.fromEncodable(options_2)`);
+    expect(output.client).toContain("try options.encodeBody(into: &requestBody)");
   });
 
   it("disambiguates commands that are also namespace nodes", () => {

--- a/src/sdk/swift-codegen/emit-files.ts
+++ b/src/sdk/swift-codegen/emit-files.ts
@@ -18,6 +18,7 @@ import {
   propertyName,
   returnSchemaName,
   returnTypeName,
+  uniquePropertyNames,
 } from "./naming.js";
 import { jsonSchemaToSwift, type JsonSchema } from "./json-schema-to-swift.js";
 import { defaultStreamChannels } from "../gateway/streaming/channels.js";
@@ -82,10 +83,11 @@ function renderOptionsStruct(cmd: CommandRegistryEntry): string | null {
   const props = (inputSchema as { properties?: Record<string, JsonSchema> }).properties ?? {};
   const required = new Set((inputSchema as { required?: string[] }).required ?? []);
   const argNames = new Set(cmd.args.map((arg) => arg.name));
-  const fields = cmd.options
-    .filter((opt) => !argNames.has(opt.name))
+  const options = cmd.options.filter((opt) => !argNames.has(opt.name));
+  const swiftNames = uniquePropertyNames(options.map((opt) => opt.name));
+  const fields = options
     .map((opt) => {
-      const swiftName = propertyName(opt.name);
+      const swiftName = swiftNames.get(opt.name)!;
       const swiftType = jsonSchemaToSwift(props[opt.name]);
       const isRequired = required.has(opt.name);
       return { rawName: opt.name, swiftName, swiftType, isRequired };
@@ -152,14 +154,14 @@ function renderReturnDeclaration(cmd: CommandRegistryEntry): string {
 function renderReturnStruct(name: string, schema: JsonSchema): string {
   const props = (schema as { properties?: Record<string, JsonSchema> }).properties ?? {};
   const required = new Set((schema as { required?: string[] }).required ?? []);
-  const fields = Object.keys(props)
-    .sort()
-    .map((rawName) => {
-      const swiftName = propertyName(rawName);
-      const swiftType = jsonSchemaToSwift(props[rawName]);
-      const isRequired = required.has(rawName);
-      return { rawName, swiftName, swiftType, isRequired };
-    });
+  const rawNames = Object.keys(props).sort();
+  const swiftNames = uniquePropertyNames(rawNames);
+  const fields = rawNames.map((rawName) => {
+    const swiftName = swiftNames.get(rawName)!;
+    const swiftType = jsonSchemaToSwift(props[rawName]);
+    const isRequired = required.has(rawName);
+    return { rawName, swiftName, swiftType, isRequired };
+  });
 
   const lines: string[] = [
     `public struct ${name}: Codable, Sendable {`,
@@ -372,13 +374,17 @@ function renderMethod(swiftName: string, cmd: CommandRegistryEntry): string {
   const inputSchema = buildInputSchema(cmd);
   const sig = buildSignature(cmd, inputSchema);
   const returnName = returnTypeName(cmd.groupSegments, cmd.command);
-  const params = renderMethodParams(cmd, sig);
+  const argNames = uniquePropertyNames(
+    sig.args.map((arg) => arg.name),
+    sig.options.length > 0 ? ["options"] : [],
+  );
+  const params = renderMethodParams(cmd, sig, argNames);
   const mutatesBody = sig.args.length > 0 || sig.options.length > 0;
   const lines: string[] = [];
   lines.push(`  public func ${swiftName}(${params}) async throws -> ${returnName} {`);
   lines.push(`    ${mutatesBody ? "var" : "let"} requestBody: [String: RaviJSON] = [:]`);
   for (const arg of sig.args) {
-    const swiftArg = propertyName(arg.name);
+    const swiftArg = argNames.get(arg.name)!;
     if (arg.required) {
       lines.push(`    requestBody[${JSON.stringify(arg.name)}] = try RaviJSON.fromEncodable(${swiftArg})`);
     } else {
@@ -405,11 +411,15 @@ function renderMethod(swiftName: string, cmd: CommandRegistryEntry): string {
   return lines.join("\n");
 }
 
-function renderMethodParams(cmd: CommandRegistryEntry, sig: CommandSignature): string {
+function renderMethodParams(
+  cmd: CommandRegistryEntry,
+  sig: CommandSignature,
+  argNames: ReadonlyMap<string, string>,
+): string {
   const inputSchema = buildInputSchema(cmd);
   const props = (inputSchema as { properties?: Record<string, JsonSchema> }).properties ?? {};
   const params: string[] = sig.args.map((arg) => {
-    const swiftArg = propertyName(arg.name);
+    const swiftArg = argNames.get(arg.name)!;
     const type = jsonSchemaToSwift(props[arg.name]);
     return `_ ${swiftArg}: ${type}${arg.required ? "" : "? = nil"}`;
   });

--- a/src/sdk/swift-codegen/naming.ts
+++ b/src/sdk/swift-codegen/naming.ts
@@ -107,6 +107,53 @@ export function propertyName(name: string): string {
   return swiftIdentifier(camelCase(name));
 }
 
+/**
+ * Resolve wire-property names to unique Swift identifiers.
+ *
+ * Different JSON keys can collapse to the same lower-camel Swift spelling
+ * (`artifactId` and `artifact_id`, for example). Keep the canonical
+ * lower-camel wire key on the preferred spelling, then fall back to the raw
+ * key's Swift-safe spelling and, only when necessary, a stable numeric suffix.
+ */
+export function uniquePropertyNames(
+  rawNames: readonly string[],
+  reservedSwiftNames: readonly string[] = [],
+): ReadonlyMap<string, string> {
+  const uniqueRawNames = [...new Set(rawNames)].sort(compareStrings);
+  const groups = new Map<string, string[]>();
+
+  for (const rawName of uniqueRawNames) {
+    const baseName = propertyName(rawName);
+    const group = groups.get(baseName) ?? [];
+    group.push(rawName);
+    groups.set(baseName, group);
+  }
+
+  const resolved = new Map<string, string>();
+  const used = new Set(reservedSwiftNames);
+  const orderedGroups = [...groups.entries()].sort(([a], [b]) => compareStrings(a, b));
+
+  // Claim every canonical lower-camel spelling first. This prevents a
+  // fallback from taking the preferred name of another property group.
+  for (const [baseName, group] of orderedGroups) {
+    const canonical = [...group].sort(compareCanonicalWireNames)[0];
+    const swiftName = nextAvailableIdentifier(baseName, used);
+    resolved.set(canonical, swiftName);
+    used.add(swiftName);
+  }
+
+  for (const [, group] of orderedGroups) {
+    const remaining = group.filter((rawName) => !resolved.has(rawName)).sort(compareFallbackWireNames);
+    for (const rawName of remaining) {
+      const swiftName = nextAvailableIdentifier(swiftIdentifier(rawName), used);
+      resolved.set(rawName, swiftName);
+      used.add(swiftName);
+    }
+  }
+
+  return resolved;
+}
+
 export function swiftIdentifier(raw: string): string {
   const safe = raw.replace(/[^A-Za-z0-9_]/g, "_").replace(/^[0-9]/, "_$&");
   const normalized = safe || "value";
@@ -129,4 +176,30 @@ function splitWords(input: string): string[] {
 function capitalize(input: string): string {
   if (!input) return input;
   return input[0].toUpperCase() + input.slice(1).toLowerCase();
+}
+
+function compareCanonicalWireNames(a: string, b: string): number {
+  const aIsCanonical = a === camelCase(a);
+  const bIsCanonical = b === camelCase(b);
+  if (aIsCanonical !== bIsCanonical) return aIsCanonical ? -1 : 1;
+  return compareStrings(a, b);
+}
+
+function compareFallbackWireNames(a: string, b: string): number {
+  const aIsAlreadySafe = a === swiftIdentifier(a);
+  const bIsAlreadySafe = b === swiftIdentifier(b);
+  if (aIsAlreadySafe !== bIsAlreadySafe) return aIsAlreadySafe ? -1 : 1;
+  return compareStrings(a, b);
+}
+
+function nextAvailableIdentifier(baseName: string, used: ReadonlySet<string>): string {
+  if (!used.has(baseName)) return baseName;
+  const separator = baseName.endsWith("_") ? "" : "_";
+  let suffix = 2;
+  while (used.has(`${baseName}${separator}${suffix}`)) suffix += 1;
+  return `${baseName}${separator}${suffix}`;
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }


### PR DESCRIPTION
## Objective

Refresh the generated Ravi contracts from the current CLI registry and make Swift generation deterministic when wire names normalize to the same Swift identifier. This restores a compilable, drift-checkable SDK snapshot on `dev`.

## Problem

- `docs/openapi.json` and the generated TypeScript/Swift sources had drifted from the live registry.
- Swift generation could emit duplicate property, argument, or options-bag identifiers after sanitizing wire names, which made valid registry shapes fail to compile.
- `ravi sdk openapi emit` defaulted to the legacy root snapshot instead of the canonical `docs/openapi.json` contract.

## Solution

- Add deterministic collision allocation for generated Swift properties, positional arguments, option fields, and the reserved options parameter while preserving their original wire keys.
- Regenerate the canonical OpenAPI document and both generated SDK surfaces from the same registry snapshot.
- Make `docs/openapi.json` the default OpenAPI output and add regression coverage for collisions and output-path behavior.

## Practical impact

- Swift SDK consumers receive generated sources that compile even when CLI names collapse to the same Swift spelling, and SDK drift checks once again describe the current public registry.

## What does NOT change

- Application runtime behavior and transport wire keys are unchanged. Only the SDK OpenAPI emit command changes its default output to `docs/openapi.json`; the legacy root `openapi.json` is not promoted back to the canonical contract.

## Validation

- `make quality` passed: Biome checked 907 files and TypeScript typecheck passed.
- `bun run test:sdk` passed: 29 tests, 0 failures.
- `swift test` passed: 5 tests, 0 failures.
- `ravi sdk swift check`, `ravi sdk openapi check --against docs/openapi.json`, and `git diff --check` passed.

## Risks

- The generated contract refresh is intentionally large, so downstream branches that also regenerate SDK artifacts may need to rebase after this PR lands.

## Rollback

- Revert this commit to restore the previous generator and snapshots if emergency compatibility requires it, understanding that doing so also restores the documented SDK drift and Swift collision failures. No persistent-state rollback is required.

## Follow-ups

- Merge this before the stacked CLI option and observer-contract PRs so each generated diff remains reviewable.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->