### PR TITLE
fix(plugins): isolate internal cache snapshots across processes

### DIFF
--- a/.ravi/specs/plugins/CHECKS.md
+++ b/.ravi/specs/plugins/CHECKS.md
@@ -1,0 +1,8 @@
+# Plugin Checks
+
+- [ ] Internal plugin materialization MUST publish a completion marker only after every embedded file is written.
+- [ ] Concurrent processes with the same artifact MUST return the same complete snapshot path.
+- [ ] Different embedded artifacts MUST return different snapshot paths.
+- [ ] Publishing a newer artifact MUST NOT remove or mutate an older published snapshot.
+- [ ] User plugins under `~/ravi/plugins/` MUST remain outside internal snapshot lifecycle operations.
+- [ ] Discovery MUST return internal plugins before user plugins.

--- a/.ravi/specs/plugins/RUNBOOK.md
+++ b/.ravi/specs/plugins/RUNBOOK.md
@@ -1,0 +1,15 @@
+# Plugin Runtime Runbook
+
+## Diagnose internal plugin discovery
+
+1. Start a fresh Ravi process and inspect the `Internal plugins loaded` log entry.
+2. Confirm its path is under `~/.cache/ravi/plugins/.snapshots/<digest>/`.
+3. Confirm each returned plugin directory contains `.claude-plugin/plugin.json`.
+4. Run a second Ravi CLI from another installed version while the first process is active.
+5. Confirm both snapshot paths remain readable and neither process reports `ENOENT` while traversing plugin files.
+
+Published snapshots are immutable. Do not repair one in place or delete it while a process may still reference it. A broken snapshot should be diagnosed from the embedded artifact and replaced by a new content-addressed snapshot.
+
+## Rollback
+
+Revert the runtime change and restart Ravi. Existing snapshot directories are cache data and may remain on disk; they are ignored by runtimes that use the former flat layout.

--- a/.ravi/specs/plugins/SPEC.md
+++ b/.ravi/specs/plugins/SPEC.md
@@ -45,8 +45,9 @@ The plugin domain exists so that capability content (skills, commands) is decoup
 - A plugin's skills MUST live under `<plugin-root>/skills/<skill-name>/SKILL.md`.
 - A skill `description` field MUST be treated as the discovery contract: it is the only signal the harness uses to decide whether to auto-load the skill on a matching prompt. Vague descriptions break discovery.
 - The runtime MUST discover plugins from two canonical sources, in order:
-  1. **Internal plugins** — embedded in the Ravi binary, extracted on start to `~/.cache/ravi/plugins/<name>/`. These MUST NOT be edited manually; they are regenerated every runtime start.
+  1. **Internal plugins** — embedded in the Ravi binary and materialized as immutable, content-addressed snapshots at `~/.cache/ravi/plugins/.snapshots/<digest>/<name>/`. Snapshots MUST be published atomically and MUST NOT be edited manually.
   2. **User plugins** — operator-installed at `~/ravi/plugins/<name>/`. These MUST persist across restarts and are the operator's source of truth.
+- Concurrent Ravi versions MUST be able to keep reading their own internal plugin snapshot. Publishing a new snapshot MUST NOT remove or mutate a snapshot already returned to another process.
 - A plugin directory without `.claude-plugin/plugin.json` MUST be ignored by user-plugin discovery (silent skip with debug log, never an error).
 - Plugins MUST NOT be discovered from arbitrary cwds today. Per-agent local plugins (`<agent-cwd>/.ravi/plugins/`) are a proposed extension governed by the `runtime-sync` capability and MUST NOT be assumed active without explicit implementation.
 - The default user-plugin name reserved for operator-installed skills with no explicit container is `ravi-user-skills`; new operator skills SHOULD install into this plugin unless a domain-specific plugin already exists.
@@ -63,3 +64,4 @@ The plugin domain exists so that capability content (skills, commands) is decoup
 - A new plugin MUST become discoverable by the runtime without code changes once placed at `~/ravi/plugins/<name>/` with a valid manifest.
 - A skill inside a plugin MUST be auto-invocable by Claude Code's Skill tool given a matching prompt and the agent has `toolgroup:navigate`.
 - Removing a plugin from `~/ravi/plugins/` MUST cause its skills to disappear from the next session's discovery without leaking residue into agent contexts.
+- Concurrent processes materializing the same embedded artifact MUST converge on one complete snapshot; different artifacts MUST resolve to different immutable paths.

--- a/.ravi/specs/plugins/WHY.md
+++ b/.ravi/specs/plugins/WHY.md
@@ -20,7 +20,7 @@ Plugins decouple identity (agent) from capability (plugin), and give the runtime
 
 Internal plugins ship inside the Ravi binary so that core capabilities (system commands, dev skills, prox flow) cannot be partially upgraded — they move with the runtime release. User plugins live at `~/ravi/plugins/` so that operators can install or modify capabilities without rebuilding the binary.
 
-The two-source split also keeps blast radius bounded: an operator who breaks a user plugin only breaks their own session; they cannot brick the runtime by editing a path that ships with the binary, because internal extraction overwrites the cache directory on every start.
+The two-source split also keeps blast radius bounded: an operator who breaks a user plugin only breaks their own session; they cannot brick the runtime by editing a path that ships with the binary. Internal plugins are published as immutable content-addressed snapshots, so rolling versions can coexist without overwriting files another process is reading.
 
 ## Why plugin ≠ skill
 

--- a/.ravi/specs/plugins/locations/CHECKS.md
+++ b/.ravi/specs/plugins/locations/CHECKS.md
@@ -1,0 +1,8 @@
+# Plugin Location Checks
+
+- [ ] Internal plugin paths MUST match `~/.cache/ravi/plugins/.snapshots/<digest>/<plugin-name>/`.
+- [ ] A snapshot MUST NOT be accepted when `.complete` is missing or does not match its digest.
+- [ ] Snapshot publication MUST use a private staging directory followed by an atomic rename.
+- [ ] Discovery MUST preserve the plugin basename, such as `ravi-system`, below the digest directory.
+- [ ] Runtime discovery MUST NOT overwrite or remove a published snapshot.
+- [ ] Automatic cleanup MUST prove a snapshot is unused before deleting it.

--- a/.ravi/specs/plugins/locations/RUNBOOK.md
+++ b/.ravi/specs/plugins/locations/RUNBOOK.md
@@ -1,0 +1,14 @@
+# Plugin Location Runbook
+
+## Inspect a snapshot
+
+1. Read the `Internal plugins loaded` log entry to obtain the resolved snapshot directory.
+2. Verify the directory is `~/.cache/ravi/plugins/.snapshots/<digest>/`.
+3. Verify `.complete` contains the same digest used by the directory name.
+4. Verify each plugin child has `.claude-plugin/plugin.json` and its expected files.
+
+Directories named `.staging-*` are unpublished work areas. A crashed process may leave one behind; it is safe to remove only when no live process is writing it. Published digest directories must not be pruned based only on age or count because a long-lived process may still hold their paths.
+
+## Version skew check
+
+Run discovery from both installed Ravi bundles. Different embedded contents should resolve to different digest directories, and both trees should stay readable for the duration of the processes.

--- a/.ravi/specs/plugins/locations/SPEC.md
+++ b/.ravi/specs/plugins/locations/SPEC.md
@@ -28,10 +28,10 @@ This capability defines the canonical filesystem locations for Ravi plugins, who
 
 ### Internal plugins (binary-shipped)
 
-- **Path:** `~/.cache/ravi/plugins/<plugin-name>/`
+- **Path:** `~/.cache/ravi/plugins/.snapshots/<artifact-digest>/<plugin-name>/`
 - **Owner:** Ravi runtime.
-- **Lifecycle:** Re-extracted on every Ravi start from the embedded `internal-plugins.json` artifact.
-- **Edits:** MUST NOT be edited manually. Edits are erased on the next start.
+- **Lifecycle:** Materialized from the embedded `internal-plugins.json` artifact into an immutable content-addressed snapshot. Identical artifacts reuse the same complete snapshot; changed artifacts publish a new one.
+- **Edits:** MUST NOT be edited manually. A process may retain its resolved snapshot path for the lifetime of a session.
 - **Examples:** `ravi-system`, `ravi-dev`.
 
 ### User plugins (operator-installed)
@@ -51,15 +51,19 @@ This capability defines the canonical filesystem locations for Ravi plugins, who
 
 ## Rules
 
-- Plugin discovery MUST scan `~/.cache/ravi/plugins/` for internal plugins and `~/ravi/plugins/` for user plugins, in that order.
+- Plugin discovery MUST resolve embedded internal plugins from their complete content-addressed snapshot, then scan `~/ravi/plugins/` for user plugins, in that order.
 - Discovery MUST require `.claude-plugin/plugin.json` at the plugin root. Directories without a manifest MUST be silently skipped at debug log level.
 - The runtime MUST NOT delete user plugins under `~/ravi/plugins/` as part of any automatic operation.
-- The runtime MAY freely overwrite `~/.cache/ravi/plugins/` at start-up; operators MUST NOT use this path as durable storage.
+- Internal snapshots MUST be assembled in a private staging directory and exposed only through an atomic publish after all files and the completion marker exist.
+- The runtime MUST NOT overwrite or remove a published snapshot in the discovery hot path. Cleanup requires a separate mechanism that can prove no live process or session still references the snapshot.
+- Operators MUST NOT use `~/.cache/ravi/plugins/` as durable storage.
 - Per-agent local plugin discovery MUST be opt-in and explicit. Until `runtime-sync` is implemented, no code path SHOULD scan `<agent-cwd>/.ravi/plugins/` for plugins.
 - Plugin names MUST be slugified consistently across the codebase using the `slugifySkillName` rules (lowercase, alnum, dot, dash, underscore).
 
 ## Acceptance Criteria
 
 - `discoverPlugins()` returns internal plugins first, then user plugins, with consistent ordering across runs.
+- Two processes publishing the same embedded artifact concurrently MUST return the same complete snapshot path without exposing staging contents.
+- A process using snapshot A MUST continue reading it successfully while another process publishes snapshot B.
 - An empty `~/ravi/plugins/` MUST cause `getUserPlugins()` to return `[]` without errors and without creating the directory.
 - A malformed user plugin (missing manifest, invalid JSON) MUST NOT crash discovery. It MUST be skipped with a logged warning carrying the path.

--- a/.ravi/specs/plugins/locations/WHY.md
+++ b/.ravi/specs/plugins/locations/WHY.md
@@ -1,0 +1,5 @@
+# Why Internal Plugins Use Immutable Snapshots
+
+Ravi may run several versions at once: the daemon, operator CLIs, cron shell commands, and rolling updates can all discover embedded plugins concurrently. A shared mutable directory lets one process delete files while another process is reading them, and it also lets an older bundle silently replace newer plugin content.
+
+Content-addressed snapshots give every artifact a stable filesystem path. Private staging plus atomic publication ensures readers observe either no snapshot or a complete snapshot, never a partially copied tree. Keeping published snapshots immutable also preserves paths already handed to long-lived provider sessions.

--- a/.ravi/specs/runtime/CHECKS.md
+++ b/.ravi/specs/runtime/CHECKS.md
@@ -16,6 +16,7 @@
 - `turn.complete` persists provider state, tokens, trace terminal state, and assistant message.
 - `turn.interrupted` clears response text and keeps pending prompt queue.
 - `turn.failed` emits user-facing error unless suppressed by internal interrupt recovery.
+- Internal `turn.failed` diagnostics retain the raw error while channel responses, live-state summaries, waited CLI errors, and observation prompts omit local paths, runtime exception details, and credential-shaped values.
 
 ## Compaction Announcements
 

--- a/.ravi/specs/runtime/SPEC.md
+++ b/.ravi/specs/runtime/SPEC.md
@@ -74,6 +74,7 @@ The runtime abstraction exists so new execution engines can be added without cop
 - The prompt generator MUST set `turnActive` before yielding a provider prompt and MUST be signaled on every terminal event path.
 - The event loop MUST persist provider session state only from canonical terminal state, not from raw provider events.
 - User prompts MUST be saved before provider handoff; assistant messages MUST be saved only after a non-interrupted terminal turn.
+- Raw runtime failures MUST remain available in internal logs, traces, and runtime events, but user-facing responses, live-state summaries, waited CLI errors, and observation prompts MUST sanitize local paths, runtime exception details, and credential-shaped values while preserving actionable provider guidance.
 - Tool start/end lifecycle MUST be recorded through canonical `tool.started` and `tool.completed` events.
 - Runtime permissions MUST flow through Ravi host services or host hooks. Providers MUST NOT create a parallel permission model.
 - `adapter.request` trace MUST be recorded before provider handoff, including prompt hashes, system prompt hashes, model, provider, resume/fork state, delivery barrier, source, and capability summary.

--- a/src/bot.runtime-guards.fixture.ts
+++ b/src/bot.runtime-guards.fixture.ts
@@ -858,10 +858,12 @@ describe("RaviBot runtime guards", () => {
     }
   });
 
-  it("cleans up the in-memory streaming session when runtime startup throws", async () => {
+  it("cleans up runtime startup failures without exposing internal paths", async () => {
     const sessionKey = "agent:main:start-failure";
+    const startupError =
+      "ENOENT: no such file or directory, scandir '/Users/luis/.cache/ravi/plugins/ravi-system/skills/slack'";
     runtimeStartImpl = () => {
-      throw new Error("boom");
+      throw new Error(startupError);
     };
 
     const bot = createBot();
@@ -873,12 +875,15 @@ describe("RaviBot runtime guards", () => {
         (entry) =>
           entry.topic === `ravi.session.${sessionKey}.runtime` &&
           entry.data?.type === "turn.failed" &&
-          entry.data?.error === "boom",
+          entry.data?.error === startupError,
       ),
     ).toBe(true);
     expect(
       emittedEvents.some(
-        (entry) => entry.topic === `ravi.session.${sessionKey}.response` && entry.data?.response === "Error: boom",
+        (entry) =>
+          entry.topic === `ravi.session.${sessionKey}.response` &&
+          entry.data?.response ===
+            "Error: The agent could not complete this request because of an internal runtime error. Please try again.",
       ),
     ).toBe(true);
   });
@@ -914,7 +919,10 @@ describe("RaviBot runtime guards", () => {
 
     const response = emittedEvents.find((entry) => entry.topic === `ravi.session.${sessionKey}.response`)?.data
       ?.response;
-    expect(String(response).startsWith("Error: TypeError: oD is not a function")).toBe(true);
+    expect(response).toBe(
+      "Error: The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+    expect(String(response)).not.toContain("TypeError");
     expect(String(response).length).toBeLessThanOrEqual(340);
   });
 

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -393,6 +393,28 @@ describe("SessionCommands wait mode", () => {
     expect(publishedPrompts[0]?.sessionName).toBe("codex-cli-locked");
   });
 
+  it("does not expose internal runtime paths when a waited session fails", async () => {
+    runtimeEvents = [
+      {
+        type: "turn.failed",
+        error: "ENOENT: no such file or directory, scandir '/Users/luis/.cache/ravi/plugins/ravi-system/skills/slack'",
+      },
+    ];
+
+    const commands = new SessionCommands();
+    const result = (commands as any).streamToSession("main", "say hi", {
+      sessionKey: "agent:main:main",
+      name: "main",
+      agentId: "main",
+      agentCwd: "/tmp/main",
+    });
+
+    await expect(result).rejects.toThrow(
+      "The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+    await expect(result).rejects.not.toThrow("/Users/luis");
+  });
+
   it("does not print a success footer when send -w fails", async () => {
     const commands = new SessionCommands();
     const logCalls: string[] = [];

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -86,6 +86,7 @@ import {
   parseRuntimeEffort,
 } from "../../runtime/effort.js";
 import type { RuntimeProviderId } from "../../runtime/types.js";
+import { publicRuntimeFailureDetail } from "../../runtime/public-failure.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
 import {
   countHistory,
@@ -5066,7 +5067,7 @@ export class SessionCommands {
     await Promise.race([streaming, new Promise((r) => setTimeout(r, 100))]);
 
     if (completionState.kind === "failed" || completionState.kind === "interrupted") {
-      throw new Error(completionState.error);
+      throw new Error(publicRuntimeFailureDetail(completionState.error));
     }
     if (completionState.kind === "timeout") {
       throw new Error(formatWaitTimeoutError(sessionName));

--- a/src/plugins/index.test.ts
+++ b/src/plugins/index.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import type { RuntimePlugin } from "../runtime/types.js";
+import { syncCodexSkills } from "./codex-skills.js";
+import { materializeInternalPluginsSnapshot } from "./index.js";
+import type { InternalPlugin } from "./internal-loader.js";
+
+const tempRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+describe("internal plugin snapshots", () => {
+  it("keeps an older snapshot readable after publishing changed plugin content", () => {
+    const root = makeTempRoot();
+    const cacheDir = join(root, "cache");
+    const firstSnapshot = materializeInternalPluginsSnapshot([createInternalPlugin("first")], { cacheDir });
+    const secondSnapshot = materializeInternalPluginsSnapshot([createInternalPlugin("second")], { cacheDir });
+
+    expect(secondSnapshot).not.toBe(firstSnapshot);
+    expect(basename(firstPluginPath(firstSnapshot))).toBe("ravi-system");
+    expect(readFileSync(join(firstSnapshot, "ravi-system", "skills", "slack", "SKILL.md"), "utf8")).toContain("first");
+    expect(readFileSync(join(secondSnapshot, "ravi-system", "skills", "slack", "SKILL.md"), "utf8")).toContain(
+      "second",
+    );
+
+    const firstPlugin: RuntimePlugin = {
+      type: "local",
+      path: firstPluginPath(firstSnapshot),
+    };
+    const synced = syncCodexSkills([firstPlugin], {
+      codexSkillsDir: join(root, "codex", "skills"),
+      manifestPath: join(root, "codex", "manifest.json"),
+    });
+
+    expect(synced).toEqual(["ravi-system-slack"]);
+  });
+
+  it("stays readable while a legacy process replaces the flat cache path", () => {
+    const root = makeTempRoot();
+    const cacheDir = join(root, "cache");
+    const snapshotDir = materializeInternalPluginsSnapshot([createInternalPlugin("snapshot")], { cacheDir });
+    const snapshotSkill = join(snapshotDir, "ravi-system", "skills", "slack", "SKILL.md");
+    const legacyPluginDir = join(cacheDir, "ravi-system");
+
+    mkdirSync(join(legacyPluginDir, "skills", "slack"), { recursive: true });
+    writeFileSync(join(legacyPluginDir, "skills", "slack", "SKILL.md"), "legacy-before");
+    rmSync(legacyPluginDir, { recursive: true, force: true });
+    mkdirSync(join(legacyPluginDir, "skills", "slack"), { recursive: true });
+    writeFileSync(join(legacyPluginDir, "skills", "slack", "SKILL.md"), "legacy-after");
+
+    expect(readFileSync(snapshotSkill, "utf8")).toContain("snapshot");
+  });
+
+  it("does not accept or publish over an incomplete snapshot", () => {
+    const root = makeTempRoot();
+    const cacheDir = join(root, "cache");
+    const plugins = [createInternalPlugin("partial")];
+    const snapshotDir = materializeInternalPluginsSnapshot(plugins, { cacheDir });
+
+    rmSync(join(snapshotDir, ".complete"));
+
+    expect(() => materializeInternalPluginsSnapshot(plugins, { cacheDir })).toThrow();
+    expect(readdirSync(join(cacheDir, ".snapshots")).filter((entry) => entry.startsWith(".staging-"))).toEqual([]);
+  });
+
+  it("rejects an internal plugin without its on-disk manifest", () => {
+    const root = makeTempRoot();
+    const plugin = createInternalPlugin("missing-manifest");
+    plugin.files = plugin.files.filter((file) => file.path !== ".claude-plugin/plugin.json");
+
+    expect(() => materializeInternalPluginsSnapshot([plugin], { cacheDir: join(root, "cache") })).toThrow(
+      "missing .claude-plugin/plugin.json",
+    );
+  });
+
+  it("publishes one complete snapshot when multiple Bun processes extract concurrently", async () => {
+    const root = makeTempRoot();
+    const cacheDir = join(root, "cache");
+    const indexModule = new URL("./index.ts", import.meta.url).href;
+    const loaderModule = new URL("./internal-loader.ts", import.meta.url).href;
+    const script = [
+      `const { materializeInternalPluginsSnapshot } = await import(${JSON.stringify(indexModule)});`,
+      `const { loadInternalPlugins } = await import(${JSON.stringify(loaderModule)});`,
+      "const snapshot = materializeInternalPluginsSnapshot(loadInternalPlugins(), { cacheDir: process.env.RAVI_TEST_PLUGIN_CACHE });",
+      "process.stdout.write(snapshot);",
+    ].join("\n");
+
+    const snapshots = await Promise.all(Array.from({ length: 6 }, () => runBunMaterializer(script, cacheDir)));
+
+    expect(new Set(snapshots).size).toBe(1);
+    const snapshotDir = snapshots[0];
+    expect(snapshotDir).toBeDefined();
+    expect(snapshotDir).toContain(join(cacheDir, ".snapshots"));
+    expect(existsSync(join(snapshotDir as string, ".complete"))).toBe(true);
+    expect(existsSync(join(snapshotDir as string, "ravi-system", "skills", "slack", "SKILL.md"))).toBe(true);
+    expect(readdirSync(join(cacheDir, ".snapshots")).filter((entry) => entry.startsWith(".staging-"))).toEqual([]);
+  }, 20_000);
+});
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "ravi-plugin-snapshot-"));
+  tempRoots.add(root);
+  return root;
+}
+
+function createInternalPlugin(label: string): InternalPlugin {
+  return {
+    name: "ravi-system",
+    manifest: { name: "ravi-system" },
+    files: [
+      {
+        path: ".claude-plugin/plugin.json",
+        content: JSON.stringify({ name: "ravi-system" }),
+      },
+      {
+        path: "skills/slack/SKILL.md",
+        content: `---\nname: slack\ndescription: ${label}\n---\n`,
+      },
+    ],
+  };
+}
+
+function firstPluginPath(snapshotDir: string): string {
+  return join(snapshotDir, "ravi-system");
+}
+
+function runBunMaterializer(script: string, cacheDir: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--eval", script], {
+      env: {
+        ...process.env,
+        RAVI_LOG_LEVEL: "error",
+        RAVI_TEST_PLUGIN_CACHE: cacheDir,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+        return;
+      }
+      reject(new Error(`snapshot materializer exited ${code}: ${stderr.trim()}`));
+    });
+  });
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -8,11 +8,21 @@
  * Plugins extend agent capabilities with skills, commands, agents, and hooks.
  */
 
-import { readdirSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
-import { loadInternalPlugins } from "./internal-loader.js";
+import { type InternalPlugin, loadInternalPlugins } from "./internal-loader.js";
 
 const log = logger.child("plugins");
 
@@ -22,28 +32,95 @@ export interface PluginSpec {
   path: string;
 }
 
-/** Directory where internal plugins are extracted (cache, regenerated on start) */
+/** Root cache for internal plugin snapshots. */
 const INTERNAL_PLUGINS_DIR = join(homedir(), ".cache", "ravi", "plugins");
 
 /** User plugins directory (custom plugins) */
 const USER_PLUGINS_DIR = join(homedir(), "ravi", "plugins");
 
-/** Track if internal plugins have been extracted this session */
-let internalPluginsExtracted = false;
+/** Process-local view of the immutable internal plugin snapshot. */
+let internalPluginSpecs: PluginSpec[] | undefined;
 let lastPluginDiscoveryLogKey: string | undefined;
 
 /**
- * Extract internal plugins to temp directory.
- * SDK needs real filesystem paths, so we write embedded content to disk.
+ * Materialize embedded plugins into an immutable, content-addressed snapshot.
+ *
+ * Multiple Ravi processes share this cache. Each process writes to a private
+ * staging directory and publishes with one atomic rename, so readers never see
+ * a plugin tree while another process is replacing it.
  */
-function extractInternalPlugins(): void {
-  if (internalPluginsExtracted) return;
+export function materializeInternalPluginsSnapshot(
+  internalPlugins: InternalPlugin[],
+  options: { cacheDir?: string } = {},
+): string {
+  const cacheDir = options.cacheDir ?? INTERNAL_PLUGINS_DIR;
+  validateInternalPlugins(internalPlugins);
+  const fingerprint = fingerprintInternalPlugins(internalPlugins);
+  const snapshotsDir = join(cacheDir, ".snapshots");
+  const snapshotDir = join(snapshotsDir, fingerprint);
+  const completionMarker = join(snapshotDir, ".complete");
 
-  const internalPlugins = loadInternalPlugins();
+  if (hasCompleteSnapshot(completionMarker, fingerprint)) {
+    return snapshotDir;
+  }
 
+  mkdirSync(snapshotsDir, { recursive: true });
+  const stagingDir = mkdtempSync(join(snapshotsDir, `.staging-${fingerprint}-`));
+
+  try {
+    writeInternalPlugins(internalPlugins, stagingDir);
+    writeFileSync(join(stagingDir, ".complete"), `${fingerprint}\n`);
+
+    try {
+      renameSync(stagingDir, snapshotDir);
+    } catch (error) {
+      // Another process may have published the same complete snapshot first.
+      if (!hasCompleteSnapshot(completionMarker, fingerprint)) {
+        throw error;
+      }
+    }
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+
+  return snapshotDir;
+}
+
+function validateInternalPlugins(internalPlugins: InternalPlugin[]): void {
   for (const plugin of internalPlugins) {
-    const pluginDir = join(INTERNAL_PLUGINS_DIR, plugin.name);
-    rmSync(pluginDir, { recursive: true, force: true });
+    if (!plugin.files.some((file) => file.path === ".claude-plugin/plugin.json")) {
+      throw new Error(`Internal plugin ${plugin.name} is missing .claude-plugin/plugin.json`);
+    }
+  }
+}
+
+function hasCompleteSnapshot(completionMarker: string, fingerprint: string): boolean {
+  try {
+    return readFileSync(completionMarker, "utf8").trim() === fingerprint;
+  } catch {
+    return false;
+  }
+}
+
+function fingerprintInternalPlugins(internalPlugins: InternalPlugin[]): string {
+  const content = internalPlugins
+    .map((plugin) => ({
+      name: plugin.name,
+      files: plugin.files
+        .map((file) => ({ path: file.path, content: file.content }))
+        .sort((left, right) => left.path.localeCompare(right.path)),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return createHash("sha256")
+    .update("ravi-internal-plugin-snapshot-v1\0")
+    .update(JSON.stringify(content))
+    .digest("hex");
+}
+
+function writeInternalPlugins(internalPlugins: InternalPlugin[], rootDir: string): void {
+  for (const plugin of internalPlugins) {
+    const pluginDir = join(rootDir, plugin.name);
 
     for (const file of plugin.files) {
       const filePath = join(pluginDir, file.path);
@@ -56,27 +133,30 @@ function extractInternalPlugins(): void {
       writeFileSync(filePath, file.content);
     }
 
-    log.debug("Extracted internal plugin", { name: plugin.name, path: pluginDir });
+    log.debug("Materialized internal plugin", { name: plugin.name, path: pluginDir });
   }
-
-  internalPluginsExtracted = true;
-  log.info("Internal plugins extracted", {
-    count: internalPlugins.length,
-    dir: INTERNAL_PLUGINS_DIR,
-  });
 }
 
 /**
- * Get internal plugins (embedded, extracted to temp).
+ * Get internal plugins from the process-local immutable snapshot.
  */
 function getInternalPlugins(): PluginSpec[] {
-  const internalPlugins = loadInternalPlugins();
-  extractInternalPlugins();
+  if (internalPluginSpecs) {
+    return internalPluginSpecs;
+  }
 
-  return internalPlugins.map((plugin) => ({
+  const internalPlugins = loadInternalPlugins();
+  const snapshotDir = materializeInternalPluginsSnapshot(internalPlugins);
+
+  internalPluginSpecs = internalPlugins.map((plugin) => ({
     type: "local" as const,
-    path: join(INTERNAL_PLUGINS_DIR, plugin.name),
+    path: join(snapshotDir, plugin.name),
   }));
+  log.info("Internal plugins loaded", {
+    count: internalPlugins.length,
+    dir: snapshotDir,
+  });
+  return internalPluginSpecs;
 }
 
 /**

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -47,6 +47,7 @@ import {
 import { resolveSessionOutputTarget } from "./session-output-target.js";
 import { resolveRuntimeIdleSessionTtlMs } from "./session-pool.js";
 import { markRuntimeLiveIdle, updateRuntimeLiveState } from "./live-state.js";
+import { formatUserFacingTurnFailure, publicRuntimeFailureDetail } from "./public-failure.js";
 import {
   createObservationEvent,
   deliverObservationEvents,
@@ -75,7 +76,6 @@ const log = logger.child("bot");
 
 const MAX_OUTPUT_LENGTH = 1000;
 const MAX_TURN_FAILURE_LOG_DETAIL = 1800;
-const MAX_TURN_FAILURE_RESPONSE = 320;
 const PROVIDER_INACTIVE_AFTER_TOOL_REASON = "provider_inactive";
 const PROVIDER_TURN_INACTIVITY_REASON = "provider_turn_inactive";
 const IDLE_SESSION_TTL_REASON = "idle_session_ttl";
@@ -504,19 +504,6 @@ function buildUserFacingFailureSuppressionScope(input: {
     ? `${source.channel}:${source.accountId ?? ""}:${source.chatId ?? source.canonicalChatId ?? ""}`
     : input.sessionKey;
   return `${input.provider}:${outputScope}`;
-}
-
-export function formatUserFacingTurnFailure(error: string): string {
-  const firstLine = error
-    .split("\n")
-    .map((line) => line.trim())
-    .find(Boolean);
-  const detail = firstLine ?? (error.trim() || "unknown error");
-  const clipped =
-    detail.length > MAX_TURN_FAILURE_RESPONSE
-      ? `${detail.slice(0, MAX_TURN_FAILURE_RESPONSE - 15)}... [truncated]`
-      : detail;
-  return `Error: ${clipped}`;
 }
 
 function resolveCostTrackingModel(
@@ -2280,7 +2267,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           provider: runtimeSession.provider,
           recoverable: event.recoverable ?? true,
           suppressedRecoverable,
-          error: event.error,
+          error: publicRuntimeFailureDetail(event.error),
           abortReason: null,
         });
         clearTraceTurnState();
@@ -2311,7 +2298,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         }
         updateRuntimeLiveState(sessionName, {
           activity: "blocked",
-          summary: truncateLiveSummary(event.error) || "turn failed",
+          summary: truncateLiveSummary(publicRuntimeFailureDetail(event.error)) || "turn failed",
           agentId: agent.id,
           runId,
           provider: runtimeSession.provider,

--- a/src/runtime/public-failure.test.ts
+++ b/src/runtime/public-failure.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { formatUserFacingTurnFailure, publicRuntimeFailureDetail } from "./public-failure.js";
+
+describe("public runtime failures", () => {
+  it("hides filesystem errors and local paths", () => {
+    const raw = "ENOENT: no such file or directory, scandir '/Users/luis/.cache/ravi/plugins/ravi-system/skills/slack'";
+    const formatted = formatUserFacingTurnFailure(raw);
+
+    expect(formatted).toBe(
+      "Error: The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+    expect(formatted).not.toContain("ENOENT");
+    expect(formatted).not.toContain("scandir");
+    expect(formatted).not.toContain("/Users/luis");
+  });
+
+  it.each([
+    "TypeError: handler is not a function",
+    "ReferenceError: runtimeState is not defined",
+    "Could not read file:///private/tmp/ravi/config.json",
+    "Failed while loading path=/workspace/ravi/runtime/config.json",
+    "Failed while loading `/tmp`",
+    "Failed while loading /nix/store/abc123-ravi/runtime.json",
+    "Failed while loading ~/ravi/main/AGENTS.md",
+    "EACCES: permission denied, open 'C:\\Users\\Luis\\secret.txt'",
+    "Failed while loading C:/custom/ravi/config.json",
+    "Failed while loading \\\\fileserver\\private\\config.json",
+    "Error [ERR_MODULE_NOT_FOUND]: Cannot find package ravi-system",
+    "Internal plugin ravi-system is missing its manifest",
+    "Cannot read properties of undefined (reading 'path')",
+    "runtimeState is not defined",
+    "Maximum call stack size exceeded",
+    "Cannot find module ravi-system",
+    "request failed with token=secret-token-value",
+    "request failed with xoxb-1234567890-abcdefghij",
+    "request failed with xapp-1234567890-abcdefghij",
+    "request failed with github_pat_1234567890abcdefghij",
+    "request failed with AIzaSyA1234567890abcdefghijklmno",
+    "request failed with eyJabcdefghij.eyJabcdefghij.signature123",
+    "database failed at postgresql://admin:secret@db.internal/ravi",
+    "request failed at https://admin:secret@example.com/private",
+    "AWS_SECRET_ACCESS_KEY=secret-value",
+    "AWS_SESSION_TOKEN=session-token-value",
+    "request failed at https://example.com/callback?auth=secret-value",
+    'Config invalid: {"password":"hunter2","host":"db"}',
+    'Config invalid: {"token":"secret-token-value"}',
+    'Config invalid: {"apiKey":"secret-api-key-value"}',
+    "Request failed with Authorization: Basic dXNlcjpzdXBlcnNlY3JldA==",
+  ])("hides technical or sensitive detail: %s", (raw) => {
+    expect(publicRuntimeFailureDetail(raw)).toBe(
+      "The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+  });
+
+  it("preserves actionable provider errors", () => {
+    expect(formatUserFacingTurnFailure("Runtime provider requires full access for this agent.")).toBe(
+      "Error: Runtime provider requires full access for this agent.",
+    );
+    expect(formatUserFacingTurnFailure("Usage limit reached. Try again after 14:30.")).toBe(
+      "Error: Usage limit reached. Try again after 14:30.",
+    );
+    expect(formatUserFacingTurnFailure("See https://status.openai.com for updates.")).toBe(
+      "Error: See https://status.openai.com for updates.",
+    );
+    expect(formatUserFacingTurnFailure("Provider says see /docs/auth for remediation.")).toBe(
+      "Error: Provider says see /docs/auth for remediation.",
+    );
+    expect(formatUserFacingTurnFailure("Provider says path=/docs/auth for remediation.")).toBe(
+      "Error: Provider says path=/docs/auth for remediation.",
+    );
+    expect(formatUserFacingTurnFailure("Account cannot call /v1/responses; verify access.")).toBe(
+      "Error: Account cannot call /v1/responses; verify access.",
+    );
+    expect(formatUserFacingTurnFailure("RateLimitError: Usage limit reached. Try again later.")).toBe(
+      "Error: RateLimitError: Usage limit reached. Try again later.",
+    );
+    expect(formatUserFacingTurnFailure("AuthenticationError: Sign in again to continue.")).toBe(
+      "Error: AuthenticationError: Sign in again to continue.",
+    );
+    expect(formatUserFacingTurnFailure("PermissionError: This model requires organization verification.")).toBe(
+      "Error: PermissionError: This model requires organization verification.",
+    );
+    expect(formatUserFacingTurnFailure("Organization acme is not defined for this account.")).toBe(
+      "Error: Organization acme is not defined for this account.",
+    );
+  });
+
+  it("uses the Error subtype and hides non-string failures", () => {
+    expect(publicRuntimeFailureDetail(new TypeError("handler failed"))).toBe(
+      "The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+    expect(publicRuntimeFailureDetail({ message: "secret internal detail" })).toBe(
+      "The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+  });
+
+  it("avoids a duplicate Error prefix and bounds long details", () => {
+    expect(formatUserFacingTurnFailure("Error: Error: retry later")).toBe("Error: retry later");
+
+    const formatted = formatUserFacingTurnFailure("x".repeat(500));
+    expect(formatted.startsWith("Error: ")).toBe(true);
+    expect(formatted).toContain("... [truncated]");
+    expect(formatted.length).toBeLessThanOrEqual(327);
+  });
+});

--- a/src/runtime/public-failure.ts
+++ b/src/runtime/public-failure.ts
@@ -1,0 +1,56 @@
+const MAX_TURN_FAILURE_RESPONSE = 320;
+const INTERNAL_RUNTIME_FAILURE_MESSAGE =
+  "The agent could not complete this request because of an internal runtime error. Please try again.";
+
+const INTERNAL_ERROR_PATTERNS = [
+  /\b(?:ENOENT|EACCES|EPERM|ENOTDIR|EISDIR|EMFILE|ENFILE|scandir|ERR_[A-Z0-9_]+)\b/i,
+  /\b(?:Type|Reference|Range|Syntax|Aggregate|URI|Eval|Internal|Invariant|Assertion)Error(?:\s+\[[^\]]+\])?:/i,
+  /^(?:Cannot (?:read|set) properties of (?:undefined|null)|Cannot access [A-Za-z_$][\w$]* before initialization|(?:[A-Za-z_$][\w$]*|\([^)]+\)) is not (?:defined|a function)|Maximum call stack size exceeded|Cannot find (?:module|package)|Unexpected token|Invalid or unexpected token|require\(\) of ES Module|Cannot use import statement)\b/i,
+  /\bfile:\/\/[^\s'"`]+/i,
+  /['"`](?:~\/|[A-Za-z]:[\\/]|\\\\|\/(?!(?:docs?|v\d+|api|oauth|auth)(?:\/|$)))[^'"`\r\n]+['"`]/i,
+  /\b(?:path|cwd|directory|file)\s*(?:[=:]\s*|\s+)(?:~\/|[A-Za-z]:[\\/]|\\\\|\/(?!(?:docs?|v\d+|api|oauth|auth)(?:\/|$)|\/))\S+/i,
+  /(?:^|[\s"=:(])(?:~\/[^\s'"`]+|[A-Za-z]:[\\/][^\s'"`]+|\\\\[^\\\s'"`]+\\[^\s'"`]+|\/(?:Users|home|private|tmp|var|opt|etc|Applications|Volumes|workspace|root|srv|usr|mnt|data|app|code|Library|nix|run|System|builds)(?:\/[^\s'"`]*)?(?=$|[\s'"`),:;.]))/i,
+  /\bInternal plugins?\b/i,
+  /\b(?:sk-[A-Za-z0-9_-]{8,}|gh[oprsu]_[A-Za-z0-9]{8,}|github_pat_[A-Za-z0-9_]{8,}|xox[baprs]-[A-Za-z0-9-]{10,}|xapp-[A-Za-z0-9-]{10,}|AIza[A-Za-z0-9_-]{20,}|AKIA[A-Z0-9]{16}|Bearer\s+\S+)/i,
+  /(?:^|[\s'"?&])(?:(?:[A-Z0-9]+[_-])*(?:TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY|AUTH|CLIENTSECRET|ACCESSTOKEN|REFRESHTOKEN|SESSIONTOKEN|SECRETACCESSKEY)(?:[_-][A-Z0-9]+)*)\s*[=:]\s*[^\s&'"]+/i,
+  /["'](?:(?:[A-Z0-9]+[_-])*(?:TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY|AUTH|CLIENTSECRET|ACCESSTOKEN|REFRESHTOKEN|SESSIONTOKEN|SECRETACCESSKEY)(?:[_-][A-Z0-9]+)*)["']\s*:\s*["'][^"']+["']/i,
+  /\b(?:Proxy-)?Authorization\s*:\s*Basic\s+\S+/i,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/,
+  /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^@\s/]+@/i,
+  /\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis):\/\/\S+/i,
+];
+
+export function publicRuntimeFailureDetail(error: unknown): string {
+  const raw = runtimeFailureText(error);
+  if (raw === null) {
+    return INTERNAL_RUNTIME_FAILURE_MESSAGE;
+  }
+
+  const firstLine = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  const detail = (firstLine ?? raw.trim()).replace(/^(?:Error:\s*)+/i, "").trim();
+
+  if (!detail || INTERNAL_ERROR_PATTERNS.some((pattern) => pattern.test(detail))) {
+    return INTERNAL_RUNTIME_FAILURE_MESSAGE;
+  }
+
+  return detail.length > MAX_TURN_FAILURE_RESPONSE
+    ? `${detail.slice(0, MAX_TURN_FAILURE_RESPONSE - 15)}... [truncated]`
+    : detail;
+}
+
+export function formatUserFacingTurnFailure(error: unknown): string {
+  return `Error: ${publicRuntimeFailureDetail(error)}`;
+}
+
+function runtimeFailureText(error: unknown): string | null {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.name && error.name !== "Error" ? `${error.name}: ${error.message}` : error.message;
+  }
+  return null;
+}

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -32,7 +32,7 @@ import { applyDirectRuntimeModelSwitch, resolveRuntimeModelSwitchStrategy } from
 import { resolveAgentModelSelection } from "./model-preset-resolver.js";
 import { DEFAULT_RUNTIME_PROVIDER_ID } from "./provider-registry.js";
 import type { RuntimeProviderId } from "./types.js";
-import { formatUserFacingTurnFailure, type RuntimeSafeEmit } from "./host-event-loop.js";
+import type { RuntimeSafeEmit } from "./host-event-loop.js";
 import { markRuntimeLiveIdle, updateRuntimeLiveState } from "./live-state.js";
 import {
   startRuntimeSession,
@@ -40,6 +40,7 @@ import {
   type PendingRuntimeSessionStart,
 } from "./session-launcher.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { formatUserFacingTurnFailure } from "./public-failure.js";
 import { resolveSessionOutputTarget } from "./session-output-target.js";
 import { resolveRuntimeForPrompt, runtimePromptRequiresRestart } from "./task-runtime-context.js";
 import {

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -13,7 +13,7 @@ import { DEFAULT_RUNTIME_PROVIDER_ID, assertRuntimeCompatibility } from "./provi
 import { completeRuntimeCredentialAttempt, markRuntimeCredentialAttemptStarted } from "./credential-store.js";
 import { createQueuedRuntimeUserMessage } from "./delivery-queue.js";
 import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
-import { formatUserFacingTurnFailure, runRuntimeEventLoop, type RuntimeSafeEmit } from "./host-event-loop.js";
+import { runRuntimeEventLoop, type RuntimeSafeEmit } from "./host-event-loop.js";
 import { getRuntimeToolAccessMode } from "./host-services.js";
 import {
   createPendingRuntimeHandle,
@@ -27,6 +27,7 @@ import { resolveRuntimeSession } from "./session-resolver.js";
 import { markRuntimeTaskAcceptedForPrompt, resolveRuntimeForPrompt } from "./task-runtime-context.js";
 import { updateRuntimeLiveState } from "./live-state.js";
 import { ensureObserverBindingsForSession } from "./observation-plane.js";
+import { formatUserFacingTurnFailure, publicRuntimeFailureDetail } from "./public-failure.js";
 
 const log = logger.child("runtime:session-launcher");
 
@@ -362,7 +363,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     drainPendingStarts();
     updateRuntimeLiveState(sessionName, {
       activity: "blocked",
-      summary: errorMessage,
+      summary: publicRuntimeFailureDetail(err),
       agentId: agent.id,
       runId,
       provider: runtimeProviderId,
@@ -398,7 +399,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
 
     if (resolvedSource && agent.mode !== "sentinel") {
       await nats.emit(`ravi.session.${sessionName}.response`, {
-        response: formatUserFacingTurnFailure(errorMessage),
+        response: formatUserFacingTurnFailure(err),
         target: resolvedSource,
         _emitId: Math.random().toString(36).slice(2, 8),
         _instanceId: instanceId,

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1304,6 +1304,47 @@ describe("runtime session trace instrumentation", () => {
     expect(getSessionTurn("turn-failed")?.status).toBe("failed");
   });
 
+  it("keeps raw failure diagnostics internal while sanitizing the external response and live state", async () => {
+    attachSpeakingOutputChat();
+    const rawError =
+      "ENOENT: no such file or directory, scandir '/Users/luis/.cache/ravi/plugins/ravi-system/skills/slack'";
+    const streaming = makeStreamingSession({ agentMode: "active" });
+    seedAdapterTrace(streaming, "turn-internal-failure");
+    const responses: string[] = [];
+    const emitSpy = spyOn(nats, "emit").mockImplementation(async (topic: string, data: unknown) => {
+      if (topic === `ravi.session.${SESSION_NAME}.response` && data && typeof data === "object") {
+        const response = (data as { response?: unknown }).response;
+        if (typeof response === "string") responses.push(response);
+      }
+    });
+
+    try {
+      await runTraceLoop(
+        streaming,
+        makeRuntimeSession([
+          {
+            type: "turn.failed",
+            error: rawError,
+            recoverable: false,
+          },
+        ]),
+      );
+    } finally {
+      emitSpy.mockRestore();
+    }
+
+    expect(responses).toEqual([
+      "Error: The agent could not complete this request because of an internal runtime error. Please try again.",
+    ]);
+    expect(responses.join("\n")).not.toContain("/Users/luis");
+    expect(getRuntimeLiveStateForSession(makeSession())?.summary).toBe(
+      "The agent could not complete this request because of an internal runtime error. Please try again.",
+    );
+
+    const terminal = listSessionEvents(SESSION_KEY).find((event) => event.eventType === "turn.failed");
+    expect(terminal?.error).toBe(rawError);
+  });
+
   it("deduplicates user-facing provider session limit failures within the same reset window", () => {
     const now = new Date("2026-06-16T15:56:00-03:00").getTime();
     const scope = "codex:whatsapp:main:120363424772797713@g.us";


### PR DESCRIPTION
## Objective

Prevent concurrent Ravi processes from deleting internal plugin files that another live session is reading, and keep internal runtime diagnostics out of user-facing responses. This fixes the `ENOENT ... scandir .../skills/slack` failure observed in session `main` after restart.

## Problem

- Every Ravi process extracted embedded plugins into the same mutable `~/.cache/ravi/plugins/<name>` directory by deleting and recreating it.
- A cron command launched an older Ravi CLI while the restarted daemon was syncing the Slack skill. The old process removed `ravi-system` mid-read, causing the startup `ENOENT`; it could also silently replace a newer plugin set with older content.
- Startup and turn failures copied raw runtime errors into channel responses, live state, waited `sessions send` errors, and observation prompts, exposing local paths and potentially credential-shaped values.

## Solution

- Materialize embedded plugins into immutable content-addressed snapshots at `~/.cache/ravi/plugins/.snapshots/<digest>/<plugin>`.
- Build each snapshot in a private staging directory, write a completion marker last, and publish it with one atomic rename.
- Reuse only complete snapshots and never mutate or prune a published snapshot in the discovery hot path, so rolling versions keep stable paths.
- Centralize public runtime-failure formatting. Channel responses, live state, waited CLI errors, and observation prompts receive sanitized details; logs, traces, and internal runtime events retain the raw diagnostic.
- Preserve actionable provider guidance such as rate limits, authentication, permission, and status messages while filtering filesystem/runtime details and common credential formats.

## Practical impact

- Restarting the daemon while cron or operator CLIs run no longer invalidates plugin paths held by session `main` or another live session.
- Users receive a stable internal-error message instead of local paths, stack/runtime details, or secrets.
- Operators still have the full underlying error in daemon logs and runtime traces.

## What does NOT change

- User plugins under `~/ravi/plugins` keep their existing discovery and lifecycle.
- Plugin order and plugin basenames presented to the SDK remain unchanged.
- Actionable provider failures remain visible to users.
- Internal runtime events and traces remain diagnostic surfaces and retain raw errors.

## Validation

- Pre-push gate passed: SDK drift check, production build, TypeScript, full `bun run test`, and SDK integration tests.
- `make quality` passed across 915 files.
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts` passed for `plugins`, `plugins/locations`, and `runtime`.
- Focused tests cover six concurrent Bun publishers, old/new artifact coexistence, a legacy flat-cache rewrite, incomplete snapshots, the production startup ENOENT path, channel/live/CLI containment, raw trace retention, provider guidance, local paths, runtime exceptions, and common credential formats.
- Independent code, spec, and failure-surface reviews found no remaining blockers.

## Risks

- Published snapshots are intentionally retained because deleting one safely requires proving no live process still references it. Cache cleanup is deferred instead of risking the same outage class.
- A completion marker proves atomic publication, not protection against later manual corruption of an immutable snapshot.

## Rollback

- Revert this commit and restart the daemon. Existing `.snapshots` directories are inert cache data for older runtimes and can remain on disk.

## Follow-ups

- Harden the separate `~/.codex/skills` synchronization path, which still updates managed destination skills in place. It did not cause this `~/.cache/ravi/plugins/...` incident and should be isolated in a follow-up PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->