### PR TITLE
fix(inbox): make Console delivery recoverable and idempotent

### DIFF
--- a/.ravi/specs/cli/inbox/CHECKS.md
+++ b/.ravi/specs/cli/inbox/CHECKS.md
@@ -6,9 +6,32 @@
 - Compatibility delivery commands that return bounded snapshots support
   `--json`.
 - Local mirror writes happen before NATS publish and Console ack.
+- NATS publish includes a server flush before `delivered_at` or Console ack.
+- Poll-lease ownership is renewed and verified before every NATS publish and
+  Console ack.
 - Console ack is not attempted for an item unless local publish succeeded.
+- Partial/error Console ack does not update `acked_at`, generation, or sequence
+  progress for the batch.
+- A later authoritative subscription cursor reconciles only already-delivered,
+  still-unacked rows in the same Console+organization scope.
+- Delivery progress sorts by sequence and advances only across a contiguous
+  successful prefix.
+- Intermediate pages advance the batch cursor but retain neither generation nor
+  ETag; `hasMore` schedules the next page immediately.
+- Ack-only redelivery preserves the exact stored payload/provenance and skips
+  enrichment, ingestion, and NATS publish.
+- Fresh Ravi state creates the Console delivery mirror and poll-lease schema.
+- A paused subscription resumes after valid login/explicit enable.
+- A concurrent poll owner is rejected until the renewable SQLite lease is
+  released or expires.
+- Concurrent ticks on one runner instance are coalesced into one poll cycle.
+- Poll-lease release failure does not suppress the next scheduled tick.
 - Replay republishes local SQLite payloads and does not call Console item
   creation endpoints.
+- Replay uses the live canonical-plus-watch publisher, flushes NATS, and updates
+  `replay_count` only after flush success.
+- Remote item-id replay fails closed when more than one Console+organization
+  scope owns the same id.
 - The compatibility delivery CLI does not expose watch creation or watch
   connector management; those belong to `ravi watch`.
 - New docs and specs do not describe Console delivery as the product inbox.
@@ -42,10 +65,30 @@ Simulate one changed pulse with one item.
 Expected order:
 
 1. local item row exists;
-2. NATS publish succeeds;
-3. local `delivered_at` is set;
-4. Console ack is sent;
-5. local `acked_at` is set after ack success.
+2. the poll lease is renewed before each applicable NATS subject;
+3. canonical and normalized watch NATS publishes succeed;
+4. NATS flush succeeds;
+5. local `delivered_at` is set;
+6. the poll lease is renewed before Console ack;
+7. Console returns `acked === requested`;
+8. local `acked_at` and contiguous cursor progress are committed.
+
+Repeat with a partial ack and a delivery sequence gap.
+
+Expected:
+
+- partial/error ack advances neither local ack state nor the cursor;
+- an advanced cursor in the next pulse heals `unacked` for locally delivered
+  rows only;
+- a sequence gap blocks that sequence and all later progress in the batch.
+
+Repeat with two poll pages under one watermark.
+
+Expected:
+
+- page one persists its contiguous cursor without generation or ETag;
+- page two is requested without an `If-None-Match` deadlock;
+- generation is committed only after the second page reaches the watermark.
 
 ## Replay Regression
 
@@ -56,4 +99,8 @@ Expected:
 - NATS payload preserves `eventId`, `sequence`, `dedupeKey`, `eventType`, and
   original timestamps;
 - replay metadata is additive;
+- canonical and normalized watch subjects are both republished when applicable;
+- NATS flush completes before `replay_count` increments;
+- a flush failure leaves `replay_count` unchanged;
 - Console is not called to create a new delivery item.
+- an ambiguous remote item id requires a local numeric row id.

--- a/.ravi/specs/cli/inbox/RUNBOOK.md
+++ b/.ravi/specs/cli/inbox/RUNBOOK.md
@@ -27,6 +27,9 @@ ravi inbox disable
 ```
 
 Use `disable` when debugging server behavior without local leases.
+Running `enable` on an already-enabled paused/errored subscription revalidates
+it, clears stale errors, and returns it to `active`; repeating `enable` after
+that is a no-op.
 
 ## One Foreground Tick
 
@@ -38,7 +41,13 @@ Expected:
 
 - missing credentials or scopes produce a safe error/paused status;
 - no-change path completes without polling;
-- changed path persists items, publishes NATS, then acks Console.
+- changed path persists items, publishes canonical and normalized watch NATS
+  events, flushes, marks delivered, then acks Console;
+- a partial/error ack leaves local ack and cursor progress unchanged;
+- a later pulse whose Console cursor has advanced heals local `unacked` rows
+  that were already delivered in that Console+organization scope;
+- multi-page polls retain neither generation nor ETag between pages;
+- cursor progress stops at the first failed or non-contiguous sequence.
 
 ## Replay Local Event
 
@@ -48,10 +57,24 @@ ravi inbox replay <item-id-or-local-row-id>
 ```
 
 Replay should publish to `ravi.console.inbox.item` from the SQLite mirror. It
-must not create a new Console delivery item.
+must not create a new Console delivery item. Success means all applicable NATS
+subjects were flushed; `replay_count` remains unchanged when publish or flush
+fails.
+
+If the same remote item id exists in multiple Console+organization scopes, use
+the local numeric row id; remote-id replay fails closed rather than guessing.
 
 If the item contains a watch event, the bridge should also expose the normalized
 watch topic from `ravi watch show <watch-id>` or the event payload.
+
+## Poll Lease Debug
+
+The poll lease is stored in `console_inbox_poll_locks`, keyed by normalized
+Console URL and organization. A second runner must wait until the current owner
+releases the lease or its bounded TTL expires. The active owner renews before
+each NATS publish and Console ack; losing ownership aborts the batch without
+advancing local ack/cursor state. A lease-release error is logged, but the daemon
+still schedules its next tick.
 
 ## NATS Debug
 

--- a/.ravi/specs/cli/inbox/SPEC.md
+++ b/.ravi/specs/cli/inbox/SPEC.md
@@ -92,6 +92,8 @@ Commands consumed by agents MUST support machine-readable output.
 - The CLI MUST refresh through Console on auth-expired responses.
 - If credentials are missing, invalid, revoked, or lack inbox scopes, the runner
   MUST skip or pause without deleting unrelated local mirror rows.
+- A paused row MUST perform bounded credential rechecks. Successful login or
+  explicit enable MUST resume it and clear stale authentication errors.
 - OSS Ravi MUST NOT store Console refresh tokens anywhere except the configured
   cloud-auth credential store.
 
@@ -106,15 +108,42 @@ The local loop MUST follow this order:
 5. If there is no change, update only local status/timestamps and sleep.
 6. If generation changed, poll/lease a bounded batch.
 7. Persist each item to the local SQLite mirror.
-8. Publish the canonical NATS event.
-9. Mark the local item delivered.
-10. Ack delivered to Console idempotently.
+8. Renew and verify ownership of the local poll lease before each NATS publish.
+9. Publish the canonical NATS event and, for watch items, its normalized
+   `ravi.watch.*` event.
+10. Flush the NATS connection and require server confirmation.
+11. Mark the local item delivered.
+12. Renew and verify ownership of the local poll lease.
+13. Ack delivered items to Console idempotently.
+14. Mark local ack state and advance the delivery cursor only after Console
+   reports `acked` equal to the number requested.
 
 The no-change path MUST remain pulse-only. It MUST NOT lease items, write
 Console receipts, or force a full Console inbox scan.
 
-The runner MUST NOT ack delivered before local persistence and NATS publish have
-completed for that item.
+The runner MUST NOT mark an item delivered or ack it before local persistence,
+all applicable NATS publishes, and the NATS flush have completed for that item.
+It MUST verify the renewable local poll lease immediately before every NATS
+publish and Console ack.
+
+An ack transport error, malformed ack, or partial ack (`acked !== requested`)
+MUST advance neither local `acked_at` nor the batch delivery cursor. Delivery
+progress MUST be evaluated in sequence order and advance only through the
+contiguous, successfully delivered prefix after a complete remote ack. A gap or
+failed delivery blocks all later sequence progress for that batch.
+
+Generation and pulse ETag state MUST be committed only after the delivered
+cursor reaches the pulse watermark and the poll reports no further page. After
+a successful intermediate page, Ravi MUST persist the contiguous batch cursor,
+drop the ETag, and immediately request the next page when `hasMore` is true.
+When the cursor remains behind but no page is currently available, it MUST stay
+retryable at the normal poll interval rather than hot-looping Console.
+
+Console's subscription cursor is authoritative evidence for prior acks. A later
+pulse MUST reconcile `acked_at` for already-delivered local rows through that
+cursor, scoped to the same Console origin and organization. It MUST NOT mark an
+undelivered row acked. This reconciliation heals a response/crash window; it
+does not make a partial ack response itself successful.
 
 ## Local Delivery Mirror
 
@@ -127,6 +156,9 @@ The SQLite mirror MUST store enough data to:
 - replay a locally stored item without creating a new Console item.
 
 The mirror SHOULD key idempotency by `(console_url, organization_id, item_id)`.
+Once `delivered_at` is set, redelivery is an ack-only retry: the stored NATS
+payload and original subscription provenance MUST remain byte-for-byte stable,
+and mail enrichment/local ingestion/NATS publish MUST NOT run again.
 
 ## NATS Event Contract
 
@@ -212,6 +244,14 @@ Replay MUST preserve `eventId`, `sequence`, `dedupeKey`, `eventType`, and
 original timestamps. Replay MAY add delivery metadata such as `replayed`,
 `replayCount`, and `replayedAt`.
 
+Replay MUST use the same canonical-plus-normalized-watch publish path as live
+delivery, MUST flush NATS before reporting success, and MUST increment the local
+replay count only after that flush succeeds.
+
+A remote `item-id` replay reference MUST resolve uniquely from the item rows'
+own Console+organization scopes. If more than one scope contains that id, the
+command MUST fail closed and require the unambiguous local numeric row id.
+
 ## Daemon Integration
 
 `ravi daemon` SHOULD start the Console delivery runner automatically when:
@@ -223,6 +263,14 @@ original timestamps. Replay MAY add delivery metadata such as `replayed`,
 
 The delivery runner MUST coordinate with itself through a local lock so only one
 local loop leases/publishes/acks Console deliveries at a time.
+Overlapping timer or foreground ticks on the same runner instance MUST also be
+coalesced before attempting the SQLite lease.
+
+The lock is a renewable SQLite lease keyed by normalized Console origin and
+organization. It MUST expire after a bounded interval, release after every tick,
+and allow a second process to take over only after release or expiry. Lease
+release errors MUST NOT prevent the running daemon from scheduling its next
+poll.
 
 ## Acceptance Criteria
 
@@ -234,8 +282,10 @@ local loop leases/publishes/acks Console deliveries at a time.
 - `ravi console delivery poll --once` runs one foreground tick and exits.
 - No-change pulse does not poll/lease Console rows.
 - Changed pulse leads to bounded poll, local persistence, NATS publish, local
-  delivered mark, and Console ack in that order.
+  flush, local delivered mark, and Console ack in that order.
 - Delivered-but-unacked items can be acked later without duplicate local publish.
-- Replay republishes from the local mirror and preserves event identity.
+- A partial/error ack advances neither local ack state nor the delivery cursor.
+- Replay republishes canonical and normalized watch subjects from the local
+  mirror, preserves event identity, and counts success only after NATS flush.
 - Console-produced watch events can be consumed by ordinary `ravi triggers`
   subscriptions through the normalized watch subject.

--- a/src/cli/commands/inbox.test.ts
+++ b/src/cli/commands/inbox.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { getItemById, publishInboxNatsEvents, upsertDeliveredItem, type InboxNatsPayload } from "../../inbox/index.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
+import { runWithContext } from "../context.js";
+import { getCommandAccessMetadata } from "../decorators.js";
+import { InboxCommands } from "./inbox.js";
+
+let stateDir: string | null = null;
+
+describe("inbox replay", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-inbox-replay-test-");
+    spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("uses the delivery publisher and increments replay count only after flush", async () => {
+    const row = seedWatchItem();
+    const actions: string[] = [];
+    const command = new InboxCommands({
+      publishInboxNatsEvents: (input) =>
+        publishInboxNatsEvents(input, {
+          publish: async (subject, payload) => {
+            actions.push(`publish:${subject}`);
+            if (subject === "ravi.console.inbox.item") {
+              expect(payload).toMatchObject({
+                eventId: "item_1",
+                sequence: 11,
+                dedupeKey: "dedupe_1",
+                eventType: "watch.github.release.published",
+                delivery: { replayed: true, replayCount: 1 },
+              });
+            } else {
+              expect(payload).toMatchObject({
+                eventId: "item_1",
+                watchId: "watch_1",
+                eventType: "release.published",
+                delivery: { replayed: true, replayCount: 1, inboxItemId: row.id },
+              });
+            }
+          },
+          flush: async () => {
+            actions.push("flush");
+            expect(getItemById(row.id)?.replayCount).toBe(0);
+          },
+        }),
+    });
+
+    const result = await command.replay(String(row.id), true);
+
+    expect(result).toMatchObject({
+      ok: true,
+      itemId: "item_1",
+      sequence: 11,
+      subject: "ravi.console.inbox.item",
+    });
+    expect(actions).toEqual([
+      "publish:ravi.console.inbox.item",
+      "publish:ravi.watch.github.release.published",
+      "flush",
+    ]);
+    expect(getItemById(row.id)?.replayCount).toBe(1);
+  });
+
+  it("does not increment replay count when delivery flush fails", async () => {
+    const row = seedWatchItem();
+    const command = new InboxCommands({
+      publishInboxNatsEvents: (input) =>
+        publishInboxNatsEvents(input, {
+          publish: async () => {},
+          flush: async () => {
+            throw new Error("flush failed");
+          },
+        }),
+    });
+
+    expect(command.replay(String(row.id), true)).rejects.toThrow("flush failed");
+    expect(getItemById(row.id)?.replayCount).toBe(0);
+  });
+
+  it("resolves a unique remote item id from the item's own Console and organization scope", async () => {
+    const row = seedWatchItem();
+    const command = new InboxCommands({
+      publishInboxNatsEvents: async () => ["ravi.console.inbox.item"],
+    });
+
+    const result = await command.replay(row.itemId, true);
+
+    expect(result).toMatchObject({ ok: true, itemId: row.itemId, sequence: row.sequence });
+    expect(getItemById(row.id)?.replayCount).toBe(1);
+  });
+
+  it("fails closed when a remote item id exists in more than one Console organization", async () => {
+    seedWatchItem();
+    const payload = makePayload();
+    upsertDeliveredItem({
+      consoleUrl: "https://other-console.ravi.bot",
+      organizationId: "org_2",
+      subscriptionId: "sub_2",
+      itemId: payload.eventId,
+      sequence: payload.sequence,
+      eventType: payload.eventType,
+      category: payload.category,
+      severity: payload.severity,
+      dedupeKey: payload.dedupeKey,
+      natsSubject: "ravi.console.inbox.item",
+      natsPayloadJson: JSON.stringify(payload),
+      deliveredAt: Date.parse(payload.delivery.localDeliveredAt),
+    });
+    const command = new InboxCommands();
+
+    await expect(runWithContext({}, () => command.replay(payload.eventId, true))).rejects.toThrow(
+      "ambiguous across Console organizations",
+    );
+  });
+});
+
+describe("inbox command access", () => {
+  it("classifies poll and replay as mutating operations", () => {
+    const access = getCommandAccessMetadata(InboxCommands);
+    expect(access.get("poll")).toMatchObject({ kind: "mutate", resource: "inbox", risk: "medium" });
+    expect(access.get("replay")).toMatchObject({ kind: "mutate", resource: "inbox", risk: "medium" });
+  });
+});
+
+function seedWatchItem() {
+  const payload = makePayload();
+  return upsertDeliveredItem({
+    consoleUrl: "https://console.ravi.bot",
+    organizationId: "org_1",
+    subscriptionId: "sub_1",
+    itemId: payload.eventId,
+    sequence: payload.sequence,
+    eventType: payload.eventType,
+    category: payload.category,
+    severity: payload.severity,
+    dedupeKey: payload.dedupeKey,
+    natsSubject: "ravi.console.inbox.item",
+    natsPayloadJson: JSON.stringify(payload),
+    deliveredAt: Date.parse(payload.delivery.localDeliveredAt),
+  }).row;
+}
+
+function makePayload(): InboxNatsPayload {
+  return {
+    version: 1,
+    eventId: "item_1",
+    sequence: 11,
+    dedupeKey: "dedupe_1",
+    eventType: "watch.github.release.published",
+    category: "source_control",
+    severity: "info",
+    sensitivity: "private",
+    title: "Release published",
+    summary: "v1.0.0",
+    organization: { id: "org_1" },
+    project: { id: "project_1" },
+    source: { type: "github", id: "repo_1" },
+    actor: { type: "user", id: "user_1" },
+    target: { type: "release", id: "release_1" },
+    payload: { watch: { id: "watch_1", placement: "console" } },
+    links: [{ label: "release", url: "https://example.com/release" }],
+    delivery: {
+      subscriptionId: "sub_1",
+      installationId: "ins_1",
+      pollId: "poll_1",
+      leaseId: "lease_1",
+      localDeliveredAt: "2026-07-21T12:00:00.000Z",
+    },
+    occurredAt: "2026-07-21T11:59:00.000Z",
+    createdAt: "2026-07-21T12:00:00.000Z",
+  };
+}

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -5,7 +5,6 @@
 import "reflect-metadata";
 import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
 import { fail } from "../context.js";
-import { publish } from "../../nats.js";
 import {
   inboxItemEnvelopeReturnSchema,
   inboxItemsReturnSchema,
@@ -19,16 +18,25 @@ import {
 import {
   INBOX_NATS_SUBJECT,
   getItemById,
-  getItemByItemId,
   getStatusSnapshot,
+  incrementItemReplayCount,
+  listItemsByItemId,
   listLocalInboxItems,
   listLocalInboxSources,
   listRecentItems,
   markLocalInboxItem,
   readLocalInboxItem,
+  publishInboxNatsEvents,
   runSingleTick,
   setEnabledForCurrentOrg,
+  type InboxNatsPayload,
 } from "../../inbox/index.js";
+
+interface InboxCommandDependencies {
+  publishInboxNatsEvents: typeof publishInboxNatsEvents;
+}
+
+const DEFAULT_DEPENDENCIES: InboxCommandDependencies = { publishInboxNatsEvents };
 
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
@@ -90,6 +98,8 @@ function parseTimestamp(value: string | undefined, label: string): number {
   scope: "open",
 })
 export class InboxCommands {
+  constructor(private readonly dependencies: InboxCommandDependencies = DEFAULT_DEPENDENCIES) {}
+
   @Command({ name: "list", description: "List local inbox items" })
   @CommandAccess({ kind: "read", resource: "inbox", action: "list", risk: "low" })
   @Returns(inboxItemsReturnSchema)
@@ -294,7 +304,7 @@ export class InboxCommands {
   }
 
   @Command({ name: "poll", description: "Run a single inbox poll cycle (foreground)" })
-  @CommandAccess({ kind: "read", resource: "inbox", action: "poll", risk: "low" })
+  @CommandAccess({ kind: "mutate", resource: "inbox", action: "poll", risk: "medium" })
   @Returns(inboxPollReturnSchema)
   async poll(
     @Option({ flags: "--once", description: "Run one cycle and exit (default)" }) _once?: boolean,
@@ -349,7 +359,7 @@ export class InboxCommands {
   }
 
   @Command({ name: "replay", description: "Republish a locally stored inbox item to NATS" })
-  @CommandAccess({ kind: "read", resource: "inbox", action: "replay", risk: "low" })
+  @CommandAccess({ kind: "mutate", resource: "inbox", action: "replay", risk: "medium" })
   @Returns(inboxReplayReturnSchema)
   async replay(
     @Arg("ref", { description: "Local row id (number) or remote item id (uuid)" }) ref: string,
@@ -362,11 +372,11 @@ export class InboxCommands {
 
     let row = /^\d+$/.test(ref) ? getItemById(Number(ref)) : null;
     if (!row) {
-      const snapshot = getStatusSnapshot();
-      const target = snapshot.subscriptions[0];
-      if (target) {
-        row = getItemByItemId(target.consoleUrl, target.organizationId, ref);
+      const matches = listItemsByItemId(ref);
+      if (matches.length > 1) {
+        fail(`Inbox item ref ${ref} is ambiguous across Console organizations; replay a local numeric row id.`);
       }
+      row = matches[0] ?? null;
     }
 
     if (!row) {
@@ -374,16 +384,16 @@ export class InboxCommands {
       return;
     }
 
-    let payload: Record<string, unknown>;
+    let payload: InboxNatsPayload;
     try {
-      payload = JSON.parse(row.natsPayloadJson) as Record<string, unknown>;
+      payload = JSON.parse(row.natsPayloadJson) as InboxNatsPayload;
     } catch (error) {
       fail(`Stored NATS payload is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
       return;
     }
 
     const replayedAt = new Date().toISOString();
-    const delivery = (payload.delivery as Record<string, unknown> | undefined) ?? {};
+    const delivery = payload.delivery ?? {};
     payload.delivery = {
       ...delivery,
       replayed: true,
@@ -391,13 +401,18 @@ export class InboxCommands {
       replayedAt,
     };
 
-    await publish(row.natsSubject || INBOX_NATS_SUBJECT, payload);
+    const subjects = await this.dependencies.publishInboxNatsEvents({
+      payload,
+      inboxItemId: row.id,
+      canonicalSubject: row.natsSubject || INBOX_NATS_SUBJECT,
+    });
+    incrementItemReplayCount(row.id);
 
     const result = {
       ok: true,
       itemId: row.itemId,
       sequence: row.sequence,
-      subject: row.natsSubject || INBOX_NATS_SUBJECT,
+      subject: subjects[0] ?? row.natsSubject ?? INBOX_NATS_SUBJECT,
       replayedAt,
     };
     if (asJson) printJson(result);

--- a/src/inbox/inbox-db.test.ts
+++ b/src/inbox/inbox-db.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { writeCloudCredentials } from "../cloud-auth/storage.js";
+import { getDb } from "../router/router-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import {
+  acquireInboxPollLock,
+  countPendingItems,
+  ensureSubscriptionRow,
+  getItemByItemId,
+  getSubscriptionByOrg,
+  inboxPollLockKey,
+  markSubscriptionPolled,
+  releaseInboxPollLock,
+  reconcileDeliveredItemsAckedThroughSequence,
+  renewInboxPollLock,
+  upsertDeliveredItem,
+} from "./inbox-db.js";
+import { setEnabledForCurrentOrg } from "./inbox-runner.js";
+
+let stateDir: string | null = null;
+
+describe("console inbox delivery state", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-console-inbox-test-");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("creates the complete delivery schema in a fresh Ravi state", () => {
+    const rows = getDb()
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name IN (
+           'console_inbox_subscriptions',
+           'console_inbox_items',
+           'console_inbox_poll_locks'
+         )
+         ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>;
+
+    expect(rows.map((row) => row.name)).toEqual([
+      "console_inbox_items",
+      "console_inbox_poll_locks",
+      "console_inbox_subscriptions",
+    ]);
+  });
+
+  it("resumes an already-enabled paused subscription idempotently", () => {
+    writeCloudCredentials(makeCredentials());
+    const row = ensureSubscriptionRow({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      installationId: "ins_1",
+    });
+    markSubscriptionPolled(row.id, { status: "paused", errorCode: "CREDENTIALS_INVALID" });
+
+    expect(setEnabledForCurrentOrg(true)).toEqual({ changed: true });
+    expect(getSubscriptionByOrg(row.consoleUrl, row.organizationId)).toMatchObject({
+      enabled: true,
+      status: "active",
+      lastErrorCode: null,
+      lastErrorAt: null,
+    });
+    expect(setEnabledForCurrentOrg(true)).toEqual({ changed: false });
+  });
+
+  it("reactivates a paused subscription after installation rotation", () => {
+    const row = ensureSubscriptionRow({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      installationId: "ins_1",
+    });
+    markSubscriptionPolled(row.id, {
+      generation: 7,
+      lastSequence: 42,
+      status: "paused",
+      errorCode: "INSTALLATION_REVOKED",
+    });
+
+    expect(
+      ensureSubscriptionRow({
+        consoleUrl: row.consoleUrl,
+        organizationId: row.organizationId,
+        installationId: "ins_2",
+      }),
+    ).toMatchObject({
+      installationId: "ins_2",
+      subscriptionId: null,
+      status: "active",
+      lastGeneration: null,
+      lastSequence: null,
+      lastErrorCode: null,
+      lastErrorAt: null,
+    });
+  });
+
+  it("allows one poll owner and permits takeover only after release or expiry", () => {
+    const lockKey = inboxPollLockKey("https://console.ravi.bot/", "org_1");
+    expect(lockKey).toBe(inboxPollLockKey("https://console.ravi.bot", "org_1"));
+
+    expect(acquireInboxPollLock({ lockKey, ownerId: "runner_a", ttlMs: 1_000, now: 1_000 })).toBe(true);
+    expect(acquireInboxPollLock({ lockKey, ownerId: "runner_b", ttlMs: 1_000, now: 1_500 })).toBe(false);
+    expect(renewInboxPollLock({ lockKey, ownerId: "runner_b", ttlMs: 1_000, now: 1_500 })).toBe(false);
+    expect(renewInboxPollLock({ lockKey, ownerId: "runner_a", ttlMs: 1_000, now: 1_600 })).toBe(true);
+    expect(releaseInboxPollLock(lockKey, "runner_b")).toBe(false);
+    expect(releaseInboxPollLock(lockKey, "runner_a")).toBe(true);
+    expect(acquireInboxPollLock({ lockKey, ownerId: "runner_b", ttlMs: 1_000, now: 1_700 })).toBe(true);
+    expect(acquireInboxPollLock({ lockKey, ownerId: "runner_c", ttlMs: 1_000, now: 2_700 })).toBe(true);
+  });
+
+  it("counts pending items by the local Console+organization mirror", () => {
+    const subscription = ensureSubscriptionRow({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      installationId: "ins_1",
+    });
+    upsertDeliveredItem({
+      consoleUrl: subscription.consoleUrl,
+      organizationId: subscription.organizationId,
+      subscriptionId: "remote_sub_1",
+      itemId: "item_1",
+      sequence: 1,
+      eventType: "task.created",
+      category: "task",
+      severity: "info",
+      dedupeKey: "task:item_1",
+      natsSubject: "ravi.console.inbox.item",
+      natsPayloadJson: "{}",
+      deliveredAt: null,
+    });
+
+    expect(
+      countPendingItems({
+        consoleUrl: subscription.consoleUrl,
+        organizationId: subscription.organizationId,
+      }),
+    ).toEqual({ undelivered: 1, unacked: 1 });
+  });
+
+  it("keeps a flushed item's payload and subscription provenance immutable on redelivery", () => {
+    const original = upsertDeliveredItem({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      subscriptionId: "sub_original",
+      itemId: "item_immutable",
+      sequence: 9,
+      eventType: "task.created",
+      category: "task",
+      severity: "info",
+      dedupeKey: "dedupe_original",
+      natsSubject: "ravi.console.inbox.item",
+      natsPayloadJson: '{"delivery":{"pollId":"original"}}',
+      deliveredAt: 10_000,
+    }).row;
+
+    const retry = upsertDeliveredItem({
+      consoleUrl: original.consoleUrl,
+      organizationId: original.organizationId,
+      subscriptionId: "sub_retry",
+      itemId: original.itemId,
+      sequence: 99,
+      eventType: "task.changed",
+      category: "changed",
+      severity: "warning",
+      dedupeKey: "dedupe_retry",
+      natsSubject: "ravi.changed",
+      natsPayloadJson: '{"delivery":{"pollId":"retry"}}',
+      deliveredAt: null,
+    });
+
+    expect(retry.created).toBe(false);
+    expect(retry.row).toMatchObject({
+      id: original.id,
+      subscriptionId: "sub_original",
+      sequence: 9,
+      eventType: "task.created",
+      category: "task",
+      severity: "info",
+      dedupeKey: "dedupe_original",
+      natsSubject: "ravi.console.inbox.item",
+      natsPayloadJson: '{"delivery":{"pollId":"original"}}',
+      deliveredAt: 10_000,
+    });
+  });
+
+  it("reconciles only delivered rows in the authoritative Console and organization scope", () => {
+    const seed = (input: {
+      consoleUrl: string;
+      organizationId: string;
+      itemId: string;
+      sequence: number;
+      deliveredAt: number | null;
+    }) =>
+      upsertDeliveredItem({
+        ...input,
+        subscriptionId: `sub_${input.organizationId}`,
+        eventType: "task.created",
+        category: "task",
+        severity: "info",
+        dedupeKey: `dedupe_${input.itemId}`,
+        natsSubject: "ravi.console.inbox.item",
+        natsPayloadJson: "{}",
+      }).row;
+
+    const delivered = seed({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      itemId: "item_delivered",
+      sequence: 4,
+      deliveredAt: 1_000,
+    });
+    const undelivered = seed({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      itemId: "item_undelivered",
+      sequence: 5,
+      deliveredAt: null,
+    });
+    const otherOrganization = seed({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_2",
+      itemId: "item_other_org",
+      sequence: 4,
+      deliveredAt: 1_000,
+    });
+
+    expect(
+      reconcileDeliveredItemsAckedThroughSequence({
+        consoleUrl: "https://console.ravi.bot",
+        organizationId: "org_1",
+        sequence: 5,
+        ackedAt: 2_000,
+      }),
+    ).toBe(1);
+    expect(getItemByItemId(delivered.consoleUrl, delivered.organizationId, delivered.itemId)?.ackedAt).toBe(2_000);
+    expect(getItemByItemId(undelivered.consoleUrl, undelivered.organizationId, undelivered.itemId)?.ackedAt).toBeNull();
+    expect(
+      getItemByItemId(otherOrganization.consoleUrl, otherOrganization.organizationId, otherOrganization.itemId)
+        ?.ackedAt,
+    ).toBeNull();
+  });
+});
+
+function makeCredentials() {
+  const now = new Date().toISOString();
+  return {
+    version: 1 as const,
+    consoleUrl: "https://console.ravi.bot",
+    installationId: "ins_1",
+    accessToken: "access-test",
+    refreshToken: "refresh-test",
+    accessTokenExpiresAt: null,
+    refreshTokenExpiresAt: null,
+    scopes: [],
+    organization: { id: "org_1" },
+    user: { id: "user_1" },
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/src/inbox/inbox-db.ts
+++ b/src/inbox/inbox-db.ts
@@ -164,14 +164,37 @@ export function setSubscriptionEnabled(id: string, enabled: boolean): void {
   getDb()
     .prepare(
       `UPDATE console_inbox_subscriptions
-       SET enabled = ?, updated_at = ?
+       SET enabled = ?,
+           status = CASE WHEN ? = 1 THEN 'active' ELSE status END,
+           last_error_code = CASE WHEN ? = 1 THEN NULL ELSE last_error_code END,
+           last_error_at = CASE WHEN ? = 1 THEN NULL ELSE last_error_at END,
+           updated_at = ?
        WHERE id = ?`,
     )
-    .run(enabled ? 1 : 0, now, id);
+    .run(enabled ? 1 : 0, enabled ? 1 : 0, enabled ? 1 : 0, enabled ? 1 : 0, now, id);
 }
 
-export function updateSubscriptionRemoteId(id: string, subscriptionId: string): void {
+/** Persist the Console subscription identity, optionally starting its cursor contract from scratch. */
+export function updateSubscriptionRemoteId(
+  id: string,
+  subscriptionId: string | null,
+  options: { resetCursor?: boolean } = {},
+): void {
   const now = Date.now();
+  if (options.resetCursor) {
+    getDb()
+      .prepare(
+        `UPDATE console_inbox_subscriptions
+         SET subscription_id = ?,
+             last_generation = NULL,
+             last_sequence = NULL,
+             updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(subscriptionId, now, id);
+    return;
+  }
+
   getDb()
     .prepare(
       `UPDATE console_inbox_subscriptions
@@ -188,6 +211,7 @@ function resetSubscriptionForInstallationRotation(id: string, installationId: st
       `UPDATE console_inbox_subscriptions
        SET installation_id = ?,
            subscription_id = NULL,
+           status = 'active',
            last_generation = NULL,
            last_sequence = NULL,
            last_error_code = NULL,
@@ -196,6 +220,53 @@ function resetSubscriptionForInstallationRotation(id: string, installationId: st
        WHERE id = ?`,
     )
     .run(installationId, now, id);
+}
+
+export function inboxPollLockKey(consoleUrl: string, organizationId: string): string {
+  return `${consoleUrl.replace(/\/+$/, "")}\u0000${organizationId}`;
+}
+
+export function acquireInboxPollLock(input: {
+  lockKey: string;
+  ownerId: string;
+  ttlMs: number;
+  now?: number;
+}): boolean {
+  const now = input.now ?? Date.now();
+  const expiresAt = now + Math.max(1_000, input.ttlMs);
+  const result = getDb()
+    .prepare(
+      `INSERT INTO console_inbox_poll_locks (lock_key, owner_id, acquired_at, expires_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(lock_key) DO UPDATE SET
+         owner_id = excluded.owner_id,
+         acquired_at = excluded.acquired_at,
+         expires_at = excluded.expires_at
+       WHERE console_inbox_poll_locks.expires_at <= ?
+          OR console_inbox_poll_locks.owner_id = excluded.owner_id`,
+    )
+    .run(input.lockKey, input.ownerId, now, expiresAt, now);
+  return result.changes > 0;
+}
+
+export function renewInboxPollLock(input: { lockKey: string; ownerId: string; ttlMs: number; now?: number }): boolean {
+  const now = input.now ?? Date.now();
+  const expiresAt = now + Math.max(1_000, input.ttlMs);
+  const result = getDb()
+    .prepare(
+      `UPDATE console_inbox_poll_locks
+       SET expires_at = ?
+       WHERE lock_key = ? AND owner_id = ? AND expires_at > ?`,
+    )
+    .run(expiresAt, input.lockKey, input.ownerId, now);
+  return result.changes > 0;
+}
+
+export function releaseInboxPollLock(lockKey: string, ownerId: string): boolean {
+  return (
+    getDb().prepare(`DELETE FROM console_inbox_poll_locks WHERE lock_key = ? AND owner_id = ?`).run(lockKey, ownerId)
+      .changes > 0
+  );
 }
 
 export function markSubscriptionPolled(
@@ -278,6 +349,15 @@ export function upsertDeliveredItem(input: {
     .get(input.consoleUrl, input.organizationId, input.itemId) as ItemRowRaw | undefined;
 
   if (existing) {
+    // Once an item has been flushed to NATS, its stored envelope is the
+    // durable record of exactly what was published. Console may redeliver the
+    // same item with a new lease/poll/subscription envelope while it is only
+    // waiting for an ack; never rewrite that published payload or its original
+    // subscription provenance.
+    if (existing.delivered_at !== null) {
+      return { created: false, row: rowToItem(existing) };
+    }
+
     getDb()
       .prepare(
         `UPDATE console_inbox_items SET
@@ -388,6 +468,46 @@ export function getItemByItemId(consoleUrl: string, organizationId: string, item
   return row ? rowToItem(row) : null;
 }
 
+/** Find every locally mirrored scope that owns a Console item id. */
+export function listItemsByItemId(itemId: string): InboxItemRow[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT * FROM console_inbox_items
+       WHERE item_id = ?
+       ORDER BY console_url ASC, organization_id ASC, id ASC`,
+    )
+    .all(itemId) as ItemRowRaw[];
+  return rows.map(rowToItem);
+}
+
+/**
+ * Heal local ack state from Console's authoritative subscription cursor.
+ *
+ * Only rows already flushed locally are eligible. An undelivered row must not
+ * become acked merely because its sequence is old, and the Console+org scope
+ * prevents one tenant's cursor from mutating another tenant's mirror.
+ */
+export function reconcileDeliveredItemsAckedThroughSequence(input: {
+  consoleUrl: string;
+  organizationId: string;
+  sequence: number;
+  ackedAt?: number;
+}): number {
+  const ackedAt = input.ackedAt ?? Date.now();
+  const result = getDb()
+    .prepare(
+      `UPDATE console_inbox_items
+       SET acked_at = ?, updated_at = ?
+       WHERE console_url = ?
+         AND organization_id = ?
+         AND sequence <= ?
+         AND delivered_at IS NOT NULL
+         AND acked_at IS NULL`,
+    )
+    .run(ackedAt, ackedAt, input.consoleUrl, input.organizationId, input.sequence);
+  return result.changes;
+}
+
 export function listRecentItems(opts: {
   consoleUrl?: string;
   organizationId?: string;
@@ -414,17 +534,20 @@ export function listRecentItems(opts: {
   return rows.map(rowToItem);
 }
 
-/** Count items pending delivery or ack (used by `ravi inbox status`). */
-export function countPendingItems(subscriptionId: string): { undelivered: number; unacked: number } {
+/** Count pending items for the durable local Console+organization mirror. */
+export function countPendingItems(input: { consoleUrl: string; organizationId: string }): {
+  undelivered: number;
+  unacked: number;
+} {
   const row = getDb()
     .prepare(
       `SELECT
          SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE 0 END) AS undelivered,
          SUM(CASE WHEN acked_at IS NULL THEN 1 ELSE 0 END) AS unacked
        FROM console_inbox_items
-       WHERE subscription_id = ?`,
+       WHERE console_url = ? AND organization_id = ?`,
     )
-    .get(subscriptionId) as { undelivered: number | null; unacked: number | null };
+    .get(input.consoleUrl, input.organizationId) as { undelivered: number | null; unacked: number | null };
   return {
     undelivered: row.undelivered ?? 0,
     unacked: row.unacked ?? 0,

--- a/src/inbox/inbox-runner.test.ts
+++ b/src/inbox/inbox-runner.test.ts
@@ -1,12 +1,55 @@
-import { describe, expect, it } from "bun:test";
-import { computeInboxDeliveryProgress } from "./inbox-runner.js";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { writeCloudCredentials } from "../cloud-auth/storage.js";
+import { getDb } from "../router/router-db.js";
+import {
+  countPendingItems,
+  ensureSubscriptionRow,
+  getItemByItemId,
+  getSubscriptionByOrg,
+  inboxPollLockKey,
+  markSubscriptionPolled,
+  updateSubscriptionRemoteId,
+  upsertDeliveredItem,
+} from "./inbox-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import type { ConsoleInboxItem, InboxNatsPayload } from "./types.js";
+import {
+  InboxRunner,
+  computeInboxDeliveryProgress,
+  isCompleteInboxAck,
+  publishInboxNatsEvents,
+} from "./inbox-runner.js";
+
+let stateDir: string | null = null;
+let originalFetch: typeof fetch;
+
+beforeEach(async () => {
+  stateDir = await createIsolatedRaviState("ravi-inbox-runner-test-");
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+  await cleanupIsolatedRaviState(stateDir);
+  stateDir = null;
+});
 
 describe("inbox runner delivery progress", () => {
-  it("advances the local cursor when every leased item was delivered", () => {
+  it("advances the local cursor when every contiguous item was delivered and acked", () => {
     expect(
       computeInboxDeliveryProgress(10, [
         { sequence: 11, delivered: true },
         { sequence: 12, delivered: true },
+      ]),
+    ).toEqual({ lastSequence: 12, hadDeliveryFailure: false });
+  });
+
+  it("orders delivery results before advancing the cursor", () => {
+    expect(
+      computeInboxDeliveryProgress(10, [
+        { sequence: 12, delivered: true },
+        { sequence: 11, delivered: true },
       ]),
     ).toEqual({ lastSequence: 12, hadDeliveryFailure: false });
   });
@@ -20,4 +63,797 @@ describe("inbox runner delivery progress", () => {
       ]),
     ).toEqual({ lastSequence: 11, hadDeliveryFailure: true });
   });
+
+  it("does not advance across a sequence gap", () => {
+    expect(
+      computeInboxDeliveryProgress(10, [
+        { sequence: 11, delivered: true },
+        { sequence: 13, delivered: true },
+      ]),
+    ).toEqual({ lastSequence: 11, hadDeliveryFailure: true });
+  });
+
+  it("advances nothing when the remote ack was partial or failed", () => {
+    expect(
+      computeInboxDeliveryProgress(
+        10,
+        [
+          { sequence: 11, delivered: true },
+          { sequence: 12, delivered: true },
+        ],
+        false,
+      ),
+    ).toEqual({ lastSequence: 10, hadDeliveryFailure: true });
+
+    expect(computeInboxDeliveryProgress(10, [{ sequence: 10, delivered: true }], false)).toEqual({
+      lastSequence: 10,
+      hadDeliveryFailure: true,
+    });
+    expect(computeInboxDeliveryProgress(10, [], false)).toEqual({
+      lastSequence: 10,
+      hadDeliveryFailure: true,
+    });
+  });
 });
+
+describe("inbox runner pending lease recovery", () => {
+  it("does not commit generation or retain ETag when a pending pulse polls an empty batch", async () => {
+    writeCloudCredentials(makeCredentials());
+    const requestHeaders: Headers[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        return jsonResponse({ subscription: makeSubscription() });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        requestHeaders.push(new Headers(init?.headers));
+        return jsonResponse(
+          {
+            version: 1,
+            changed: true,
+            subscribed: true,
+            subscription: makeSubscription(),
+            watermark: {
+              organizationId: "org_1",
+              generation: 7,
+              latestSequence: 1,
+              latestItemAt: "2026-07-21T12:00:00.000Z",
+              cacheKey: "generation:7",
+              updatedAt: "2026-07-21T12:00:00.000Z",
+            },
+          },
+          { ETag: '"generation-7"' },
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        return jsonResponse({
+          version: 1,
+          hasMore: false,
+          items: [],
+          leaseId: "lease_1",
+          leaseSeconds: 60,
+          pollId: "poll_1",
+          serverTime: "2026-07-21T12:00:00.000Z",
+          subscription: makeSubscription(),
+        });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    await runner.tickOnce();
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: null,
+      lastSequence: 0,
+    });
+
+    await runner.tickOnce();
+    expect(requestHeaders).toHaveLength(2);
+    expect(requestHeaders[1]?.has("If-None-Match")).toBe(false);
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")?.lastGeneration).toBeNull();
+  });
+
+  it("continues a multi-batch watermark without committing generation or reusing its ETag", async () => {
+    writeCloudCredentials(makeCredentials());
+    const requestHeaders: Headers[] = [];
+    let pulseAttempts = 0;
+    let pollAttempts = 0;
+    let ackAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        return jsonResponse({ subscription: makeSubscription() });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        requestHeaders.push(new Headers(init?.headers));
+        pulseAttempts += 1;
+        return jsonResponse(
+          makePendingPulse({
+            latestSequence: 2,
+            subscription: makeSubscription({ lastDeliveredSequence: pulseAttempts - 1 }),
+          }),
+          { ETag: '"generation-7"' },
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        pollAttempts += 1;
+        return jsonResponse(
+          makePoll({
+            hasMore: pollAttempts === 1,
+            items: [makeInboxItem(pollAttempts)],
+            subscription: makeSubscription({ lastDeliveredSequence: pollAttempts - 1 }),
+          }),
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/ack") {
+        ackAttempts += 1;
+        return jsonResponse({ acked: 1 });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner({
+      nats: { publish: async () => {}, flush: async () => {} },
+    });
+    await runner.tickOnce();
+
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: null,
+      lastSequence: 1,
+    });
+
+    await runner.tickOnce();
+
+    expect(pulseAttempts).toBe(2);
+    expect(pollAttempts).toBe(2);
+    expect(ackAttempts).toBe(2);
+    expect(requestHeaders[1]?.has("If-None-Match")).toBe(false);
+    expect(requestHeaders[1]?.has("X-Ravi-Inbox-Generation")).toBe(false);
+    expect(requestHeaders[1]?.get("X-Ravi-Inbox-Last-Delivered-Sequence")).toBe("1");
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: 7,
+      lastSequence: 2,
+    });
+  });
+
+  it("heals a delivered row from an advanced Console cursor after a partial ack response", async () => {
+    writeCloudCredentials(makeCredentials());
+    const actions: string[] = [];
+    let pulseAttempts = 0;
+    let ackAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        return jsonResponse({ subscription: makeSubscription() });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        pulseAttempts += 1;
+        return jsonResponse(
+          makePendingPulse({
+            changed: pulseAttempts === 1,
+            latestSequence: 1,
+            subscription: makeSubscription({ lastDeliveredSequence: pulseAttempts === 1 ? 0 : 1 }),
+          }),
+          { ETag: '"generation-7"' },
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        return jsonResponse(makePoll({ items: [makeInboxItem(1)] }));
+      }
+      if (url.pathname === "/api/cli/inbox/ack") {
+        ackAttempts += 1;
+        const row = getItemByItemId("https://console.ravi.bot", "org_1", "item_1");
+        expect(row?.deliveredAt).not.toBeNull();
+        expect(row?.ackedAt).toBeNull();
+        actions.push("delivered");
+        actions.push("ack");
+        // Model a response lost/under-counted after Console advanced its
+        // authoritative cursor. The next pulse must heal the local mirror.
+        return jsonResponse({ acked: 0 });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner({
+      nats: {
+        publish: async () => {
+          const row = getItemByItemId("https://console.ravi.bot", "org_1", "item_1");
+          expect(row).not.toBeNull();
+          expect(row?.deliveredAt).toBeNull();
+          actions.push("persist");
+          actions.push("publish");
+        },
+        flush: async () => {
+          expect(getItemByItemId("https://console.ravi.bot", "org_1", "item_1")?.deliveredAt).toBeNull();
+          actions.push("flush");
+        },
+      },
+    });
+
+    await runner.tickOnce();
+    expect(actions).toEqual(["persist", "publish", "flush", "delivered", "ack"]);
+    expect(ackAttempts).toBe(1);
+    expect(countPendingItems({ consoleUrl: "https://console.ravi.bot", organizationId: "org_1" })).toEqual({
+      undelivered: 0,
+      unacked: 1,
+    });
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: null,
+      lastSequence: 0,
+    });
+
+    await runner.tickOnce();
+    expect(countPendingItems({ consoleUrl: "https://console.ravi.bot", organizationId: "org_1" })).toEqual({
+      undelivered: 0,
+      unacked: 0,
+    });
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: 7,
+      lastSequence: 1,
+    });
+  });
+
+  it("retries only the ack for an already-delivered item without rewriting or enriching it", async () => {
+    writeCloudCredentials(makeCredentials());
+    seedExistingSubscription({ subscriptionId: "sub_1", generation: 6, sequence: 10 });
+    const preservedPayload = JSON.stringify({ exact: "published-envelope", delivery: { pollId: "original" } });
+    const existing = upsertDeliveredItem({
+      consoleUrl: "https://console.ravi.bot",
+      organizationId: "org_1",
+      subscriptionId: "original_subscription",
+      itemId: "item_11",
+      sequence: 11,
+      eventType: "mail.message.received",
+      category: "mail",
+      severity: "info",
+      dedupeKey: "original_dedupe",
+      natsSubject: "ravi.console.inbox.item",
+      natsPayloadJson: preservedPayload,
+      deliveredAt: 123_456,
+    }).row;
+    let ackAttempts = 0;
+    let publishAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        return jsonResponse(
+          makePendingPulse({
+            latestSequence: 11,
+            subscription: makeSubscription({ lastDeliveredSequence: 10 }),
+          }),
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        return jsonResponse(
+          makePoll({
+            items: [
+              makeInboxItem(11, {
+                eventType: "mail.message.received",
+                category: "mail",
+                dedupeKey: "retry_dedupe",
+              }),
+            ],
+            subscription: makeSubscription({ lastDeliveredSequence: 10 }),
+          }),
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/ack") {
+        ackAttempts += 1;
+        return jsonResponse({ acked: 1 });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const enrich = mock(async () => {
+      throw new Error("enrichment must not run for ack-only retry");
+    });
+    const runner = new InboxRunner({
+      nats: {
+        publish: async () => {
+          publishAttempts += 1;
+        },
+        flush: async () => {},
+      },
+    });
+    Object.defineProperty(runner, "enrichLocalPayload", { value: enrich });
+
+    await runner.tickOnce();
+
+    expect(enrich).not.toHaveBeenCalled();
+    expect(publishAttempts).toBe(0);
+    expect(ackAttempts).toBe(1);
+    expect(getItemByItemId("https://console.ravi.bot", "org_1", "item_11")).toMatchObject({
+      id: existing.id,
+      subscriptionId: "original_subscription",
+      dedupeKey: "original_dedupe",
+      natsPayloadJson: preservedPayload,
+      deliveredAt: 123_456,
+    });
+  });
+
+  it("coalesces concurrent tickOnce calls on the same runner instance", async () => {
+    writeCloudCredentials(makeCredentials());
+    let subscriptionAttempts = 0;
+    let pulseAttempts = 0;
+    let signalPulseStarted!: () => void;
+    let completePulse!: (response: Response) => void;
+    const pulseStarted = new Promise<void>((resolve) => {
+      signalPulseStarted = resolve;
+    });
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        subscriptionAttempts += 1;
+        return jsonResponse({ subscription: makeSubscription() });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        pulseAttempts += 1;
+        signalPulseStarted();
+        return await new Promise<Response>((resolve) => {
+          completePulse = resolve;
+        });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    const first = runner.tickOnce();
+    await pulseStarted;
+    const second = runner.tickOnce();
+    completePulse(
+      jsonResponse(
+        makePendingPulse({
+          changed: false,
+          latestSequence: 0,
+          subscription: makeSubscription({ lastDeliveredSequence: 0 }),
+        }),
+      ),
+    );
+    await Promise.all([first, second]);
+
+    expect(subscriptionAttempts).toBe(1);
+    expect(pulseAttempts).toBe(1);
+  });
+
+  it("drops a fresh pending ETag when poll throws so the next tick can resume", async () => {
+    writeCloudCredentials(makeCredentials());
+    const requestHeaders: Headers[] = [];
+    let pollAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        return jsonResponse({ subscription: makeSubscription() });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        requestHeaders.push(new Headers(init?.headers));
+        return jsonResponse(makePendingPulse(), { ETag: '"generation-7"' });
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        pollAttempts += 1;
+        if (pollAttempts === 1) throw new Error("poll transport failed");
+        return jsonResponse(makeEmptyPoll());
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    await runner.tickOnce();
+    await runner.tickOnce();
+
+    expect(pollAttempts).toBe(2);
+    expect(requestHeaders).toHaveLength(2);
+    expect(requestHeaders[0]?.has("If-None-Match")).toBe(false);
+    expect(requestHeaders[1]?.has("If-None-Match")).toBe(false);
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")?.lastGeneration).toBeNull();
+  });
+
+  it("resets an old cursor when the pulse adopts a different pending subscription", async () => {
+    writeCloudCredentials(makeCredentials());
+    seedExistingSubscription({ subscriptionId: "sub_old", generation: 6, sequence: 42 });
+    const requestHeaders: Headers[] = [];
+    let pollAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        requestHeaders.push(new Headers(init?.headers));
+        return jsonResponse(
+          makePendingPulse({ subscription: makeSubscription({ id: "sub_new", lastDeliveredSequence: 0 }) }),
+          { ETag: '"generation-7"' },
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        pollAttempts += 1;
+        if (pollAttempts === 1) throw new Error("poll failed after subscription drift");
+        return jsonResponse(makeEmptyPoll({ subscription: makeSubscription({ id: "sub_new" }) }));
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    await runner.tickOnce();
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      subscriptionId: "sub_new",
+      lastGeneration: null,
+      lastSequence: null,
+    });
+
+    await runner.tickOnce();
+    expect(pollAttempts).toBe(2);
+    expect(requestHeaders[1]?.has("If-None-Match")).toBe(false);
+    expect(requestHeaders[1]?.has("X-Ravi-Inbox-Generation")).toBe(false);
+  });
+
+  it("resets the cursor when a missing remote subscription is recreated", async () => {
+    writeCloudCredentials(makeCredentials());
+    seedExistingSubscription({ subscriptionId: "sub_missing", generation: 6, sequence: 42 });
+    const requestHeaders: Headers[] = [];
+    let pulseAttempts = 0;
+    let pollAttempts = 0;
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/subscriptions/global") {
+        return jsonResponse({ subscription: makeSubscription({ id: "sub_recreated" }) });
+      }
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        requestHeaders.push(new Headers(init?.headers));
+        pulseAttempts += 1;
+        return jsonResponse(
+          makePendingPulse({
+            subscription: pulseAttempts === 1 ? null : makeSubscription({ id: "sub_recreated" }),
+          }),
+          { ETag: '"generation-7"' },
+        );
+      }
+      if (url.pathname === "/api/cli/inbox/poll") {
+        pollAttempts += 1;
+        if (pollAttempts === 1) throw new Error("poll failed after subscription recreation");
+        return jsonResponse(makeEmptyPoll({ subscription: makeSubscription({ id: "sub_recreated" }) }));
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    await runner.tickOnce();
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      subscriptionId: "sub_recreated",
+      lastGeneration: null,
+      lastSequence: null,
+    });
+
+    await runner.tickOnce();
+    expect(pollAttempts).toBe(2);
+    expect(requestHeaders[1]?.has("If-None-Match")).toBe(false);
+    expect(requestHeaders[1]?.has("X-Ravi-Inbox-Generation")).toBe(false);
+  });
+
+  it("does not commit a pulse after poll ownership is lost while the request is in flight", async () => {
+    writeCloudCredentials(makeCredentials());
+    seedExistingSubscription({ subscriptionId: "sub_1", generation: 6, sequence: 0 });
+    let signalPulseStarted!: () => void;
+    let completePulse!: (response: Response) => void;
+    const pulseStarted = new Promise<void>((resolve) => {
+      signalPulseStarted = resolve;
+    });
+
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+      if (url.pathname === "/api/cli/inbox/pulse") {
+        signalPulseStarted();
+        return await new Promise<Response>((resolve) => {
+          completePulse = resolve;
+        });
+      }
+      throw new Error(`Unexpected inbox request: ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const runner = new InboxRunner();
+    const tick = runner.tickOnce();
+    await pulseStarted;
+
+    const lockKey = inboxPollLockKey("https://console.ravi.bot", "org_1");
+    getDb()
+      .prepare(
+        `UPDATE console_inbox_poll_locks
+         SET owner_id = ?, expires_at = ?
+         WHERE lock_key = ?`,
+      )
+      .run("takeover-runner", Date.now() + 60_000, lockKey);
+    completePulse(
+      jsonResponse(
+        makePendingPulse({
+          changed: false,
+          generation: 7,
+          latestSequence: 0,
+          subscription: makeSubscription({ lastDeliveredSequence: 0 }),
+        }),
+        { ETag: '"generation-7"' },
+      ),
+    );
+    await tick;
+
+    expect(getSubscriptionByOrg("https://console.ravi.bot", "org_1")).toMatchObject({
+      lastGeneration: 6,
+      lastSequence: 0,
+    });
+  });
+});
+
+describe("inbox ack completeness", () => {
+  it("accepts only an exact full ack", () => {
+    expect(isCompleteInboxAck({ acked: 2 }, 2)).toBe(true);
+    expect(isCompleteInboxAck({ acked: 1 }, 2)).toBe(false);
+    expect(isCompleteInboxAck({ acked: 3 }, 2)).toBe(false);
+    expect(isCompleteInboxAck({ acked: 0 }, 0)).toBe(false);
+  });
+});
+
+describe("inbox NATS delivery", () => {
+  it("checks the lease before every subject and flushes after canonical and watch publishes", async () => {
+    const actions: string[] = [];
+    const subjects = await publishInboxNatsEvents(
+      {
+        payload: makePayload("watch.github.release.published"),
+        inboxItemId: 42,
+        beforePublish: () => {
+          actions.push("lease");
+        },
+      },
+      {
+        publish: async (subject, payload) => {
+          actions.push(`publish:${subject}`);
+          if (subject.startsWith("ravi.watch.")) {
+            expect(payload).toMatchObject({
+              eventId: "item_1",
+              watchId: "watch_1",
+              delivery: { inboxItemId: 42 },
+            });
+          }
+        },
+        flush: async () => {
+          actions.push("flush");
+        },
+      },
+    );
+
+    expect(subjects).toEqual(["ravi.console.inbox.item", "ravi.watch.github.release.published"]);
+    expect(actions).toEqual([
+      "lease",
+      "publish:ravi.console.inbox.item",
+      "lease",
+      "publish:ravi.watch.github.release.published",
+      "flush",
+    ]);
+  });
+
+  it("publishes only the canonical subject for non-watch items", async () => {
+    const actions: string[] = [];
+    const subjects = await publishInboxNatsEvents(
+      { payload: makePayload("task.created") },
+      {
+        publish: async (subject) => {
+          actions.push(`publish:${subject}`);
+        },
+        flush: async () => {
+          actions.push("flush");
+        },
+      },
+    );
+
+    expect(subjects).toEqual(["ravi.console.inbox.item"]);
+    expect(actions).toEqual(["publish:ravi.console.inbox.item", "flush"]);
+  });
+
+  it("does not resolve delivery when the NATS flush fails", async () => {
+    expect(
+      publishInboxNatsEvents(
+        { payload: makePayload("task.created") },
+        {
+          publish: async () => {},
+          flush: async () => {
+            throw new Error("flush failed");
+          },
+        },
+      ),
+    ).rejects.toThrow("flush failed");
+  });
+
+  it("stops before a watch publish when the lease check fails", async () => {
+    const actions: string[] = [];
+    let checks = 0;
+
+    expect(
+      publishInboxNatsEvents(
+        {
+          payload: makePayload("watch.github.release.published"),
+          beforePublish: () => {
+            checks += 1;
+            actions.push("lease");
+            if (checks === 2) throw new Error("lease lost");
+          },
+        },
+        {
+          publish: async (subject) => {
+            actions.push(`publish:${subject}`);
+          },
+          flush: async () => {
+            actions.push("flush");
+          },
+        },
+      ),
+    ).rejects.toThrow("lease lost");
+    expect(actions).toEqual(["lease", "publish:ravi.console.inbox.item", "lease"]);
+  });
+});
+
+function makePayload(eventType: string): InboxNatsPayload {
+  return {
+    version: 1,
+    eventId: "item_1",
+    sequence: 11,
+    dedupeKey: "dedupe_1",
+    eventType,
+    category: "source_control",
+    severity: "info",
+    sensitivity: "private",
+    title: "Release published",
+    summary: "v1.0.0",
+    organization: { id: "org_1" },
+    project: { id: "project_1" },
+    source: { type: "github", id: "repo_1" },
+    actor: { type: "user", id: "user_1" },
+    target: { type: "release", id: "release_1" },
+    payload: {
+      watch: { id: "watch_1", placement: "console" },
+      tag: "v1.0.0",
+    },
+    links: [{ label: "release", url: "https://example.com/release" }],
+    delivery: {
+      subscriptionId: "sub_1",
+      installationId: "ins_1",
+      pollId: "poll_1",
+      leaseId: "lease_1",
+      localDeliveredAt: "2026-07-21T12:00:00.000Z",
+    },
+    occurredAt: "2026-07-21T11:59:00.000Z",
+    createdAt: "2026-07-21T12:00:00.000Z",
+  };
+}
+
+function makeCredentials() {
+  const now = "2026-07-21T12:00:00.000Z";
+  return {
+    version: 1 as const,
+    consoleUrl: "https://console.ravi.bot",
+    installationId: "ins_1",
+    accessToken: "access-test",
+    refreshToken: "refresh-test",
+    accessTokenExpiresAt: null,
+    refreshTokenExpiresAt: null,
+    scopes: ["console.inbox.read", "console.inbox.subscribe", "console.inbox.deliver", "console.inbox.ack"],
+    organization: { id: "org_1" },
+    user: { id: "user_1" },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makeSubscription(
+  overrides: Partial<ReturnType<typeof makeSubscriptionBase>> = {},
+): ReturnType<typeof makeSubscriptionBase> {
+  return { ...makeSubscriptionBase(), ...overrides };
+}
+
+function makeSubscriptionBase() {
+  return {
+    id: "sub_1",
+    deliveryMode: "pull",
+    lastDeliveredSequence: 0,
+    lastPollAt: null,
+    localInstallationId: "ins_1",
+    name: "global",
+    status: "active",
+  };
+}
+
+function makePendingPulse(
+  overrides: {
+    subscription?: ReturnType<typeof makeSubscription> | null;
+    changed?: boolean;
+    generation?: number;
+    latestSequence?: number;
+  } = {},
+) {
+  const generation = overrides.generation ?? 7;
+  return {
+    version: 1,
+    changed: overrides.changed ?? true,
+    subscribed: true,
+    subscription: overrides.subscription === undefined ? makeSubscription() : overrides.subscription,
+    watermark: {
+      organizationId: "org_1",
+      generation,
+      latestSequence: overrides.latestSequence ?? 1,
+      latestItemAt: "2026-07-21T12:00:00.000Z",
+      cacheKey: `generation:${generation}`,
+      updatedAt: "2026-07-21T12:00:00.000Z",
+    },
+  };
+}
+
+function makeEmptyPoll(overrides: { subscription?: ReturnType<typeof makeSubscription> } = {}) {
+  return {
+    version: 1,
+    hasMore: false,
+    items: [],
+    leaseId: "lease_1",
+    leaseSeconds: 60,
+    pollId: "poll_1",
+    serverTime: "2026-07-21T12:00:00.000Z",
+    subscription: overrides.subscription ?? makeSubscription(),
+  };
+}
+
+function makePoll(
+  overrides: { hasMore?: boolean; items?: ConsoleInboxItem[]; subscription?: ReturnType<typeof makeSubscription> } = {},
+) {
+  return {
+    ...makeEmptyPoll({ subscription: overrides.subscription }),
+    hasMore: overrides.hasMore ?? false,
+    items: overrides.items ?? [],
+  };
+}
+
+function makeInboxItem(sequence: number, overrides: Partial<ConsoleInboxItem> = {}): ConsoleInboxItem {
+  return {
+    id: `delivery_${sequence}`,
+    itemId: `item_${sequence}`,
+    sequence,
+    dedupeKey: `dedupe_${sequence}`,
+    eventType: "task.created",
+    category: "task",
+    severity: "info",
+    sensitivity: "private",
+    title: `Task ${sequence}`,
+    summary: null,
+    source: { type: "console", id: `source_${sequence}` },
+    actor: { type: "user", id: "user_1" },
+    target: { type: "task", id: `task_${sequence}` },
+    organization: { id: "org_1" },
+    project: null,
+    payload: null,
+    links: null,
+    occurredAt: "2026-07-21T11:59:00.000Z",
+    createdAt: "2026-07-21T12:00:00.000Z",
+    lease: {
+      expiresAt: "2026-07-21T12:01:00.000Z",
+      id: `lease_${sequence}`,
+      seconds: 60,
+    },
+    ...overrides,
+  };
+}
+
+function seedExistingSubscription(input: { subscriptionId: string; generation: number; sequence: number }): void {
+  const row = ensureSubscriptionRow({
+    consoleUrl: "https://console.ravi.bot",
+    organizationId: "org_1",
+    installationId: "ins_1",
+  });
+  updateSubscriptionRemoteId(row.id, input.subscriptionId);
+  markSubscriptionPolled(row.id, {
+    generation: input.generation,
+    lastSequence: input.sequence,
+    success: true,
+    status: "active",
+  });
+}
+
+function jsonResponse(
+  payload: unknown,
+  headers?: Headers | Record<string, string> | Array<[string, string]>,
+): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...Object.fromEntries(new Headers(headers)) },
+  });
+}

--- a/src/inbox/inbox-runner.ts
+++ b/src/inbox/inbox-runner.ts
@@ -6,9 +6,9 @@
  *   2. Upsert the global subscription on Console.
  *   3. Cheap pulse with conditional headers. 304/204 -> sleep.
  *   4. On generation change, lease a batch via `/api/cli/inbox/poll`.
- *   5. Persist each item locally, publish `ravi.console.inbox.item` to NATS,
- *      then ack delivered. Local persistence happens before publish so a crash
- *      between publish and ack still leaves the durable mirror.
+ *   5. Persist each item locally, publish its canonical and normalized watch
+ *      subjects, flush NATS, then ack delivered. Local persistence happens
+ *      before publish so a crash between publish and ack leaves the mirror.
  *   6. Apply backoff on transport/auth errors. AUTH_REQUIRED /
  *      INSTALLATION_REVOKED parks the subscription until `ravi login` runs.
  *
@@ -16,6 +16,7 @@
  * `.ravi/specs/watch/SPEC.md`.
  */
 
+import { randomUUID } from "node:crypto";
 import { ConsoleApiClient, refreshCredentialsForStore } from "../cloud-auth/client.js";
 import { isCloudAuthError } from "../cloud-auth/errors.js";
 import { deleteCloudCredentials, readCloudCredentials, writeCloudCredentials } from "../cloud-auth/storage.js";
@@ -25,7 +26,7 @@ import {
   annotateConsoleMailPayloadWithLocalIngest,
   ingestConsoleMailReceivedEvent,
 } from "../mailbox/console-ingest.js";
-import { publish } from "../nats.js";
+import { flushNats, publish } from "../nats.js";
 import { logger } from "../utils/logger.js";
 import { watchEventFromInboxPayload } from "../watch/events.js";
 import {
@@ -35,14 +36,19 @@ import {
   upsertGlobalInboxSubscription,
 } from "./inbox-client.js";
 import {
+  acquireInboxPollLock,
   countPendingItems,
   ensureSubscriptionRow,
   getItemByItemId,
   getSubscriptionByOrg,
+  inboxPollLockKey,
   listSubscriptions,
   markItemAcked,
   markItemDelivered,
   markSubscriptionPolled,
+  reconcileDeliveredItemsAckedThroughSequence,
+  releaseInboxPollLock,
+  renewInboxPollLock,
   setSubscriptionEnabled,
   updateSubscriptionRemoteId,
   upsertDeliveredItem,
@@ -66,9 +72,31 @@ const PAUSED_RECHECK_MS = 60_000;
 const POLL_BATCH_LIMIT = 25;
 const MAIL_ENRICHMENT_ATTEMPTS = 5;
 const MAIL_ENRICHMENT_INITIAL_DELAY_MS = 500;
+const POLL_LOCK_TTL_MS = 120_000;
+const POLL_LOCK_RENEW_MS = 30_000;
 
 interface RunnerOptions {
   intervalMs?: number;
+  nats?: InboxNatsPublishDependencies;
+}
+
+interface InboxNatsPublishDependencies {
+  publish: (subject: string, payload: Record<string, unknown>) => Promise<void>;
+  flush: () => Promise<void>;
+}
+
+class InboxPollLeaseLostError extends Error {
+  constructor(message = "Inbox poll lease was lost.", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "InboxPollLeaseLostError";
+  }
+}
+
+class IncompleteInboxAckError extends Error {
+  constructor(requested: number, acked: number) {
+    super(`Console acknowledged ${acked} of ${requested} inbox items.`);
+    this.name = "IncompleteInboxAckError";
+  }
 }
 
 interface OrgState {
@@ -81,15 +109,19 @@ interface OrgState {
   lastEtag: string | null;
 }
 
-class InboxRunner {
+export class InboxRunner {
   private running = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private states = new Map<string, OrgState>();
   private intervalMs: number;
   private currentBackoffMs = 0;
+  private readonly lockOwnerId = randomUUID();
+  private readonly natsDependencies: InboxNatsPublishDependencies;
+  private tickInFlight: Promise<void> | null = null;
 
   constructor(options: RunnerOptions = {}) {
     this.intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.natsDependencies = options.nats ?? { publish, flush: flushNats };
   }
 
   async start(): Promise<void> {
@@ -111,7 +143,21 @@ class InboxRunner {
 
   /** Foreground one-shot. Returns when a single tick completes. */
   async tickOnce(): Promise<void> {
-    await this.tick();
+    await this.runTick();
+  }
+
+  /** Coalesce overlapping timer/foreground calls on this runner instance. */
+  private runTick(): Promise<void> {
+    if (this.tickInFlight) return this.tickInFlight;
+    const current = (async () => {
+      try {
+        await this.tick();
+      } finally {
+        this.tickInFlight = null;
+      }
+    })();
+    this.tickInFlight = current;
+    return current;
   }
 
   private scheduleTick(delay: number): void {
@@ -119,7 +165,7 @@ class InboxRunner {
     if (this.timer) clearTimeout(this.timer);
     this.timer = setTimeout(() => {
       this.timer = null;
-      this.tick().catch((err) => {
+      this.runTick().catch((err) => {
         log.error("Inbox runner tick failed", { error: errMessage(err) });
       });
     }, delay);
@@ -127,6 +173,10 @@ class InboxRunner {
 
   private async tick(): Promise<void> {
     let nextDelay = this.intervalMs;
+    let activeLockKey: string | null = null;
+    let lockRenewalTimer: ReturnType<typeof setInterval> | null = null;
+    let pollLockLost = false;
+    let invalidateEtagOnError: OrgState | null = null;
 
     try {
       const credentials = readCloudCredentials();
@@ -153,10 +203,76 @@ class InboxRunner {
         organizationId,
         installationId: credentials.installationId,
       });
-      if (!row.enabled || row.status === "paused") {
+      if (!row.enabled) {
         nextDelay = PAUSED_RECHECK_MS;
         return;
       }
+
+      activeLockKey = inboxPollLockKey(row.consoleUrl, row.organizationId);
+      if (
+        !acquireInboxPollLock({
+          lockKey: activeLockKey,
+          ownerId: this.lockOwnerId,
+          ttlMs: POLL_LOCK_TTL_MS,
+        })
+      ) {
+        log.debug("Skipping inbox tick: another process owns the poll lease", {
+          consoleUrl: row.consoleUrl,
+          organizationId: row.organizationId,
+        });
+        activeLockKey = null;
+        return;
+      }
+
+      const requirePollLock = (): void => {
+        if (pollLockLost || !activeLockKey) {
+          throw new InboxPollLeaseLostError();
+        }
+        try {
+          if (
+            !renewInboxPollLock({
+              lockKey: activeLockKey,
+              ownerId: this.lockOwnerId,
+              ttlMs: POLL_LOCK_TTL_MS,
+            })
+          ) {
+            pollLockLost = true;
+            throw new InboxPollLeaseLostError();
+          }
+        } catch (error) {
+          pollLockLost = true;
+          if (error instanceof InboxPollLeaseLostError) throw error;
+          throw new InboxPollLeaseLostError("Inbox poll lease renewal failed.", { cause: error });
+        }
+      };
+      lockRenewalTimer = setInterval(() => {
+        if (pollLockLost || !activeLockKey) return;
+        try {
+          if (
+            !renewInboxPollLock({
+              lockKey: activeLockKey,
+              ownerId: this.lockOwnerId,
+              ttlMs: POLL_LOCK_TTL_MS,
+            })
+          ) {
+            pollLockLost = true;
+          }
+        } catch (error) {
+          pollLockLost = true;
+          log.warn("Inbox poll lease renewal errored", {
+            consoleUrl: row.consoleUrl,
+            organizationId: row.organizationId,
+            error: errMessage(error),
+          });
+        }
+        if (pollLockLost) {
+          log.warn("Inbox poll lease renewal failed", {
+            consoleUrl: row.consoleUrl,
+            organizationId: row.organizationId,
+          });
+        }
+      }, POLL_LOCK_RENEW_MS);
+      lockRenewalTimer.unref?.();
 
       const state =
         this.states.get(row.id) ??
@@ -178,6 +294,20 @@ class InboxRunner {
       this.states.set(row.id, state);
 
       const client = new ConsoleApiClient({ consoleUrl: row.consoleUrl });
+      let effectiveLastSequence = row.lastSequence ?? 0;
+
+      const adoptRemoteSubscription = (
+        subscriptionId: string | null,
+        options: { resetCursor: boolean; resetEtag: boolean },
+      ): void => {
+        requirePollLock();
+        state.remoteId = subscriptionId;
+        if (options.resetEtag) state.lastEtag = null;
+        updateSubscriptionRemoteId(row.id, subscriptionId, {
+          resetCursor: options.resetCursor,
+        });
+        if (options.resetCursor) effectiveLastSequence = 0;
+      };
 
       if (!state.remoteId) {
         const { subscription } = await this.withAutoRefresh(client, credentials, (token) =>
@@ -185,10 +315,10 @@ class InboxRunner {
             installationName: credentials.installationId,
           }),
         );
-        state.remoteId = subscription?.id ?? null;
-        if (state.remoteId) {
-          updateSubscriptionRemoteId(row.id, state.remoteId);
-        }
+        adoptRemoteSubscription(subscription?.id ?? null, {
+          resetCursor: false,
+          resetEtag: false,
+        });
       }
 
       const pulse = await this.withAutoRefresh(client, credentials, (token) =>
@@ -199,7 +329,16 @@ class InboxRunner {
         }),
       );
 
-      if (pulse.etag) state.lastEtag = pulse.etag;
+      // Once a fresh pulse has returned, every downstream failure must force a
+      // fresh pulse on the next tick. Keeping its ETag after an incomplete
+      // poll/publish/ack cycle can turn the retry into an endless 304 loop.
+      if (pulse.pulse) invalidateEtagOnError = state;
+      requirePollLock();
+      if (pulse.pulse) {
+        state.lastEtag = pulse.etag;
+      } else if (pulse.etag) {
+        state.lastEtag = pulse.etag;
+      }
 
       if (pulse.status === 304 || pulse.status === 204) {
         markSubscriptionPolled(row.id, { success: true, status: "active" });
@@ -228,14 +367,17 @@ class InboxRunner {
           }),
         );
         activeSubscription = subscription ?? null;
-        state.remoteId = activeSubscription?.id ?? null;
-        state.lastEtag = null;
-        if (state.remoteId) updateSubscriptionRemoteId(row.id, state.remoteId);
+        adoptRemoteSubscription(activeSubscription?.id ?? null, {
+          resetCursor: true,
+          resetEtag: true,
+        });
       }
 
       if (!state.remoteId && activeSubscription?.id) {
-        state.remoteId = activeSubscription.id;
-        updateSubscriptionRemoteId(row.id, state.remoteId);
+        adoptRemoteSubscription(activeSubscription.id, {
+          resetCursor: false,
+          resetEtag: false,
+        });
       } else if (state.remoteId && activeSubscription?.id && activeSubscription.id !== state.remoteId) {
         // Server returned a different active subscription than the one
         // we have locally. Happens after a CLI re-login that rotated the
@@ -246,13 +388,9 @@ class InboxRunner {
           previousSubscriptionId: state.remoteId,
           nextSubscriptionId: activeSubscription.id,
         });
-        state.remoteId = activeSubscription.id;
-        state.lastEtag = null;
-        updateSubscriptionRemoteId(row.id, state.remoteId);
-        markSubscriptionPolled(row.id, {
-          success: true,
-          status: "active",
-          generation: payload.watermark.generation,
+        adoptRemoteSubscription(activeSubscription.id, {
+          resetCursor: true,
+          resetEtag: true,
         });
       }
 
@@ -261,10 +399,24 @@ class InboxRunner {
         subscriptionCursor !== null && subscriptionCursor < payload.watermark.latestSequence;
 
       // Adopt cursor when Console reports we are ahead of our local record.
-      const cursorUpdate =
-        subscriptionCursor !== null && subscriptionCursor > (row.lastSequence ?? 0)
-          ? { lastSequence: subscriptionCursor }
-          : {};
+      const remoteCursorIsAhead = subscriptionCursor !== null && subscriptionCursor > effectiveLastSequence;
+      const cursorUpdate = remoteCursorIsAhead ? { lastSequence: subscriptionCursor } : {};
+      if (subscriptionCursor !== null) {
+        requirePollLock();
+        const reconciled = reconcileDeliveredItemsAckedThroughSequence({
+          consoleUrl: row.consoleUrl,
+          organizationId: row.organizationId,
+          sequence: subscriptionCursor,
+        });
+        if (reconciled > 0) {
+          log.info("Reconciled locally delivered inbox items from Console cursor", {
+            consoleUrl: row.consoleUrl,
+            organizationId: row.organizationId,
+            subscriptionCursor,
+            reconciled,
+          });
+        }
+      }
 
       if (!payload.changed && !hasPendingRemoteItems) {
         // Caught up: it's safe to mark generation locally because there
@@ -295,16 +447,18 @@ class InboxRunner {
           subscriptionId: state.remoteId,
         }),
       );
+      requirePollLock();
 
       const acks: Array<{
         itemId: string;
         status: "delivered";
         leaseId?: string;
       }> = [];
-      const baseSequence = subscriptionCursor ?? row.lastSequence ?? 0;
+      const baseSequence = subscriptionCursor ?? effectiveLastSequence;
       const deliveryResults: Array<{ sequence: number; delivered: boolean }> = [];
 
       for (const item of poll.items) {
+        requirePollLock();
         const handled = await this.handleItem({
           consoleUrl: row.consoleUrl,
           organizationId: row.organizationId,
@@ -314,6 +468,7 @@ class InboxRunner {
           pollId: poll.pollId,
           client,
           credentials,
+          assertPollLock: requirePollLock,
         });
         if (handled.delivered) {
           acks.push({
@@ -325,40 +480,75 @@ class InboxRunner {
         deliveryResults.push({ sequence: item.sequence, delivered: handled.delivered });
       }
 
+      // An empty poll does not mean completion when the pulse still reports a
+      // remote cursor behind the watermark (for example, another lease has not
+      // expired yet). Keep generation/ETag retryable in that case.
+      let remoteAckSucceeded = poll.items.length === 0 && !hasPendingRemoteItems;
       if (acks.length > 0) {
         try {
-          await this.withAutoRefresh(client, credentials, (token) =>
+          requirePollLock();
+          const ackResult = await this.withAutoRefresh(client, credentials, (token) =>
             ackInboxItemsRemote(client, token, {
               acks,
               subscriptionId: state.remoteId,
             }),
           );
+          if (!isCompleteInboxAck(ackResult, acks.length)) {
+            throw new IncompleteInboxAckError(acks.length, ackResult.acked);
+          }
+          // Do not commit local ack/cursor state after another owner has taken over.
+          requirePollLock();
           const ackedAt = Date.now();
           for (const ack of acks) {
             const localItem = getItemByItemId(row.consoleUrl, row.organizationId, ack.itemId);
             if (localItem) markItemAcked(localItem.id, ackedAt);
           }
+          remoteAckSucceeded = true;
         } catch (error) {
+          if (error instanceof InboxPollLeaseLostError) throw error;
           log.warn("Inbox ack failed; will retry on next tick", { error: errMessage(error) });
         }
       }
 
-      const deliveryProgress = computeInboxDeliveryProgress(baseSequence, deliveryResults);
+      const deliveryProgress = computeInboxDeliveryProgress(baseSequence, deliveryResults, remoteAckSucceeded);
+      requirePollLock();
+      const lastSequence = Math.max(deliveryProgress.lastSequence, effectiveLastSequence);
+      const needsContinuation = poll.hasMore || lastSequence < payload.watermark.latestSequence;
+      const deliveryIncomplete = deliveryProgress.hadDeliveryFailure || needsContinuation;
+      if (deliveryIncomplete) {
+        state.lastEtag = null;
+      }
       markSubscriptionPolled(row.id, {
-        ...(deliveryProgress.hadDeliveryFailure ? {} : { generation }),
-        lastSequence: Math.max(deliveryProgress.lastSequence, row.lastSequence ?? 0),
+        ...(deliveryIncomplete ? {} : { generation }),
+        lastSequence,
         success: true,
         status: "active",
       });
 
       this.currentBackoffMs = 0;
+      // `hasMore` guarantees another page is immediately available. A cursor
+      // still behind the watermark with no page can mean another lease is
+      // active, so keep it retryable without a zero-delay Console hot loop.
       if (poll.hasMore) {
         nextDelay = 0;
       }
     } catch (error) {
-      nextDelay = this.handleError(error);
+      if (invalidateEtagOnError) invalidateEtagOnError.lastEtag = null;
+      if (error instanceof InboxPollLeaseLostError) {
+        log.warn("Inbox poll lease lost; another runner may continue delivery", { error: error.message });
+        nextDelay = this.intervalMs;
+      } else {
+        nextDelay = this.handleError(error);
+      }
     } finally {
-      if (this.running) this.scheduleTick(nextDelay);
+      if (lockRenewalTimer) clearInterval(lockRenewalTimer);
+      try {
+        if (activeLockKey) releaseInboxPollLock(activeLockKey, this.lockOwnerId);
+      } catch (error) {
+        log.warn("Inbox poll lease release failed", { error: errMessage(error) });
+      } finally {
+        if (this.running) this.scheduleTick(nextDelay);
+      }
     }
   }
 
@@ -371,7 +561,21 @@ class InboxRunner {
     pollId: string;
     client: ConsoleApiClient;
     credentials: CloudCredentials;
+    assertPollLock: () => void;
   }): Promise<{ delivered: boolean }> {
+    input.assertPollLock();
+    const alreadyDelivered = getItemByItemId(input.consoleUrl, input.organizationId, input.item.itemId);
+    if (alreadyDelivered && alreadyDelivered.deliveredAt !== null) {
+      // Console is retrying only the ack. Preserve and reuse the exact durable
+      // envelope already flushed locally; enrichment and ingestion can have
+      // side effects and must not run again for an ack-only retry.
+      log.debug("Retrying only the Console ack for an already-delivered inbox item", {
+        itemId: input.item.itemId,
+        sequence: input.item.sequence,
+      });
+      return { delivered: true };
+    }
+
     const localDeliveredAt = new Date().toISOString();
     const natsPayload: InboxNatsPayload = {
       version: 1,
@@ -403,6 +607,7 @@ class InboxRunner {
     };
 
     const enrichedNatsPayload = await this.enrichLocalPayload(input, natsPayload);
+    input.assertPollLock();
 
     // 1. Persist locally before publish so a crash leaves a durable replay row.
     const { row: localItem, created } = upsertDeliveredItem({
@@ -433,15 +638,18 @@ class InboxRunner {
       return { delivered: true };
     }
 
-    const watchEvent = watchEventFromInboxPayload(enrichedNatsPayload, { inboxItemId: localItem.id });
-
-    // 2. Publish to NATS.
+    // 2. Publish every local subject and wait for server confirmation.
     try {
-      await publish(INBOX_NATS_SUBJECT, enrichedNatsPayload as unknown as Record<string, unknown>);
-      if (watchEvent) {
-        await publish(watchEvent.subject, watchEvent as unknown as Record<string, unknown>);
-      }
+      await publishInboxNatsEvents(
+        {
+          payload: enrichedNatsPayload,
+          inboxItemId: localItem.id,
+          beforePublish: input.assertPollLock,
+        },
+        this.natsDependencies,
+      );
     } catch (error) {
+      if (error instanceof InboxPollLeaseLostError) throw error;
       log.error("Failed to publish inbox event to NATS", {
         itemId: input.item.itemId,
         error: errMessage(error),
@@ -450,6 +658,7 @@ class InboxRunner {
     }
 
     // 3. Mark delivered locally so we can ack to Console.
+    input.assertPollLock();
     markItemDelivered(localItem.id, Date.now());
     return { delivered: true };
   }
@@ -582,19 +791,59 @@ function errMessage(error: unknown): string {
 export function computeInboxDeliveryProgress(
   baseSequence: number,
   items: Array<{ sequence: number; delivered: boolean }>,
+  remoteAckSucceeded = true,
 ): { lastSequence: number; hadDeliveryFailure: boolean } {
+  if (!remoteAckSucceeded) {
+    return { lastSequence: baseSequence, hadDeliveryFailure: true };
+  }
+
   let lastSequence = baseSequence;
   let blockedByFailure = false;
-  for (const item of items) {
-    if (!item.delivered) {
+
+  const ordered = [...items].sort((left, right) => left.sequence - right.sequence);
+  for (const item of ordered) {
+    // A stale duplicate at or behind the authoritative cursor cannot move it.
+    if (item.sequence <= lastSequence) continue;
+
+    const isNextSequence = item.sequence === lastSequence + 1;
+    if (blockedByFailure || !item.delivered || !isNextSequence) {
       blockedByFailure = true;
       continue;
     }
-    if (!blockedByFailure && item.sequence > lastSequence) {
-      lastSequence = item.sequence;
-    }
+    lastSequence = item.sequence;
   }
   return { lastSequence, hadDeliveryFailure: blockedByFailure };
+}
+
+export function isCompleteInboxAck(result: { acked: number }, requested: number): boolean {
+  return Number.isInteger(result.acked) && requested > 0 && result.acked === requested;
+}
+
+export async function publishInboxNatsEvents(
+  input: {
+    payload: InboxNatsPayload;
+    inboxItemId?: number | string | null;
+    canonicalSubject?: string;
+    beforePublish?: () => void | Promise<void>;
+  },
+  dependencies: InboxNatsPublishDependencies = { publish, flush: flushNats },
+): Promise<string[]> {
+  const subjects: string[] = [];
+  const canonicalSubject = input.canonicalSubject?.trim() || INBOX_NATS_SUBJECT;
+
+  await input.beforePublish?.();
+  await dependencies.publish(canonicalSubject, input.payload as unknown as Record<string, unknown>);
+  subjects.push(canonicalSubject);
+
+  const watchEvent = watchEventFromInboxPayload(input.payload, { inboxItemId: input.inboxItemId });
+  if (watchEvent) {
+    await input.beforePublish?.();
+    await dependencies.publish(watchEvent.subject, watchEvent as unknown as Record<string, unknown>);
+    subjects.push(watchEvent.subject);
+  }
+
+  await dependencies.flush();
+  return subjects;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -643,7 +892,8 @@ export function setEnabledForCurrentOrg(enabled: boolean): { changed: boolean } 
     });
     return { changed: true };
   }
-  if (row.enabled === enabled) return { changed: false };
+  const needsResume = enabled && (row.status !== "active" || row.lastErrorCode !== null || row.lastErrorAt !== null);
+  if (row.enabled === enabled && !needsResume) return { changed: false };
   setSubscriptionEnabled(row.id, enabled);
   return { changed: true };
 }
@@ -653,7 +903,10 @@ export function getStatusSnapshot() {
   const credentials = readCloudCredentials();
   const subscriptions = listSubscriptions().map((sub) => ({
     ...sub,
-    pending: countPendingItems(sub.id),
+    pending: countPendingItems({
+      consoleUrl: sub.consoleUrl,
+      organizationId: sub.organizationId,
+    }),
   }));
   return {
     credentialsPresent: Boolean(credentials),

--- a/src/inbox/index.ts
+++ b/src/inbox/index.ts
@@ -31,13 +31,20 @@ export {
 } from "./inbox-client.js";
 
 export {
+  acquireInboxPollLock,
   countPendingItems,
   ensureSubscriptionRow,
   getItemById,
   getItemByItemId,
   getSubscriptionByOrg,
+  inboxPollLockKey,
+  incrementItemReplayCount,
+  listItemsByItemId,
   listRecentItems,
   listSubscriptions,
+  reconcileDeliveredItemsAckedThroughSequence,
+  releaseInboxPollLock,
+  renewInboxPollLock,
   setSubscriptionEnabled,
   upsertDeliveredItem,
 } from "./inbox-db.js";
@@ -45,6 +52,7 @@ export {
 export {
   getInboxRunner,
   getStatusSnapshot,
+  publishInboxNatsEvents,
   runSingleTick,
   setEnabledForCurrentOrg,
   startInboxRunner,

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -110,6 +110,12 @@ export async function publish(topic: string, data: Record<string, unknown>): Pro
   conn.publish(topic, sc.encode(JSON.stringify(data)));
 }
 
+/** Wait until the server has processed everything published on this connection. */
+export async function flushNats(): Promise<void> {
+  const conn = await ensureConnected();
+  await conn.flush();
+}
+
 export interface SubscribeOptions {
   /** NATS queue group name. When set, only one subscriber in the group receives each message. */
   queue?: string;

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -1828,6 +1828,64 @@ function getDb(): Database {
     CREATE INDEX IF NOT EXISTS idx_session_trace_blobs_created
       ON session_trace_blobs(created_at);
 
+    -- Console delivery bridge: durable local mirror and per-org poll lease.
+    CREATE TABLE IF NOT EXISTS console_inbox_subscriptions (
+      id              TEXT PRIMARY KEY,
+      console_url     TEXT NOT NULL,
+      organization_id TEXT NOT NULL,
+      subscription_id TEXT,
+      installation_id TEXT NOT NULL,
+      status          TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','paused','errored')),
+      enabled         INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0,1)),
+      last_generation INTEGER,
+      last_sequence   INTEGER,
+      last_poll_at    INTEGER,
+      last_success_at INTEGER,
+      last_error_code TEXT,
+      last_error_at   INTEGER,
+      created_at      INTEGER NOT NULL,
+      updated_at      INTEGER NOT NULL,
+      UNIQUE(console_url, organization_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_console_inbox_subs_enabled
+      ON console_inbox_subscriptions(enabled, status);
+
+    CREATE TABLE IF NOT EXISTS console_inbox_items (
+      id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+      console_url        TEXT NOT NULL,
+      organization_id    TEXT NOT NULL,
+      subscription_id    TEXT NOT NULL,
+      item_id            TEXT NOT NULL,
+      sequence           INTEGER NOT NULL,
+      event_type         TEXT NOT NULL,
+      category           TEXT NOT NULL,
+      severity           TEXT NOT NULL,
+      dedupe_key         TEXT NOT NULL,
+      nats_subject       TEXT NOT NULL,
+      nats_payload_json  TEXT NOT NULL,
+      delivered_at       INTEGER,
+      acked_at           INTEGER,
+      replay_count       INTEGER NOT NULL DEFAULT 0,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      UNIQUE(console_url, organization_id, item_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_console_inbox_items_sub
+      ON console_inbox_items(subscription_id, sequence);
+    CREATE INDEX IF NOT EXISTS idx_console_inbox_items_seq
+      ON console_inbox_items(console_url, organization_id, sequence DESC);
+    CREATE INDEX IF NOT EXISTS idx_console_inbox_items_dedupe
+      ON console_inbox_items(dedupe_key);
+
+    CREATE TABLE IF NOT EXISTS console_inbox_poll_locks (
+      lock_key    TEXT PRIMARY KEY,
+      owner_id    TEXT NOT NULL,
+      acquired_at INTEGER NOT NULL,
+      expires_at  INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_console_inbox_poll_locks_expiry
+      ON console_inbox_poll_locks(expires_at);
+
     -- Local-first sync: optional, best-effort replication ledger.
     -- SQLite remains the local source of truth; these tables are durable queues
     -- for remote bridge delivery and cursor-based remote intake.

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -180,6 +180,53 @@ describe("router context queries", () => {
     expect(reactionIndexes).toContain("idx_reaction_actions_source");
   });
 
+  it("scopes Console inbox item idempotency by Console and organization", () => {
+    const db = getDb();
+    const insert = db.prepare(
+      `INSERT INTO console_inbox_items (
+         console_url,
+         organization_id,
+         subscription_id,
+         item_id,
+         sequence,
+         event_type,
+         category,
+         severity,
+         dedupe_key,
+         nats_subject,
+         nats_payload_json,
+         created_at,
+         updated_at
+       ) VALUES (?, ?, ?, 'shared-item', 1, 'task.created', 'task', 'info', ?, 'ravi.console.inbox.item', '{}', 1, 1)`,
+    );
+    const insertScope = (consoleUrl: string, organizationId: string) =>
+      insert.run(
+        consoleUrl,
+        organizationId,
+        `subscription:${consoleUrl}:${organizationId}`,
+        `dedupe:${consoleUrl}:${organizationId}`,
+      );
+
+    insertScope("https://console-a.ravi.bot", "org-a");
+    insertScope("https://console-a.ravi.bot", "org-b");
+    insertScope("https://console-b.ravi.bot", "org-a");
+
+    expect(() => insertScope("https://console-a.ravi.bot", "org-a")).toThrow(/UNIQUE constraint failed/);
+    expect(
+      db
+        .prepare(
+          `SELECT console_url AS consoleUrl, organization_id AS organizationId, item_id AS itemId
+           FROM console_inbox_items
+           ORDER BY console_url, organization_id`,
+        )
+        .all(),
+    ).toEqual([
+      { consoleUrl: "https://console-a.ravi.bot", organizationId: "org-a", itemId: "shared-item" },
+      { consoleUrl: "https://console-a.ravi.bot", organizationId: "org-b", itemId: "shared-item" },
+      { consoleUrl: "https://console-b.ravi.bot", organizationId: "org-a", itemId: "shared-item" },
+    ]);
+  });
+
   it("gets reading lists by exact primary-key id without falling back to name", () => {
     const missingId = "crl_0123456789abcdef01234567";
     const list = dbCreateChatReadingList({


### PR DESCRIPTION
## Objective

Make Console delivery recoverable across crashes, retries, partial acknowledgements, concurrent pollers, and multi-page batches without silently skipping cursor progress. Local NATS delivery remains explicitly at-least-once around crash boundaries.

## Problem

- The runner could commit generation/ETag or cursor state before a complete batch was durably published and acknowledged, creating 304 and pagination deadlocks.
- Lease loss, partial acknowledgements, and crashes between Console acknowledgement and the local commit could leave local and remote state divergent.
- Delivered-but-unacknowledged retries could rerun enrichment and overwrite the original payload, while ambiguous replay IDs could select the wrong Console organization.

## Solution

- Add a scoped renewable SQLite poll lease and enforce ownership before each publish, delivery/cursor state commit, and remote acknowledgement; require a successful NATS flush before marking an item delivered.
- Enforce the order persist → canonical/watch publish → NATS flush → local delivered state → exact Console ack, advancing only a contiguous acknowledged prefix.
- Defer generation commits and clear ETag across intermediate pages until the delivered cursor reaches the watermark with no page remaining; reconcile already-delivered rows from the authoritative remote cursor and make delivered retries ack-only with the original durable payload.
- Reset cursor state atomically on subscription drift, fail closed on ambiguous replay IDs, and coalesce overlapping ticks in one runner.

## Practical impact

- Console-produced watch events can resume after daemon restarts and transport failures without silent cursor skips or stuck multi-page delivery. Automatic redelivery of rows already recorded as delivered is ack-only and is not republished; explicit operator replay remains available, and the publish-to-local-commit crash window remains at-least-once.

## What does NOT change

- Console remains authoritative for subscription policy, item visibility, leases, and ack validity. Existing compatibility commands and canonical/watch NATS subjects remain the public surface.

## Validation

- Focused Inbox database, runner, and CLI coverage passed: 31 tests, 0 failures.
- The complete configured `bun run test` suite passed on the final rebased commit.
- `make quality` passed: Biome checked 906 files and TypeScript typecheck passed; `git diff --check` also passed.

## Risks

- Delivery now intentionally retries rather than advancing when ownership, flush, or exact ack evidence is missing, so an unhealthy Console or NATS connection may retain more pending rows. A crash after NATS accepts a publish but before local `delivered_at` is committed can still republish that item.

## Rollback

- Revert this commit to restore the previous runner. The additive local SQLite schema can remain present and is safe for the older code to ignore.

## Follow-ups

- The existing `ravi inbox` commands remain compatibility aliases; renaming the surface to Console delivery is intentionally outside this reliability PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->