### PR TITLE
feat(slack): admit explicitly addressed foreign bots

### DIFF
--- a/.ravi/specs/channels/adapters/slack/CHECKS.md
+++ b/.ravi/specs/channels/adapters/slack/CHECKS.md
@@ -3,7 +3,20 @@
 - [ ] Inbound channel message MUST persist chat, message and participant records.
 - [ ] Thread reply MUST include the Slack thread target.
 - [ ] Outbound response MUST use Slack native delivery.
-- [ ] Bot and self messages MUST be ignored.
+- [ ] Human message admission MUST remain unchanged.
+- [ ] The local bot MUST be ignored when either event `bot_id` or `user` matches `auth.test`.
+- [ ] Foreign bot messages MUST fail closed unless `auth.test` returns `ok=true` with complete `bot_id`, `user_id`, and `team_id`.
+- [ ] Outer `payload.team_id` / `event.team` MUST identify one Slack team equal to authenticated `team_id`; absence, conflict, or logical-account fallback MUST fail closed.
+- [ ] Successful `auth.test` discovery MUST be cached, concurrent calls coalesced, and failures retried only after a bounded backoff.
+- [ ] A stuck `auth.test` MUST receive an abort signal, time out, fail closed, release the shared in-flight slot, and permit a later retry.
+- [ ] A foreign bot MUST require an explicit local-user mention or a chat-scoped alias at the beginning with a Unicode whitespace/punctuation boundary.
+- [ ] Aliases MUST come only from the current channel account's `defaults.botMessageAliasesByChat`; wrong-chat, wrong-account, middle, partial-word, and env aliases MUST be rejected.
+- [ ] Raw bot/user ids and `senderKind=bot` MUST survive chat, message, participant, source, and context provenance.
+- [ ] Bot/user candidate identities MAY produce `actorType=agent` only when all resolved ids identify one consistent agent; contact-only and owner conflicts MUST be unknown with no authority.
+- [ ] A resolved bot agent MUST become runtime principal `agent:<actorAgentId>` without stripping the executor agent's effective capabilities.
+- [ ] Daemon-restart resume MUST select stashed agent actor metadata and preserve its `agent:<actorAgentId>` authority principal.
+- [ ] Bot actor lookup MUST preserve canonical UUID/slug aliases, exact-empty fallback, cross-workspace isolation, and alias-collision fail-closed behavior.
+- [ ] Admitted bot messages MUST preserve root/thread routing and duplicate-envelope suppression.
 - [ ] Missing credentials MUST disable the adapter.
 - [ ] Env fallback MUST be opt-in.
 - [ ] Tests MUST cover routing policy and native delivery.

--- a/.ravi/specs/channels/adapters/slack/RUNBOOK.md
+++ b/.ravi/specs/channels/adapters/slack/RUNBOOK.md
@@ -12,6 +12,22 @@
 4. Send a DM or channel message to the Slack app.
 5. Confirm the Ravi session responds in Slack.
 
+## Foreign Bot Interop
+
+Foreign bots are mention-only by default. To add an alias for a specific chat,
+store it on that Slack channel account (not in the environment):
+
+```bash
+ravi channels set <slack-channel> defaults '{"botMessageAliasesByChat":{"C123":["Ravi"]}}'
+```
+
+Restart the channel runner after changing defaults. Then verify all four cases:
+
+1. `<@local_bot_user_id> status` from the foreign bot is admitted;
+2. `Ravi—status` is admitted only in `C123`;
+3. `oi Ravi`, `Ravinder`, and the same alias in another chat/account are ignored;
+4. a message emitted by the local bot itself is ignored even if it mentions or aliases itself.
+
 ## Debug
 
 - No connection: check `ravi channels show <slack-channel>` and
@@ -19,6 +35,21 @@
 - No inbound: check Socket Mode logs and Slack app event subscriptions.
 - Wrong thread: check `RAVI_SLACK_SUBSCRIPTION_SCOPE`, `RAVI_SLACK_THREAD_REPLY_MODE`, `RAVI_SLACK_ROOT_REPLY_MODE`.
 - Duplicate response: check duplicate runner processes and Socket Mode lock.
+- All bot messages ignored: inspect the `auth.test` warning. Ravi requires `ok=true`
+  with a complete local `bot_id` + `user_id` + `team_id`, and requires outer
+  `payload.team_id` / `event.team` to identify that same team. Missing or conflicting
+  team provenance fails closed; Ravi never substitutes the logical channel account id.
+  Discovery is aborted after its five-second timeout, uses a bounded retry backoff,
+  and retries on a later bot message instead of caching failure permanently.
+- Foreign bot admitted but actor is unknown: inspect `identityProvenance.botIdentityReason`.
+  `contact_identity_not_agent`, `conflicting_platform_owners`, `conflicting_agents`,
+  and `ambiguous_instance_alias` are intentional fail-closed results. Link both Slack
+  bot/user ids only when they represent the same agent; do not convert a bot identity
+  into a contact to grant authority.
+- Alias not matching: confirm it is under the active Slack channel account's
+  `defaults.botMessageAliasesByChat`, keyed by the raw Slack chat id. Aliases are not
+  loaded from env and must start the text as a complete word with a Unicode
+  whitespace/punctuation boundary.
 - Known contact treated as unknown / false permission denial:
   1. Compare the `instance_id` the runtime addresses (account slug) against the
      `instanceId` stored on the workspace's platform identities (often the configured UUID)
@@ -42,4 +73,5 @@
   agent-identity/effective capabilities across turns and turn-context rotations. If a later
   turn drops to `missing_contact` or zero capabilities for an unchanged agent, inspect the
   turn's `identityProvenance` and confirm no conflicting alias identity was introduced
-  between turns.
+  between turns. A consistent bot identity should report `actorPrincipal=agent:<agentId>`;
+  `missing_contact` for that actor indicates the actor principal was not propagated.

--- a/.ravi/specs/channels/adapters/slack/SPEC.md
+++ b/.ravi/specs/channels/adapters/slack/SPEC.md
@@ -48,10 +48,64 @@ Thread replies MUST follow `channels/slack/threads`: a Slack `thread_ts` is a se
 
 The adapter MUST ignore:
 
-- bot messages;
 - hidden events;
 - non-message events;
-- unsupported subtypes except accepted thread broadcast behavior.
+- unsupported subtypes except accepted thread broadcast, file share, and
+  explicitly admitted bot-message behavior.
+
+## Foreign Bot Intake
+
+Human message admission MUST remain unchanged. Bot-authored messages MUST fail
+closed by default, but the adapter MAY admit a foreign bot so agents can
+interoperate in shared Slack channels.
+
+Before deciding whether to admit any bot-authored message, the adapter MUST use
+`auth.test` with that channel account's bot token to discover both the local
+`bot_id`, bot `user_id`, and `team_id`, and MUST require `ok=true`. It MUST
+extract the Slack team from outer `payload.team_id` and/or `event.team` without
+falling back to Ravi's logical account id. The present outer team values MUST
+identify one team and equal the authenticated `team_id`; missing or conflicting
+team provenance MUST ignore the bot message. It MUST ignore a self message when
+either raw event id matches the corresponding local id. A successful discovery MAY be cached;
+concurrent discovery MUST share one in-flight request. Missing, incomplete, or
+failed discovery MUST ignore the bot message and MAY use only a bounded failure
+backoff before retrying. Discovery itself MUST also have a bounded timeout (five
+seconds by default); the underlying HTTP request MUST receive an abort signal,
+and a timeout MUST fail closed and MUST release the in-flight slot so a later bot
+message can retry. A failure MUST NOT become a permanent cached identity.
+
+A foreign bot message MUST be admitted only when at least one of these rules
+matches:
+
+- the text contains an explicit Slack `<@local_bot_user_id>` mention; or
+- the text starts with a configured alias for that exact Slack chat id.
+
+Aliases MUST be configured per canonical Slack channel/account under
+`ChannelConfig.defaults.botMessageAliasesByChat`. They MUST NOT come from an
+environment variable or leak between channel accounts. Alias matching is
+case-insensitive and MUST require the complete alias followed by end-of-text,
+whitespace, or Unicode punctuation. Leading whitespace, middle-of-text matches,
+partial words, and aliases from another chat MUST NOT admit the message.
+
+Admitted bot messages MUST keep raw `user`, `bot_id`, team, channel, timestamp,
+and `senderKind=bot` provenance. The effective sender is raw `user` when present
+and otherwise `bot_id`. Both candidate ids MUST be resolved through the same
+canonical instance alias contract below, including collision detection and the
+exact empty legacy fallback.
+
+The actor MAY be `agent` only when every resolved candidate id belongs to one
+and the same agent. Unresolved companion ids do not conflict with that unique
+agent. Contact-only identities, an agent/contact mix, multiple agent owners, or
+an alias collision MUST resolve to `unknown` with no contact, agent, or platform
+identity authority attached. Resolution provenance MUST include the candidate
+ids, the matched candidate when successful, and a non-secret bot resolution
+reason. A resolved agent actor MUST enter the runtime as the corresponding
+`agent:<actorAgentId>` principal; it MUST NOT fall through to `missing_contact`
+or erase the executor agent's effective capabilities.
+
+Admission MUST reuse existing route, root/thread, canonical chat, persistence,
+and envelope-deduplication behavior. A duplicate Socket Mode envelope MUST still
+produce at most one prompt.
 
 ## Credentials
 
@@ -114,6 +168,9 @@ Agents and operators MUST receive typed Ravi operations such as `slack.channels.
 ## Delivery Barrier
 
 Normal inbound Slack user messages MUST publish session prompts with `deliveryBarrier=after_tool`.
+
+An admitted foreign bot message MUST use the same delivery barrier because it
+is live channel input.
 
 This classifies Slack input as live human conversation, allowing the runtime to interrupt an unrelated active text response after safe tool/compaction barriers. The adapter MUST NOT publish normal user messages as `after_response`, because that can let stale active-turn output reach Slack before the new Slack message is processed.
 

--- a/.ravi/specs/channels/adapters/slack/WHY.md
+++ b/.ravi/specs/channels/adapters/slack/WHY.md
@@ -19,6 +19,33 @@ The safer default is thread-first routing:
 
 This keeps the first Slack adapter useful for real work while preserving the Ravi principle that channels transport context and Ravi owns routing/session semantics.
 
+## Why Foreign Bots Are Explicitly Addressed
+
+Slack Connect and shared automation channels often contain messages authored by
+other bots. Ignoring every `bot_id` prevents useful agent-to-agent coordination,
+while admitting every bot message creates loops and lets ambient automation drive
+an agent. Ravi therefore discovers its own bot/user pair with `auth.test`, always
+filters self output, and admits a foreign bot only through an explicit mention or
+a chat-scoped alias at the beginning of the text.
+
+Aliases live on the channel account rather than in process environment so two
+workspaces can use different names without sharing policy. Complete-word Unicode
+boundaries make the operator-visible rule match natural text without accepting
+partial names. Authentication discovery is coalesced and successful results are
+cached, but each request has a bounded timeout and failures get only a short
+backoff: this avoids a stuck Web API call or a transient Slack failure turning
+into a daemon-lifetime outage without creating an API storm.
+
+Slack bot events may carry both a bot id and a user id. Either can be linked in
+the identity graph, so resolving only the first id loses valid agent identity;
+blindly choosing the first match can also grant the wrong authority. Resolving
+both through the canonical instance aliases and requiring one consistent agent
+owner preserves interoperability while keeping contact-only, mixed-owner, and
+ambiguous cases fail-closed. Raw ids remain provenance, not product identity.
+Once resolved, that actor is represented by its `agent:*` runtime principal;
+the session's executor keeps its own effective capabilities instead of treating
+the foreign agent like an unresolved contact.
+
 ## Why Canonicalize Instance Identity
 
 A Slack workspace can be referenced by more than one instance value over its lifetime: the

--- a/src/channels/slack/client.test.ts
+++ b/src/channels/slack/client.test.ts
@@ -3,8 +3,10 @@ import { SlackWebApiClient } from "./client.js";
 
 describe("Slack Web API client", () => {
   it("reads token scopes from auth.test response headers", async () => {
-    const fetchImpl = mock(async () =>
-      jsonResponse(
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchImpl = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+      requestSignal = init?.signal;
+      return jsonResponse(
         {
           ok: true,
           team: "RBBT",
@@ -17,19 +19,21 @@ describe("Slack Web API client", () => {
           "x-oauth-scopes": "channels:read,channels:manage,chat:write",
           "x-accepted-oauth-scopes": "identity.basic",
         },
-      ),
-    ) as unknown as typeof fetch;
+      );
+    }) as unknown as typeof fetch;
     const client = new SlackWebApiClient({
       appToken: "xapp-secret",
       botToken: "xoxb-secret",
       fetchImpl,
     });
 
-    await expect(client.authTest()).resolves.toMatchObject({
+    const controller = new AbortController();
+    await expect(client.authTest({ signal: controller.signal })).resolves.toMatchObject({
       team: "RBBT",
       scopes: ["channels:read", "channels:manage", "chat:write"],
       acceptedScopes: ["identity.basic"],
     });
+    expect(requestSignal).toBe(controller.signal);
   });
 
   it("lists conversations with cursor pagination", async () => {

--- a/src/channels/slack/client.ts
+++ b/src/channels/slack/client.ts
@@ -476,11 +476,12 @@ export class SlackWebApiClient {
     });
   }
 
-  async authTest(): Promise<SlackAuthTestResponse> {
+  async authTest(options: { signal?: AbortSignal } = {}): Promise<SlackAuthTestResponse> {
     const { payload, headers } = await this.apiRequestWithHeaders<SlackAuthTestResponse>(
       "auth.test",
       this.botToken,
       {},
+      options,
     );
     return {
       ...payload,
@@ -724,7 +725,7 @@ export class SlackWebApiClient {
     method: string,
     token: string,
     body: Record<string, unknown>,
-    options: { okErrors?: readonly string[] } = {},
+    options: { okErrors?: readonly string[]; signal?: AbortSignal } = {},
   ): Promise<T> {
     const { payload } = await this.apiRequestWithHeaders<T>(method, token, body, options);
     return payload;
@@ -760,7 +761,7 @@ export class SlackWebApiClient {
     method: string,
     token: string,
     body: Record<string, unknown>,
-    options: { okErrors?: readonly string[] } = {},
+    options: { okErrors?: readonly string[]; signal?: AbortSignal } = {},
   ): Promise<{ payload: T; headers: Headers }> {
     const res = await this.fetchImpl(`${this.apiBaseUrl}/${method}`, {
       method: "POST",
@@ -769,6 +770,7 @@ export class SlackWebApiClient {
         "content-type": "application/x-www-form-urlencoded",
       },
       body: encodeSlackFormBody(body),
+      signal: options.signal,
     });
 
     const payload = (await res.json()) as T;

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -49,11 +49,14 @@ export {
   DEFAULT_SLACK_ROUTING_POLICY,
   cleanSlackId,
   envelopeEvent,
+  isSlackMessageEventStructurallyEligible,
   normalizeSlackRoutingPolicy,
   resolveSlackThreadContext,
   shouldIgnoreSlackMessageEvent,
   slackPeerKindForChannelType,
+  slackRoutingPolicyFromChannelDefaults,
   slackRoutingPolicyFromEnv,
+  slackSenderIdForEvent,
   slackTsToMs,
 } from "./routing.js";
 export {
@@ -67,6 +70,7 @@ export {
 } from "./socket-mode.js";
 export type { SlackNativeRuntime, SlackSocketModeServiceOptions, SlackTargetScope } from "./socket-mode.js";
 export type {
+  SlackBotMessageAliasesByChat,
   SlackEventPayload,
   SlackEventsApiPayload,
   SlackFilePayload,

--- a/src/channels/slack/routing.test.ts
+++ b/src/channels/slack/routing.test.ts
@@ -1,13 +1,39 @@
 import { describe, expect, it } from "bun:test";
 import {
   DEFAULT_SLACK_ROUTING_POLICY,
+  isSlackMessageEventStructurallyEligible,
   normalizeSlackRoutingPolicy,
   resolveSlackThreadContext,
   shouldIgnoreSlackMessageEvent,
   slackPeerKindForChannelType,
+  slackRoutingPolicyFromChannelDefaults,
+  slackRoutingPolicyFromEnv,
 } from "./routing.js";
 
 describe("Slack routing policy", () => {
+  it("keeps foreign bot aliases disabled by default and out of environment config", () => {
+    expect(normalizeSlackRoutingPolicy({}).botMessageAliasesByChat).toEqual({});
+    expect(
+      slackRoutingPolicyFromEnv({
+        RAVI_SLACK_BOT_MESSAGE_ALIASES_BY_CHAT: '{"C1":["Ravi"]}',
+      } as NodeJS.ProcessEnv).botMessageAliasesByChat,
+    ).toEqual({});
+  });
+
+  it("normalizes chat-scoped bot aliases from channel defaults", () => {
+    expect(
+      slackRoutingPolicyFromChannelDefaults(
+        {
+          botMessageAliasesByChat: {
+            C1: [" Ravi ", "ravi", "Hana", ""],
+            C2: "not-an-array",
+          },
+        },
+        {} as NodeJS.ProcessEnv,
+      ).botMessageAliasesByChat,
+    ).toEqual({ C1: ["ravi", "Hana"] });
+  });
+
   it("keeps threaded messages in the same thread by default", () => {
     const thread = resolveSlackThreadContext(
       { ts: "1710000000.000200", thread_ts: "1710000000.000100" },
@@ -49,10 +75,102 @@ describe("Slack routing policy", () => {
     expect(slackPeerKindForChannelType(undefined)).toBe("group");
   });
 
-  it("ignores bot and non-message events", () => {
+  it("ignores non-message events and foreign bots when local auth identity is unavailable", () => {
     expect(shouldIgnoreSlackMessageEvent({ type: "reaction_added", user: "U1", channel: "C1", ts: "1.0" })).toBe(true);
     expect(shouldIgnoreSlackMessageEvent({ type: "message", bot_id: "B1", channel: "C1", ts: "1.0" })).toBe(true);
     expect(shouldIgnoreSlackMessageEvent({ type: "message", user: "U1", channel: "C1", ts: "1.0" })).toBe(false);
+  });
+
+  it("structurally prefilters unsupported or malformed messages before identity policy", () => {
+    expect(isSlackMessageEventStructurallyEligible({ type: "reaction_added", channel: "C1", ts: "1.0" })).toBe(false);
+    expect(isSlackMessageEventStructurallyEligible({ type: "message", hidden: true, channel: "C1", ts: "1.0" })).toBe(
+      false,
+    );
+    expect(
+      isSlackMessageEventStructurallyEligible({
+        type: "message",
+        subtype: "message_changed",
+        channel: "C1",
+        ts: "1.0",
+      }),
+    ).toBe(false);
+    expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: " ", ts: "1.0" })).toBe(false);
+    expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: "C1", ts: " " })).toBe(false);
+    expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: "C1", ts: "1.0" })).toBe(true);
+  });
+
+  it("ignores the local bot by either bot_id or user id", () => {
+    const options = { selfBotId: "BLOCAL", selfUserId: "ULOCAL" };
+    expect(
+      shouldIgnoreSlackMessageEvent(
+        {
+          type: "message",
+          subtype: "bot_message",
+          bot_id: "BLOCAL",
+          user: "UOTHER",
+          channel: "C1",
+          ts: "1.0",
+          text: "<@ULOCAL> loop",
+        },
+        options,
+      ),
+    ).toBe(true);
+    expect(
+      shouldIgnoreSlackMessageEvent(
+        {
+          type: "message",
+          subtype: "bot_message",
+          bot_id: "BOTHER",
+          user: "ULOCAL",
+          channel: "C1",
+          ts: "1.0",
+          text: "<@ULOCAL> loop",
+        },
+        options,
+      ),
+    ).toBe(true);
+  });
+
+  it("admits a foreign bot only when explicitly mentioned or addressed by a chat alias", () => {
+    const options = {
+      selfBotId: "BLOCAL",
+      selfUserId: "ULOCAL",
+      botMessageAliasesByChat: { C1: ["Hana"] },
+    };
+    const bot = {
+      type: "message",
+      subtype: "bot_message",
+      bot_id: "BFOREIGN",
+      channel: "C1",
+      ts: "1.0",
+    } as const;
+
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, text: "status update" }, options)).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, text: "oi <@ULOCAL>, consegue responder?" }, options)).toBe(false);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, text: "hana: consegue responder?" }, options)).toBe(false);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, text: "Hana—consegue responder?" }, options)).toBe(false);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, text: "Hana" }, options)).toBe(false);
+  });
+
+  it("rejects aliases from another chat, mid-sentence, or partial words", () => {
+    const options = {
+      selfBotId: "BLOCAL",
+      selfUserId: "ULOCAL",
+      botMessageAliasesByChat: { C1: ["Hana"] },
+    };
+    const bot = {
+      type: "message",
+      subtype: "bot_message",
+      bot_id: "BFOREIGN",
+      ts: "1.0",
+    } as const;
+
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, channel: "C2", text: "Hana, oi" }, options)).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, channel: "C1", text: "oi Hana, tudo bem?" }, options)).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, channel: "C1", text: "Hanami não é alias" }, options)).toBe(true);
+    expect(shouldIgnoreSlackMessageEvent({ ...bot, channel: "C1", text: " Hana, não começa no alias" }, options)).toBe(
+      true,
+    );
   });
 
   it("accepts Slack file_share events so audio uploads are routed", () => {

--- a/src/channels/slack/routing.ts
+++ b/src/channels/slack/routing.ts
@@ -1,4 +1,5 @@
 import type {
+  SlackBotMessageAliasesByChat,
   SlackEventPayload,
   SlackRootReplyMode,
   SlackRoutingPolicy,
@@ -12,7 +13,14 @@ export const DEFAULT_SLACK_ROUTING_POLICY: SlackRoutingPolicy = {
   subscriptionScope: "thread",
   threadReplyMode: "same_thread",
   rootReplyMode: "channel_root",
+  botMessageAliasesByChat: {},
 };
+
+export interface SlackMessageEventIgnoreOptions {
+  readonly selfBotId?: string;
+  readonly selfUserId?: string;
+  readonly botMessageAliasesByChat?: SlackBotMessageAliasesByChat;
+}
 
 export function normalizeSlackRoutingPolicy(input: Partial<SlackRoutingPolicy> = {}): SlackRoutingPolicy {
   return {
@@ -25,6 +33,7 @@ export function normalizeSlackRoutingPolicy(input: Partial<SlackRoutingPolicy> =
     rootReplyMode: isSlackRootReplyMode(input.rootReplyMode)
       ? input.rootReplyMode
       : DEFAULT_SLACK_ROUTING_POLICY.rootReplyMode,
+    botMessageAliasesByChat: normalizeSlackBotMessageAliasesByChat(input.botMessageAliasesByChat),
   };
 }
 
@@ -33,6 +42,25 @@ export function slackRoutingPolicyFromEnv(env: NodeJS.ProcessEnv = process.env):
     subscriptionScope: env.RAVI_SLACK_SUBSCRIPTION_SCOPE as SlackSubscriptionScope | undefined,
     threadReplyMode: env.RAVI_SLACK_THREAD_REPLY_MODE as SlackThreadReplyMode | undefined,
     rootReplyMode: env.RAVI_SLACK_ROOT_REPLY_MODE as SlackRootReplyMode | undefined,
+  });
+}
+
+export function slackRoutingPolicyFromChannelDefaults(
+  defaults: Record<string, unknown> | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): SlackRoutingPolicy {
+  const environmentPolicy = slackRoutingPolicyFromEnv(env);
+  return normalizeSlackRoutingPolicy({
+    subscriptionScope: isSlackSubscriptionScope(defaults?.subscriptionScope)
+      ? defaults.subscriptionScope
+      : environmentPolicy.subscriptionScope,
+    threadReplyMode: isSlackThreadReplyMode(defaults?.threadReplyMode)
+      ? defaults.threadReplyMode
+      : environmentPolicy.threadReplyMode,
+    rootReplyMode: isSlackRootReplyMode(defaults?.rootReplyMode)
+      ? defaults.rootReplyMode
+      : environmentPolicy.rootReplyMode,
+    botMessageAliasesByChat: defaults?.botMessageAliasesByChat as SlackBotMessageAliasesByChat | undefined,
   });
 }
 
@@ -67,14 +95,46 @@ export function slackPeerKindForChannelType(channelType: string | undefined): "d
   return channelType === "im" ? "dm" : "group";
 }
 
-export function shouldIgnoreSlackMessageEvent(event: SlackEventPayload): boolean {
-  if (event.type !== "message") return true;
-  if (event.hidden === true) return true;
-  if (!cleanSlackId(event.channel)) return true;
-  if (!cleanSlackId(event.ts)) return true;
-  if (event.bot_id) return true;
-  if (event.subtype && event.subtype !== "thread_broadcast" && event.subtype !== "file_share") return true;
-  return !cleanSlackId(event.user);
+export function shouldIgnoreSlackMessageEvent(
+  event: SlackEventPayload,
+  options: SlackMessageEventIgnoreOptions = {},
+): boolean {
+  if (!isSlackMessageEventStructurallyEligible(event)) return true;
+
+  const userId = cleanSlackId(event.user);
+  const botId = cleanSlackId(event.bot_id);
+  const isBotMessage = Boolean(botId || event.subtype === "bot_message");
+  if (!isBotMessage) return !userId;
+
+  if (!botId && !userId) return true;
+  const selfBotId = cleanSlackId(options.selfBotId);
+  const selfUserId = cleanSlackId(options.selfUserId);
+  if (!selfBotId && !selfUserId) return true;
+  if ((selfBotId && botId === selfBotId) || (selfUserId && userId === selfUserId)) return true;
+
+  const text = typeof event.text === "string" ? event.text : "";
+  return !(
+    (selfUserId && text.includes(`<@${selfUserId}>`)) ||
+    isSlackMessageAddressedByAlias({
+      channelId: cleanSlackId(event.channel),
+      text,
+      aliasesByChat: options.botMessageAliasesByChat,
+    })
+  );
+}
+
+export function isSlackMessageEventStructurallyEligible(event: SlackEventPayload): boolean {
+  return (
+    event.type === "message" &&
+    event.hidden !== true &&
+    Boolean(cleanSlackId(event.channel)) &&
+    Boolean(cleanSlackId(event.ts)) &&
+    isSupportedSlackMessageSubtype(event.subtype)
+  );
+}
+
+export function slackSenderIdForEvent(event: SlackEventPayload): string | undefined {
+  return cleanSlackId(event.user) ?? cleanSlackId(event.bot_id);
 }
 
 export function slackTsToMs(ts: string | undefined, fallback = Date.now()): number {
@@ -108,4 +168,48 @@ function isSlackThreadReplyMode(value: unknown): value is SlackThreadReplyMode {
 
 function isSlackRootReplyMode(value: unknown): value is SlackRootReplyMode {
   return value === "channel_root" || value === "new_thread" || value === "policy_default";
+}
+
+function isSupportedSlackMessageSubtype(value: string | undefined): boolean {
+  return !value || value === "thread_broadcast" || value === "file_share" || value === "bot_message";
+}
+
+function isSlackMessageAddressedByAlias(input: {
+  channelId: string | undefined;
+  text: string;
+  aliasesByChat: SlackBotMessageAliasesByChat | undefined;
+}): boolean {
+  if (!input.channelId) return false;
+  const aliases = input.aliasesByChat?.[input.channelId] ?? [];
+  return aliases.some((alias) => slackTextStartsWithAlias(input.text, alias));
+}
+
+function slackTextStartsWithAlias(text: string, alias: string): boolean {
+  const cleanedAlias = cleanSlackId(alias);
+  if (!cleanedAlias) return false;
+  const pattern = new RegExp(`^${escapeRegExp(cleanedAlias)}(?:$|[\\s\\p{P}])`, "iu");
+  return pattern.test(text);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeSlackBotMessageAliasesByChat(input: unknown): SlackBotMessageAliasesByChat {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return {};
+  const entries: Array<[string, string[]]> = [];
+  for (const [rawChatId, rawAliases] of Object.entries(input)) {
+    const chatId = cleanSlackId(rawChatId);
+    if (!chatId || !Array.isArray(rawAliases)) continue;
+    const aliases = Array.from(
+      new Map(
+        rawAliases
+          .map((alias) => (typeof alias === "string" ? alias.trim() : ""))
+          .filter(Boolean)
+          .map((alias) => [alias.toLowerCase(), alias]),
+      ).values(),
+    );
+    if (aliases.length > 0) entries.push([chatId, aliases]);
+  }
+  return Object.fromEntries(entries);
 }

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -4,6 +4,7 @@ import {
   ensureContactFromInbound,
   linkContactIdentity,
   resolvePlatformIdentity,
+  upsertAgentPlatformIdentity,
 } from "../../contacts.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
 import { canWithCapabilities } from "../../permissions/provider-runtime.js";
@@ -38,7 +39,7 @@ import {
   SlackTextDelivery,
   createSlackNativeRuntimesFromEnv,
 } from "./socket-mode.js";
-import type { SlackSocketEnvelope } from "./types.js";
+import type { SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
 
 let stateDir: string | null = null;
 
@@ -55,12 +56,18 @@ function seedAgent(id: string, cwd: string): void {
     .run(id, id, cwd, now, now);
 }
 
-function slackChannel(input: { name: string; credentialConnection?: string; enabled?: boolean }) {
+function slackChannel(input: {
+  name: string;
+  credentialConnection?: string;
+  enabled?: boolean;
+  defaults?: Record<string, unknown>;
+}) {
   return {
     name: input.name,
     provider: "slack",
     enabled: input.enabled ?? true,
     ...(input.credentialConnection ? { credentialConnection: input.credentialConnection } : {}),
+    ...(input.defaults ? { defaults: input.defaults } : {}),
     createdAt: 1,
     updatedAt: 1,
   };
@@ -129,6 +136,41 @@ describe("Slack Socket Mode routing", () => {
     expect(resolveSecret.mock.calls.map((call) => call[0].connection)).toEqual(["hana-secret", "rbbt-secret"]);
     expect(runtimes.map((runtime) => runtime.accountId)).toEqual(["hana-slack", "ravi-rbbt-slack"]);
     expect(runtimes.map((runtime) => runtime.connection)).toEqual(["hana-secret", "rbbt-secret"]);
+  });
+
+  it("keeps bot alias defaults isolated per configured Slack account", async () => {
+    const resolveSecret = mock(async ({ connection }: { connection: string }) => ({
+      secret: JSON.stringify({ appToken: `xapp-${connection}`, botToken: `xoxb-${connection}` }),
+      connection: { connection },
+    }));
+
+    const runtimes = await createSlackNativeRuntimesFromEnv({} as NodeJS.ProcessEnv, {
+      resolveSecret,
+      channels: {
+        "ravi-rbbt-slack": slackChannel({
+          name: "ravi-rbbt-slack",
+          credentialConnection: "rbbt-secret",
+          defaults: { botMessageAliasesByChat: { CDEMO: ["Ravi"] } },
+        }),
+        "hana-slack": slackChannel({
+          name: "hana-slack",
+          credentialConnection: "hana-secret",
+          defaults: { botMessageAliasesByChat: { CDEMO: ["Hana"] } },
+        }),
+      },
+    });
+
+    const policies = Object.fromEntries(
+      runtimes.map((runtime) => [
+        runtime.accountId,
+        (runtime.socketMode as unknown as { routingPolicy: { botMessageAliasesByChat: unknown } }).routingPolicy
+          .botMessageAliasesByChat,
+      ]),
+    );
+    expect(policies).toEqual({
+      "hana-slack": { CDEMO: ["Hana"] },
+      "ravi-rbbt-slack": { CDEMO: ["Ravi"] },
+    });
   });
 
   it("routes Slack channels through group routes and attaches the source chat for output", async () => {
@@ -1194,6 +1236,929 @@ describe("Slack Socket Mode routing", () => {
       actorType: "contact",
       contactId: identity.contact!.id,
       platformIdentityId: identity.platformIdentity!.id,
+    });
+  });
+});
+
+describe("Slack Socket Mode foreign bot intake", () => {
+  const SLUG = "ravi-rbbt-slack";
+  const UUID = "0bc9635c-1ee9-42e3-9112-95be9cdb0334";
+  let stateDir: string | null = null;
+
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-slack-foreign-bot-");
+    seedAgent("route-agent", "/tmp/route-agent");
+    seedAgent("foreign-one", "/tmp/foreign-one");
+    seedAgent("foreign-two", "/tmp/foreign-two");
+  });
+
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  function botRouterConfig(): RouterConfig {
+    return {
+      agents: {
+        "route-agent": { id: "route-agent", cwd: "/tmp/route-agent", dmScope: "per-peer" },
+        "foreign-one": { id: "foreign-one", cwd: "/tmp/foreign-one", dmScope: "per-peer" },
+        "foreign-two": { id: "foreign-two", cwd: "/tmp/foreign-two", dmScope: "per-peer" },
+      },
+      routes: [
+        {
+          pattern: "group:C123",
+          accountId: SLUG,
+          agent: "route-agent",
+          session: "route-agent",
+          priority: 100,
+          policy: "open",
+          channel: "slack",
+        },
+      ],
+      defaultAgent: "route-agent",
+      defaultDmScope: "per-peer",
+      accountAgents: { [SLUG]: "route-agent" },
+      instanceToAccount: { [UUID]: SLUG },
+      instances: {
+        [SLUG]: {
+          name: SLUG,
+          instanceId: UUID,
+          channel: "slack",
+          dmPolicy: "open",
+          groupPolicy: "open",
+          contactIntakeMode: "off",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      },
+    };
+  }
+
+  function botEnvelope(input: {
+    envelopeId: string;
+    ts: string;
+    text: string;
+    botId: string;
+    userId?: string;
+    channelId?: string;
+    threadTs?: string;
+    teamId?: string | null;
+    eventTeamId?: string | null;
+  }): SlackSocketEnvelope {
+    return {
+      envelope_id: input.envelopeId,
+      payload: {
+        ...(input.teamId === null ? {} : { team_id: input.teamId ?? "T1" }),
+        event_id: `Ev-${input.envelopeId}`,
+        event_time: 1_713_000_000,
+        event: {
+          type: "message",
+          subtype: "bot_message",
+          channel: input.channelId ?? "C123",
+          channel_type: "channel",
+          user: input.userId,
+          bot_id: input.botId,
+          text: input.text,
+          ts: input.ts,
+          thread_ts: input.threadTs,
+          ...(input.eventTeamId === null || input.eventTeamId === undefined ? {} : { team: input.eventTeamId }),
+        },
+      },
+    };
+  }
+
+  function humanEnvelope(input: {
+    envelopeId: string;
+    ts: string;
+    teamId?: string | null;
+    eventTeamId?: string | null;
+  }): SlackSocketEnvelope {
+    return {
+      envelope_id: input.envelopeId,
+      payload: {
+        ...(input.teamId === null ? {} : { team_id: input.teamId ?? "T1" }),
+        event_id: `Ev-${input.envelopeId}`,
+        event_time: 1_713_000_000,
+        event: {
+          type: "message",
+          channel: "C123",
+          channel_type: "channel",
+          user: "UHUMAN",
+          text: "human message",
+          ts: input.ts,
+          ...(input.eventTeamId === null || input.eventTeamId === undefined ? {} : { team: input.eventTeamId }),
+        },
+      },
+    };
+  }
+
+  function makeBotService(input: {
+    published: Array<{ sessionName: string; payload: Record<string, unknown> }>;
+    authTest: (options?: { signal?: AbortSignal }) => Promise<{
+      ok: boolean;
+      bot_id?: string;
+      user_id?: string;
+      team_id?: string;
+    }>;
+    routingPolicy?: Partial<SlackRoutingPolicy>;
+    now?: () => number;
+    authTestFailureRetryMs?: number;
+    authTestTimeoutMs?: number;
+  }): SlackSocketModeService {
+    return new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: SLUG,
+      routeAccountId: SLUG,
+      instanceId: SLUG,
+      routingPolicy: input.routingPolicy,
+      getRouterConfig: botRouterConfig,
+      publishPrompt: async (sessionName, payload) => {
+        input.published.push({ sessionName, payload });
+      },
+      webClient: { authTest: input.authTest } as never,
+      now: input.now,
+      authTestFailureRetryMs: input.authTestFailureRetryMs,
+      authTestTimeoutMs: input.authTestTimeoutMs,
+    });
+  }
+
+  it("preserves human intake without Slack team provenance and does not call auth.test", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" }));
+    const service = makeBotService({ published, authTest });
+
+    expect(
+      await service.handleEnvelope(
+        humanEnvelope({
+          envelopeId: "human-without-team",
+          ts: "1713000090.000100",
+          teamId: null,
+          eventTeamId: null,
+        }),
+      ),
+    ).toBe("processed");
+    expect(authTest).not.toHaveBeenCalled();
+    expect(published).toHaveLength(1);
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(dbGetChat(source.canonicalChatId!)).toMatchObject({
+      rawProvenance: { teamId: SLUG },
+    });
+  });
+
+  it("preserves event.team precedence for conflicting human team values without calling auth.test", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" }));
+    const service = makeBotService({ published, authTest });
+
+    expect(
+      await service.handleEnvelope(
+        humanEnvelope({
+          envelopeId: "human-conflicting-team",
+          ts: "1713000091.000100",
+          teamId: "T-PAYLOAD",
+          eventTeamId: "T-EVENT",
+        }),
+      ),
+    ).toBe("processed");
+    expect(authTest).not.toHaveBeenCalled();
+    expect(published).toHaveLength(1);
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(dbGetChat(source.canonicalChatId!)).toMatchObject({
+      rawProvenance: { teamId: "T-EVENT" },
+    });
+  });
+
+  it("ignores the local bot by bot and user ids while caching successful auth.test", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" }));
+    const service = makeBotService({ published, authTest });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "self-bot-id",
+          ts: "1713000100.000100",
+          text: "<@ULOCAL> loop",
+          botId: "BLOCAL",
+          userId: "UOTHER",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "self-user-id",
+          ts: "1713000101.000100",
+          text: "<@ULOCAL> loop",
+          botId: "BOTHER",
+          userId: "ULOCAL",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "foreign-mentioned",
+          ts: "1713000102.000100",
+          text: "oi <@ULOCAL>",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+
+    expect(authTest).toHaveBeenCalledTimes(1);
+    expect(published).toHaveLength(1);
+  });
+
+  it("requires the envelope and auth.test to identify the same Slack team", async () => {
+    const fromEvent: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const matchingAuth = mock(async () => ({
+      ok: true,
+      bot_id: "BLOCAL",
+      user_id: "ULOCAL",
+      team_id: "T1",
+    }));
+    const matchingService = makeBotService({ published: fromEvent, authTest: matchingAuth });
+
+    expect(
+      await matchingService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "team-from-event",
+          ts: "1713000102.000200",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: null,
+          eventTeamId: "T1",
+        }),
+      ),
+    ).toBe("processed");
+    expect(fromEvent).toHaveLength(1);
+
+    const mismatched: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const mismatchedAuth = mock(async () => ({
+      ok: true,
+      bot_id: "BLOCAL",
+      user_id: "ULOCAL",
+      team_id: "T2",
+    }));
+    const mismatchedService = makeBotService({ published: mismatched, authTest: mismatchedAuth });
+    expect(
+      await mismatchedService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "team-mismatch",
+          ts: "1713000102.000300",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(mismatchedAuth).toHaveBeenCalledTimes(1);
+    expect(mismatched).toHaveLength(0);
+  });
+
+  it("fails closed before auth.test when Slack team provenance is absent or conflicting", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({
+      ok: true,
+      bot_id: "BLOCAL",
+      user_id: "ULOCAL",
+      team_id: "T1",
+    }));
+    const service = makeBotService({ published, authTest });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "team-absent",
+          ts: "1713000102.000400",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: null,
+          eventTeamId: null,
+        }),
+      ),
+    ).toBe("ignored");
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "team-conflict",
+          ts: "1713000102.000500",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: "T1",
+          eventTeamId: "T2",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(authTest).not.toHaveBeenCalled();
+    expect(published).toHaveLength(0);
+  });
+
+  it("requires auth.test ok=true and a complete team-bound identity", async () => {
+    for (const [index, response] of [
+      { ok: false, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" },
+      { ok: true, bot_id: "BLOCAL", user_id: "ULOCAL" },
+    ].entries()) {
+      const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+      const service = makeBotService({ published, authTest: mock(async () => response) });
+      expect(
+        await service.handleEnvelope(
+          botEnvelope({
+            envelopeId: `auth-invalid-${index}`,
+            ts: `1713000102.00060${index}`,
+            text: "<@ULOCAL> status",
+            botId: "BFOREIGN",
+          }),
+        ),
+      ).toBe("ignored");
+      expect(published).toHaveLength(0);
+    }
+  });
+
+  it("rejects structurally invalid bot candidates before auth.test", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" }));
+    const service = makeBotService({ published, authTest });
+    const invalidEvents = [
+      {
+        type: "reaction_added",
+        subtype: "bot_message",
+        bot_id: "BFOREIGN",
+        channel: "C123",
+        ts: "1713000103.000100",
+      },
+      {
+        type: "message",
+        subtype: "bot_message",
+        hidden: true,
+        bot_id: "BFOREIGN",
+        channel: "C123",
+        ts: "1713000104.000100",
+      },
+      {
+        type: "message",
+        subtype: "message_changed",
+        bot_id: "BFOREIGN",
+        channel: "C123",
+        ts: "1713000105.000100",
+      },
+      {
+        type: "message",
+        subtype: "bot_message",
+        bot_id: "BFOREIGN",
+        ts: "1713000106.000100",
+      },
+      {
+        type: "message",
+        subtype: "bot_message",
+        bot_id: "BFOREIGN",
+        channel: "C123",
+      },
+    ];
+
+    for (const [index, event] of invalidEvents.entries()) {
+      expect(
+        await service.handleEnvelope({
+          envelope_id: `structurally-invalid-bot-${index}`,
+          payload: { event },
+        }),
+      ).toBe("ignored");
+    }
+
+    expect(authTest).not.toHaveBeenCalled();
+    expect(published).toHaveLength(0);
+  });
+
+  it("coalesces concurrent auth.test discovery for foreign bot messages", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    let releaseAuth!: (value: { ok: boolean; bot_id: string; user_id: string; team_id: string }) => void;
+    const pendingAuth = new Promise<{ ok: boolean; bot_id: string; user_id: string; team_id: string }>((resolve) => {
+      releaseAuth = resolve;
+    });
+    const authTest = mock(async () => pendingAuth);
+    const service = makeBotService({ published, authTest });
+
+    const first = service.handleEnvelope(
+      botEnvelope({
+        envelopeId: "concurrent-1",
+        ts: "1713000110.000100",
+        text: "<@ULOCAL> first",
+        botId: "BFOREIGN",
+      }),
+    );
+    const second = service.handleEnvelope(
+      botEnvelope({
+        envelopeId: "concurrent-2",
+        ts: "1713000111.000100",
+        text: "<@ULOCAL> second",
+        botId: "BFOREIGN",
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(authTest).toHaveBeenCalledTimes(1);
+    releaseAuth({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" });
+    expect(await Promise.all([first, second])).toEqual(["processed", "processed"]);
+    expect(published).toHaveLength(2);
+  });
+
+  it("fail-closes auth.test errors and retries only after the bounded failure TTL", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    let now = 1_000;
+    let attempts = 0;
+    const authTest = mock(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary_auth_failure");
+      return { ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" };
+    });
+    const service = makeBotService({
+      published,
+      authTest,
+      now: () => now,
+      authTestFailureRetryMs: 100,
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-failure-1",
+          ts: "1713000120.000100",
+          text: "<@ULOCAL> first",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    now = 1_050;
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-failure-2",
+          ts: "1713000121.000100",
+          text: "<@ULOCAL> second",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(authTest).toHaveBeenCalledTimes(1);
+
+    now = 1_100;
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-retry",
+          ts: "1713000122.000100",
+          text: "<@ULOCAL> retry",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    expect(authTest).toHaveBeenCalledTimes(2);
+    expect(published).toHaveLength(1);
+  });
+
+  it("does not cache an incomplete auth.test identity and retries after the failure TTL", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    let now = 2_000;
+    let attempts = 0;
+    const authTest = mock(async () => {
+      attempts += 1;
+      if (attempts === 1) return { ok: true, bot_id: "BLOCAL" };
+      return { ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" };
+    });
+    const service = makeBotService({
+      published,
+      authTest,
+      now: () => now,
+      authTestFailureRetryMs: 100,
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-incomplete-1",
+          ts: "1713000125.000100",
+          text: "<@ULOCAL> first",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    now = 2_050;
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-incomplete-2",
+          ts: "1713000126.000100",
+          text: "<@ULOCAL> second",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(authTest).toHaveBeenCalledTimes(1);
+
+    now = 2_100;
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-incomplete-retry",
+          ts: "1713000127.000100",
+          text: "<@ULOCAL> retry",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    expect(authTest).toHaveBeenCalledTimes(2);
+    expect(published).toHaveLength(1);
+  });
+
+  it("times out a stuck auth.test, fails closed, and permits a later retry", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    let attempts = 0;
+    let timedOutSignal: AbortSignal | undefined;
+    const authTest = mock(async (options?: { signal?: AbortSignal }) => {
+      attempts += 1;
+      if (attempts === 1) {
+        timedOutSignal = options?.signal;
+        return new Promise<{ ok: boolean; bot_id: string; user_id: string; team_id: string }>((_, reject) => {
+          timedOutSignal?.addEventListener("abort", () => reject(timedOutSignal?.reason), { once: true });
+        });
+      }
+      return { ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" };
+    });
+    const service = makeBotService({
+      published,
+      authTest,
+      authTestFailureRetryMs: 0,
+      authTestTimeoutMs: 10,
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-timeout",
+          ts: "1713000128.000100",
+          text: "<@ULOCAL> first",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("ignored");
+    expect(timedOutSignal?.aborted).toBe(true);
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "auth-timeout-retry",
+          ts: "1713000129.000100",
+          text: "<@ULOCAL> retry",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    expect(authTest).toHaveBeenCalledTimes(2);
+    expect(published).toHaveLength(1);
+  });
+
+  it("resolves one consistent agent across bot ids, preserves provenance, threads, and dedupe", async () => {
+    const identity = upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "BFOREIGN",
+      linkedBy: "test",
+      linkReason: "slack_connect_agent_interop",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" }));
+    const service = makeBotService({ published, authTest });
+    const envelope = botEnvelope({
+      envelopeId: "agent-thread",
+      ts: "1713000130.000200",
+      threadTs: "1713000130.000100",
+      text: "<@ULOCAL> consegue responder?",
+      userId: "UFOREIGN",
+      botId: "BFOREIGN",
+    });
+
+    expect(await service.handleEnvelope(envelope)).toBe("processed");
+    expect(await service.handleEnvelope(envelope)).toBe("duplicate");
+    expect(published).toHaveLength(1);
+
+    const source = published[0]!.payload.source as MessageTarget;
+    const context = published[0]!.payload.context as MessageContext;
+    expect(source).toMatchObject({
+      instanceId: UUID,
+      threadId: "1713000130.000100",
+      actorType: "agent",
+      actorAgentId: "foreign-one",
+      platformIdentityId: identity.id,
+      rawSenderId: "UFOREIGN",
+      normalizedSenderId: "BFOREIGN",
+    });
+    expect(source.identityProvenance).toMatchObject({
+      source: "platform_identities",
+      canonicalInstance: UUID,
+      matchedInstance: UUID,
+      matchedPlatformUserId: "BFOREIGN",
+      candidatePlatformUserIds: ["UFOREIGN", "BFOREIGN"],
+      botIdentityReason: "resolved_agent",
+    });
+    expect(context).toMatchObject({
+      senderId: "UFOREIGN",
+      senderName: "<@UFOREIGN>",
+      actorType: "agent",
+      actorAgentId: "foreign-one",
+    });
+
+    const canonicalChatId = source.canonicalChatId!;
+    expect(dbGetChat(canonicalChatId)).toMatchObject({
+      instanceId: UUID,
+      platformChatId: "C123#1713000130.000100",
+      chatType: "thread",
+      rawProvenance: {
+        senderKind: "bot",
+        userId: "UFOREIGN",
+        botId: "BFOREIGN",
+      },
+    });
+    expect(
+      dbFindChatMessage({
+        channel: "slack",
+        instanceId: UUID,
+        chatId: canonicalChatId,
+        providerMessageId: "1713000130.000200",
+      }),
+    ).toMatchObject({
+      actorType: "agent",
+      agentId: "foreign-one",
+      platformIdentityId: identity.id,
+      rawSenderId: "UFOREIGN",
+      normalizedSenderId: "BFOREIGN",
+      rawProvenance: {
+        senderKind: "bot",
+        userId: "UFOREIGN",
+        botId: "BFOREIGN",
+      },
+    });
+    expect(dbListChatParticipants(canonicalChatId)).toEqual([
+      expect.objectContaining({
+        agentId: "foreign-one",
+        rawPlatformUserId: "UFOREIGN",
+        normalizedPlatformUserId: "BFOREIGN",
+        metadata: expect.objectContaining({ slackSenderKind: "bot", slackBotId: "BFOREIGN" }),
+      }),
+    ]);
+
+    const session = getSessionByName(published[0]!.sessionName)!;
+    const runtimePrompt: RuntimeLaunchPrompt = { prompt: "consegue responder?", source, context };
+    const { runtimeContext } = buildRuntimeRequestContext({
+      dbSessionKey: session.sessionKey,
+      sessionName: published[0]!.sessionName,
+      sessionCwd: "/tmp/route-agent",
+      agent: { id: "route-agent", cwd: "/tmp/route-agent" },
+      prompt: runtimePrompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution: {
+        options: {},
+        sources: { model: null, effort: null, thinking: null },
+        hasTaskRuntimeContext: false,
+      },
+      resolvedSource: source,
+    });
+    expect(runtimeContext.metadata).toMatchObject({
+      actorPrincipal: "agent:foreign-one",
+      actorResolution: "resolved",
+    });
+    expect(Number(runtimeContext.metadata?.agentIdentityCapabilityCount)).toBeGreaterThan(0);
+    expect(canWithCapabilities(runtimeContext.capabilities, "use", "tool", "Read")).toBe(true);
+  });
+
+  it("admits a bot-only alias message but keeps a contact-owned bot fail-closed", async () => {
+    const contact = ensureContactFromInbound({
+      channel: "slack",
+      instanceId: UUID,
+      platformSenderId: "BFOREIGN",
+      contactIdentity: "BFOREIGN",
+      displayName: "External integration",
+      intakeMode: "pending",
+      source: "test",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = makeBotService({
+      published,
+      authTest: mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" })),
+      routingPolicy: { botMessageAliasesByChat: { C123: ["Hana"] } },
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "bot-only-contact",
+          ts: "1713000140.000100",
+          text: "Hana—status",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    expect(contact.platformIdentity).not.toBeNull();
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(source).toMatchObject({
+      actorType: "unknown",
+      rawSenderId: "BFOREIGN",
+      normalizedSenderId: "BFOREIGN",
+    });
+    expect(source.contactId).toBeUndefined();
+    expect(source.platformIdentityId).toBeUndefined();
+    expect(source.identityProvenance).toMatchObject({
+      senderKind: "bot",
+      botIdentityReason: "contact_identity_not_agent",
+    });
+    expect(dbGetChat(source.canonicalChatId!)).toMatchObject({
+      rawProvenance: {
+        senderKind: "bot",
+        userId: null,
+        botId: "BFOREIGN",
+      },
+    });
+    expect(
+      dbFindChatMessage({
+        channel: "slack",
+        instanceId: UUID,
+        chatId: source.canonicalChatId!,
+        providerMessageId: "1713000140.000100",
+      }),
+    ).toMatchObject({
+      rawProvenance: {
+        senderKind: "bot",
+        userId: null,
+        botId: "BFOREIGN",
+      },
+    });
+    expect(String(published[0]!.payload.prompt)).toContain("<@BFOREIGN>: Hana—status");
+  });
+
+  it("resolves bot user_id and bot_id to one agent when both identities agree", async () => {
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "UFOREIGN",
+    });
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "BFOREIGN",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = makeBotService({
+      published,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T1",
+      })),
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "consistent-bot-identities",
+          ts: "1713000145.000100",
+          text: "<@ULOCAL> status",
+          userId: "UFOREIGN",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(source).toMatchObject({
+      actorType: "agent",
+      actorAgentId: "foreign-one",
+      rawSenderId: "UFOREIGN",
+      normalizedSenderId: "UFOREIGN",
+    });
+    expect(source.identityProvenance).toMatchObject({
+      matchedPlatformUserId: "UFOREIGN",
+      candidatePlatformUserIds: ["UFOREIGN", "BFOREIGN"],
+      botIdentityReason: "resolved_agent",
+      platformIdentityCandidates: [
+        expect.objectContaining({ platformUserId: "UFOREIGN", ownerType: "agent" }),
+        expect.objectContaining({ platformUserId: "BFOREIGN", ownerType: "agent" }),
+      ],
+    });
+  });
+
+  it("fails closed when the bot user and bot ids resolve to different owners", async () => {
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "UFOREIGN",
+    });
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-two",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "BFOREIGN",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = makeBotService({
+      published,
+      authTest: mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" })),
+    });
+
+    expect(
+      await service.handleEnvelope(
+        botEnvelope({
+          envelopeId: "conflicting-agents",
+          ts: "1713000150.000100",
+          text: "<@ULOCAL> status",
+          userId: "UFOREIGN",
+          botId: "BFOREIGN",
+        }),
+      ),
+    ).toBe("processed");
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(source.actorType).toBe("unknown");
+    expect(source.actorAgentId).toBeUndefined();
+    expect(source.platformIdentityId).toBeUndefined();
+    expect(source.identityProvenance).toMatchObject({ botIdentityReason: "conflicting_agents" });
+  });
+
+  it("fails closed when an agent bot id conflicts with a contact-owned user id", async () => {
+    ensureContactFromInbound({
+      channel: "slack",
+      instanceId: UUID,
+      platformSenderId: "UCONTACT",
+      contactIdentity: "UCONTACT",
+      intakeMode: "pending",
+      source: "test",
+    });
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "BAGENT",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = makeBotService({
+      published,
+      authTest: mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" })),
+    });
+
+    await service.handleEnvelope(
+      botEnvelope({
+        envelopeId: "agent-contact-conflict",
+        ts: "1713000160.000100",
+        text: "<@ULOCAL> status",
+        userId: "UCONTACT",
+        botId: "BAGENT",
+      }),
+    );
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(source.actorType).toBe("unknown");
+    expect(source.contactId).toBeUndefined();
+    expect(source.actorAgentId).toBeUndefined();
+    expect(source.identityProvenance).toMatchObject({ botIdentityReason: "conflicting_platform_owners" });
+  });
+
+  it("keeps canonical instance alias collisions fail-closed for bot identities", async () => {
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-one",
+      channel: "slack",
+      instanceId: UUID,
+      platformUserId: "BFOREIGN",
+    });
+    upsertAgentPlatformIdentity({
+      agentId: "foreign-two",
+      channel: "slack",
+      instanceId: SLUG,
+      platformUserId: "BFOREIGN",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = makeBotService({
+      published,
+      authTest: mock(async () => ({ ok: true, bot_id: "BLOCAL", user_id: "ULOCAL", team_id: "T1" })),
+      routingPolicy: { botMessageAliasesByChat: { C123: ["Hana"] } },
+    });
+
+    await service.handleEnvelope(
+      botEnvelope({
+        envelopeId: "alias-owner-conflict",
+        ts: "1713000170.000100",
+        text: "Hana, status",
+        botId: "BFOREIGN",
+      }),
+    );
+    const source = published[0]!.payload.source as MessageTarget;
+    expect(source.actorType).toBe("unknown");
+    expect(source.actorAgentId).toBeUndefined();
+    expect(source.identityProvenance).toMatchObject({
+      canonicalInstance: UUID,
+      reason: "ambiguous_instance_alias",
+      botIdentityReason: "ambiguous_instance_alias",
     });
   });
 });

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,5 +1,5 @@
 import { configStore } from "../../config-store.js";
-import { resolvePlatformIdentity } from "../../contacts.js";
+import { resolvePlatformIdentity, type PlatformIdentity } from "../../contacts.js";
 import { publish } from "../../nats.js";
 import { publishSessionPrompt } from "../../omni/session-stream.js";
 import {
@@ -41,21 +41,34 @@ import {
   SLACK_AMBIGUOUS_INSTANCE_ALIAS_REASON,
   SLACK_IDENTITY_NOT_FOUND_REASON,
   type SlackInstanceAliasResolution,
+  type SlackScopedIdentityResolution,
 } from "./instance-alias.js";
 import { storeSlackInteractionResponseUrl } from "./interactions.js";
 import {
   cleanSlackId,
   envelopeEvent,
+  isSlackMessageEventStructurallyEligible,
+  normalizeSlackRoutingPolicy,
   resolveSlackThreadContext,
   shouldIgnoreSlackMessageEvent,
   slackPeerKindForChannelType,
+  slackRoutingPolicyFromChannelDefaults,
   slackRoutingPolicyFromEnv,
+  slackSenderIdForEvent,
   slackTsToMs,
 } from "./routing.js";
-import type { SlackNormalizedFile, SlackNormalizedMessage, SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
+import type {
+  SlackEventPayload,
+  SlackNormalizedFile,
+  SlackNormalizedMessage,
+  SlackRoutingPolicy,
+  SlackSocketEnvelope,
+} from "./types.js";
 
 const log = logger.child("channels:slack");
 const SLACK_THREAD_CREATED_TOPIC = "ravi.inbound.thread.created";
+const DEFAULT_SLACK_AUTH_TEST_FAILURE_RETRY_MS = 5_000;
+const DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS = 5_000;
 
 type PublishPrompt = typeof publishSessionPrompt;
 type PublishInteraction = (topic: string, payload: Record<string, unknown>) => Promise<void>;
@@ -74,6 +87,17 @@ interface SlackActorIdentity extends MessageActorMetadata {
   readonly actorType: "contact" | "agent" | "unknown";
 }
 
+interface SlackLocalBotIdentity {
+  readonly botId: string;
+  readonly userId: string;
+  readonly teamId: string;
+}
+
+interface SlackBotIdentityResolutionOutcome {
+  readonly platformUserId: string;
+  readonly resolution: SlackScopedIdentityResolution<PlatformIdentity>;
+}
+
 export interface SlackSocketModeServiceOptions {
   readonly appToken: string;
   readonly botToken: string;
@@ -87,6 +111,12 @@ export interface SlackSocketModeServiceOptions {
   readonly publishInteraction?: PublishInteraction;
   readonly openWebSocket?: WebSocketFactory;
   readonly reconnectDelayMs?: number;
+  /** Negative-cache backoff for failed auth.test calls. Successful identities remain cached. */
+  readonly authTestFailureRetryMs?: number;
+  /** Maximum time bot intake waits for Slack auth.test before failing closed. */
+  readonly authTestTimeoutMs?: number;
+  /** Clock injection for bounded auth.test retry tests. */
+  readonly now?: () => number;
 }
 
 export interface SlackNativeRuntime {
@@ -375,23 +405,21 @@ export class SlackSocketModeService {
   private readonly openWebSocket: WebSocketFactory;
   private readonly routingPolicy: SlackRoutingPolicy;
   private readonly reconnectDelayMs: number;
+  private readonly authTestFailureRetryMs: number;
+  private readonly authTestTimeoutMs: number;
+  private readonly now: () => number;
   private readonly seenEnvelopeIds = new RecentIdCache();
+  private localBotIdentity: SlackLocalBotIdentity | null = null;
+  private localBotIdentityInFlight: Promise<SlackLocalBotIdentity | null> | null = null;
+  private nextLocalBotIdentityAttemptAt = 0;
   private running = false;
   private socket: WebSocket | null = null;
   private loopPromise: Promise<void> | null = null;
 
   constructor(private readonly options: SlackSocketModeServiceOptions) {
-    this.routingPolicy = slackRoutingPolicyFromEnv({
-      ...process.env,
-      ...(options.routingPolicy?.subscriptionScope
-        ? { RAVI_SLACK_SUBSCRIPTION_SCOPE: options.routingPolicy.subscriptionScope }
-        : {}),
-      ...(options.routingPolicy?.threadReplyMode
-        ? { RAVI_SLACK_THREAD_REPLY_MODE: options.routingPolicy.threadReplyMode }
-        : {}),
-      ...(options.routingPolicy?.rootReplyMode
-        ? { RAVI_SLACK_ROOT_REPLY_MODE: options.routingPolicy.rootReplyMode }
-        : {}),
+    this.routingPolicy = normalizeSlackRoutingPolicy({
+      ...slackRoutingPolicyFromEnv(),
+      ...(options.routingPolicy ?? {}),
     });
     this.webClient =
       options.webClient ??
@@ -404,6 +432,19 @@ export class SlackSocketModeService {
     this.publishInteraction = options.publishInteraction ?? publish;
     this.openWebSocket = options.openWebSocket ?? ((url) => new WebSocket(url));
     this.reconnectDelayMs = options.reconnectDelayMs ?? 5_000;
+    this.authTestFailureRetryMs = Math.max(
+      0,
+      Number.isFinite(options.authTestFailureRetryMs)
+        ? (options.authTestFailureRetryMs ?? DEFAULT_SLACK_AUTH_TEST_FAILURE_RETRY_MS)
+        : DEFAULT_SLACK_AUTH_TEST_FAILURE_RETRY_MS,
+    );
+    this.authTestTimeoutMs = Math.max(
+      1,
+      Number.isFinite(options.authTestTimeoutMs)
+        ? (options.authTestTimeoutMs ?? DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS)
+        : DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS,
+    );
+    this.now = options.now ?? Date.now;
   }
 
   start(): void {
@@ -446,7 +487,7 @@ export class SlackSocketModeService {
       return "processed";
     }
 
-    const normalized = this.normalizeEnvelope(envelope);
+    const normalized = await this.normalizeEnvelope(envelope);
     if (!normalized) return "ignored";
 
     await this.routeMessage(normalized);
@@ -498,17 +539,39 @@ export class SlackSocketModeService {
     });
   }
 
-  private normalizeEnvelope(envelope: SlackSocketEnvelope): SlackNormalizedMessage | null {
+  private async normalizeEnvelope(envelope: SlackSocketEnvelope): Promise<SlackNormalizedMessage | null> {
     const event = envelopeEvent(envelope);
-    if (!event || shouldIgnoreSlackMessageEvent(event)) return null;
+    if (!event || !isSlackMessageEventStructurallyEligible(event)) return null;
+
+    const payload = envelope.payload as { team_id?: string; event_id?: string; event_time?: number } | undefined;
+    const isBotMessage = isSlackBotMessageCandidate(event);
+    let teamId: string;
+    let localBotIdentity: SlackLocalBotIdentity | null = null;
+    if (isBotMessage) {
+      const teamIds = uniqueCleanSlackIds([payload?.team_id, event.team]);
+      if (teamIds.length !== 1) return null;
+      teamId = teamIds[0]!;
+      localBotIdentity = await this.resolveLocalBotIdentity();
+      if (!localBotIdentity || localBotIdentity.teamId !== teamId) return null;
+    } else {
+      teamId = cleanSlackId(event.team) ?? cleanSlackId(payload?.team_id) ?? this.options.accountId;
+    }
+    if (
+      shouldIgnoreSlackMessageEvent(event, {
+        selfBotId: localBotIdentity?.botId,
+        selfUserId: localBotIdentity?.userId,
+        botMessageAliasesByChat: this.routingPolicy.botMessageAliasesByChat,
+      })
+    ) {
+      return null;
+    }
 
     const channelId = cleanSlackId(event.channel);
-    const userId = cleanSlackId(event.user);
+    const slackUserId = cleanSlackId(event.user);
+    const userId = slackSenderIdForEvent(event);
     const ts = cleanSlackId(event.ts);
     if (!channelId || !userId || !ts) return null;
 
-    const payload = envelope.payload as { team_id?: string; event_id?: string; event_time?: number } | undefined;
-    const teamId = cleanSlackId(event.team) ?? cleanSlackId(payload?.team_id) ?? this.options.accountId;
     const thread = resolveSlackThreadContext(event, this.routingPolicy);
     const eventTimeMs = payload?.event_time ? payload.event_time * 1000 : slackTsToMs(ts);
     const text = typeof event.text === "string" ? event.text : "";
@@ -520,6 +583,9 @@ export class SlackSocketModeService {
       channelId,
       channelType: cleanSlackId(event.channel_type) ?? "channel",
       userId,
+      slackUserId,
+      botId: cleanSlackId(event.bot_id),
+      senderKind: isBotMessage ? "bot" : "user",
       text,
       files,
       ts,
@@ -529,6 +595,57 @@ export class SlackSocketModeService {
       eventTimeMs,
       rawEnvelope: envelope,
     };
+  }
+
+  private async resolveLocalBotIdentity(): Promise<SlackLocalBotIdentity | null> {
+    if (this.localBotIdentity) return this.localBotIdentity;
+    if (this.localBotIdentityInFlight) return this.localBotIdentityInFlight;
+
+    const attemptedAt = this.now();
+    if (attemptedAt < this.nextLocalBotIdentityAttemptAt) return null;
+
+    const authTest = (this.webClient as Partial<Pick<SlackWebApiClient, "authTest">>).authTest;
+    if (typeof authTest !== "function") {
+      this.nextLocalBotIdentityAttemptAt = attemptedAt + this.authTestFailureRetryMs;
+      return null;
+    }
+
+    const request = withAbortableTimeout(
+      (signal) => authTest.call(this.webClient, { signal }),
+      this.authTestTimeoutMs,
+      "Slack auth.test timed out",
+    )
+      .then((response) => {
+        if (response.ok !== true) {
+          throw new Error("Slack auth.test did not return ok=true");
+        }
+        const botId = cleanSlackId(response.bot_id);
+        const userId = cleanSlackId(response.user_id);
+        const teamId = cleanSlackId(response.team_id);
+        if (!botId || !userId || !teamId) {
+          throw new Error("Slack auth.test returned an incomplete bot_id/user_id/team_id identity");
+        }
+        const identity: SlackLocalBotIdentity = { botId, userId, teamId };
+        this.localBotIdentity = identity;
+        this.nextLocalBotIdentityAttemptAt = 0;
+        return identity;
+      })
+      .catch((error) => {
+        this.nextLocalBotIdentityAttemptAt = this.now() + this.authTestFailureRetryMs;
+        log.warn("Slack bot message ignored because local bot identity could not be resolved", {
+          accountId: this.options.accountId,
+          retryAt: this.nextLocalBotIdentityAttemptAt,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      });
+
+    this.localBotIdentityInFlight = request;
+    try {
+      return await request;
+    } finally {
+      if (this.localBotIdentityInFlight === request) this.localBotIdentityInFlight = null;
+    }
   }
 
   private normalizeInteractionEnvelope(envelope: SlackSocketEnvelope): Record<string, unknown> | null {
@@ -664,6 +781,9 @@ export class SlackSocketModeService {
         threadTs: routeThreadId ?? null,
         envelopeId: message.envelopeId ?? null,
         eventId: message.eventId ?? null,
+        senderKind: message.senderKind,
+        userId: message.slackUserId ?? null,
+        botId: message.botId ?? null,
       },
       seenAt: message.eventTimeMs,
     });
@@ -740,7 +860,9 @@ export class SlackSocketModeService {
     const actorIdentity = resolveSlackActorIdentity({
       chatId: canonicalChat.id,
       instanceAliases,
-      platformUserId: message.userId,
+      platformUserId: message.slackUserId ?? message.userId,
+      alternatePlatformUserIds: message.botId ? [message.botId] : [],
+      senderKind: message.senderKind,
     });
     const processedFiles = await this.processFiles(message, resolved.agent.cwd);
     dbUpsertChatMessage({
@@ -749,8 +871,8 @@ export class SlackSocketModeService {
       instanceId,
       providerMessageId: message.ts,
       rawChatId: message.channelId,
-      rawSenderId: message.userId,
-      normalizedSenderId: message.userId,
+      rawSenderId: actorIdentity.rawSenderId ?? message.userId,
+      normalizedSenderId: actorIdentity.normalizedSenderId ?? message.userId,
       actorType: actorIdentity.actorType,
       contactId: actorIdentity.contactId,
       agentId: actorIdentity.actorAgentId,
@@ -762,6 +884,9 @@ export class SlackSocketModeService {
         teamId: message.teamId,
         eventId: message.eventId ?? null,
         envelopeId: message.envelopeId ?? null,
+        senderKind: message.senderKind,
+        userId: message.slackUserId ?? null,
+        botId: message.botId ?? null,
         fileIds: message.files.map((file) => file.id),
       },
       providerTimestamp: message.eventTimeMs,
@@ -772,14 +897,17 @@ export class SlackSocketModeService {
       platformIdentityId: actorIdentity.platformIdentityId,
       contactId: actorIdentity.contactId,
       agentId: actorIdentity.actorAgentId,
-      rawPlatformUserId: message.userId,
-      normalizedPlatformUserId: message.userId,
+      rawPlatformUserId: actorIdentity.rawSenderId ?? message.userId,
+      normalizedPlatformUserId: actorIdentity.normalizedSenderId ?? message.userId,
       role: "member",
       status: "active",
       source: actorIdentity.actorType === "unknown" ? "inbound_message" : "slack_socket_mode:identity_resolved",
       metadata: {
         slackTeamId: message.teamId,
         slackChannelType: message.channelType,
+        slackSenderKind: message.senderKind,
+        slackUserId: message.slackUserId ?? null,
+        slackBotId: message.botId ?? null,
         actorType: actorIdentity.actorType,
         identityProvenance: actorIdentity.identityProvenance ?? null,
       },
@@ -978,11 +1106,44 @@ export class SlackSocketModeService {
   }
 }
 
+function isSlackBotMessageCandidate(event: SlackEventPayload): boolean {
+  return Boolean(cleanSlackId(event.bot_id) || event.subtype === "bot_message");
+}
+
+function withAbortableTimeout<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(message);
+      controller.abort(error);
+      reject(error);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([Promise.resolve().then(() => run(controller.signal)), timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 function resolveSlackActorIdentity(input: {
   chatId: string;
   instanceAliases: SlackInstanceAliasResolution;
   platformUserId: string;
+  alternatePlatformUserIds?: readonly string[];
+  senderKind?: "user" | "bot";
 }): SlackActorIdentity {
+  if (input.senderKind === "bot") {
+    return resolveSlackBotActorIdentity({
+      instanceAliases: input.instanceAliases,
+      platformUserIds: uniqueCleanSlackIds([input.platformUserId, ...(input.alternatePlatformUserIds ?? [])]),
+    });
+  }
+
   const scoped = resolveScopedSlackIdentity(
     input.instanceAliases,
     (instanceId) => resolvePlatformIdentity({ channel: "slack", instanceId, platformUserId: input.platformUserId }),
@@ -1072,6 +1233,133 @@ function resolveSlackActorIdentity(input: {
       matchedInstance: null,
     }),
   };
+}
+
+function resolveSlackBotActorIdentity(input: {
+  instanceAliases: SlackInstanceAliasResolution;
+  platformUserIds: readonly string[];
+}): SlackActorIdentity {
+  const platformUserIds = uniqueCleanSlackIds(input.platformUserIds);
+  const primaryPlatformUserId = platformUserIds[0] ?? "unknown";
+  const outcomes: SlackBotIdentityResolutionOutcome[] = platformUserIds.map((platformUserId) => ({
+    platformUserId,
+    resolution: resolveScopedSlackIdentity(
+      input.instanceAliases,
+      (instanceId) => resolvePlatformIdentity({ channel: "slack", instanceId, platformUserId }),
+      (identity) => (identity.ownerType && identity.ownerId ? `${identity.ownerType}:${identity.ownerId}` : null),
+    ),
+  }));
+
+  if (outcomes.some((outcome) => outcome.resolution.reason === SLACK_AMBIGUOUS_INSTANCE_ALIAS_REASON)) {
+    return unknownSlackBotActor({
+      instanceAliases: input.instanceAliases,
+      primaryPlatformUserId,
+      outcomes,
+      botIdentityReason: "ambiguous_instance_alias",
+      aliasReason: SLACK_AMBIGUOUS_INSTANCE_ALIAS_REASON,
+    });
+  }
+
+  const resolved = outcomes.filter(
+    (outcome): outcome is SlackBotIdentityResolutionOutcome & { resolution: { identity: PlatformIdentity } } =>
+      Boolean(outcome.resolution.identity),
+  );
+  const agentOwnerIds = new Set(
+    resolved
+      .map((outcome) =>
+        outcome.resolution.identity.ownerType === "agent" ? outcome.resolution.identity.ownerId : null,
+      )
+      .filter((ownerId): ownerId is string => Boolean(ownerId)),
+  );
+  const allResolvedIdsBelongToOneAgent =
+    resolved.length > 0 &&
+    agentOwnerIds.size === 1 &&
+    resolved.every(
+      (outcome) =>
+        outcome.resolution.identity.ownerType === "agent" &&
+        outcome.resolution.identity.ownerId === Array.from(agentOwnerIds)[0],
+    );
+
+  if (!allResolvedIdsBelongToOneAgent) {
+    const hasAgent = resolved.some((outcome) => outcome.resolution.identity.ownerType === "agent");
+    const hasNonAgent = resolved.some((outcome) => outcome.resolution.identity.ownerType !== "agent");
+    return unknownSlackBotActor({
+      instanceAliases: input.instanceAliases,
+      primaryPlatformUserId,
+      outcomes,
+      botIdentityReason:
+        resolved.length === 0
+          ? "identity_not_found"
+          : hasAgent && hasNonAgent
+            ? "conflicting_platform_owners"
+            : hasAgent
+              ? "conflicting_agents"
+              : "contact_identity_not_agent",
+      aliasReason: SLACK_IDENTITY_NOT_FOUND_REASON,
+    });
+  }
+
+  const matched = resolved[0]!;
+  const identity = matched.resolution.identity;
+  return {
+    actorType: "agent",
+    actorAgentId: identity.ownerId!,
+    platformIdentityId: identity.id,
+    rawSenderId: primaryPlatformUserId,
+    normalizedSenderId: identity.normalizedPlatformUserId,
+    identityConfidence: identity.confidence,
+    identityProvenance: {
+      ...buildSlackInstanceProvenance(input.instanceAliases, {
+        reason: matched.resolution.reason,
+        matchedInstance: matched.resolution.matchedInstance,
+      }),
+      senderKind: "bot",
+      matchedPlatformUserId: matched.platformUserId,
+      candidatePlatformUserIds: platformUserIds,
+      botIdentityReason: "resolved_agent",
+      platformIdentityCandidates: botIdentityCandidateProvenance(outcomes),
+    },
+  };
+}
+
+function unknownSlackBotActor(input: {
+  instanceAliases: SlackInstanceAliasResolution;
+  primaryPlatformUserId: string;
+  outcomes: readonly SlackBotIdentityResolutionOutcome[];
+  botIdentityReason: string;
+  aliasReason: typeof SLACK_AMBIGUOUS_INSTANCE_ALIAS_REASON | typeof SLACK_IDENTITY_NOT_FOUND_REASON;
+}): SlackActorIdentity {
+  return {
+    actorType: "unknown",
+    rawSenderId: input.primaryPlatformUserId,
+    normalizedSenderId: input.primaryPlatformUserId,
+    identityConfidence: 0,
+    identityProvenance: {
+      ...buildSlackInstanceProvenance(input.instanceAliases, {
+        reason: input.aliasReason,
+        matchedInstance: null,
+      }),
+      senderKind: "bot",
+      candidatePlatformUserIds: input.outcomes.map((outcome) => outcome.platformUserId),
+      botIdentityReason: input.botIdentityReason,
+      platformIdentityCandidates: botIdentityCandidateProvenance(input.outcomes),
+    },
+  };
+}
+
+function botIdentityCandidateProvenance(
+  outcomes: readonly SlackBotIdentityResolutionOutcome[],
+): Array<Record<string, unknown>> {
+  return outcomes.map((outcome) => ({
+    platformUserId: outcome.platformUserId,
+    matchedInstance: outcome.resolution.matchedInstance,
+    reason: outcome.resolution.reason,
+    ownerType: outcome.resolution.identity?.ownerType ?? null,
+  }));
+}
+
+function uniqueCleanSlackIds(values: readonly unknown[]): string[] {
+  return Array.from(new Set(values.map(cleanSlackId).filter((value): value is string => Boolean(value))));
 }
 
 function isSlackBlockKitInteractionType(value: string | undefined): boolean {
@@ -1238,7 +1526,7 @@ export async function createSlackNativeRuntimeFromEnv(
     instanceId: credentials.instanceId,
     connection: credentials.connection,
   };
-  const routingPolicy = slackRoutingPolicyFromEnv(env);
+  const routingPolicy = slackRoutingPolicyFromChannelDefaults(options.channel?.defaults, env);
   const webClient = new SlackWebApiClient({
     appToken: credentials.appToken,
     botToken: credentials.botToken,

--- a/src/channels/slack/types.ts
+++ b/src/channels/slack/types.ts
@@ -1,11 +1,13 @@
 export type SlackSubscriptionScope = "chat" | "thread" | "chat_and_thread";
 export type SlackThreadReplyMode = "same_thread" | "channel_root" | "policy_default";
 export type SlackRootReplyMode = "channel_root" | "new_thread" | "policy_default";
+export type SlackBotMessageAliasesByChat = Readonly<Record<string, readonly string[]>>;
 
 export interface SlackRoutingPolicy {
   readonly subscriptionScope: SlackSubscriptionScope;
   readonly threadReplyMode: SlackThreadReplyMode;
   readonly rootReplyMode: SlackRootReplyMode;
+  readonly botMessageAliasesByChat: SlackBotMessageAliasesByChat;
 }
 
 export interface SlackThreadContext {
@@ -81,7 +83,12 @@ export interface SlackNormalizedMessage {
   readonly teamId: string;
   readonly channelId: string;
   readonly channelType: string;
+  /** Effective sender id: Slack `user` when present, otherwise `bot_id`. */
   readonly userId: string;
+  /** Raw Slack `user` field, kept separate when a bot-only event falls back to `bot_id`. */
+  readonly slackUserId?: string;
+  readonly botId?: string;
+  readonly senderKind: "user" | "bot";
   readonly text: string;
   readonly files: readonly SlackNormalizedFile[];
   readonly ts: string;

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -667,6 +667,38 @@ describe("runtime request context authority", () => {
     expect(canWithCapabilities(runtimeContext.capabilities, "admin", "system", "*")).toBe(false);
   });
 
+  it("resolves a verified external agent actor without stripping executor capabilities", () => {
+    dbCreateAgent({ id: agent.id, cwd: agent.cwd });
+    dbCreateAgent({ id: "foreign-agent", cwd: "/tmp/foreign-agent" });
+    getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
+
+    const prompt = promptForContact("", "agent interop");
+    for (const actor of [prompt.source!, prompt.context!]) {
+      actor.actorType = "agent";
+      actor.actorAgentId = "foreign-agent";
+      delete actor.contactId;
+    }
+
+    const { runtimeContext } = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: "/tmp/provider-agent",
+      agent,
+      prompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+      resolvedSource: prompt.source,
+    });
+
+    expect(runtimeContext.metadata).toMatchObject({
+      actorPrincipal: "agent:foreign-agent",
+      actorResolution: "resolved",
+    });
+    expect(Number(runtimeContext.metadata?.agentIdentityCapabilityCount)).toBeGreaterThan(0);
+    expect(canWithCapabilities(runtimeContext.capabilities, "use", "tool", "Read")).toBe(true);
+  });
+
   it("does not require chat delegation overrides in the agent identity model", () => {
     dbCreateAgent({ id: agent.id, cwd: agent.cwd });
     getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
@@ -942,6 +974,54 @@ describe("runtime request context authority", () => {
       actor: {
         actorType: "contact",
         contactId: "luis",
+        canonicalChatId: "chat_group_1",
+      },
+    });
+    expect(canWithCapabilities(runtimeContext.capabilities, "use", "tool", "Read")).toBe(true);
+    expect(canWithCapabilities(runtimeContext.capabilities, "admin", "system", "*")).toBe(false);
+  });
+
+  it("preserves the agent principal for daemon restart resume prompts with an agent snapshot source", () => {
+    dbCreateAgent({ id: agent.id, cwd: agent.cwd });
+    dbCreateAgent({ id: "foreign-agent", cwd: "/tmp/foreign-agent" });
+    getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
+
+    const prompt: RuntimeLaunchPrompt = {
+      prompt: "[System] Daemon reiniciou (test). Continue de onde parou.",
+      source: {
+        channel: "slack",
+        accountId: "ravi-slack",
+        chatId: "C123",
+        canonicalChatId: "chat_group_1",
+        actorType: "agent",
+        actorAgentId: "foreign-agent",
+      },
+      _daemonRestartResume: {
+        restartEpoch: "restart-agent-test",
+        sessionKey,
+      },
+    };
+
+    const { runtimeContext } = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: "/tmp/provider-agent",
+      agent,
+      prompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+      resolvedSource: prompt.source,
+    });
+
+    expect(runtimeContext.metadata).toMatchObject({
+      authorityMode: "agent-identity",
+      actorPrincipal: "agent:foreign-agent",
+      actorResolution: "resolved",
+      surfacePrincipal: "chat:chat_group_1",
+      actor: {
+        actorType: "agent",
+        actorAgentId: "foreign-agent",
         canonicalChatId: "chat_group_1",
       },
     });

--- a/src/runtime/runtime-request-context.ts
+++ b/src/runtime/runtime-request-context.ts
@@ -433,6 +433,9 @@ function resolveActorPrincipal(actorMetadata: MessageActorMetadata | undefined):
   if (actorMetadata?.actorType === "contact" && actorMetadata.contactId) {
     return { subjectType: "contact", subjectId: actorMetadata.contactId };
   }
+  if (actorMetadata?.actorType === "agent" && actorMetadata.actorAgentId) {
+    return { subjectType: "agent", subjectId: actorMetadata.actorAgentId };
+  }
   if (actorMetadata?.actorType === "automation" && actorMetadata.automationId) {
     return { subjectType: "automation", subjectId: actorMetadata.automationId };
   }
@@ -543,7 +546,7 @@ function resolveAutomationPromptPrincipal(
     return { subjectType: "automation", subjectId: "heartbeat" };
   }
   if (prompt._daemonRestartResume) {
-    if (hasResolvedContactActor(source) || hasResolvedContactActor(context)) {
+    if (hasResolvedExternalActor(source) || hasResolvedExternalActor(context)) {
       return null;
     }
     return { subjectType: "automation", subjectId: "daemon-restart" };
@@ -551,8 +554,13 @@ function resolveAutomationPromptPrincipal(
   return null;
 }
 
-function hasResolvedContactActor(metadata: { actorType?: string; contactId?: string } | undefined): boolean {
-  return metadata?.actorType === "contact" && Boolean(cleanStringValue(metadata.contactId));
+function hasResolvedExternalActor(
+  metadata: { actorType?: string; contactId?: string; actorAgentId?: string } | undefined,
+): boolean {
+  return Boolean(
+    (metadata?.actorType === "contact" && cleanStringValue(metadata.contactId)) ||
+      (metadata?.actorType === "agent" && cleanStringValue(metadata.actorAgentId)),
+  );
 }
 
 function buildAutomationIdentityProvenance(prompt: RuntimeLaunchPrompt): Record<string, unknown> | undefined {

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -562,6 +562,58 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
     expect(restartPrompt?.prompt).toContain("Daemon reiniciou");
   });
 
+  it("selects the stashed agent envelope when daemon restart metadata is appended", () => {
+    const original = createQueuedRuntimeUserMessage({
+      prompt: "continue agent handoff",
+      source: {
+        channel: "slack",
+        accountId: "ravi-slack",
+        chatId: "C123",
+        canonicalChatId: "chat_slack",
+        sourceMessageId: "1713000130.000200",
+        actorType: "agent",
+        actorAgentId: "foreign-agent",
+      },
+      context: {
+        channelId: "slack",
+        channelName: "Slack",
+        accountId: "ravi-slack",
+        chatId: "C123",
+        canonicalChatId: "chat_slack",
+        messageId: "1713000130.000200",
+        senderId: "UFOREIGN",
+        isGroup: true,
+        timestamp: Date.now(),
+        actorType: "agent",
+        actorAgentId: "foreign-agent",
+      },
+    });
+    const resume = createQueuedRuntimeUserMessage({
+      prompt: "[System] Daemon reiniciou (test). Continue de onde parou.",
+      deliveryBarrier: "after_response",
+      deliveryBarrierSource: "default",
+      _daemonRestartResume: {
+        restartEpoch: "restart-agent-test",
+        sessionKey: "agent:dev:slack:ravi-slack:group:C123",
+      },
+    });
+
+    const restartPrompt = buildStashedRestartPrompt([original, resume]);
+
+    expect(restartPrompt?.source).toMatchObject({
+      channel: "slack",
+      canonicalChatId: "chat_slack",
+      actorType: "agent",
+      actorAgentId: "foreign-agent",
+    });
+    expect(restartPrompt?.context).toMatchObject({
+      actorType: "agent",
+      actorAgentId: "foreign-agent",
+      senderId: "UFOREIGN",
+    });
+    expect(restartPrompt?._resumeStashedMessages).toBe(true);
+  });
+
   it("does not replace the active turn source when an after_response session followup is queued", async () => {
     const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-followup-source-");
     try {

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -1873,12 +1873,14 @@ function hasResolvedActorMetadata(
     | {
         actorType?: string;
         contactId?: string;
+        actorAgentId?: string;
         automationId?: string;
       }
     | undefined,
 ): boolean {
   return Boolean(
     (metadata?.actorType === "contact" && metadata.contactId) ||
+      (metadata?.actorType === "agent" && metadata.actorAgentId) ||
       (metadata?.actorType === "automation" && metadata.automationId),
   );
 }


### PR DESCRIPTION
## Objective

Allow external Slack bots to invoke Ravi only when they explicitly address it, without granting ordinary bot traffic additional authority. Admission and identity resolution are workspace-bound and fail closed.

## Problem

- Ravi discarded every Slack `bot_message`, which blocked legitimate bot-to-agent collaboration.
- Admitting all bot messages would create loop, routing, and authority risks for traffic that was never addressed to Ravi.
- Slack user, bot, and team identifiers can be ambiguous across instances, and daemon restart could replace an already verified agent principal with daemon automation authority.

## Solution

- Resolve the local Slack identity through cached, coalesced, timeout-bound `auth.test` calls and reject missing, conflicting, or cross-workspace identity.
- Ignore Ravi's own bot and admit foreign bots only through an explicit `<@local_bot_user_id>` mention or an alias configured for that account and chat.
- Promote the actor to `agent:<id>` only when every resolved user/bot candidate belongs to the same agent; unresolved companion IDs do not conflict, while any resolved owner conflict keeps the actor untrusted.
- Preserve the verified agent principal through routing, dispatch, and daemon-restart resume, while recording additive Slack user/bot/team provenance on canonical records.

## Practical impact

- Explicitly addressed bots and agents can collaborate with Ravi in Slack, while unaddressed bot traffic remains silent and identity conflicts receive no inferred authority.

## What does NOT change

- Human Slack admission, authority resolution, routing, outbound sending, credentials, Socket Mode configuration, and thread behavior retain their existing semantics. Persisted human records only receive additive Slack sender-provenance fields.

## Validation

- `bun test src/channels/slack` passed, including 96 focused Slack cases.
- `bun test src/runtime/session-dispatcher.test.ts` passed: 28 tests, 0 failures.
- The focused daemon-restart agent-principal regression passed: 1 test, 0 failures.
- `make quality` passed: Biome checked 904 files and TypeScript typecheck passed; `git diff --check` also passed.

## Risks

- If `auth.test` is unavailable or inconsistent, foreign-bot admission fails closed during the bounded backoff. Broad chat aliases can admit a bot in that configured chat, so alias scope remains security-sensitive.

## Rollback

- Revert this commit to restore blanket bot-message rejection. Removing configured bot aliases immediately disables alias-based admission without changing persisted human traffic.

## Follow-ups

- Monitor unresolved identity collisions before considering any broader bot-admission policy.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->