### PR TITLE
fix(runtime): classify Kimi quota 403

### DIFF
--- a/src/runtime/credential-classifier.test.ts
+++ b/src/runtime/credential-classifier.test.ts
@@ -59,6 +59,39 @@ describe("runtime credential classifier", () => {
     expect(signal.retryableByCredential).toBe(false);
   });
 
+  it("classifies the real Kimi 403 billing-cycle usage limit as exhausted quota", () => {
+    const signal = classifyRuntimeCredentialFailure({
+      runtimeProvider: "pi",
+      upstreamProvider: "kimi-coding",
+      model: "kimi-coding/kimi-k3",
+      httpStatus: 403,
+      providerType: "permission_error",
+      message:
+        '403 {"error":{"type":"permission_error","message":"You\'ve reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: https://www.kimi.com/code/#pricing"},"type":"error"}',
+    });
+
+    expect(signal.kind).toBe("quota_exhausted");
+    expect(signal.confidence).toBe("high");
+    expect(signal.scope).toBe("account");
+    expect(signal.retryableByCredential).toBe(true);
+  });
+
+  it("keeps non-quota 403 permission errors classified as permission denied", () => {
+    const signal = classifyRuntimeCredentialFailure({
+      runtimeProvider: "pi",
+      upstreamProvider: "kimi-coding",
+      model: "kimi-coding/kimi-k3",
+      httpStatus: 403,
+      providerType: "permission_error",
+      message: "You do not have permission to access this model in your region.",
+    });
+
+    expect(signal.kind).toBe("permission_denied");
+    expect(signal.confidence).toBe("medium");
+    expect(signal.scope).toBe("request");
+    expect(signal.retryableByCredential).toBe(false);
+  });
+
   it("classifies Codex context window exhaustion as a request context limit", () => {
     const signal = classifyRuntimeCredentialFailure({
       runtimeProvider: "codex",

--- a/src/runtime/credential-classifier.ts
+++ b/src/runtime/credential-classifier.ts
@@ -51,7 +51,14 @@ export function classifyRuntimeCredentialFailure(
   const limitDimensions = extractLimitDimensions(headers);
   const rawHeaders = redactHeaders(headers);
 
-  const classified = classifyKind({ status, providerCode, providerType, text });
+  const classified = classifyKind({
+    status,
+    providerCode,
+    providerType,
+    text,
+    runtimeProvider: input.runtimeProvider,
+    model: input.model,
+  });
   return {
     kind: classified.kind,
     confidence: classified.confidence,
@@ -107,7 +114,14 @@ export function evaluateCredentialLimitPressure(
   };
 }
 
-function classifyKind(input: { status?: number; providerCode?: string; providerType?: string; text: string }): {
+function classifyKind(input: {
+  status?: number;
+  providerCode?: string;
+  providerType?: string;
+  text: string;
+  runtimeProvider: RuntimeProviderId;
+  model?: string;
+}): {
   kind: RuntimeCredentialFailureKind;
   confidence: RuntimeCredentialFailureConfidence;
   scope: RuntimeCredentialFailureScope;
@@ -132,6 +146,9 @@ function classifyKind(input: { status?: number; providerCode?: string; providerT
       return { kind: "quota_exhausted", confidence: "high", scope: "account" };
     }
     return { kind: "rate_limited", confidence: "high", scope: inferLimitScope(text) };
+  }
+  if (isKimiBillingCycleQuota403(input)) {
+    return { kind: "quota_exhausted", confidence: "high", scope: "account" };
   }
   if (input.status === 403 || code === "permission_error" || type === "permission_error") {
     return { kind: "permission_denied", confidence: "medium", scope: inferPermissionScope(text) };
@@ -158,6 +175,29 @@ function classifyKind(input: { status?: number; providerCode?: string; providerT
   }
 
   return { kind: "unknown", confidence: "low", scope: "unknown" };
+}
+
+function isKimiBillingCycleQuota403(input: {
+  status?: number;
+  providerCode?: string;
+  providerType?: string;
+  text: string;
+  runtimeProvider: RuntimeProviderId;
+  model?: string;
+}): boolean {
+  if (input.runtimeProvider !== "pi") return false;
+  if (input.status !== 403) return false;
+  if (
+    normalizeToken(input.providerCode) !== "permission_error" &&
+    normalizeToken(input.providerType) !== "permission_error"
+  ) {
+    return false;
+  }
+  if (!input.model?.startsWith("kimi-coding/")) return false;
+  return (
+    input.text.includes("reached your usage limit for this billing cycle") &&
+    input.text.includes("quota will be refreshed in the next cycle")
+  );
 }
 
 function isRetryableByCredential(kind: RuntimeCredentialFailureKind, scope: RuntimeCredentialFailureScope): boolean {


### PR DESCRIPTION
## Problem
Kimi via Pi can return a 403 `permission_error` for billing-cycle usage exhaustion. The runtime credential classifier treated every 403 permission error as `permission_denied`, so this quota condition was not surfaced as `quota_exhausted`.

## Solution
Add a narrow Kimi-specific quota classifier before the generic 403 permission branch. It only matches Pi runtime failures for `kimi-coding/` models with HTTP 403, `permission_error`, and the observed billing-cycle quota wording.

## Changes
- Classifies the observed Kimi billing-cycle 403 as `quota_exhausted` with account scope.
- Keeps non-quota 403 permission failures classified as `permission_denied`.
- Adds positive and negative tests in `credential-classifier.test.ts`.

## How It Works
The classifier now passes runtime provider and model into the internal kind classifier. A helper recognizes the specific Kimi billing-cycle quota phrase only when the provider/model/status/error type all match.

## Validation
- `ravi specs get task/default --mode checks` -> unavailable locally: `Spec not found`.
- Corpus evidence: event 4474626 described as `provider=pi`, `model=kimi-coding/kimi-k3`, `403 permission_error`, usage limit for this billing cycle.
- `ravi events replay --since 2026-07-20T19:30:00Z --until 2026-07-20T19:45:00Z --contains "usage limit for this billing cycle" -n 5 --json` found the same Kimi quota message in the event window.
- `bunx biome check src/runtime/credential-classifier.ts src/runtime/credential-classifier.test.ts` -> pass.
- `bun run typecheck` -> pass.
- `bun test src/runtime/credential-classifier.test.ts` -> 6 pass, 0 fail.
- `bun test src/runtime/credential-classifier.test.ts src/runtime/credential-refresh.test.ts src/runtime/credential-store.test.ts` -> 14 pass, 0 fail.
- `bun run test` currently fails outside this change in tasks/projects baseline: 226 pass, 5 skip, 37 fail. Representative cause: external `default` task profile requires `goal`, `success_criteria`, and `consumer`, while task tests expect the built-in default profile.

## Risk
Low. The new branch is deliberately narrow and requires provider, model prefix, status, error type, and exact billing-cycle quota wording. Generic 403 permission errors continue through the existing path.

## Rollback
Revert this commit to return all 403 permission errors to the previous generic `permission_denied` classification.

## Follow-ups
None in this PR. Wider provider quota classification and live failover wiring should stay in separate changes.

## Notes for Reviewer
No merge, deploy, daemon restart, schema change, or live provider call was performed.