### PR TITLE
fix(cli): normalize negated option semantics

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "fdc8765bea4b81b6"
+    "version": "8330fb46ed5b1d1f"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -5987,7 +5987,7 @@
                     "type": "string"
                   },
                   "noActivate": {
-                    "default": true,
+                    "default": false,
                     "description": "Create publish records without activating a site release",
                     "type": "boolean"
                   },
@@ -7590,7 +7590,7 @@
                     "type": "string"
                   },
                   "noAutoplay": {
-                    "default": true,
+                    "default": false,
                     "description": "Do not autoplay in extension clients",
                     "type": "boolean"
                   },
@@ -25332,7 +25332,7 @@
                     "type": "string"
                   },
                   "noCascade": {
-                    "default": true,
+                    "default": false,
                     "description": "Do not revoke descendant contexts (use only for narrow rotation; emits a loud warning)",
                     "type": "boolean"
                   },
@@ -33236,7 +33236,7 @@
                     "type": "string"
                   },
                   "noStore": {
-                    "default": true,
+                    "default": false,
                     "description": "Alias for --print-only (do not write to ~/.ravi/credentials.json)",
                     "type": "boolean"
                   },
@@ -34214,12 +34214,12 @@
                     "type": "string"
                   },
                   "noMaxAcuLimit": {
-                    "default": true,
+                    "default": false,
                     "description": "Intentionally omit max_acu_limit",
                     "type": "boolean"
                   },
                   "noResumable": {
-                    "default": true,
+                    "default": false,
                     "description": "Disposable session, do not preserve VM state",
                     "type": "boolean"
                   },
@@ -50616,7 +50616,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "noPostTranscribe": {
-                    "default": true,
+                    "default": false,
                     "description": "Skip post-call audio transcription",
                     "type": "boolean"
                   },
@@ -53941,7 +53941,7 @@
                     "type": "string"
                   },
                   "noActivate": {
-                    "default": true,
+                    "default": false,
                     "description": "Create publish records without activating a site release",
                     "type": "boolean"
                   },
@@ -87563,7 +87563,7 @@
                     "type": "string"
                   },
                   "noAck": {
-                    "default": true,
+                    "default": false,
                     "description": "Don't send read receipt",
                     "type": "boolean"
                   }

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -4990,7 +4990,7 @@ export const ArtifactsPublishInputSchema = {
       "type": "string"
     },
     "noActivate": {
-      "default": true,
+      "default": false,
       "description": "Create publish records without activating a site release",
       "type": "boolean"
     },
@@ -6279,7 +6279,7 @@ export const AudioTtsInputSchema = {
       "type": "string"
     },
     "noAutoplay": {
-      "default": true,
+      "default": false,
       "description": "Do not autoplay in extension clients",
       "type": "boolean"
     },
@@ -21091,7 +21091,7 @@ export const ContextRevokeInputSchema = {
       "type": "string"
     },
     "noCascade": {
-      "default": true,
+      "default": false,
       "description": "Do not revoke descendant contexts (use only for narrow rotation; emits a loud warning)",
       "type": "boolean"
     },
@@ -26833,7 +26833,7 @@ export const DaemonInitAdminKeyInputSchema = {
       "type": "string"
     },
     "noStore": {
-      "default": true,
+      "default": false,
       "description": "Alias for --print-only (do not write to ~/.ravi/credentials.json)",
       "type": "boolean"
     },
@@ -27495,12 +27495,12 @@ export const DevinSessionsCreateInputSchema = {
       "type": "string"
     },
     "noMaxAcuLimit": {
-      "default": true,
+      "default": false,
       "description": "Intentionally omit max_acu_limit",
       "type": "boolean"
     },
     "noResumable": {
-      "default": true,
+      "default": false,
       "description": "Disposable session, do not preserve VM state",
       "type": "boolean"
     },
@@ -40953,7 +40953,7 @@ export const MeetingsFinalizeInputSchema = {
   "additionalProperties": false,
   "properties": {
     "noPostTranscribe": {
-      "default": true,
+      "default": false,
       "description": "Skip post-call audio transcription",
       "type": "boolean"
     },
@@ -43340,7 +43340,7 @@ export const PagesPublishInputSchema = {
       "type": "string"
     },
     "noActivate": {
-      "default": true,
+      "default": false,
       "description": "Create publish records without activating a site release",
       "type": "boolean"
     },
@@ -68074,7 +68074,7 @@ export const WhatsappDmReadInputSchema = {
       "type": "string"
     },
     "noAck": {
-      "default": true,
+      "default": false,
       "description": "Don't send read receipt",
       "type": "boolean"
     }

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:5a7761fa7bc22992d1f8ff60bc07571166533154d12a566813c9e657cc429ea2";
+export const REGISTRY_HASH = "sha256:5e491db4e5c6aee8924f990d75c9dec72803c696d40751376949fd4e714088b0";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "333c8e66f098";
+export const GIT_SHA = "1498326f084b";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -5044,7 +5044,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noActivate": {
-        "default": true,
+        "default": false,
         "description": "Create publish records without activating a site release",
         "type": "boolean"
       },
@@ -6354,7 +6354,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noAutoplay": {
-        "default": true,
+        "default": false,
         "description": "Do not autoplay in extension clients",
         "type": "boolean"
       },
@@ -21354,7 +21354,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noCascade": {
-        "default": true,
+        "default": false,
         "description": "Do not revoke descendant contexts (use only for narrow rotation; emits a loud warning)",
         "type": "boolean"
       },
@@ -27228,7 +27228,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noStore": {
-        "default": true,
+        "default": false,
         "description": "Alias for --print-only (do not write to ~/.ravi/credentials.json)",
         "type": "boolean"
       },
@@ -27912,12 +27912,12 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noMaxAcuLimit": {
-        "default": true,
+        "default": false,
         "description": "Intentionally omit max_acu_limit",
         "type": "boolean"
       },
       "noResumable": {
-        "default": true,
+        "default": false,
         "description": "Disposable session, do not preserve VM state",
         "type": "boolean"
       },
@@ -41562,7 +41562,7 @@ public enum RaviSchemas {
     "additionalProperties": false,
     "properties": {
       "noPostTranscribe": {
-        "default": true,
+        "default": false,
         "description": "Skip post-call audio transcription",
         "type": "boolean"
       },
@@ -44005,7 +44005,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noActivate": {
-        "default": true,
+        "default": false,
         "description": "Create publish records without activating a site release",
         "type": "boolean"
       },
@@ -69305,7 +69305,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "noAck": {
-        "default": true,
+        "default": false,
         "description": "Don't send read receipt",
         "type": "boolean"
       }

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:5a7761fa7bc22992d1f8ff60bc07571166533154d12a566813c9e657cc429ea2"
-public let RAVI_GIT_SHA = "333c8e66f098"
+public let RAVI_REGISTRY_HASH = "sha256:5e491db4e5c6aee8924f990d75c9dec72803c696d40751376949fd4e714088b0"
+public let RAVI_GIT_SHA = "1498326f084b"

--- a/src/cli/commands/artifacts.ts
+++ b/src/cli/commands/artifacts.ts
@@ -837,7 +837,7 @@ export class ArtifactsCommands {
     @Option({ flags: "--replace-release", description: "Replace the full active route map instead of merging" })
     replaceRelease?: boolean,
     @Option({ flags: "--no-activate", description: "Create publish records without activating a site release" })
-    activate?: boolean,
+    noActivate?: boolean,
     @Option({ flags: "--console <url>", description: "Console base URL" }) consoleUrl?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
@@ -859,7 +859,7 @@ export class ArtifactsCommands {
         idempotencyKey,
         reason,
         replaceRelease,
-        activate,
+        activate: !noActivate,
         console: consoleUrl,
         json: asJson,
       });

--- a/src/cli/commands/context.test.ts
+++ b/src/cli/commands/context.test.ts
@@ -744,15 +744,21 @@ describe("ContextCommands", () => {
 
     const command = new ContextCommands();
     const lines: string[] = [];
+    const errors: string[] = [];
     const originalLog = console.log;
+    const originalError = console.error;
     console.log = (value?: unknown) => {
       lines.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      errors.push(String(value));
     };
 
     try {
       command.revoke("ctx_123", true, undefined, true);
     } finally {
       console.log = originalLog;
+      console.error = originalError;
     }
 
     const payload = JSON.parse(lines[0] ?? "{}");
@@ -765,6 +771,8 @@ describe("ContextCommands", () => {
       cascaded: [],
       revokedAt: 5000,
     });
+    expect(revokedCalls.at(-1)).toEqual({ contextId: "ctx_123", options: { cascade: false, reason: undefined } });
+    expect(errors.join("\n")).toContain("--no-cascade leaves descendant contexts active");
   });
 
   it("fails on malformed capability specs", () => {

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -372,16 +372,17 @@ export class ContextCommands {
       flags: "--no-cascade",
       description: "Do not revoke descendant contexts (use only for narrow rotation; emits a loud warning)",
     })
-    cascade = true,
+    noCascade = false,
     @Option({ flags: "--reason <text>", description: "Reason recorded in metadata for audit and forensics" })
     reason?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson = false,
   ) {
-    if (cascade === false) {
+    if (noCascade) {
       console.error(
         "WARNING: --no-cascade leaves descendant contexts active. Workers using child rctx_* keys will keep auth.",
       );
     }
+    const cascade = !noCascade;
     const result = revokeRuntimeContext(contextId, { cascade, reason });
     const payload = this.serializeRevokeResult(result.context, result.cascaded, result.revokedAt);
     this.printPayload(payload, asJson, () =>

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
 import { DaemonCommands, findSourceProjectRoot, resolveDaemonRuntimeTarget } from "./daemon.js";
 
 const tempDirs: string[] = [];
@@ -127,5 +128,53 @@ describe("DaemonCommands --json", () => {
     );
     expect(payload.stdout).toBeUndefined();
     expect(payload.stderr).toBeUndefined();
+  });
+});
+
+describe("DaemonCommands init-admin-key negated storage", () => {
+  let stateDir: string | null = null;
+  let previousCredentialsPath: string | undefined;
+
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-daemon-admin-key-");
+    previousCredentialsPath = process.env.RAVI_CREDENTIALS_PATH;
+    process.env.RAVI_CREDENTIALS_PATH = join(stateDir, "credentials.json");
+  });
+
+  afterEach(async () => {
+    if (previousCredentialsPath === undefined) delete process.env.RAVI_CREDENTIALS_PATH;
+    else process.env.RAVI_CREDENTIALS_PATH = previousCredentialsPath;
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  async function issueAdminKey(noStore: boolean) {
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      return new DaemonCommands().initAdminKey("test", false, noStore, false, true);
+    } finally {
+      console.log = originalLog;
+    }
+  }
+
+  it("persists credentials by default", async () => {
+    const result = await issueAdminKey(false);
+
+    expect("persisted" in result).toBe(true);
+    if (!("persisted" in result)) throw new Error("expected a newly issued admin key");
+    expect(result.persisted).toBe(true);
+    expect(result.credentialsPath).toBe(process.env.RAVI_CREDENTIALS_PATH!);
+    expect(existsSync(process.env.RAVI_CREDENTIALS_PATH!)).toBe(true);
+  });
+
+  it("does not persist credentials when --no-store is present", async () => {
+    const result = await issueAdminKey(true);
+
+    expect("persisted" in result).toBe(true);
+    if (!("persisted" in result)) throw new Error("expected a newly issued admin key");
+    expect(result.persisted).toBe(false);
+    expect(result.credentialsPath).toBeNull();
+    expect(existsSync(process.env.RAVI_CREDENTIALS_PATH!)).toBe(false);
   });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -992,7 +992,7 @@ ANTHROPIC_API_KEY=
       flags: "--no-store",
       description: "Alias for --print-only (do not write to ~/.ravi/credentials.json)",
     })
-    store = true,
+    noStore = false,
     @Option({
       flags: "--from-env",
       description:
@@ -1001,7 +1001,7 @@ ANTHROPIC_API_KEY=
     fromEnv = false,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson = false,
   ) {
-    const persist = printOnly === false && store !== false;
+    const persist = printOnly === false && !noStore;
     const resolvedLabel = label?.trim() || hostname() || "admin";
 
     const live = listLiveAdminContexts();

--- a/src/cli/commands/devin.test.ts
+++ b/src/cli/commands/devin.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { runWithContext } from "../context.js";
+import { determineMaxAcuLimit, resolveResumable } from "./devin.js";
+
+const originalDefaultMaxAcuLimit = process.env.DEVIN_DEFAULT_MAX_ACU_LIMIT;
+
+afterEach(() => {
+  if (originalDefaultMaxAcuLimit === undefined) delete process.env.DEVIN_DEFAULT_MAX_ACU_LIMIT;
+  else process.env.DEVIN_DEFAULT_MAX_ACU_LIMIT = originalDefaultMaxAcuLimit;
+});
+
+describe("Devin negated options", () => {
+  it("resolves resumable from validated command arguments", () => {
+    expect(resolveResumable()).toEqual({ value: undefined, source: "omitted" });
+    expect(resolveResumable(true, false)).toEqual({ value: true, source: "explicit" });
+    expect(resolveResumable(undefined, true)).toEqual({ value: false, source: "explicit" });
+  });
+
+  it("rejects contradictory resumable arguments from remote callers", () => {
+    expect(() => runWithContext({}, () => resolveResumable(true, true))).toThrow(
+      "Use either --resumable or --no-resumable",
+    );
+  });
+
+  it("uses the validated noMaxAcuLimit argument instead of process.argv", () => {
+    process.env.DEVIN_DEFAULT_MAX_ACU_LIMIT = "25";
+
+    expect(determineMaxAcuLimit(undefined, false)).toEqual({ maxAcuLimit: 25, source: "env" });
+    expect(determineMaxAcuLimit(undefined, true)).toEqual({ source: "omitted" });
+    expect(determineMaxAcuLimit("12", false)).toEqual({ maxAcuLimit: 12, source: "explicit" });
+  });
+
+  it("rejects max ACU together with its negated flag", () => {
+    expect(() => runWithContext({}, () => determineMaxAcuLimit("12", true))).toThrow(
+      "Use either --max-acu or --no-max-acu-limit",
+    );
+  });
+});

--- a/src/cli/commands/devin.ts
+++ b/src/cli/commands/devin.ts
@@ -84,10 +84,6 @@ function readPrompt(prompt?: string, promptFile?: string): string {
   fail("--prompt or --prompt-file is required.");
 }
 
-function rawFlagPresent(flag: string): boolean {
-  return process.argv.includes(flag);
-}
-
 function formatTime(value: number | undefined): string {
   if (!value) return "-";
   const ms = value > 10_000_000_000 ? value : value * 1000;
@@ -220,15 +216,17 @@ function resolveDevinId(identifier: string): string {
   fail(`Unknown Devin session: ${identifier}`);
 }
 
-function determineMaxAcuLimit(explicitValue?: string): {
+export function determineMaxAcuLimit(
+  explicitValue?: string,
+  noMaxAcuLimit = false,
+): {
   maxAcuLimit?: number;
   source: "explicit" | "env" | "omitted";
 } {
   const explicit = parsePositiveInteger(explicitValue, "--max-acu");
-  const omit = rawFlagPresent("--no-max-acu-limit") || rawFlagPresent("--omit-max-acu-limit");
-  if (explicit !== undefined && omit) fail("Use either --max-acu or --no-max-acu-limit, not both.");
+  if (explicit !== undefined && noMaxAcuLimit) fail("Use either --max-acu or --no-max-acu-limit, not both.");
   if (explicit !== undefined) return { maxAcuLimit: explicit, source: "explicit" };
-  if (omit) return { source: "omitted" };
+  if (noMaxAcuLimit) return { source: "omitted" };
   const configured = getDefaultMaxAcuLimit();
   if (configured !== undefined) return { maxAcuLimit: configured, source: "env" };
   fail("DEVIN_DEFAULT_MAX_ACU_LIMIT is not configured. Use --max-acu <n> or --no-max-acu-limit explicitly.");
@@ -268,9 +266,10 @@ function resolveCreateAsUser(explicit?: string): ResolvedField<string> {
   return { value: undefined, source: "omitted" };
 }
 
-function resolveResumable(): ResolvedField<boolean> {
-  if (rawFlagPresent("--no-resumable")) return { value: false, source: "explicit" };
-  if (rawFlagPresent("--resumable")) return { value: true, source: "explicit" };
+export function resolveResumable(resumable?: boolean, noResumable = false): ResolvedField<boolean> {
+  if (resumable === true && noResumable) fail("Use either --resumable or --no-resumable, not both.");
+  if (noResumable) return { value: false, source: "explicit" };
+  if (resumable === true) return { value: true, source: "explicit" };
   return { value: undefined, source: "omitted" };
 }
 
@@ -418,16 +417,16 @@ export class DevinSessionCommands {
     @Option({ flags: "--child-playbook <id>", description: "Child playbook ID" }) childPlaybookId?: string,
     @Option({ flags: "--devin-mode <mode>", description: "Agent mode: normal|fast|lite|ultra" }) devinMode?: string,
     @Option({ flags: "--platform <platform>", description: "VM platform override (org-specific)" }) platform?: string,
-    @Option({ flags: "--resumable", description: "Preserve VM state for resume (default: true)" }) _resumable?: boolean,
+    @Option({ flags: "--resumable", description: "Preserve VM state for resume (default: true)" }) resumable?: boolean,
     @Option({ flags: "--no-resumable", description: "Disposable session, do not preserve VM state" })
-    _noResumable?: boolean,
+    noResumable?: boolean,
     @Option({ flags: "--structured-output-required", description: "Require structured output before turn ends" })
     structuredOutputRequired?: boolean,
     @Option({ flags: "--devin-id <id>", description: "Idempotent session creation key" }) devinId?: string,
     @Option({ flags: "--advanced-mode <mode>", description: "Legacy: analyze|create|improve|batch|manage" })
     advancedMode?: string,
     @Option({ flags: "--max-acu <n>", description: "Per-session max ACU ceiling" }) maxAcu?: string,
-    @Option({ flags: "--no-max-acu-limit", description: "Intentionally omit max_acu_limit" }) _noMaxAcuLimit?: boolean,
+    @Option({ flags: "--no-max-acu-limit", description: "Intentionally omit max_acu_limit" }) noMaxAcuLimit?: boolean,
     @Option({ flags: "--bypass-approval", description: "Request bypass_approval=true" }) bypassApproval?: boolean,
     @Option({ flags: "--as-user <id>", description: "create_as_user_id (impersonate user)" }) createAsUserId?: string,
     @Option({ flags: "--structured-output-schema <json>", description: "JSON schema for structured output" })
@@ -440,7 +439,7 @@ export class DevinSessionCommands {
     const client = createDevinClientFromEnv();
     const text = readPrompt(prompt, promptFile).trim();
     if (!text) fail("Prompt is empty.");
-    const acu = determineMaxAcuLimit(maxAcu);
+    const acu = determineMaxAcuLimit(maxAcu, noMaxAcuLimit);
     const defaultTags = parseStringList(process.env.DEVIN_DEFAULT_TAGS);
     const tagList = [...new Set(["ravi", ...defaultTags, ...parseStringList(tags)])].sort();
 
@@ -448,7 +447,7 @@ export class DevinSessionCommands {
     const resolvedPlatform = resolvePlatform(platform);
     const resolvedRepos = resolveRepos(repos);
     const resolvedCreateAsUser = resolveCreateAsUser(createAsUserId);
-    const resolvedResumable = resolveResumable();
+    const resolvedResumable = resolveResumable(resumable, noResumable);
     const sessionSecrets = parseSessionSecrets(sessionSecretRefs);
 
     const input: CreateDevinSessionInput = {

--- a/src/cli/commands/pages.test.ts
+++ b/src/cli/commands/pages.test.ts
@@ -289,11 +289,12 @@ describe("pages CLI commands", () => {
     });
   });
 
-  it("publishes a local source to a Pages site through the artifact upload pipeline", async () => {
+  it("activates by default and disables activation only with --no-activate", async () => {
     stateDir = await createIsolatedRaviState("ravi-pages-publish-command-test-");
     const dir = await tempDir();
     await writeFile(join(dir, "index.html"), "<h1>Docs</h1>");
     const calls: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const activations: boolean[] = [];
     const client = {
       me: mock(async () => ({
         user: { email: "alice@example.com" },
@@ -319,6 +320,7 @@ describe("pages CLI commands", () => {
       finalizeArtifactPublish: mock(async (input: Record<string, unknown>, accessToken: string) => {
         expect(accessToken).toBe("access-secret");
         calls.push({ method: "finalizeArtifactPublish", payload: input });
+        activations.push((input.publish as { activate?: boolean } | undefined)?.activate ?? false);
         expect(input).toMatchObject({
           uploadSessionId: "upl_123",
           idempotencyKey: "idem-1",
@@ -328,7 +330,6 @@ describe("pages CLI commands", () => {
           },
           publish: {
             siteRef: "demo",
-            activate: true,
             replaceRelease: true,
             reason: "ship docs",
             visibility: "public",
@@ -355,7 +356,7 @@ describe("pages CLI commands", () => {
     } as unknown as ConsoleApiClient;
     const command = new PagesCommands({ client, readCredentials: makeReadCredentials() });
 
-    const { output } = await captureConsole(() =>
+    const publish = (noActivate?: boolean) =>
       command.publish(
         ["proj", "demo", dir],
         undefined,
@@ -372,14 +373,23 @@ describe("pages CLI commands", () => {
         "idem-1",
         "ship docs",
         true,
-        undefined,
+        noActivate,
         undefined,
         true,
-      ),
-    );
-    const payload = JSON.parse(output);
+      );
 
-    expect(calls.map((call) => call.method)).toEqual(["createPageUploadSession", "finalizeArtifactPublish"]);
+    const defaultResult = await captureConsole(() => publish());
+    const noActivateResult = await captureConsole(() => publish(true));
+    const payload = JSON.parse(noActivateResult.output);
+
+    expect(JSON.parse(defaultResult.output)).toMatchObject({ success: true });
+    expect(calls.map((call) => call.method)).toEqual([
+      "createPageUploadSession",
+      "finalizeArtifactPublish",
+      "createPageUploadSession",
+      "finalizeArtifactPublish",
+    ]);
+    expect(activations).toEqual([true, false]);
     expect(payload).toMatchObject({
       success: true,
       url: "https://demo.ravi.page/guide",

--- a/src/cli/commands/pages.ts
+++ b/src/cli/commands/pages.ts
@@ -189,7 +189,7 @@ export class PagesCommands {
     @Option({ flags: "--replace-release", description: "Replace the full active route map instead of merging" })
     replaceRelease?: boolean,
     @Option({ flags: "--no-activate", description: "Create publish records without activating a site release" })
-    activate?: boolean,
+    noActivate?: boolean,
     @Option({ flags: "--console <url>", description: "Console base URL" }) consoleUrl?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
     @Option({ flags: "--site <site>", description: "Legacy site slug/id; defaults to the project Pages host" })
@@ -216,7 +216,7 @@ export class PagesCommands {
           idempotencyKey,
           reason,
           replaceRelease,
-          activate,
+          activate: !noActivate,
           console: consoleUrl,
           tool: "ravi pages publish",
           publishToPages: true,

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Command as CommanderCommand } from "commander";
+import { runWithContext } from "./context.js";
 import { Arg, Command, CommandAccess, Group, Option } from "./decorators.js";
 import { registerCommands } from "./registry.js";
 
@@ -39,6 +40,8 @@ interface CapturedCall {
 
 const capturedDirect: CapturedCall[] = [];
 const capturedNested: CapturedCall[] = [];
+const capturedNegated: boolean[] = [];
+const capturedPaired: Array<{ resumable: boolean | undefined; noResumable: boolean }> = [];
 
 @Group({ name: "shadow", description: "Direct command + nested group with --json", scope: "open" })
 class ShadowDirectCommands {
@@ -58,7 +61,68 @@ class ShadowNestedCommands {
   }
 }
 
+@Group({ name: "negative", description: "Negated options", scope: "open" })
+class NegatedOptionCommands {
+  @Command({ name: "run", description: "Capture a negated option" })
+  @CommandAccess({ kind: "read", resource: "negative", action: "run", risk: "low" })
+  run(@Option({ flags: "--no-cascade", description: "Preserve descendants" }) noCascade = false) {
+    capturedNegated.push(noCascade);
+  }
+}
+
+@Group({ name: "paired", description: "Positive and negated options", scope: "open" })
+class PairedOptionCommands {
+  @Command({ name: "run", description: "Capture paired options" })
+  @CommandAccess({ kind: "read", resource: "paired", action: "run", risk: "low" })
+  run(
+    @Option({ flags: "--resumable", description: "Enable resume" }) resumable?: boolean,
+    @Option({ flags: "--no-resumable", description: "Disable resume" }) noResumable = false,
+  ) {
+    capturedPaired.push({ resumable, noResumable });
+  }
+}
+
+async function parseAsLocalOperator(program: CommanderCommand, argv: string[]): Promise<void> {
+  const contextKey = process.env.RAVI_CONTEXT_KEY;
+  delete process.env.RAVI_CONTEXT_KEY;
+  try {
+    await runWithContext({}, () => program.parseAsync(argv));
+  } finally {
+    if (contextKey === undefined) delete process.env.RAVI_CONTEXT_KEY;
+    else process.env.RAVI_CONTEXT_KEY = contextKey;
+  }
+}
+
 describe("registerCommands", () => {
+  it("binds negated Commander options as no-prefixed flag presence", async () => {
+    capturedNegated.length = 0;
+    const program = new CommanderCommand();
+    program.exitOverride();
+    registerCommands(program, [NegatedOptionCommands]);
+
+    await parseAsLocalOperator(program, ["node", "test", "negative", "run"]);
+    await parseAsLocalOperator(program, ["node", "test", "negative", "run", "--no-cascade"]);
+
+    expect(capturedNegated).toEqual([false, true]);
+  });
+
+  it("keeps paired positive and negated flags distinguishable", async () => {
+    capturedPaired.length = 0;
+    const program = new CommanderCommand();
+    program.exitOverride();
+    registerCommands(program, [PairedOptionCommands]);
+
+    await parseAsLocalOperator(program, ["node", "test", "paired", "run"]);
+    await parseAsLocalOperator(program, ["node", "test", "paired", "run", "--resumable"]);
+    await parseAsLocalOperator(program, ["node", "test", "paired", "run", "--no-resumable"]);
+
+    expect(capturedPaired).toEqual([
+      { resumable: undefined, noResumable: false },
+      { resumable: true, noResumable: false },
+      { resumable: undefined, noResumable: true },
+    ]);
+  });
+
   it("reuses existing nested command nodes for direct commands with subcommands", () => {
     const program = new CommanderCommand();
 
@@ -112,7 +176,7 @@ describe("registerCommands", () => {
     it("propagates --json to a nested subcommand when the parent declares the same flag", async () => {
       capturedNested.length = 0;
       const program = buildProgram();
-      await program.parseAsync(["node", "test", "shadow", "item", "show", "id-123", "--json"]);
+      await parseAsLocalOperator(program, ["node", "test", "shadow", "item", "show", "id-123", "--json"]);
 
       expect(capturedNested).toEqual([{ id: "id-123", json: true }]);
     });
@@ -120,7 +184,7 @@ describe("registerCommands", () => {
     it("still delivers --json to the parent direct command when used without a subcommand", async () => {
       capturedDirect.length = 0;
       const program = buildProgram();
-      await program.parseAsync(["node", "test", "shadow", "item", "id-456", "--json"]);
+      await parseAsLocalOperator(program, ["node", "test", "shadow", "item", "id-456", "--json"]);
 
       expect(capturedDirect).toEqual([{ id: "id-456", json: true }]);
     });
@@ -128,7 +192,7 @@ describe("registerCommands", () => {
     it("omits --json from nested subcommand options when the user did not pass it", async () => {
       capturedNested.length = 0;
       const program = buildProgram();
-      await program.parseAsync(["node", "test", "shadow", "item", "show", "id-789"]);
+      await parseAsLocalOperator(program, ["node", "test", "shadow", "item", "show", "id-789"]);
 
       expect(capturedNested).toEqual([{ id: "id-789", json: undefined }]);
     });

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -201,9 +201,10 @@ function registerCommand(
       const optAtIndex = optionsMeta.find((o) => o.index === i);
       if (optAtIndex) {
         const optName = extractOptionName(optAtIndex.flags);
-        finalArgs.push(options[optName]);
-        if (options[optName] !== undefined) {
-          input[optName] = options[optName];
+        const optionValue = resolveOptionValue(options, optAtIndex.flags, optionsMeta, cmd);
+        finalArgs.push(optionValue);
+        if (optionValue !== undefined) {
+          input[optName] = optionValue;
         }
       }
     }
@@ -270,6 +271,35 @@ function registerCommand(
 
     if (isError) process.exit(1);
   });
+}
+
+function resolveOptionValue(
+  options: Record<string, unknown>,
+  flags: string,
+  commandOptions: Array<{ flags: string }>,
+  command: CommanderCommand,
+): unknown {
+  const optionName = extractOptionName(flags);
+  const longFlag = flags.match(/--([a-zA-Z-]+)/)?.[1];
+  if (!longFlag?.startsWith("no-")) {
+    const value = options[optionName];
+    const hasNegatedPair = commandOptions.some(
+      (option) => option.flags.match(/--([a-zA-Z-]+)/)?.[1] === `no-${longFlag}`,
+    );
+    // Commander stores a paired `--foo`/`--no-foo` under the positive key.
+    // A false value therefore means the positive flag was not present.
+    if (hasNegatedPair && (value === false || command.getOptionValueSource(optionName) !== "cli")) {
+      return undefined;
+    }
+    return value;
+  }
+
+  // Commander exposes `--no-foo` as the positive `foo` option (true when
+  // omitted, false when present). Decorated methods and the generated command
+  // contract expose `noFoo`, so convert Commander's state to flag presence.
+  const positiveName = longFlag.slice(3).replace(/-([a-z])/g, (_, character: string) => character.toUpperCase());
+  const positiveValue = options[positiveName];
+  return typeof positiveValue === "boolean" ? !positiveValue : undefined;
 }
 
 interface DispatchRemoteCommandInput {

--- a/src/cli/schema-inference.test.ts
+++ b/src/cli/schema-inference.test.ts
@@ -95,11 +95,11 @@ describe("inferOptionSchema — booleans", () => {
     expect(schema.parse(true)).toBe(true);
   });
 
-  it("--no-color produces boolean defaulting to true", () => {
+  it("--no-color exposes flag presence and defaults to false", () => {
     const { schema, parsed } = inferOptionSchema(opt({ flags: "--no-color" }));
     expect(parsed.kind).toBe("negated-boolean");
-    expect(schema.parse(undefined)).toBe(true);
-    expect(schema.parse(false)).toBe(false);
+    expect(schema.parse(undefined)).toBe(false);
+    expect(schema.parse(true)).toBe(true);
   });
 });
 

--- a/src/cli/schema-inference.ts
+++ b/src/cli/schema-inference.ts
@@ -14,7 +14,7 @@ import { extractOptionName } from "./utils.js";
  * Kinds of option flags inferred from the DSL.
  *
  * - boolean         — bare flag, `--json`
- * - negated-boolean — `--no-color`; semantically defaults to `true`
+ * - negated-boolean — `--no-color`; public `noColor` presence defaults to `false`
  * - required-value  — `--limit <n>`; commander always passes a string
  * - optional-value  — `--tag [name]`; value optional, still string when present
  * - variadic        — `--items <a...>` / `[a...]`; collected into an array
@@ -87,7 +87,7 @@ export interface InferredOptionSchema {
  * picked to match commander.js runtime values):
  *
  *   --json                                  -> z.boolean().optional()
- *   --no-color                              -> z.boolean().default(true)
+ *   --no-color                              -> z.boolean().default(false)
  *   --limit <n>                             -> z.string().optional()
  *   --limit <n> defaultValue: "10"          -> z.string().default("10")
  *   --tag [name]                            -> z.string().optional()
@@ -108,7 +108,7 @@ export function inferOptionSchema(opt: OptionMetadata): InferredOptionSchema {
     }
     case "negated-boolean": {
       const base = z.boolean();
-      schema = opt.defaultValue !== undefined ? base.default(Boolean(opt.defaultValue)) : base.default(true);
+      schema = opt.defaultValue !== undefined ? base.default(Boolean(opt.defaultValue)) : base.default(false);
       break;
     }
     case "required-value":

--- a/src/cli/tools-export.test.ts
+++ b/src/cli/tools-export.test.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import { describe, expect, it } from "bun:test";
+import type { ContextRecord } from "../router/router-db.js";
+import { runWithContext } from "./context.js";
+import { Command, CommandAccess, Group, Option } from "./decorators.js";
+import { extractTools } from "./tools-export.js";
+
+@Group({ name: "negated", description: "Negated option fixture", scope: "open" })
+class NegatedToolCommands {
+  @Command({ name: "run", description: "Expose negated flag presence" })
+  @CommandAccess({ kind: "read", resource: "negated", action: "run", risk: "low", input: ["noCache"] })
+  run(@Option({ flags: "--no-cache", description: "Disable cache" }) noCache = false) {
+    console.log(JSON.stringify({ noCache }));
+  }
+}
+
+const context: ContextRecord = {
+  contextId: "ctx_negated_test",
+  contextKey: "rctx_negated_test",
+  kind: "test-runtime",
+  agentId: "negated-test",
+  capabilities: [
+    { permission: "read", objectType: "negated", objectId: "run", source: "test" },
+    { permission: "execute", objectType: "group", objectId: "negated", source: "test" },
+  ],
+  createdAt: Date.now(),
+};
+
+describe("tools export negated options", () => {
+  it("uses the same no-prefixed logical contract as CLI and gateway calls", async () => {
+    const tool = extractTools([NegatedToolCommands]).find((candidate) => candidate.name === "negated_run");
+    expect(tool).toBeDefined();
+
+    const omitted = await runWithContext({ agentId: context.agentId, context }, () => tool!.handler({}));
+    const present = await runWithContext({ agentId: context.agentId, context }, () => tool!.handler({ noCache: true }));
+
+    expect(JSON.parse(omitted.content[0]?.text ?? "{}")).toEqual({ noCache: false });
+    expect(JSON.parse(present.content[0]?.text ?? "{}")).toEqual({ noCache: true });
+  });
+});

--- a/src/sdk/gateway/dispatcher.test.ts
+++ b/src/sdk/gateway/dispatcher.test.ts
@@ -11,6 +11,13 @@ import { dispatch, type AuditEvent } from "./dispatcher.js";
 
 @Group({ name: "demo", description: "Gateway demo commands", scope: "open" })
 class GatewayDemoCommands {
+  @Command({ name: "negated", description: "Expose negated flag presence" })
+  @CommandAccess({ kind: "read", resource: "demo", action: "negated", risk: "low", input: ["noCache"] })
+  @Returns(z.object({ noCache: z.boolean() }))
+  negated(@Option({ flags: "--no-cache", description: "Disable cache" }) noCache = false) {
+    return { noCache };
+  }
+
   @Command({ name: "echo", description: "Echo a name" })
   @CommandAccess({ kind: "read", resource: "demo", action: "echo", risk: "low", input: ["name", "limit"] })
   @Returns(
@@ -265,6 +272,34 @@ describe("dispatch — body shape (flat-only)", () => {
 });
 
 describe("dispatch — validation", () => {
+  it("defaults negated flags to false and honors explicit true over the gateway", async () => {
+    const audits = captureAudits();
+
+    const defaultResult = await dispatch(
+      findCmd("demo.negated"),
+      {},
+      {},
+      {
+        contextRecord: demoContext,
+        emitAudit: audits.emit,
+      },
+    );
+    const disabledResult = await dispatch(
+      findCmd("demo.negated"),
+      { noCache: true },
+      {},
+      {
+        contextRecord: demoContext,
+        emitAudit: audits.emit,
+      },
+    );
+
+    expect(defaultResult.response.status).toBe(200);
+    expect(disabledResult.response.status).toBe(200);
+    expect(await defaultResult.response.json()).toEqual({ noCache: false });
+    expect(await disabledResult.response.json()).toEqual({ noCache: true });
+  });
+
   it("returns 400 ValidationError when required arg is missing", async () => {
     const audits = captureAudits();
     const result = await dispatch(findCmd("demo.echo"), {}, {}, { emitAudit: audits.emit });


### PR DESCRIPTION
## Objective

Make negated CLI flags carry the same boolean meaning through Commander, decorated command methods, remote gateway payloads, tool schemas, and generated SDK contracts.

## Problem

- Commander stores `--no-foo` under the positive `foo` key and defaults it to `true`, while Ravi's decorated public contract exposes flag presence as `noFoo`.
- The registry forwarded Commander's internal value directly, so omitted negated flags and explicit flags could be inverted or serialized under the wrong semantics.
- Several handlers compensated by inspecting process arguments or by accepting a positive boolean whose meaning differed from the published schema.

## Solution

- Centralize option binding in the registry and translate negated flags into explicit public flag-presence booleans.
- Handle paired `--foo` / `--no-foo` declarations without inventing a value when neither flag was supplied.
- Update affected commands to consume the validated method argument and regenerate the derived contracts.

## Practical impact

- CLI users, agents, remote gateway callers, and SDK clients now observe the same behavior for flags such as `--no-activate` and `--no-store`.

## What does NOT change

- Standalone positive flags, value-bearing options, command names, and external wire field names retain their existing behavior. Only positive flags paired with `--no-*` gain explicit omitted-value handling.

## Validation

- Focused registry, schema-inference, gateway, tools-export, Pages, context, daemon, and Devin tests passed: 102 tests, 0 failures.
- TypeScript, Biome, SDK generation checks, and `git diff --check` passed.
- The configured repository test suite passed on a descendant stack in which this commit was unchanged.

## Risks

- Commands that accidentally depended on Commander's positive default for a `--no-*` declaration will now receive the documented flag-presence value instead.

## Rollback

- Revert this commit to restore the previous binding behavior; no data migration or persistent-state rollback is required.

## Follow-ups

- This PR is stacked on `codex/sdk-generated-contract-refresh` because the option registry changes regenerate the same SDK artifacts.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->