### PR TITLE
fix(slack): separate Connect origin from installation

### DIFF
--- a/.ravi/specs/channels/adapters/slack/CHECKS.md
+++ b/.ravi/specs/channels/adapters/slack/CHECKS.md
@@ -6,7 +6,11 @@
 - [ ] Human message admission MUST remain unchanged.
 - [ ] The local bot MUST be ignored when either event `bot_id` or `user` matches `auth.test`.
 - [ ] Foreign bot messages MUST fail closed unless `auth.test` returns `ok=true` with complete `bot_id`, `user_id`, and `team_id`.
-- [ ] Outer `payload.team_id` / `event.team` MUST identify one Slack team equal to authenticated `team_id`; absence, conflict, or logical-account fallback MUST fail closed.
+- [ ] When `authorizations` is present, it MUST be a usable array with a `team_id` matching the authenticated local team; empty, malformed, team-less, non-matching, or truncated values without that match MUST fail closed.
+- [ ] The received authorization list MUST NOT be treated as complete; supporting a truncated non-match requires `apps.event.authorizations.list`, not legacy fallback.
+- [ ] Only when `authorizations` is absent MAY outer `payload.team_id` / inner `event.team` prove the installation; they MUST identify one team equal to authenticated `team_id`, without logical-account fallback.
+- [ ] `source_team` MUST define message origin when present; otherwise outer/inner team values MUST identify one origin. Missing origin or conflicting outer/inner origin MUST fail closed.
+- [ ] Resolved origin, `source_team`, `user_team`, `event.team`, `payload.team_id`, received authorization team ids, and local authenticated team MUST remain separate provenance fields.
 - [ ] Successful `auth.test` discovery MUST be cached, concurrent calls coalesced, and failures retried only after a bounded backoff.
 - [ ] A stuck `auth.test` MUST receive an abort signal, time out, fail closed, release the shared in-flight slot, and permit a later retry.
 - [ ] A foreign bot MUST require an explicit local-user mention or a chat-scoped alias at the beginning with a Unicode whitespace/punctuation boundary.

--- a/.ravi/specs/channels/adapters/slack/RUNBOOK.md
+++ b/.ravi/specs/channels/adapters/slack/RUNBOOK.md
@@ -36,9 +36,19 @@ Restart the channel runner after changing defaults. Then verify all four cases:
 - Wrong thread: check `RAVI_SLACK_SUBSCRIPTION_SCOPE`, `RAVI_SLACK_THREAD_REPLY_MODE`, `RAVI_SLACK_ROOT_REPLY_MODE`.
 - Duplicate response: check duplicate runner processes and Socket Mode lock.
 - All bot messages ignored: inspect the `auth.test` warning. Ravi requires `ok=true`
-  with a complete local `bot_id` + `user_id` + `team_id`, and requires outer
-  `payload.team_id` / `event.team` to identify that same team. Missing or conflicting
-  team provenance fails closed; Ravi never substitutes the logical channel account id.
+  with a complete local `bot_id` + `user_id` + `team_id`. A matching
+  `authorizations[].team_id` proves the installation even when `source_team`,
+  `event.team`, or `payload.team_id` describes another Slack workspace. Since Slack
+  can truncate the authorization list, a present-but-missing match fails closed; use
+  `apps.event.authorizations.list` before adding support for that false-negative case.
+  Only an actually absent `authorizations` key enables the strict legacy check:
+  `payload.team_id` and `event.team` must identify one team equal to the local
+  authenticated team. `source_team` must preserve origin when those values differ, and
+  a missing origin always fails closed. Ravi never substitutes the logical channel
+  account id. Inspect the separate
+  `originTeamId`, `sourceTeamId`, `userTeamId`, `eventTeamId`, `payloadTeamId`,
+  `authorizedTeamIds`, and `localTeamId` provenance fields to identify which check
+  applied. `teamId` remains the legacy event-first effective value.
   Discovery is aborted after its five-second timeout, uses a bounded retry backoff,
   and retries on a later bot message instead of caching failure permanently.
 - Foreign bot admitted but actor is unknown: inspect `identityProvenance.botIdentityReason`.

--- a/.ravi/specs/channels/adapters/slack/SPEC.md
+++ b/.ravi/specs/channels/adapters/slack/SPEC.md
@@ -62,11 +62,30 @@ interoperate in shared Slack channels.
 Before deciding whether to admit any bot-authored message, the adapter MUST use
 `auth.test` with that channel account's bot token to discover both the local
 `bot_id`, bot `user_id`, and `team_id`, and MUST require `ok=true`. It MUST
-extract the Slack team from outer `payload.team_id` and/or `event.team` without
-falling back to Ravi's logical account id. The present outer team values MUST
-identify one team and equal the authenticated `team_id`; missing or conflicting
-team provenance MUST ignore the bot message. It MUST ignore a self message when
-either raw event id matches the corresponding local id. A successful discovery MAY be cached;
+prove that the event is visible to that local installation. A matching
+`authorizations[].team_id` is positive proof. When the `authorizations` key is
+present, it MUST be an array containing at least one clean team id and one value
+MUST equal the authenticated `team_id`; empty, malformed, team-less, or
+non-matching values MUST fail closed. Slack may truncate the received array to
+one representative installation, so a non-match can be a deliberate false
+negative. Supporting that case requires full resolution through
+`apps.event.authorizations.list`; the adapter MUST NOT treat the received list
+as complete or silently fall back. Only when the `authorizations` key is absent
+MAY the adapter use the legacy installation proof: the present outer
+`payload.team_id` and inner `event.team` values MUST identify one team equal to
+the authenticated `team_id`. Missing, conflicting, or mismatched legacy values
+MUST fail closed; Ravi's logical account id MUST NOT be substituted as proof.
+
+Resolved origin, `event.source_team`, `event.user_team`, `event.team`,
+`payload.team_id`, received authorization team ids, and the local authenticated
+team MUST be preserved as separate provenance. `source_team` is the preferred
+message-origin value when present;
+without it, the present `event.team` / `payload.team_id` values MUST identify one
+origin. A bot message with no resolvable origin MUST fail closed. A matching
+authorization MAY prove visibility when those outer/inner values differ only if
+`source_team` explicitly preserves the origin. It MUST ignore a self message
+when either raw event id matches the corresponding local id. A successful
+discovery MAY be cached;
 concurrent discovery MUST share one in-flight request. Missing, incomplete, or
 failed discovery MUST ignore the bot message and MAY use only a bounded failure
 backoff before retrying. Discovery itself MUST also have a bounded timeout (five

--- a/.ravi/specs/channels/adapters/slack/WHY.md
+++ b/.ravi/specs/channels/adapters/slack/WHY.md
@@ -36,6 +36,20 @@ cached, but each request has a bounded timeout and failures get only a short
 backoff: this avoids a stuck Web API call or a transient Slack failure turning
 into a daemon-lifetime outage without creating an API storm.
 
+Slack Connect also separates message origin from app visibility. `source_team`
+may name the workspace that authored a message while `authorizations[].team_id`
+names an installation on whose behalf Slack delivered the event. Requiring both
+to equal `auth.test.team_id` drops valid cross-workspace bot messages. Ravi uses
+a matching authorization only as positive installation proof. If the key is
+present but does not contain the local team, Ravi fails closed: Slack may have
+truncated a valid installation from the received value, but proving that safely
+requires `apps.event.authorizations.list`. The older outer/inner comparison is a
+strict compatibility fallback only when the key is absent, and it never uses
+the logical Ravi account id. `source_team` remains mandatory as origin whenever
+outer/inner values differ, and each signal is retained separately so
+authorization does not overwrite origin provenance or the legacy effective
+`teamId` value.
+
 Slack bot events may carry both a bot id and a user id. Either can be linked in
 the identity graph, so resolving only the first id loses valid agent identity;
 blindly choosing the first match can also grant the wrong authority. Resolving

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -71,6 +71,7 @@ export {
 export type { SlackNativeRuntime, SlackSocketModeServiceOptions, SlackTargetScope } from "./socket-mode.js";
 export type {
   SlackBotMessageAliasesByChat,
+  SlackEventAuthorization,
   SlackEventPayload,
   SlackEventsApiPayload,
   SlackFilePayload,

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1347,11 +1347,15 @@ describe("Slack Socket Mode foreign bot intake", () => {
     threadTs?: string;
     teamId?: string | null;
     eventTeamId?: string | null;
+    sourceTeamId?: string | null;
+    userTeamId?: string | null;
+    authorizations?: unknown;
   }): SlackSocketEnvelope {
     return {
       envelope_id: input.envelopeId,
       payload: {
         ...(input.teamId === null ? {} : { team_id: input.teamId ?? "T1" }),
+        ...(input.authorizations === undefined ? {} : { authorizations: input.authorizations }),
         event_id: `Ev-${input.envelopeId}`,
         event_time: 1_713_000_000,
         event: {
@@ -1365,6 +1369,10 @@ describe("Slack Socket Mode foreign bot intake", () => {
           ts: input.ts,
           thread_ts: input.threadTs,
           ...(input.eventTeamId === null || input.eventTeamId === undefined ? {} : { team: input.eventTeamId }),
+          ...(input.sourceTeamId === null || input.sourceTeamId === undefined
+            ? {}
+            : { source_team: input.sourceTeamId }),
+          ...(input.userTeamId === null || input.userTeamId === undefined ? {} : { user_team: input.userTeamId }),
         },
       },
     };
@@ -1375,11 +1383,15 @@ describe("Slack Socket Mode foreign bot intake", () => {
     ts: string;
     teamId?: string | null;
     eventTeamId?: string | null;
+    sourceTeamId?: string | null;
+    userTeamId?: string | null;
+    authorizations?: unknown;
   }): SlackSocketEnvelope {
     return {
       envelope_id: input.envelopeId,
       payload: {
         ...(input.teamId === null ? {} : { team_id: input.teamId ?? "T1" }),
+        ...(input.authorizations === undefined ? {} : { authorizations: input.authorizations }),
         event_id: `Ev-${input.envelopeId}`,
         event_time: 1_713_000_000,
         event: {
@@ -1390,6 +1402,10 @@ describe("Slack Socket Mode foreign bot intake", () => {
           text: "human message",
           ts: input.ts,
           ...(input.eventTeamId === null || input.eventTeamId === undefined ? {} : { team: input.eventTeamId }),
+          ...(input.sourceTeamId === null || input.sourceTeamId === undefined
+            ? {}
+            : { source_team: input.sourceTeamId }),
+          ...(input.userTeamId === null || input.userTeamId === undefined ? {} : { user_team: input.userTeamId }),
         },
       },
     };
@@ -1461,6 +1477,9 @@ describe("Slack Socket Mode foreign bot intake", () => {
           ts: "1713000091.000100",
           teamId: "T-PAYLOAD",
           eventTeamId: "T-EVENT",
+          sourceTeamId: "T-SOURCE",
+          userTeamId: "T-USER",
+          authorizations: "malformed",
         }),
       ),
     ).toBe("processed");
@@ -1468,7 +1487,16 @@ describe("Slack Socket Mode foreign bot intake", () => {
     expect(published).toHaveLength(1);
     const source = published[0]!.payload.source as MessageTarget;
     expect(dbGetChat(source.canonicalChatId!)).toMatchObject({
-      rawProvenance: { teamId: "T-EVENT" },
+      rawProvenance: {
+        teamId: "T-EVENT",
+        originTeamId: "T-SOURCE",
+        sourceTeamId: "T-SOURCE",
+        userTeamId: "T-USER",
+        eventTeamId: "T-EVENT",
+        payloadTeamId: "T-PAYLOAD",
+        authorizedTeamIds: [],
+        localTeamId: null,
+      },
     });
   });
 
@@ -1514,38 +1542,195 @@ describe("Slack Socket Mode foreign bot intake", () => {
     expect(published).toHaveLength(1);
   });
 
-  it("requires the envelope and auth.test to identify the same Slack team", async () => {
-    const fromEvent: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
-    const matchingAuth = mock(async () => ({
+  it("uses the authorized installation while preserving a distinct Slack Connect origin", async () => {
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authTest = mock(async () => ({
       ok: true,
       bot_id: "BLOCAL",
       user_id: "ULOCAL",
-      team_id: "T1",
+      team_id: "T222",
     }));
-    const matchingService = makeBotService({ published: fromEvent, authTest: matchingAuth });
+    const service = makeBotService({ published, authTest });
 
     expect(
-      await matchingService.handleEnvelope(
+      await service.handleEnvelope(
         botEnvelope({
-          envelopeId: "team-from-event",
+          envelopeId: "slack-connect-authorized-installation",
           ts: "1713000102.000200",
           text: "<@ULOCAL> status",
           botId: "BFOREIGN",
-          teamId: null,
-          eventTeamId: "T1",
+          teamId: "T111",
+          eventTeamId: "T111",
+          sourceTeamId: "T111",
+          userTeamId: "T111",
+          authorizations: [{ team_id: "T222" }],
         }),
       ),
     ).toBe("processed");
-    expect(fromEvent).toHaveLength(1);
+    expect(authTest).toHaveBeenCalledTimes(1);
+    expect(published).toHaveLength(1);
 
+    const source = published[0]!.payload.source as MessageTarget;
+    const provenance = {
+      teamId: "T111",
+      originTeamId: "T111",
+      sourceTeamId: "T111",
+      userTeamId: "T111",
+      eventTeamId: "T111",
+      payloadTeamId: "T111",
+      authorizedTeamIds: ["T222"],
+      localTeamId: "T222",
+    };
+    expect(dbGetChat(source.canonicalChatId!)).toMatchObject({ rawProvenance: provenance });
+    expect(
+      dbFindChatMessage({
+        channel: "slack",
+        instanceId: UUID,
+        chatId: source.canonicalChatId!,
+        providerMessageId: "1713000102.000200",
+      }),
+    ).toMatchObject({ rawProvenance: provenance });
+    expect(dbListChatParticipants(source.canonicalChatId!)[0]?.metadata).toMatchObject({
+      slackTeamId: "T111",
+      slackOriginTeamId: "T111",
+      slackSourceTeamId: "T111",
+      slackUserTeamId: "T111",
+      slackEventTeamId: "T111",
+      slackPayloadTeamId: "T111",
+      slackAuthorizedTeamIds: ["T222"],
+      slackLocalTeamId: "T222",
+    });
+  });
+
+  it("accepts any matching authorization but fails closed when the truncated value omits the local team", async () => {
+    const authorized: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const authorizedService = makeBotService({
+      published: authorized,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T222",
+      })),
+    });
+    expect(
+      await authorizedService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "one-of-several-authorizations",
+          ts: "1713000102.000250",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: "T111",
+          eventTeamId: "T333",
+          sourceTeamId: "T111",
+          authorizations: [{ team_id: "T333" }, { team_id: "T222" }],
+        }),
+      ),
+    ).toBe("processed");
+    expect(authorized).toHaveLength(1);
+    const authorizedSource = authorized[0]!.payload.source as MessageTarget;
+    expect(dbGetChat(authorizedSource.canonicalChatId!)).toMatchObject({
+      rawProvenance: {
+        teamId: "T333",
+        originTeamId: "T111",
+        sourceTeamId: "T111",
+        userTeamId: null,
+        eventTeamId: "T333",
+        payloadTeamId: "T111",
+        authorizedTeamIds: ["T333", "T222"],
+        localTeamId: "T222",
+      },
+    });
+
+    const truncated: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const truncatedService = makeBotService({
+      published: truncated,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T222",
+      })),
+    });
+    expect(
+      await truncatedService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "truncated-authorization-legacy-proof",
+          ts: "1713000102.000275",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: "T222",
+          eventTeamId: "T222",
+          sourceTeamId: "T111",
+          authorizations: [{ team_id: "T333" }],
+        }),
+      ),
+    ).toBe("ignored");
+    expect(truncated).toHaveLength(0);
+
+    const withoutOrigin: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const withoutOriginService = makeBotService({
+      published: withoutOrigin,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T222",
+      })),
+    });
+    expect(
+      await withoutOriginService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "authorization-proof-without-origin",
+          ts: "1713000102.000290",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: null,
+          eventTeamId: null,
+          sourceTeamId: null,
+          authorizations: [{ team_id: "T222" }],
+        }),
+      ),
+    ).toBe("ignored");
+    expect(withoutOrigin).toHaveLength(0);
+
+    const conflictingWithoutSource: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const conflictingWithoutSourceService = makeBotService({
+      published: conflictingWithoutSource,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T222",
+      })),
+    });
+    expect(
+      await conflictingWithoutSourceService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "authorization-proof-with-conflicting-implicit-origin",
+          ts: "1713000102.000295",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: "T111",
+          eventTeamId: "T333",
+          sourceTeamId: null,
+          authorizations: [{ team_id: "T222" }],
+        }),
+      ),
+    ).toBe("ignored");
+    expect(conflictingWithoutSource).toHaveLength(0);
+  });
+
+  it("fails closed when neither authorization nor legacy team fields prove the installation", async () => {
     const mismatched: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
     const mismatchedAuth = mock(async () => ({
       ok: true,
       bot_id: "BLOCAL",
       user_id: "ULOCAL",
-      team_id: "T2",
+      team_id: "T222",
     }));
     const mismatchedService = makeBotService({ published: mismatched, authTest: mismatchedAuth });
+
     expect(
       await mismatchedService.handleEnvelope(
         botEnvelope({
@@ -1553,11 +1738,70 @@ describe("Slack Socket Mode foreign bot intake", () => {
           ts: "1713000102.000300",
           text: "<@ULOCAL> status",
           botId: "BFOREIGN",
+          teamId: "T111",
+          eventTeamId: "T111",
+          sourceTeamId: "T111",
+          authorizations: [{ team_id: "T333" }],
         }),
       ),
     ).toBe("ignored");
     expect(mismatchedAuth).toHaveBeenCalledTimes(1);
     expect(mismatched).toHaveLength(0);
+  });
+
+  it("uses the strict legacy proof only when authorizations is absent", async () => {
+    const legacyPublished: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const legacyService = makeBotService({
+      published: legacyPublished,
+      authTest: mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T1",
+      })),
+    });
+    expect(
+      await legacyService.handleEnvelope(
+        botEnvelope({
+          envelopeId: "legacy-authorization-fallback",
+          ts: "1713000102.000310",
+          text: "<@ULOCAL> status",
+          botId: "BFOREIGN",
+          teamId: "T1",
+          eventTeamId: "T1",
+        }),
+      ),
+    ).toBe("processed");
+    expect(legacyPublished).toHaveLength(1);
+
+    for (const [index, authorizations] of [[], "malformed", [null], [{}], [{ team_id: " " }]].entries()) {
+      const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+      const authTest = mock(async () => ({
+        ok: true,
+        bot_id: "BLOCAL",
+        user_id: "ULOCAL",
+        team_id: "T1",
+      }));
+      const service = makeBotService({
+        published,
+        authTest,
+      });
+      expect(
+        await service.handleEnvelope(
+          botEnvelope({
+            envelopeId: `invalid-authorizations-${index}`,
+            ts: `1713000102.00032${index}`,
+            text: "<@ULOCAL> status",
+            botId: "BFOREIGN",
+            teamId: "T1",
+            eventTeamId: "T1",
+            authorizations,
+          }),
+        ),
+      ).toBe("ignored");
+      expect(authTest).not.toHaveBeenCalled();
+      expect(published).toHaveLength(0);
+    }
   });
 
   it("fails closed before auth.test when Slack team provenance is absent or conflicting", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -557,18 +557,51 @@ export class SlackSocketModeService {
     const event = envelopeEvent(envelope);
     if (!event || !isSlackMessageEventStructurallyEligible(event)) return null;
 
-    const payload = envelope.payload as { team_id?: string; event_id?: string; event_time?: number } | undefined;
+    const payload = envelope.payload as
+      | {
+          team_id?: string;
+          event_id?: string;
+          event_time?: number;
+          authorizations?: unknown;
+        }
+      | undefined;
     const isBotMessage = isSlackBotMessageCandidate(event);
-    let teamId: string;
+    const sourceTeamId = cleanSlackId(event.source_team);
+    const userTeamId = cleanSlackId(event.user_team);
+    const eventTeamId = cleanSlackId(event.team);
+    const payloadTeamId = cleanSlackId(payload?.team_id);
+    const authorizationsPresent = Boolean(payload && Object.prototype.hasOwnProperty.call(payload, "authorizations"));
+    const authorizationsValid = Array.isArray(payload?.authorizations);
+    const authorizedTeamIds = slackAuthorizationTeamIds(payload?.authorizations);
+    let teamId = eventTeamId ?? payloadTeamId ?? this.options.accountId;
+    let originTeamId: string | undefined;
     let localBotIdentity: SlackLocalBotIdentity | null = null;
     if (isBotMessage) {
-      const teamIds = uniqueCleanSlackIds([payload?.team_id, event.team]);
-      if (teamIds.length !== 1) return null;
-      teamId = teamIds[0]!;
+      const legacyInstallationTeamIds = uniqueCleanSlackIds([payloadTeamId, eventTeamId]);
+      originTeamId =
+        sourceTeamId ?? (legacyInstallationTeamIds.length === 1 ? legacyInstallationTeamIds[0] : undefined);
+      if (!originTeamId) return null;
+      if (authorizationsPresent) {
+        if (!authorizationsValid || authorizedTeamIds.length === 0) return null;
+      } else if (legacyInstallationTeamIds.length !== 1) {
+        return null;
+      }
       localBotIdentity = await this.resolveLocalBotIdentity();
-      if (!localBotIdentity || localBotIdentity.teamId !== teamId) return null;
+      if (
+        !localBotIdentity ||
+        !hasSlackBotInstallationProof({
+          localTeamId: localBotIdentity.teamId,
+          authorizationsPresent,
+          authorizedTeamIds,
+          legacyInstallationTeamIds,
+        })
+      ) {
+        return null;
+      }
+      teamId = eventTeamId ?? payloadTeamId ?? originTeamId;
     } else {
-      teamId = cleanSlackId(event.team) ?? cleanSlackId(payload?.team_id) ?? this.options.accountId;
+      const originCandidates = uniqueCleanSlackIds([payloadTeamId, eventTeamId]);
+      originTeamId = sourceTeamId ?? (originCandidates.length === 1 ? originCandidates[0] : undefined);
     }
     if (
       shouldIgnoreSlackMessageEvent(event, {
@@ -594,6 +627,13 @@ export class SlackSocketModeService {
 
     return {
       teamId,
+      originTeamId,
+      sourceTeamId,
+      userTeamId,
+      eventTeamId,
+      payloadTeamId,
+      authorizedTeamIds,
+      localTeamId: localBotIdentity?.teamId,
       channelId,
       channelType: cleanSlackId(event.channel_type) ?? "channel",
       userId,
@@ -790,7 +830,7 @@ export class SlackSocketModeService {
       title: message.channelId,
       rawProvenance: {
         source: "slack.socket_mode",
-        teamId: message.teamId,
+        ...slackTeamProvenance(message),
         channelId: message.channelId,
         threadTs: routeThreadId ?? null,
         envelopeId: message.envelopeId ?? null,
@@ -895,7 +935,7 @@ export class SlackSocketModeService {
       content: buildSlackMessageContent(message, processedFiles),
       rawProvenance: {
         source: "slack.socket_mode",
-        teamId: message.teamId,
+        ...slackTeamProvenance(message),
         eventId: message.eventId ?? null,
         envelopeId: message.envelopeId ?? null,
         senderKind: message.senderKind,
@@ -918,6 +958,13 @@ export class SlackSocketModeService {
       source: actorIdentity.actorType === "unknown" ? "inbound_message" : "slack_socket_mode:identity_resolved",
       metadata: {
         slackTeamId: message.teamId,
+        slackOriginTeamId: message.originTeamId ?? null,
+        slackSourceTeamId: message.sourceTeamId ?? null,
+        slackUserTeamId: message.userTeamId ?? null,
+        slackEventTeamId: message.eventTeamId ?? null,
+        slackPayloadTeamId: message.payloadTeamId ?? null,
+        slackAuthorizedTeamIds: message.authorizedTeamIds,
+        slackLocalTeamId: message.localTeamId ?? null,
         slackChannelType: message.channelType,
         slackSenderKind: message.senderKind,
         slackUserId: message.slackUserId ?? null,
@@ -954,7 +1001,7 @@ export class SlackSocketModeService {
         title: message.channelId,
         rawProvenance: {
           source: "slack.socket_mode",
-          teamId: message.teamId,
+          ...slackTeamProvenance(message),
           channelId: message.channelId,
         },
         seenAt: message.eventTimeMs,
@@ -1028,6 +1075,13 @@ export class SlackSocketModeService {
         routeAccountId: this.options.routeAccountId ?? this.options.accountId,
         instanceId: input.instanceId,
         teamId: input.message.teamId,
+        originTeamId: input.message.originTeamId,
+        sourceTeamId: input.message.sourceTeamId,
+        userTeamId: input.message.userTeamId,
+        eventTeamId: input.message.eventTeamId,
+        payloadTeamId: input.message.payloadTeamId,
+        authorizedTeamIds: input.message.authorizedTeamIds,
+        localTeamId: input.message.localTeamId,
         channelId: input.message.channelId,
         channelType: input.message.channelType,
         peerKind: input.peerKind,
@@ -1122,6 +1176,39 @@ export class SlackSocketModeService {
 
 function isSlackBotMessageCandidate(event: SlackEventPayload): boolean {
   return Boolean(cleanSlackId(event.bot_id) || event.subtype === "bot_message");
+}
+
+function slackAuthorizationTeamIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueCleanSlackIds(
+    value.map((authorization) => {
+      if (!authorization || typeof authorization !== "object" || Array.isArray(authorization)) return undefined;
+      return (authorization as Record<string, unknown>).team_id;
+    }),
+  );
+}
+
+function hasSlackBotInstallationProof(input: {
+  localTeamId: string;
+  authorizationsPresent: boolean;
+  authorizedTeamIds: readonly string[];
+  legacyInstallationTeamIds: readonly string[];
+}): boolean {
+  if (input.authorizationsPresent) return input.authorizedTeamIds.includes(input.localTeamId);
+  return input.legacyInstallationTeamIds.length === 1 && input.legacyInstallationTeamIds[0] === input.localTeamId;
+}
+
+function slackTeamProvenance(message: SlackNormalizedMessage): Record<string, unknown> {
+  return {
+    teamId: message.teamId,
+    originTeamId: message.originTeamId ?? null,
+    sourceTeamId: message.sourceTeamId ?? null,
+    userTeamId: message.userTeamId ?? null,
+    eventTeamId: message.eventTeamId ?? null,
+    payloadTeamId: message.payloadTeamId ?? null,
+    authorizedTeamIds: message.authorizedTeamIds,
+    localTeamId: message.localTeamId ?? null,
+  };
 }
 
 function withAbortableTimeout<T>(

--- a/src/channels/slack/types.ts
+++ b/src/channels/slack/types.ts
@@ -33,7 +33,16 @@ export interface SlackEventsApiPayload {
   readonly type?: string;
   readonly event_id?: string;
   readonly event_time?: number;
-  readonly authorizations?: readonly Record<string, unknown>[];
+  readonly authorizations?: readonly SlackEventAuthorization[];
+}
+
+export interface SlackEventAuthorization {
+  readonly enterprise_id?: string | null;
+  readonly team_id?: string | null;
+  readonly user_id?: string | null;
+  readonly is_bot?: boolean | null;
+  readonly is_enterprise_install?: boolean | null;
+  readonly [key: string]: unknown;
 }
 
 export interface SlackEventPayload {
@@ -47,6 +56,8 @@ export interface SlackEventPayload {
   readonly ts?: string;
   readonly thread_ts?: string;
   readonly team?: string;
+  readonly source_team?: string | null;
+  readonly user_team?: string | null;
   readonly event_ts?: string;
   readonly files?: readonly SlackFilePayload[];
   readonly edited?: Record<string, unknown>;
@@ -80,7 +91,22 @@ export interface SlackNormalizedFile {
 }
 
 export interface SlackNormalizedMessage {
+  /** Legacy effective team value retained for existing consumers. */
   readonly teamId: string;
+  /** Resolved message origin: `source_team`, otherwise one unambiguous outer/inner team. */
+  readonly originTeamId?: string;
+  /** Workspace from which Slack says the message originated. */
+  readonly sourceTeamId?: string;
+  /** Workspace associated with the sending Slack user when provided. */
+  readonly userTeamId?: string;
+  /** Raw inner `event.team`, which is not necessarily the token installation. */
+  readonly eventTeamId?: string;
+  /** Raw outer Events API `payload.team_id`. */
+  readonly payloadTeamId?: string;
+  /** Team ids exposed by the possibly truncated Events API authorization list. */
+  readonly authorizedTeamIds: readonly string[];
+  /** Workspace returned by `auth.test` for the local channel account token. */
+  readonly localTeamId?: string;
   readonly channelId: string;
   readonly channelType: string;
   /** Effective sender id: Slack `user` when present, otherwise `bot_id`. */


### PR DESCRIPTION
## Objective

Correct foreign-bot intake for Slack Connect by separating message origin from the local app installation that authorizes delivery.

## Problem

- Valid Slack Connect events can originate in workspace T111 while the Ravi installation and token belong to T222.
- Requiring outer and inner message team fields to equal `auth.test.team_id` rejects those valid events.
- Treating Slack authorization data as complete or falling back after malformed modern data could admit events without explicit installation proof.

## Solution

- Resolve message origin independently, preferring `source_team` and otherwise requiring unambiguous outer and inner team provenance.
- When `authorizations` is present, require a usable array containing the local `auth.test.team_id`; malformed, empty, team-less, or non-matching data fails closed.
- Use the strict legacy outer and inner team proof only when the `authorizations` key is absent.
- Preserve origin, source, user, event, payload, authorized, and local team ids as separate provenance while keeping legacy `teamId` behavior stable.
- Add coverage for the official cross-workspace shape, truncated and malformed authorizations, missing or conflicting origin, legacy fallback, self-loop filtering, and unchanged human admission.

## Practical impact

Explicitly addressed foreign bots can reach Ravi through Slack Connect without confusing the author workspace with the workspace that installed Ravi. Rejected events produce no routed prompt.

## What does NOT change

- Human Slack admission, configured-account routing, outbound delivery, and self-loop filtering retain their existing behavior.
- No public `message.persisted` or `message.recorded` event is introduced; durability and idempotency remain internal.

## Validation

- 67 focused Slack tests passed with 390 assertions.
- TypeScript typecheck, Biome, build, diff check, and the spec quality gate passed.
- The complete pre-push test and SDK suite passed.

## Risks

Slack can truncate the received authorization list. A present list without the local team deliberately fails closed, so some valid deliveries may be rejected until full authorization resolution is implemented.

## Rollback

Revert commit `e2c69aa8` to restore the previous same-team-only foreign-bot admission behavior.

## Follow-ups

- If truncated authorization false negatives become material, resolve the complete installation set with `apps.event.authorizations.list` before admission.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->