### PR TITLE
fix(cli): make PM2 bootstrap synchronously loadable

### DIFF
--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -1,5 +1,15 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
@@ -34,6 +44,82 @@ afterAll(() => {
 });
 
 describe("daemon runtime target", () => {
+  it("builds a CLI bundle that PM2 can synchronously require under Bun", () => {
+    const tempRoot = makeTempDir("ravi-daemon-pm2-bootstrap-");
+    const bundleDir = join(tempRoot, "dist", "bundle");
+    const bundlePath = join(bundleDir, "index.js");
+    const wrapperPath = join(tempRoot, "pm2-require-wrapper.cjs");
+    const fakeBinDir = join(tempRoot, "bin");
+    const fakePm2Path = join(fakeBinDir, "pm2");
+
+    mkdirSync(bundleDir, { recursive: true });
+    mkdirSync(fakeBinDir, { recursive: true });
+    writeFileSync(join(tempRoot, "package.json"), JSON.stringify({ name: "ravi.bot", version: "test" }), "utf8");
+    symlinkSync(join(process.cwd(), "node_modules"), join(tempRoot, "node_modules"), "dir");
+    writeFileSync(
+      wrapperPath,
+      [
+        'const Module = require("node:module");',
+        "const originalRequire = Module.prototype.require;",
+        "Module.prototype.require = function patchedRequire() {",
+        "  return originalRequire.apply(this, arguments);",
+        "};",
+        "require(process.env.RAVI_TEST_BUNDLE);",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(fakePm2Path, '#!/bin/sh\n[ "$1" = "jlist" ] && printf "[]"\nexit 0\n', "utf8");
+    chmodSync(fakePm2Path, 0o755);
+
+    const build = spawnSync(
+      "bun",
+      [
+        "build",
+        "src/cli/index.ts",
+        "--outdir",
+        bundleDir,
+        "--target",
+        "bun",
+        "--minify",
+        "--external",
+        "ink",
+        "--external",
+        "react",
+        "--external",
+        "@anthropic-ai/*",
+        "--external",
+        "openai",
+        "--external",
+        "@google/*",
+        "--external",
+        "nats",
+        "--external",
+        "@elevenlabs/*",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      },
+    );
+    expect(build.status).toBe(0);
+    expect(build.stderr).not.toContain("error:");
+
+    const result = spawnSync("bun", [wrapperPath, "daemon", "status"], {
+      cwd: tempRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        RAVI_STATE_DIR: join(tempRoot, "state"),
+        RAVI_TEST_BUNDLE: bundlePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Ravi Daemon Status");
+    expect(result.stderr).not.toContain("require() async module");
+  });
+
   it("restarts the installed runtime from any operator cwd without requiring a source project root", () => {
     const tempRoot = makeTempDir("ravi-daemon-runtime-");
     const bundlePath = join(tempRoot, "install", "global", "node_modules", "ravi.bot", "dist", "bundle", "index.js");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -241,12 +241,21 @@ program
 // Parse and execute
 maybeSuggestKnownRootCommand(process.argv.slice(2), program);
 
-const handledByAppAlias = await maybeRunAppAliasRoute(process.argv.slice(2), {
-  staticRootCommands: rootCommandNames(program),
+void bootstrapCli().catch((error: unknown) => {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
 });
-if (handledByAppAlias) process.exit(process.exitCode ?? 0);
 
-program.parse();
+async function bootstrapCli(): Promise<void> {
+  const handledByAppAlias = await maybeRunAppAliasRoute(process.argv.slice(2), {
+    staticRootCommands: rootCommandNames(program),
+  });
+  if (handledByAppAlias) {
+    process.exit(process.exitCode ?? 0);
+  }
+
+  program.parse();
+}
 
 function maybeSuggestKnownRootCommand(args: string[], command: Command): void {
   const requested = args[0];


### PR DESCRIPTION
## Objective

Prevent the Ravi daemon bundle from failing during PM2's Bun bootstrap while preserving the current CLI routing and PM2 runtime identity. This fixes the startup exception without changing daemon process configuration or deployment behavior.

## Problem

- The CLI entrypoint used top-level `await` to resolve dynamic Ravi App aliases before Commander parsing.
- The Bun-targeted bundle therefore became an async module, while PM2 6 loads `--interpreter bun` applications through a synchronous `require()`.
- Bun rejects that combination with `TypeError: require() async module ... is unsupported`, so daemon starts/restarts log an uncaught bootstrap exception. The process could appear online only because Ravi's global exception handler kept it alive, which is not a safe startup contract.

## Solution

- Move alias resolution and Commander parsing into an async `bootstrapCli()` function invoked without module-level `await`.
- Catch bootstrap failures at the entrypoint boundary and return a non-zero process status.
- Add a regression test that builds the real CLI entrypoint and loads the generated bundle through a PM2-like synchronous Bun `require()` wrapper.

## Practical impact

- `ravi daemon start` and `ravi daemon restart` can load the CLI bundle cleanly under the current PM2/Bun setup.
- Dynamic app aliases still resolve before Commander parses static commands.
- Future top-level-await regressions in the CLI bundle fail in the daemon test suite.

## What does NOT change

- PM2 launch arguments, process name, runtime-target detection, updater behavior, and persisted PM2 metadata remain unchanged.
- No daemon API, CLI command, channel behavior, or user-facing event is added or removed.

## Validation

- Reproduced the original exception with the pre-fix bundle in an isolated PM2 home.
- Verified the fixed production bundle loads without the exception in the same isolated PM2 setup.
- `RAVI_LOG_LEVEL=error bun test src/cli/commands/daemon.test.ts src/apps/router.test.ts src/cli/root-version.test.ts` — 28 passed.
- `bun run typecheck` — passed.
- `bunx @biomejs/biome check src/cli/index.ts src/cli/commands/daemon.test.ts` — passed.
- `bun run build` — passed.
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts` — passed.
- Repository pre-push suite, including build, typecheck, CLI tests, runtime tests, and SDK tests — passed.

## Risks

- Low: CLI startup is now asynchronous behind a synchronous module boundary. Ordering is preserved inside `bootstrapCli()`, and failures are explicitly caught with a non-zero exit status.
- The regression harness assumes the repository's supported Unix-like runtime/CI environment.

## Rollback

- Revert commit `eb9ead76`; no data or configuration migration is involved.

## Follow-ups

- A future migration to have PM2 manage the Bun executable directly can be evaluated separately, together with the required runtime-target and updater compatibility changes. It is not required for this fix.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->