### PR TITLE
fix(slack): recover half-open Socket Mode connections

### DIFF
--- a/.ravi/specs/channels/adapters/slack/CHECKS.md
+++ b/.ravi/specs/channels/adapters/slack/CHECKS.md
@@ -24,6 +24,14 @@
 - [ ] Missing credentials MUST disable the adapter.
 - [ ] Env fallback MUST be opt-in.
 - [ ] Tests MUST cover routing policy and native delivery.
+- [ ] A newly started Socket Mode service MUST remain connecting until the active socket opens and receives its bounded initial `hello`.
+- [ ] A quiet healthy workspace MUST remain connected through WebSocket ping/pong heartbeats without requiring application messages.
+- [ ] A missing `hello` or pong MUST terminate and replace the stale socket without waiting for its `close` callback.
+- [ ] Socket errors and Slack `disconnect` warnings or `refresh_requested` envelopes MUST trigger bounded reconnection.
+- [ ] Late callbacks from a retired socket generation MUST NOT replace, close, or regress the health state of the active socket.
+- [ ] Explicit shutdown MUST cancel heartbeat/deadline timers and MUST NOT reconnect afterward.
+- [ ] Explicit shutdown MUST settle while `apps.connections.open` is pending and MUST ignore its late result.
+- [ ] Socket lifecycle snapshots MUST report connecting, connected, and reconnecting with non-secret reasons and health timestamps.
 - [ ] An identity stored under the configured UUID MUST resolve when inbound Slack uses the account slug for that same instance.
 - [ ] An identity stored under the configured slug MUST resolve when inbound Slack uses the configured UUID for that same instance.
 - [ ] The same Slack user id in another workspace MUST NOT be selected.

--- a/.ravi/specs/channels/adapters/slack/SPEC.md
+++ b/.ravi/specs/channels/adapters/slack/SPEC.md
@@ -28,6 +28,33 @@ The Slack adapter MUST support:
 - working presence via temporary reaction on the inbound Slack message;
 - delivery event emission.
 
+## Socket Liveness
+
+The adapter MUST verify Socket Mode liveness independently of application
+message traffic so a quiet workspace can remain connected without masking a
+half-open connection.
+
+For every Socket Mode connection, the adapter MUST:
+
+- require the initial Slack `hello` within a bounded timeout;
+- send transport-level WebSocket ping frames on a bounded interval;
+- require a matching pong within a bounded deadline;
+- terminate and replace the socket when the hello or pong deadline expires,
+  without depending on the stale socket to emit `close`;
+- reconnect after a socket error even when no later `close` callback arrives;
+- rotate the connection when Slack sends a `disconnect` envelope whose reason
+  is `warning` or `refresh_requested`;
+- ignore late callbacks and timers from a retired socket generation; and
+- cancel heartbeat, deadline, and reconnect work during explicit shutdown.
+- let explicit shutdown settle without waiting for an in-flight
+  `apps.connections.open` request to finish.
+
+The adapter MUST expose live lifecycle state from actual socket events. Calling
+`start()` MUST NOT itself mean `connected`; only the active socket's open/hello
+lifecycle may establish health. State snapshots MUST distinguish connecting,
+connected, and reconnecting, and MUST retain non-secret transition reasons and
+timestamps useful for health diagnosis.
+
 ## Thread Policy
 
 The adapter MUST distinguish:

--- a/.ravi/specs/channels/runner/CHECKS.md
+++ b/.ravi/specs/channels/runner/CHECKS.md
@@ -6,3 +6,10 @@
 - [ ] Runner MUST run without Slack credentials and report the adapter as disabled.
 - [ ] Runner MUST emit delivery events after adapter send.
 - [ ] Runner shutdown MUST close sockets and NATS clients.
+- [ ] Runner MUST NOT report a Slack adapter as connected before the active socket reports healthy lifecycle state.
+- [ ] Runner status MUST reflect connecting, connected, reconnecting, and disconnected transitions for each Slack account.
+- [ ] Adapter status MUST include non-secret transition reasons and lifecycle/health timestamps.
+- [ ] One Slack account reconnecting MUST NOT regress the status of another healthy Slack account.
+- [ ] Runner shutdown MUST suppress late adapter callbacks and MUST leave every stopped Slack adapter disconnected.
+- [ ] PM2 process liveness alone MUST NOT be presented as Slack connection health.
+- [ ] A PM2 PID change during health probing MUST refresh the process snapshot and retry the replacement PID once.

--- a/.ravi/specs/channels/runner/SPEC.md
+++ b/.ravi/specs/channels/runner/SPEC.md
@@ -39,7 +39,30 @@ The runner MUST expose:
 - `ravi channels run`
 - `ravi channels probe`
 
+## Adapter Health
+
+The runner MUST derive each adapter's live status from the adapter lifecycle,
+not from process existence or from having invoked `start()` successfully.
+
+For each configured Slack account, runner status MUST:
+
+- remain starting/connecting until the active Socket Mode connection is
+  actually healthy;
+- transition through connected and reconnecting as the socket heartbeat and
+  recovery loop changes state;
+- retain non-secret transition reasons and lifecycle/health timestamps;
+- recover independently from the state of other Slack accounts; and
+- transition to disconnected during explicit runner shutdown without allowing
+  retired adapter callbacks to restore an online state.
+
+A PM2 process reported as online MUST NOT, by itself, be treated as proof that a
+Slack adapter is connected.
+
+Live status MUST scope its health request to the PM2 runner PID. If that PID
+changes while the request is in flight, status MUST refresh the PM2 snapshot
+and retry once against the replacement process instead of reporting the stale
+PID as current.
+
 ## Locks
 
 Adapters SHOULD use process or credential-scoped locks before opening external sockets. Slack MUST prevent duplicate Socket Mode consumers for the same connection.
-

--- a/.ravi/specs/quality/ci-gates/CHECKS.md
+++ b/.ravi/specs/quality/ci-gates/CHECKS.md
@@ -19,6 +19,8 @@ status: active
 
 ## Coverage Gate Checks
 
+- A diff containing `src/channels/**` without a mapped health, runner, or Socket Mode test fails with a message naming the expected channel coverage.
+- A diff containing `src/channels/**` and at least one mapped focused channel test passes the coverage gate.
 - A diff containing `src/omni/consumer.ts` without a corresponding test file in the diff fails with a message naming the expected coverage, even if the test file exists on disk.
 - A diff containing `src/omni/consumer.ts` and `src/omni/consumer-context.test.ts` passes the coverage gate.
 - A docs-only diff (`docs/**` or `.ravi/specs/**` only) skips the coverage gate but still runs spec validation.

--- a/.ravi/specs/quality/ci-gates/SPEC.md
+++ b/.ravi/specs/quality/ci-gates/SPEC.md
@@ -46,6 +46,7 @@ The incident that motivated this capability: PR #131 passed GitHub CI but failed
 
 The following source paths are considered runtime/consumer paths that require focused test coverage:
 
+- `src/channels/**`
 - `src/omni/**`
 - `src/router/**`
 - `src/runtime/**`
@@ -53,6 +54,10 @@ The following source paths are considered runtime/consumer paths that require fo
 - `src/triggers/**`
 - `src/approval/**`
 - `src/devin/**`
+
+High-risk channel lifecycle files MUST also map to their own focused health,
+runner, or Socket Mode test so an unrelated channel test cannot satisfy their
+coverage requirement.
 
 ## Validation
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.4",
         "reflect-metadata": "^0.2.2",
+        "ws": "^8.21.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -32,6 +33,7 @@
         "@types/node": "^22.0.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/react": "^19.2.10",
+        "@types/ws": "^8.18.1",
         "bun-types": "^1.3.8",
         "typescript": "^5.6.0",
       },
@@ -273,6 +275,8 @@
     "@types/qrcode-terminal": ["@types/qrcode-terminal@0.12.2", "", {}, "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q=="],
 
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
@@ -812,7 +816,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
 
@@ -825,6 +829,10 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@elevenlabs/elevenlabs-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "@google/genai/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -903,6 +911,8 @@
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 
     "ink/react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "ink/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typecheck": "bun tsc --noEmit",
     "lint": "bunx biome check src/",
     "lint:fix": "bunx biome check --write src/",
-    "test": "bun test src/bash/ src/hooks/ src/router/ src/heartbeat/ src/permissions/ src/triggers/ src/omni/ src/plugins/ src/adapters/ src/approval/ src/tui/hooks/runtime-feed.test.ts src/tui/hooks/runtime-display.test.ts src/gateway-typing.test.ts && bun test src/tasks/ src/projects/ src/workflow-substrate/ src/whatsapp-overlay/ && bun run test:cli-commands && bun test src/bot.runtime-guards.test.ts && bun test src/remote-spawn-nats.test.ts && bun test src/runtime/index.test.ts src/runtime/model-catalog.test.ts src/runtime/allowed-skills.test.ts src/runtime/observation-plane.test.ts src/runtime/runtime-request-context.test.ts && bun test src/runtime/context-registry.test.ts && bun test src/cli/context.test.ts src/cli/logging.test.ts src/cli/tui-launcher.test.ts && bun test src/utils/logger.test.ts && bun test src/transcripts.test.ts && bun test src/ci/quality-gate.test.ts && bun run test:sdk",
+    "test": "bun test src/channels/ && bun test src/bash/ src/hooks/ src/router/ src/heartbeat/ src/permissions/ src/triggers/ src/omni/ src/plugins/ src/adapters/ src/approval/ src/tui/hooks/runtime-feed.test.ts src/tui/hooks/runtime-display.test.ts src/gateway-typing.test.ts && bun test src/tasks/ src/projects/ src/workflow-substrate/ src/whatsapp-overlay/ && bun run test:cli-commands && bun test src/bot.runtime-guards.test.ts && bun test src/remote-spawn-nats.test.ts && bun test src/runtime/index.test.ts src/runtime/model-catalog.test.ts src/runtime/allowed-skills.test.ts src/runtime/observation-plane.test.ts src/runtime/runtime-request-context.test.ts && bun test src/runtime/context-registry.test.ts && bun test src/cli/context.test.ts src/cli/logging.test.ts src/cli/tui-launcher.test.ts && bun test src/utils/logger.test.ts && bun test src/transcripts.test.ts && bun test src/ci/quality-gate.test.ts && bun run test:sdk",
     "test:sdk": "bun test src/sdk/client-codegen/ ./tests/integration/sdk-roundtrip.test.ts ./packages/ravi-os-sdk/src/__tests__/types.test-d.ts ./packages/ravi-os-sdk/src/__tests__/streaming.test.ts && bun run sdk:check",
     "test:cli-commands": "for f in src/cli/commands/*.test.ts; do bun test \"$f\" || exit 1; done",
     "test:live": "RAVI_LIVE_TESTS=1 bun test src/runtime/*.live.test.ts && RAVI_LIVE_TESTS=1 bun test src/bot.live.test.ts",
@@ -92,6 +92,7 @@
     "qrcode-terminal": "^0.12.0",
     "react": "^19.2.4",
     "reflect-metadata": "^0.2.2",
+    "ws": "^8.21.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -99,6 +100,7 @@
     "@types/node": "^22.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/react": "^19.2.10",
+    "@types/ws": "^8.18.1",
     "bun-types": "^1.3.8",
     "typescript": "^5.6.0"
   }

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -12984,6 +12984,36 @@ export const ChannelsRestartReturnSchema = {
           ],
           "type": "object"
         },
+        "health": {
+          "additionalProperties": false,
+          "properties": {
+            "checkedAt": {
+              "type": "number"
+            },
+            "reachable": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "ready",
+                "starting",
+                "degraded",
+                "unreachable",
+                "stopped"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reachable",
+            "checkedAt"
+          ],
+          "type": "object"
+        },
         "pm2Available": {
           "type": "boolean"
         },
@@ -13071,6 +13101,127 @@ export const ChannelsRestartReturnSchema = {
             "type": "object"
           },
           "type": "array"
+        },
+        "runner": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "adapters": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "channelId": {
+                        "type": "string"
+                      },
+                      "connectedAt": {
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "lastPongAt": {
+                        "type": "number"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "reconnectCount": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "enum": [
+                          "disabled",
+                          "starting",
+                          "connected",
+                          "degraded",
+                          "reconnecting",
+                          "disconnected",
+                          "failed"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "channelId",
+                      "status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "observedAt": {
+                  "type": "number"
+                },
+                "outbound": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "consumer": {
+                      "type": "string"
+                    },
+                    "consuming": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "infrastructureReady": {
+                      "type": "boolean"
+                    },
+                    "stream": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "stream",
+                    "consumer",
+                    "enabled",
+                    "infrastructureReady",
+                    "consuming"
+                  ],
+                  "type": "object"
+                },
+                "pid": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991,
+                  "type": "integer"
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "schemaVersion": {
+                  "const": 1,
+                  "type": "number"
+                },
+                "startedAt": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "schemaVersion",
+                "observedAt",
+                "running",
+                "startedAt",
+                "pid",
+                "outbound",
+                "adapters"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -13460,6 +13611,36 @@ export const ChannelsStartReturnSchema = {
           ],
           "type": "object"
         },
+        "health": {
+          "additionalProperties": false,
+          "properties": {
+            "checkedAt": {
+              "type": "number"
+            },
+            "reachable": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "ready",
+                "starting",
+                "degraded",
+                "unreachable",
+                "stopped"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reachable",
+            "checkedAt"
+          ],
+          "type": "object"
+        },
         "pm2Available": {
           "type": "boolean"
         },
@@ -13547,6 +13728,127 @@ export const ChannelsStartReturnSchema = {
             "type": "object"
           },
           "type": "array"
+        },
+        "runner": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "adapters": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "channelId": {
+                        "type": "string"
+                      },
+                      "connectedAt": {
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "lastPongAt": {
+                        "type": "number"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "reconnectCount": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "enum": [
+                          "disabled",
+                          "starting",
+                          "connected",
+                          "degraded",
+                          "reconnecting",
+                          "disconnected",
+                          "failed"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "channelId",
+                      "status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "observedAt": {
+                  "type": "number"
+                },
+                "outbound": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "consumer": {
+                      "type": "string"
+                    },
+                    "consuming": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "infrastructureReady": {
+                      "type": "boolean"
+                    },
+                    "stream": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "stream",
+                    "consumer",
+                    "enabled",
+                    "infrastructureReady",
+                    "consuming"
+                  ],
+                  "type": "object"
+                },
+                "pid": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991,
+                  "type": "integer"
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "schemaVersion": {
+                  "const": 1,
+                  "type": "number"
+                },
+                "startedAt": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "schemaVersion",
+                "observedAt",
+                "running",
+                "startedAt",
+                "pid",
+                "outbound",
+                "adapters"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -13674,6 +13976,36 @@ export const ChannelsStatusReturnSchema = {
       ],
       "type": "object"
     },
+    "health": {
+      "additionalProperties": false,
+      "properties": {
+        "checkedAt": {
+          "type": "number"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "ready",
+            "starting",
+            "degraded",
+            "unreachable",
+            "stopped"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "reachable",
+        "checkedAt"
+      ],
+      "type": "object"
+    },
     "pm2Available": {
       "type": "boolean"
     },
@@ -13761,6 +14093,127 @@ export const ChannelsStatusReturnSchema = {
         "type": "object"
       },
       "type": "array"
+    },
+    "runner": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "adapters": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "channelId": {
+                    "type": "string"
+                  },
+                  "connectedAt": {
+                    "type": "number"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "lastPongAt": {
+                    "type": "number"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "reconnectCount": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "status": {
+                    "enum": [
+                      "disabled",
+                      "starting",
+                      "connected",
+                      "degraded",
+                      "reconnecting",
+                      "disconnected",
+                      "failed"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "channelId",
+                  "status"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "observedAt": {
+              "type": "number"
+            },
+            "outbound": {
+              "additionalProperties": false,
+              "properties": {
+                "consumer": {
+                  "type": "string"
+                },
+                "consuming": {
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "infrastructureReady": {
+                  "type": "boolean"
+                },
+                "stream": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "stream",
+                "consumer",
+                "enabled",
+                "infrastructureReady",
+                "consuming"
+              ],
+              "type": "object"
+            },
+            "pid": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "running": {
+              "type": "boolean"
+            },
+            "schemaVersion": {
+              "const": 1,
+              "type": "number"
+            },
+            "startedAt": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "schemaVersion",
+            "observedAt",
+            "running",
+            "startedAt",
+            "pid",
+            "outbound",
+            "adapters"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [
@@ -13900,6 +14353,36 @@ export const ChannelsStopReturnSchema = {
           ],
           "type": "object"
         },
+        "health": {
+          "additionalProperties": false,
+          "properties": {
+            "checkedAt": {
+              "type": "number"
+            },
+            "reachable": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "ready",
+                "starting",
+                "degraded",
+                "unreachable",
+                "stopped"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reachable",
+            "checkedAt"
+          ],
+          "type": "object"
+        },
         "pm2Available": {
           "type": "boolean"
         },
@@ -13987,6 +14470,127 @@ export const ChannelsStopReturnSchema = {
             "type": "object"
           },
           "type": "array"
+        },
+        "runner": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "adapters": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "channelId": {
+                        "type": "string"
+                      },
+                      "connectedAt": {
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "lastPongAt": {
+                        "type": "number"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "reconnectCount": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "enum": [
+                          "disabled",
+                          "starting",
+                          "connected",
+                          "degraded",
+                          "reconnecting",
+                          "disconnected",
+                          "failed"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "channelId",
+                      "status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "observedAt": {
+                  "type": "number"
+                },
+                "outbound": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "consumer": {
+                      "type": "string"
+                    },
+                    "consuming": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "infrastructureReady": {
+                      "type": "boolean"
+                    },
+                    "stream": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "stream",
+                    "consumer",
+                    "enabled",
+                    "infrastructureReady",
+                    "consuming"
+                  ],
+                  "type": "object"
+                },
+                "pid": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991,
+                  "type": "integer"
+                },
+                "running": {
+                  "type": "boolean"
+                },
+                "schemaVersion": {
+                  "const": 1,
+                  "type": "number"
+                },
+                "startedAt": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "schemaVersion",
+                "observedAt",
+                "running",
+                "startedAt",
+                "pid",
+                "outbound",
+                "adapters"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -2321,6 +2321,12 @@ export type ChannelsRestartReturn = {
       running: boolean;
       status: string;
     };
+    health?: {
+      checkedAt: number;
+      reachable: boolean;
+      reason?: string;
+      status: "ready" | "starting" | "degraded" | "unreachable" | "stopped";
+    };
     pm2Available: boolean;
     processName: string;
     processes: Array<{
@@ -2334,6 +2340,29 @@ export type ChannelsRestartReturn = {
       running: boolean;
       status: string;
     }>;
+    runner?: ({
+      adapters: Array<{
+        channelId: string;
+        connectedAt?: number;
+        id: string;
+        lastPongAt?: number;
+        reason?: string;
+        reconnectCount?: number;
+        status: "disabled" | "starting" | "connected" | "degraded" | "reconnecting" | "disconnected" | "failed";
+      }>;
+      observedAt: number;
+      outbound: {
+        consumer: string;
+        consuming: boolean;
+        enabled: boolean;
+        infrastructureReady: boolean;
+        stream: string;
+      };
+      pid: number;
+      running: boolean;
+      schemaVersion: 1;
+      startedAt: number | null;
+    }) | null;
   };
   target?: {
     bundlePath: string;
@@ -2409,6 +2438,12 @@ export type ChannelsStartReturn = {
       running: boolean;
       status: string;
     };
+    health?: {
+      checkedAt: number;
+      reachable: boolean;
+      reason?: string;
+      status: "ready" | "starting" | "degraded" | "unreachable" | "stopped";
+    };
     pm2Available: boolean;
     processName: string;
     processes: Array<{
@@ -2422,6 +2457,29 @@ export type ChannelsStartReturn = {
       running: boolean;
       status: string;
     }>;
+    runner?: ({
+      adapters: Array<{
+        channelId: string;
+        connectedAt?: number;
+        id: string;
+        lastPongAt?: number;
+        reason?: string;
+        reconnectCount?: number;
+        status: "disabled" | "starting" | "connected" | "degraded" | "reconnecting" | "disconnected" | "failed";
+      }>;
+      observedAt: number;
+      outbound: {
+        consumer: string;
+        consuming: boolean;
+        enabled: boolean;
+        infrastructureReady: boolean;
+        stream: string;
+      };
+      pid: number;
+      running: boolean;
+      schemaVersion: 1;
+      startedAt: number | null;
+    }) | null;
   };
   target?: {
     bundlePath: string;
@@ -2446,6 +2504,12 @@ export type ChannelsStatusReturn = {
     running: boolean;
     status: string;
   };
+  health?: {
+    checkedAt: number;
+    reachable: boolean;
+    reason?: string;
+    status: "ready" | "starting" | "degraded" | "unreachable" | "stopped";
+  };
   pm2Available: boolean;
   processName: string;
   processes: Array<{
@@ -2459,6 +2523,29 @@ export type ChannelsStatusReturn = {
     running: boolean;
     status: string;
   }>;
+  runner?: ({
+    adapters: Array<{
+      channelId: string;
+      connectedAt?: number;
+      id: string;
+      lastPongAt?: number;
+      reason?: string;
+      reconnectCount?: number;
+      status: "disabled" | "starting" | "connected" | "degraded" | "reconnecting" | "disconnected" | "failed";
+    }>;
+    observedAt: number;
+    outbound: {
+      consumer: string;
+      consuming: boolean;
+      enabled: boolean;
+      infrastructureReady: boolean;
+      stream: string;
+    };
+    pid: number;
+    running: boolean;
+    schemaVersion: 1;
+    startedAt: number | null;
+  }) | null;
 };
 
 /** Input shape for `channels.stop`. */
@@ -2486,6 +2573,12 @@ export type ChannelsStopReturn = {
       running: boolean;
       status: string;
     };
+    health?: {
+      checkedAt: number;
+      reachable: boolean;
+      reason?: string;
+      status: "ready" | "starting" | "degraded" | "unreachable" | "stopped";
+    };
     pm2Available: boolean;
     processName: string;
     processes: Array<{
@@ -2499,6 +2592,29 @@ export type ChannelsStopReturn = {
       running: boolean;
       status: string;
     }>;
+    runner?: ({
+      adapters: Array<{
+        channelId: string;
+        connectedAt?: number;
+        id: string;
+        lastPongAt?: number;
+        reason?: string;
+        reconnectCount?: number;
+        status: "disabled" | "starting" | "connected" | "degraded" | "reconnecting" | "disconnected" | "failed";
+      }>;
+      observedAt: number;
+      outbound: {
+        consumer: string;
+        consuming: boolean;
+        enabled: boolean;
+        infrastructureReady: boolean;
+        stream: string;
+      };
+      pid: number;
+      running: boolean;
+      schemaVersion: 1;
+      startedAt: number | null;
+    }) | null;
   };
   target?: {
     bundlePath: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:a5bf134c7b648edd0dfd492c0b3bc352f468b7da7d896dbbe4e003722fcb39bb";
+export const REGISTRY_HASH = "sha256:593c8a5800d290268a78d35e472fcdf4c4945c11034b8223ad3d52511a7627d8";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "86280f640db6";
+export const GIT_SHA = "98ae95bdd4f3";

--- a/src/channels/health.test.ts
+++ b/src/channels/health.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, mock } from "bun:test";
+import { JSONCodec } from "nats";
+import {
+  CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION,
+  channelRunnerHealthSubject,
+  createChannelRunnerHealthSnapshot,
+  probeChannelRunnerHealth,
+  startChannelRunnerHealthResponder,
+  type ChannelRunnerHealthMessage,
+  type ChannelRunnerHealthRequestConnection,
+  type ChannelRunnerHealthSubscription,
+  type ChannelRunnerRuntimeStatus,
+} from "./health.js";
+
+const codec = JSONCodec<unknown>();
+
+function runtimeStatus(pid = 4242): ChannelRunnerRuntimeStatus {
+  return {
+    running: true,
+    startedAt: 1_721_563_200_000,
+    pid,
+    outbound: {
+      stream: "CHANNEL_OUTBOUND",
+      consumer: "ravi-channels-outbound",
+      enabled: true,
+      infrastructureReady: true,
+      consuming: true,
+    },
+    adapters: [
+      {
+        id: "slack:hana-slack",
+        channelId: "slack",
+        status: "connected",
+        connectedAt: 1_721_563_201_000,
+        lastPongAt: 1_721_563_202_000,
+        reconnectCount: 1,
+      },
+    ],
+  };
+}
+
+class TestSubscription implements ChannelRunnerHealthSubscription {
+  private readonly messages: ChannelRunnerHealthMessage[] = [];
+  private waiter: (() => void) | null = null;
+  private stopped = false;
+  unsubscribe = mock(() => {
+    this.stopped = true;
+    this.waiter?.();
+  });
+
+  push(message: ChannelRunnerHealthMessage): void {
+    this.messages.push(message);
+    this.waiter?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<ChannelRunnerHealthMessage> {
+    while (!this.stopped) {
+      const message = this.messages.shift();
+      if (message) {
+        yield message;
+        continue;
+      }
+      await new Promise<void>((resolve) => {
+        this.waiter = resolve;
+      });
+      this.waiter = null;
+    }
+  }
+}
+
+describe("channel runner health contract", () => {
+  it("uses a PID-scoped internal NATS subject", () => {
+    expect(channelRunnerHealthSubject(4242)).toBe("_RAVI.channels.health.4242");
+    expect(() => channelRunnerHealthSubject(0)).toThrow("positive integer");
+    expect(() => channelRunnerHealthSubject(1.5)).toThrow("positive integer");
+  });
+
+  it("builds an isolated versioned snapshot", () => {
+    const status = runtimeStatus();
+    const snapshot = createChannelRunnerHealthSnapshot(status, 1_721_563_203_000);
+
+    expect(snapshot).toEqual({
+      schemaVersion: CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION,
+      observedAt: 1_721_563_203_000,
+      ...status,
+    });
+    status.adapters[0]!.status = "failed";
+    expect(snapshot.adapters[0]?.status).toBe("connected");
+  });
+
+  it("responds with the current snapshot and stops the subscription", async () => {
+    const subscription = new TestSubscription();
+    const subscribe = mock((_subject: string) => subscription);
+    const getStatus = mock(() => runtimeStatus());
+    let response: Uint8Array | undefined;
+    const responder = startChannelRunnerHealthResponder({
+      pid: 4242,
+      getStatus,
+      connection: { subscribe },
+      now: () => 1_721_563_203_000,
+    });
+
+    subscription.push({
+      data: codec.encode({}),
+      respond(data) {
+        response = data;
+        return true;
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(responder.subject).toBe("_RAVI.channels.health.4242");
+    expect(subscribe).toHaveBeenCalledWith(responder.subject);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(codec.decode(response!)).toEqual(createChannelRunnerHealthSnapshot(runtimeStatus(), 1_721_563_203_000));
+
+    await responder.stop();
+    expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("channel runner health probe", () => {
+  it("accepts a valid snapshot from the exact PM2 PID", async () => {
+    const snapshot = createChannelRunnerHealthSnapshot(runtimeStatus(), 1_721_563_203_000);
+    const request = mock(async () => ({ data: codec.encode(snapshot) }));
+
+    const result = await probeChannelRunnerHealth({
+      pid: 4242,
+      timeoutMs: 123,
+      connect: async () => ({ request }),
+    });
+
+    expect(result).toEqual({ reachable: true, snapshot });
+    expect(request).toHaveBeenCalledWith("_RAVI.channels.health.4242", expect.any(Uint8Array), { timeout: 123 });
+  });
+
+  it("rejects malformed and mismatched responses", async () => {
+    const invalid = await probeChannelRunnerHealth({
+      pid: 4242,
+      connect: async () => ({
+        request: async () => ({ data: codec.encode({ schemaVersion: 1, pid: 4242 }) }),
+      }),
+    });
+    const mismatch = await probeChannelRunnerHealth({
+      pid: 4242,
+      connect: async () => ({
+        request: async () => ({ data: codec.encode(createChannelRunnerHealthSnapshot(runtimeStatus(7777))) }),
+      }),
+    });
+
+    expect(invalid).toEqual({ reachable: false, reason: "invalid_response" });
+    expect(mismatch).toEqual({ reachable: false, reason: "pid_mismatch" });
+  });
+
+  it("distinguishes timeout, no responders, and unavailable NATS", async () => {
+    const failingConnection = (error: Error & { code?: string }): ChannelRunnerHealthRequestConnection => ({
+      request: async () => {
+        throw error;
+      },
+    });
+    const timeoutError = Object.assign(new Error("request timeout"), { code: "TIMEOUT" });
+    const noRespondersError = Object.assign(new Error("503"), { code: "503" });
+
+    await expect(
+      probeChannelRunnerHealth({ pid: 4242, connect: async () => failingConnection(timeoutError) }),
+    ).resolves.toEqual({ reachable: false, reason: "timeout" });
+    await expect(
+      probeChannelRunnerHealth({ pid: 4242, connect: async () => failingConnection(noRespondersError) }),
+    ).resolves.toEqual({ reachable: false, reason: "no_responders" });
+    await expect(
+      probeChannelRunnerHealth({
+        pid: 4242,
+        connect: async () => {
+          throw new Error("NATS down");
+        },
+      }),
+    ).resolves.toEqual({ reachable: false, reason: "nats_unavailable" });
+  });
+});

--- a/src/channels/health.ts
+++ b/src/channels/health.ts
@@ -1,0 +1,248 @@
+import { JSONCodec } from "nats";
+
+export const CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION = 1 as const;
+export const CHANNEL_RUNNER_HEALTH_SUBJECT_PREFIX = "_RAVI.channels.health";
+export const DEFAULT_CHANNEL_RUNNER_HEALTH_TIMEOUT_MS = 750;
+
+export type ChannelAdapterHealthState =
+  | "disabled"
+  | "starting"
+  | "connected"
+  | "degraded"
+  | "reconnecting"
+  | "disconnected"
+  | "failed";
+
+export interface ChannelAdapterHealth {
+  id: string;
+  channelId: string;
+  status: ChannelAdapterHealthState;
+  reason?: string;
+  connectedAt?: number;
+  lastPongAt?: number;
+  reconnectCount?: number;
+}
+
+export interface ChannelRunnerRuntimeStatus {
+  running: boolean;
+  startedAt: number | null;
+  pid: number;
+  outbound: {
+    stream: string;
+    consumer: string;
+    enabled: boolean;
+    infrastructureReady: boolean;
+    consuming: boolean;
+  };
+  adapters: ChannelAdapterHealth[];
+}
+
+export interface ChannelRunnerHealthSnapshot extends ChannelRunnerRuntimeStatus {
+  schemaVersion: typeof CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION;
+  observedAt: number;
+}
+
+export type ChannelRunnerHealthProbeFailureReason =
+  | "timeout"
+  | "no_responders"
+  | "nats_unavailable"
+  | "invalid_response"
+  | "pid_mismatch";
+
+export type ChannelRunnerHealthProbeResult =
+  | { reachable: true; snapshot: ChannelRunnerHealthSnapshot }
+  | { reachable: false; reason: ChannelRunnerHealthProbeFailureReason };
+
+export interface ChannelRunnerHealthMessage {
+  readonly data: Uint8Array;
+  respond(data: Uint8Array): boolean;
+}
+
+export interface ChannelRunnerHealthSubscription extends AsyncIterable<ChannelRunnerHealthMessage> {
+  unsubscribe(): void;
+}
+
+export interface ChannelRunnerHealthResponderConnection {
+  subscribe(subject: string): ChannelRunnerHealthSubscription;
+}
+
+export interface ChannelRunnerHealthRequestConnection {
+  request(subject: string, data: Uint8Array, options: { timeout: number }): Promise<{ readonly data: Uint8Array }>;
+}
+
+export interface ChannelRunnerHealthResponder {
+  readonly subject: string;
+  stop(): Promise<void>;
+}
+
+const codec = JSONCodec<unknown>();
+
+export function channelRunnerHealthSubject(pid: number): string {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    throw new Error("Channel runner health PID must be a positive integer");
+  }
+  return `${CHANNEL_RUNNER_HEALTH_SUBJECT_PREFIX}.${pid}`;
+}
+
+export function createChannelRunnerHealthSnapshot(
+  status: ChannelRunnerRuntimeStatus,
+  observedAt = Date.now(),
+): ChannelRunnerHealthSnapshot {
+  return {
+    schemaVersion: CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION,
+    observedAt,
+    running: status.running,
+    startedAt: status.startedAt,
+    pid: status.pid,
+    outbound: { ...status.outbound },
+    adapters: status.adapters.map((adapter) => ({ ...adapter })),
+  };
+}
+
+export function startChannelRunnerHealthResponder(options: {
+  pid: number;
+  getStatus: () => ChannelRunnerRuntimeStatus;
+  connection: ChannelRunnerHealthResponderConnection;
+  now?: () => number;
+}): ChannelRunnerHealthResponder {
+  const subject = channelRunnerHealthSubject(options.pid);
+  const subscription = options.connection.subscribe(subject);
+  let stopped = false;
+
+  const loop = (async () => {
+    for await (const message of subscription) {
+      if (stopped) break;
+      try {
+        const snapshot = createChannelRunnerHealthSnapshot(options.getStatus(), options.now?.() ?? Date.now());
+        message.respond(codec.encode(snapshot));
+      } catch {
+        // A health read must never take down the channel runner or expose an internal error.
+      }
+    }
+  })();
+
+  return {
+    subject,
+    async stop(): Promise<void> {
+      if (stopped) return;
+      stopped = true;
+      subscription.unsubscribe();
+      await loop.catch(() => {});
+    },
+  };
+}
+
+export async function probeChannelRunnerHealth(options: {
+  pid: number;
+  timeoutMs?: number;
+  connect?: () => Promise<ChannelRunnerHealthRequestConnection>;
+}): Promise<ChannelRunnerHealthProbeResult> {
+  let subject: string;
+  try {
+    subject = channelRunnerHealthSubject(options.pid);
+  } catch {
+    return { reachable: false, reason: "invalid_response" };
+  }
+
+  let connection: ChannelRunnerHealthRequestConnection;
+  try {
+    connection = await (options.connect ?? defaultHealthConnection)();
+  } catch {
+    return { reachable: false, reason: "nats_unavailable" };
+  }
+
+  let response: { readonly data: Uint8Array };
+  try {
+    response = await connection.request(subject, codec.encode({}), {
+      timeout: options.timeoutMs ?? DEFAULT_CHANNEL_RUNNER_HEALTH_TIMEOUT_MS,
+    });
+  } catch (error) {
+    return { reachable: false, reason: healthRequestFailureReason(error) };
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = codec.decode(response.data);
+  } catch {
+    return { reachable: false, reason: "invalid_response" };
+  }
+
+  if (!isChannelRunnerHealthSnapshot(decoded)) {
+    return { reachable: false, reason: "invalid_response" };
+  }
+  if (decoded.pid !== options.pid) {
+    return { reachable: false, reason: "pid_mismatch" };
+  }
+  return { reachable: true, snapshot: decoded };
+}
+
+export function isChannelRunnerHealthSnapshot(value: unknown): value is ChannelRunnerHealthSnapshot {
+  if (!isRecord(value)) return false;
+  if (value.schemaVersion !== CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION) return false;
+  if (!isPositiveInteger(value.pid)) return false;
+  if (typeof value.running !== "boolean") return false;
+  if (value.startedAt !== null && !isFiniteNumber(value.startedAt)) return false;
+  if (!isFiniteNumber(value.observedAt)) return false;
+  if (!isRecord(value.outbound)) return false;
+  if (typeof value.outbound.stream !== "string" || typeof value.outbound.consumer !== "string") return false;
+  if (typeof value.outbound.enabled !== "boolean") return false;
+  if (typeof value.outbound.infrastructureReady !== "boolean") return false;
+  if (typeof value.outbound.consuming !== "boolean") return false;
+  if (!Array.isArray(value.adapters) || !value.adapters.every(isChannelAdapterHealth)) return false;
+  return true;
+}
+
+function isChannelAdapterHealth(value: unknown): value is ChannelAdapterHealth {
+  if (!isRecord(value)) return false;
+  if (typeof value.id !== "string" || typeof value.channelId !== "string") return false;
+  if (!CHANNEL_ADAPTER_HEALTH_STATES.has(value.status)) return false;
+  if (value.reason !== undefined && typeof value.reason !== "string") return false;
+  if (value.connectedAt !== undefined && !isFiniteNumber(value.connectedAt)) return false;
+  if (value.lastPongAt !== undefined && !isFiniteNumber(value.lastPongAt)) return false;
+  if (
+    value.reconnectCount !== undefined &&
+    (typeof value.reconnectCount !== "number" ||
+      !Number.isSafeInteger(value.reconnectCount) ||
+      value.reconnectCount < 0)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+const CHANNEL_ADAPTER_HEALTH_STATES = new Set<unknown>([
+  "disabled",
+  "starting",
+  "connected",
+  "degraded",
+  "reconnecting",
+  "disconnected",
+  "failed",
+]);
+
+function healthRequestFailureReason(error: unknown): ChannelRunnerHealthProbeFailureReason {
+  const record = isRecord(error) ? error : {};
+  const code = typeof record.code === "string" ? record.code.toUpperCase() : "";
+  const name = error instanceof Error ? error.name.toUpperCase() : "";
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  if (code === "503" || code === "NO_RESPONDERS" || message.includes("no responders")) return "no_responders";
+  if (code === "TIMEOUT" || name.includes("TIMEOUT") || message.includes("timeout")) return "timeout";
+  return "nats_unavailable";
+}
+
+async function defaultHealthConnection(): Promise<ChannelRunnerHealthRequestConnection> {
+  const { ensureConnected } = await import("../nats.js");
+  return await ensureConnected();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -3,6 +3,7 @@ import { CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS } from "./outbound-receipts.js";
 import {
   CHANNEL_OUTBOUND_RECEIPT_PRUNE_INTERVAL_MS,
   pruneChannelOutboundReceiptLedger,
+  slackAdapterHealth,
   startChannelOutboundReceiptPruner,
 } from "./runner.js";
 
@@ -45,5 +46,55 @@ describe("channel runner outbound receipt maintenance", () => {
     stop();
     expect(clearIntervalForTest).toHaveBeenCalledWith(timer);
     expect(CHANNEL_OUTBOUND_RECEIPT_PRUNE_INTERVAL_MS).toBe(6 * 60 * 60 * 1_000);
+  });
+});
+
+describe("channel runner Slack health projection", () => {
+  it("does not call an opening socket connected before Slack hello", () => {
+    expect(
+      slackAdapterHealth("hana-slack", {
+        state: "connecting",
+        reconnectCount: 0,
+        reason: "awaiting_hello",
+      }),
+    ).toEqual({
+      id: "slack:hana-slack",
+      channelId: "slack",
+      status: "starting",
+      reason: "awaiting_hello",
+      reconnectCount: 0,
+    });
+  });
+
+  it("projects heartbeat and reconnect lifecycle without exposing credentials", () => {
+    const health = slackAdapterHealth("hana-slack", {
+      state: "connected",
+      connectedAt: 1_721_563_201_000,
+      lastPongAt: 1_721_563_202_000,
+      reconnectCount: 2,
+    });
+
+    expect(health).toEqual({
+      id: "slack:hana-slack",
+      channelId: "slack",
+      status: "connected",
+      connectedAt: 1_721_563_201_000,
+      lastPongAt: 1_721_563_202_000,
+      reconnectCount: 2,
+    });
+    expect(JSON.stringify(health)).not.toContain("xapp-");
+    expect(JSON.stringify(health)).not.toContain("xoxb-");
+
+    expect(
+      slackAdapterHealth("hana-slack", {
+        state: "reconnecting",
+        reconnectCount: 3,
+        reason: "heartbeat_timeout",
+      }),
+    ).toMatchObject({
+      status: "reconnecting",
+      reason: "heartbeat_timeout",
+      reconnectCount: 3,
+    });
   });
 });

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -1,7 +1,13 @@
 import { closeAllRaviDbs } from "../db/close-all.js";
-import { closeNats, connectNats } from "../nats.js";
+import { closeNats, connectNats, getNats } from "../nats.js";
 import { configStore } from "../config-store.js";
 import { logger } from "../utils/logger.js";
+import {
+  startChannelRunnerHealthResponder,
+  type ChannelAdapterHealth,
+  type ChannelRunnerHealthResponder,
+  type ChannelRunnerRuntimeStatus,
+} from "./health.js";
 import type { NativePresenceDelivery, NativeTextDelivery } from "./native/types.js";
 import { ChannelOutboundConsumer } from "./outbound-consumer.js";
 import {
@@ -15,7 +21,11 @@ import {
   ensureChannelOutboundInfrastructure,
 } from "./outbound-stream.js";
 import { ChannelPresenceConsumer } from "./presence-consumer.js";
-import { createSlackNativeRuntimesFromEnv, type SlackNativeRuntime } from "./slack/index.js";
+import {
+  createSlackNativeRuntimesFromEnv,
+  type SlackNativeRuntime,
+  type SlackSocketModeStatus,
+} from "./slack/index.js";
 
 const log = logger.child("channels:runner");
 
@@ -37,30 +47,9 @@ export interface ChannelRunnerOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-export interface ChannelRunnerStatus {
-  running: boolean;
-  startedAt: number | null;
-  pid: number;
-  outbound: {
-    stream: string;
-    consumer: string;
-    infrastructureReady: boolean;
-    consuming: boolean;
-  };
-  adapters: Array<{
-    id: string;
-    channelId: string;
-    status: "disabled" | "starting" | "connected" | "degraded" | "reconnecting" | "disconnected" | "failed";
-    reason?: string;
-  }>;
-}
+export type ChannelRunnerStatus = ChannelRunnerRuntimeStatus;
 
-interface AdapterStatus {
-  id: string;
-  channelId: string;
-  status: ChannelRunnerStatus["adapters"][number]["status"];
-  reason?: string;
-}
+type AdapterStatus = ChannelAdapterHealth;
 
 export class ChannelRunner {
   private running = false;
@@ -73,6 +62,7 @@ export class ChannelRunner {
   private slackRuntimes: SlackNativeRuntime[] = [];
   private adapterStatuses = new Map<string, AdapterStatus>();
   private stopReceiptPruner: (() => void) | null = null;
+  private healthResponder: ChannelRunnerHealthResponder | null = null;
 
   constructor(private readonly options: ChannelRunnerOptions = {}) {}
 
@@ -81,6 +71,10 @@ export class ChannelRunner {
       log.warn("Channel runner already started");
       return;
     }
+
+    this.startedAt = null;
+    this.outboundInfrastructureReady = false;
+    this.adapterStatuses.clear();
 
     const env = this.options.env ?? process.env;
     await connectNats(this.options.natsUrl ?? env.NATS_URL ?? "nats://127.0.0.1:4222", {
@@ -102,6 +96,11 @@ export class ChannelRunner {
     this.outboundInfrastructureReady = true;
     this.running = true;
     this.startedAt = Date.now();
+    this.healthResponder = startChannelRunnerHealthResponder({
+      pid: process.pid,
+      getStatus: () => this.status(),
+      connection: getNats(),
+    });
 
     await this.startSlack(env);
 
@@ -131,6 +130,8 @@ export class ChannelRunner {
   async stop(): Promise<void> {
     if (!this.running) return;
     this.running = false;
+    await this.healthResponder?.stop();
+    this.healthResponder = null;
     this.stopReceiptPruner?.();
     this.stopReceiptPruner = null;
     log.info("Stopping channel runner", { pid: process.pid });
@@ -145,6 +146,8 @@ export class ChannelRunner {
     this.slackRuntimes = [];
     this.deliveries = [];
     this.presenceDeliveries = [];
+    this.outboundInfrastructureReady = false;
+    this.startedAt = null;
     configStore.stop();
     closeAllRaviDbs();
     await closeNats({ drainTimeoutMs: 2_000 });
@@ -159,10 +162,11 @@ export class ChannelRunner {
       outbound: {
         stream: CHANNEL_OUTBOUND_STREAM,
         consumer: CHANNEL_OUTBOUND_CONSUMER,
+        enabled: this.options.consumeOutbound !== false,
         infrastructureReady: this.outboundInfrastructureReady,
         consuming: this.outboundConsumer?.isConsuming() ?? false,
       },
-      adapters: Array.from(this.adapterStatuses.values()).sort((a, b) => a.id.localeCompare(b.id)),
+      adapters: this.currentAdapterStatuses(),
     };
   }
 
@@ -181,12 +185,21 @@ export class ChannelRunner {
         this.deliveries.push(runtime.delivery);
         this.presenceDeliveries.push(runtime.presence);
         runtime.socketMode.start();
-        this.markAdapter(`slack:${runtime.accountId}`, "slack", "connected");
+        this.markAdapter(`slack:${runtime.accountId}`, "slack", "starting", "opening_socket");
       }
     } catch (error) {
-      this.markAdapter("slack", "slack", "failed", error instanceof Error ? error.message : String(error));
+      this.markAdapter("slack", "slack", "failed", "startup_failed");
       log.error("Failed to start Slack native runtime", { error });
     }
+  }
+
+  private currentAdapterStatuses(): AdapterStatus[] {
+    const statuses = new Map(this.adapterStatuses);
+    for (const runtime of this.slackRuntimes) {
+      const socketStatus = runtime.socketMode.status();
+      statuses.set(`slack:${runtime.accountId}`, slackAdapterHealth(runtime.accountId, socketStatus));
+    }
+    return Array.from(statuses.values()).sort((a, b) => a.id.localeCompare(b.id));
   }
 
   private markAdapter(id: string, channelId: string, status: AdapterStatus["status"], reason?: string): void {
@@ -197,6 +210,26 @@ export class ChannelRunner {
       ...(reason ? { reason } : {}),
     });
   }
+}
+
+export function slackAdapterHealth(accountId: string, status: SlackSocketModeStatus): ChannelAdapterHealth {
+  const adapterStatus: ChannelAdapterHealth["status"] =
+    status.state === "stopped"
+      ? "disconnected"
+      : status.state === "connecting"
+        ? "starting"
+        : status.state === "reconnecting"
+          ? "reconnecting"
+          : "connected";
+  return {
+    id: `slack:${accountId}`,
+    channelId: "slack",
+    status: adapterStatus,
+    ...(status.reason ? { reason: status.reason } : {}),
+    ...(status.connectedAt !== undefined ? { connectedAt: status.connectedAt } : {}),
+    ...(status.lastPongAt !== undefined ? { lastPongAt: status.lastPongAt } : {}),
+    reconnectCount: status.reconnectCount,
+  };
 }
 
 export function pruneChannelOutboundReceiptLedger(

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -68,7 +68,14 @@ export {
   createSlackNativeRuntimeFromEnv,
   createSlackNativeRuntimesFromEnv,
 } from "./socket-mode.js";
-export type { SlackNativeRuntime, SlackSocketModeServiceOptions, SlackTargetScope } from "./socket-mode.js";
+export type {
+  SlackNativeRuntime,
+  SlackSocketModeReason,
+  SlackSocketModeServiceOptions,
+  SlackSocketModeState,
+  SlackSocketModeStatus,
+  SlackTargetScope,
+} from "./socket-mode.js";
 export type {
   SlackBotMessageAliasesByChat,
   SlackEventAuthorization,

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   createContact,
   ensureContactFromInbound,
@@ -41,6 +42,77 @@ import {
   slackClientMessageId,
 } from "./socket-mode.js";
 import type { SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
+
+class FakeSlackWebSocket extends EventEmitter {
+  readyState = 0;
+  readonly ping = mock(() => {});
+  readonly send = mock((_data: string) => {});
+  readonly terminate = mock(() => {
+    this.readyState = 3;
+  });
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+
+  receive(payload: Record<string, unknown>): void {
+    this.emit("message", Buffer.from(JSON.stringify(payload)));
+  }
+
+  receivePong(): void {
+    this.emit("pong");
+  }
+
+  fail(): void {
+    this.emit("error", new Error("fake socket failure"));
+  }
+
+  closeFromPeer(): void {
+    this.readyState = 3;
+    this.emit("close", 1006, Buffer.alloc(0));
+  }
+}
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+    await sleep(1);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createSocketLifecycleHarness(
+  overrides: {
+    reconnectDelayMs?: number;
+    heartbeatIntervalMs?: number;
+    pongTimeoutMs?: number;
+    helloTimeoutMs?: number;
+  } = {},
+) {
+  const sockets: FakeSlackWebSocket[] = [];
+  const openSocketConnection = mock(async () => `wss://socket-${sockets.length + 1}.example.test`);
+  const service = new SlackSocketModeService({
+    appToken: "xapp-test",
+    botToken: "xoxb-test",
+    accountId: "test-slack",
+    webClient: { openSocketConnection } as never,
+    openWebSocket: () => {
+      const socket = new FakeSlackWebSocket();
+      sockets.push(socket);
+      return socket as never;
+    },
+    reconnectDelayMs: overrides.reconnectDelayMs ?? 2,
+    heartbeatIntervalMs: overrides.heartbeatIntervalMs ?? 30,
+    pongTimeoutMs: overrides.pongTimeoutMs ?? 15,
+    helloTimeoutMs: overrides.helloTimeoutMs ?? 50,
+  });
+  return { service, sockets, openSocketConnection };
+}
 
 let stateDir: string | null = null;
 
@@ -1280,6 +1352,217 @@ describe("Slack Socket Mode routing", () => {
       contactId: identity.contact!.id,
       platformIdentityId: identity.platformIdentity!.id,
     });
+  });
+});
+
+describe("Slack Socket Mode connection liveness", () => {
+  it("reports connected only after Slack hello", async () => {
+    const { service, sockets } = createSocketLifecycleHarness();
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    expect(service.status()).toMatchObject({ state: "connecting", reason: "opening_socket" });
+
+    sockets[0]!.open();
+    expect(service.status()).toMatchObject({ state: "connecting", reason: "awaiting_hello" });
+    expect(service.status().connectedAt).toBeUndefined();
+    sockets[0]!.receivePong();
+
+    sockets[0]!.receive({ type: "hello", num_connections: 1 });
+    await waitForCondition(() => service.status().state === "connected");
+    expect(service.status().reason).toBeUndefined();
+    expect(service.status().connectedAt).toBeNumber();
+
+    await service.stop();
+    expect(service.status()).toMatchObject({ state: "stopped", reason: "stopped" });
+  });
+
+  it("terminates a half-open socket and reconnects without waiting for close", async () => {
+    const { service, sockets, openSocketConnection } = createSocketLifecycleHarness({
+      pongTimeoutMs: 8,
+      helloTimeoutMs: 100,
+    });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    sockets[0]!.open();
+    sockets[0]!.receive({ type: "hello" });
+
+    await waitForCondition(() => sockets.length === 2);
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+    expect(openSocketConnection).toHaveBeenCalledTimes(2);
+    expect(service.status()).toMatchObject({ state: "reconnecting", reconnectCount: 1 });
+
+    await service.stop();
+  });
+
+  it("keeps a quiet workspace healthy when heartbeat pongs continue", async () => {
+    const { service, sockets } = createSocketLifecycleHarness({
+      heartbeatIntervalMs: 8,
+      pongTimeoutMs: 12,
+      helloTimeoutMs: 100,
+    });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    const socket = sockets[0]!;
+    socket.open();
+    socket.receive({ type: "hello" });
+    socket.receivePong();
+    await waitForCondition(() => service.status().state === "connected");
+    await waitForCondition(() => socket.ping.mock.calls.length >= 2);
+    socket.receivePong();
+    await sleep(3);
+
+    expect(service.status().state).toBe("connected");
+    expect(service.status().lastPongAt).toBeNumber();
+    expect(socket.terminate).not.toHaveBeenCalled();
+
+    await service.stop();
+  });
+
+  it("reconnects when an open socket never receives hello", async () => {
+    const { service, sockets } = createSocketLifecycleHarness({
+      heartbeatIntervalMs: 100,
+      pongTimeoutMs: 80,
+      helloTimeoutMs: 8,
+    });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    sockets[0]!.open();
+    sockets[0]!.receivePong();
+
+    await waitForCondition(() => sockets.length === 2);
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+    expect(service.status()).toMatchObject({ state: "reconnecting", reconnectCount: 1 });
+
+    await service.stop();
+  });
+
+  it("reconnects immediately when Slack requests connection refresh", async () => {
+    const { service, sockets } = createSocketLifecycleHarness({ reconnectDelayMs: 1_000 });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    sockets[0]!.open();
+    sockets[0]!.receivePong();
+    sockets[0]!.receive({ type: "hello" });
+    await waitForCondition(() => service.status().state === "connected");
+
+    sockets[0]!.receive({ type: "disconnect", reason: "refresh_requested" });
+    await waitForCondition(() => sockets.length === 2);
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+    expect(service.status().reconnectCount).toBe(1);
+
+    await service.stop();
+  });
+
+  it("coalesces error and close into one reconnect", async () => {
+    const { service, sockets, openSocketConnection } = createSocketLifecycleHarness();
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    sockets[0]!.open();
+    sockets[0]!.receivePong();
+    sockets[0]!.fail();
+    sockets[0]!.closeFromPeer();
+
+    await waitForCondition(() => sockets.length === 2);
+    await sleep(10);
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+    expect(openSocketConnection).toHaveBeenCalledTimes(2);
+    expect(service.status().reconnectCount).toBe(1);
+
+    await service.stop();
+  });
+
+  it("ignores late callbacks from a replaced socket", async () => {
+    const { service, sockets, openSocketConnection } = createSocketLifecycleHarness({
+      heartbeatIntervalMs: 100,
+      pongTimeoutMs: 80,
+      helloTimeoutMs: 100,
+    });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    const staleSocket = sockets[0]!;
+    staleSocket.open();
+    staleSocket.receivePong();
+    staleSocket.fail();
+    await waitForCondition(() => sockets.length === 2);
+
+    const currentSocket = sockets[1]!;
+    currentSocket.open();
+    currentSocket.receivePong();
+    currentSocket.receive({ type: "hello" });
+    await waitForCondition(() => service.status().state === "connected");
+
+    staleSocket.receivePong();
+    staleSocket.receive({ type: "disconnect", reason: "refresh_requested" });
+    staleSocket.fail();
+    await sleep(5);
+
+    expect(service.status().state).toBe("connected");
+    expect(currentSocket.terminate).not.toHaveBeenCalled();
+    expect(openSocketConnection).toHaveBeenCalledTimes(2);
+
+    await service.stop();
+  });
+
+  it("stops promptly while apps.connections.open is still pending", async () => {
+    let resolveOpen: ((url: string) => void) | undefined;
+    const openSocketConnection = mock(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveOpen = resolve;
+        }),
+    );
+    const openWebSocket = mock((_url: string) => new FakeSlackWebSocket() as never);
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "test-slack",
+      webClient: { openSocketConnection } as never,
+      openWebSocket,
+    });
+
+    service.start();
+    await waitForCondition(() => openSocketConnection.mock.calls.length === 1);
+    await Promise.race([
+      service.stop(),
+      sleep(500).then(() => {
+        throw new Error("stop waited for apps.connections.open");
+      }),
+    ]);
+
+    resolveOpen?.("wss://late.example.test");
+    await sleep(5);
+    expect(openWebSocket).not.toHaveBeenCalled();
+    expect(service.status().state).toBe("stopped");
+  });
+
+  it("stops promptly on a half-open socket and does not reconnect", async () => {
+    const { service, sockets, openSocketConnection } = createSocketLifecycleHarness({
+      pongTimeoutMs: 100,
+      helloTimeoutMs: 100,
+    });
+
+    service.start();
+    await waitForCondition(() => sockets.length === 1);
+    sockets[0]!.open();
+
+    await Promise.race([
+      service.stop(),
+      sleep(500).then(() => {
+        throw new Error("stop did not settle promptly");
+      }),
+    ]);
+    await sleep(10);
+
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+    expect(openSocketConnection).toHaveBeenCalledTimes(1);
+    expect(service.status().state).toBe("stopped");
   });
 });
 

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { WebSocket as NodeWebSocket } from "ws";
 import { configStore } from "../../config-store.js";
 import { resolvePlatformIdentity, type PlatformIdentity } from "../../contacts.js";
 import { publish } from "../../nats.js";
@@ -70,10 +71,35 @@ const log = logger.child("channels:slack");
 const SLACK_THREAD_CREATED_TOPIC = "ravi.inbound.thread.created";
 const DEFAULT_SLACK_AUTH_TEST_FAILURE_RETRY_MS = 5_000;
 const DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS = 5_000;
+const DEFAULT_SLACK_HEARTBEAT_INTERVAL_MS = 10_000;
+const DEFAULT_SLACK_PONG_TIMEOUT_MS = 5_000;
+const DEFAULT_SLACK_HELLO_TIMEOUT_MS = 10_000;
 
 type PublishPrompt = typeof publishSessionPrompt;
 type PublishInteraction = (topic: string, payload: Record<string, unknown>) => Promise<void>;
-type WebSocketFactory = (url: string) => WebSocket;
+type WebSocketFactory = (url: string) => NodeWebSocket;
+type SocketTimer = ReturnType<typeof setTimeout>;
+
+export type SlackSocketModeState = "stopped" | "connecting" | "connected" | "reconnecting";
+
+export type SlackSocketModeReason =
+  | "stopped"
+  | "opening_socket"
+  | "awaiting_hello"
+  | "open_failed"
+  | "hello_timeout"
+  | "heartbeat_timeout"
+  | "socket_error"
+  | "socket_closed"
+  | "slack_disconnect";
+
+export interface SlackSocketModeStatus {
+  readonly state: SlackSocketModeState;
+  readonly connectedAt?: number;
+  readonly lastPongAt?: number;
+  readonly reconnectCount: number;
+  readonly reason?: SlackSocketModeReason;
+}
 
 interface ProcessedSlackFile extends SlackNormalizedFile {
   readonly localPath?: string;
@@ -112,6 +138,15 @@ export interface SlackSocketModeServiceOptions {
   readonly publishInteraction?: PublishInteraction;
   readonly openWebSocket?: WebSocketFactory;
   readonly reconnectDelayMs?: number;
+  /** Interval between successful heartbeat round-trips. */
+  readonly heartbeatIntervalMs?: number;
+  /** Maximum time to wait for a pong after each ping. */
+  readonly pongTimeoutMs?: number;
+  /** Maximum time an open transport may wait for Slack's hello envelope. */
+  readonly helloTimeoutMs?: number;
+  /** Timer injection for deterministic Socket Mode lifecycle tests. */
+  readonly setTimeout?: typeof setTimeout;
+  readonly clearTimeout?: typeof clearTimeout;
   /** Negative-cache backoff for failed auth.test calls. Successful identities remain cached. */
   readonly authTestFailureRetryMs?: number;
   /** Maximum time bot intake waits for Slack auth.test before failing closed. */
@@ -419,6 +454,11 @@ export class SlackSocketModeService {
   private readonly openWebSocket: WebSocketFactory;
   private readonly routingPolicy: SlackRoutingPolicy;
   private readonly reconnectDelayMs: number;
+  private readonly heartbeatIntervalMs: number;
+  private readonly pongTimeoutMs: number;
+  private readonly helloTimeoutMs: number;
+  private readonly scheduleTimeout: typeof setTimeout;
+  private readonly cancelTimeout: typeof clearTimeout;
   private readonly authTestFailureRetryMs: number;
   private readonly authTestTimeoutMs: number;
   private readonly now: () => number;
@@ -427,8 +467,17 @@ export class SlackSocketModeService {
   private localBotIdentityInFlight: Promise<SlackLocalBotIdentity | null> | null = null;
   private nextLocalBotIdentityAttemptAt = 0;
   private running = false;
-  private socket: WebSocket | null = null;
+  private socket: NodeWebSocket | null = null;
   private loopPromise: Promise<void> | null = null;
+  private socketGeneration = 0;
+  private settleCurrentSocket: (() => void) | null = null;
+  private interruptConnectionOpen: (() => void) | null = null;
+  private interruptReconnectDelay: (() => void) | null = null;
+  private lifecycleState: SlackSocketModeState = "stopped";
+  private lifecycleReason: SlackSocketModeReason | undefined = "stopped";
+  private connectedAt: number | undefined;
+  private lastPongAt: number | undefined;
+  private reconnectCount = 0;
 
   constructor(private readonly options: SlackSocketModeServiceOptions) {
     this.routingPolicy = normalizeSlackRoutingPolicy({
@@ -444,8 +493,13 @@ export class SlackSocketModeService {
     this.getRouterConfig = options.getRouterConfig ?? (() => configStore.getConfig());
     this.publishPrompt = options.publishPrompt ?? publishSessionPrompt;
     this.publishInteraction = options.publishInteraction ?? publish;
-    this.openWebSocket = options.openWebSocket ?? ((url) => new WebSocket(url));
+    this.openWebSocket = options.openWebSocket ?? ((url) => new NodeWebSocket(url));
     this.reconnectDelayMs = options.reconnectDelayMs ?? 5_000;
+    this.heartbeatIntervalMs = positiveDuration(options.heartbeatIntervalMs, DEFAULT_SLACK_HEARTBEAT_INTERVAL_MS);
+    this.pongTimeoutMs = positiveDuration(options.pongTimeoutMs, DEFAULT_SLACK_PONG_TIMEOUT_MS);
+    this.helloTimeoutMs = positiveDuration(options.helloTimeoutMs, DEFAULT_SLACK_HELLO_TIMEOUT_MS);
+    this.scheduleTimeout = options.setTimeout ?? setTimeout;
+    this.cancelTimeout = options.clearTimeout ?? clearTimeout;
     this.authTestFailureRetryMs = Math.max(
       0,
       Number.isFinite(options.authTestFailureRetryMs)
@@ -464,15 +518,36 @@ export class SlackSocketModeService {
   start(): void {
     if (this.running) return;
     this.running = true;
+    this.connectedAt = undefined;
+    this.reconnectCount = 0;
+    this.setLifecycle("connecting", "opening_socket");
     this.loopPromise = this.runLoop();
   }
 
   async stop(): Promise<void> {
     this.running = false;
-    this.socket?.close();
+    this.interruptConnectionOpen?.();
+    this.interruptConnectionOpen = null;
+    this.interruptReconnectDelay?.();
+    this.interruptReconnectDelay = null;
+    this.settleCurrentSocket?.();
+    this.settleCurrentSocket = null;
+    this.terminateSocket(this.socket);
     this.socket = null;
     await this.loopPromise?.catch(() => {});
     this.loopPromise = null;
+    this.connectedAt = undefined;
+    this.setLifecycle("stopped", "stopped");
+  }
+
+  status(): SlackSocketModeStatus {
+    return {
+      state: this.lifecycleState,
+      ...(this.connectedAt !== undefined ? { connectedAt: this.connectedAt } : {}),
+      ...(this.lastPongAt !== undefined ? { lastPongAt: this.lastPongAt } : {}),
+      reconnectCount: this.reconnectCount,
+      ...(this.lifecycleReason ? { reason: this.lifecycleReason } : {}),
+    };
   }
 
   async handleEnvelope(
@@ -509,48 +584,206 @@ export class SlackSocketModeService {
   }
 
   private async runLoop(): Promise<void> {
+    let attemptedConnection = false;
     while (this.running) {
+      if (attemptedConnection) {
+        this.reconnectCount += 1;
+        this.setLifecycle("reconnecting", "opening_socket");
+      }
       try {
-        const url = await this.webClient.openSocketConnection();
-        await this.runSocket(url);
+        const url = await this.openSocketConnectionUntilStopped();
+        if (!url || !this.running) return;
+        const ended = await this.runSocket(url);
+        attemptedConnection = true;
+        if (!this.running) return;
+        if (ended !== "slack_disconnect") {
+          await this.waitForReconnectDelay();
+        }
       } catch (error) {
         if (!this.running) return;
+        attemptedConnection = true;
+        this.connectedAt = undefined;
+        this.setLifecycle("reconnecting", "open_failed");
         log.warn("Slack Socket Mode loop failed; reconnecting", { error });
-        await delay(this.reconnectDelayMs);
+        await this.waitForReconnectDelay();
       }
     }
   }
 
-  private runSocket(url: string): Promise<void> {
+  private runSocket(
+    url: string,
+  ): Promise<Exclude<SlackSocketModeReason, "stopped" | "opening_socket" | "open_failed">> {
     return new Promise((resolve) => {
       const socket = this.openWebSocket(url);
+      const generation = ++this.socketGeneration;
       this.socket = socket;
+      let settled = false;
+      let helloTimer: SocketTimer | null = null;
+      let heartbeatTimer: SocketTimer | null = null;
+      let pongTimer: SocketTimer | null = null;
 
-      socket.onopen = () => {
-        log.info("Slack Socket Mode connected", { accountId: this.options.accountId });
+      const isCurrent = () => this.running && this.socket === socket && this.socketGeneration === generation;
+      const clearTimer = (timer: SocketTimer | null) => {
+        if (timer) this.cancelTimeout(timer);
       };
-      socket.onmessage = (event) => {
-        this.handleSocketMessage(event.data, socket).catch((error) => {
-          log.error("Failed to handle Slack Socket Mode message", { error });
-        });
+      const clearSocketTimers = () => {
+        clearTimer(helloTimer);
+        clearTimer(heartbeatTimer);
+        clearTimer(pongTimer);
+        helloTimer = null;
+        heartbeatTimer = null;
+        pongTimer = null;
       };
-      socket.onerror = (event) => {
-        log.warn("Slack Socket Mode socket error", { event });
-      };
-      socket.onclose = () => {
+      const finish = (
+        reason: Exclude<SlackSocketModeReason, "stopped" | "opening_socket" | "open_failed">,
+        force: boolean,
+      ) => {
+        if (settled) return;
+        settled = true;
+        clearSocketTimers();
+        if (this.settleCurrentSocket === settleForStop) this.settleCurrentSocket = null;
         if (this.socket === socket) this.socket = null;
-        log.info("Slack Socket Mode disconnected", { accountId: this.options.accountId });
-        resolve();
+        if (this.running) {
+          this.connectedAt = undefined;
+          this.setLifecycle("reconnecting", reason);
+        }
+        if (force) this.terminateSocket(socket);
+        log.info("Slack Socket Mode disconnected", { accountId: this.options.accountId, reason });
+        resolve(reason);
       };
+      const settleForStop = () => {
+        if (settled) return;
+        settled = true;
+        clearSocketTimers();
+        if (this.socket === socket) this.socket = null;
+        this.terminateSocket(socket);
+        resolve("socket_closed");
+      };
+      const armPongDeadline = () => {
+        clearTimer(pongTimer);
+        pongTimer = this.timeout(() => {
+          if (!isCurrent()) return;
+          log.warn("Slack Socket Mode heartbeat timed out", { accountId: this.options.accountId });
+          finish("heartbeat_timeout", true);
+        }, this.pongTimeoutMs);
+      };
+      const sendPing = () => {
+        if (!isCurrent() || socket.readyState !== NodeWebSocket.OPEN) return;
+        try {
+          socket.ping();
+          armPongDeadline();
+        } catch (error) {
+          log.warn("Slack Socket Mode heartbeat failed", { accountId: this.options.accountId, error });
+          finish("socket_error", true);
+        }
+      };
+
+      this.settleCurrentSocket = settleForStop;
+
+      socket.on("open", () => {
+        if (!isCurrent()) return;
+        this.setLifecycle(this.reconnectCount > 0 ? "reconnecting" : "connecting", "awaiting_hello");
+        helloTimer = this.timeout(() => {
+          if (!isCurrent()) return;
+          log.warn("Slack Socket Mode hello timed out", { accountId: this.options.accountId });
+          finish("hello_timeout", true);
+        }, this.helloTimeoutMs);
+        sendPing();
+      });
+      socket.on("pong", () => {
+        if (!isCurrent()) return;
+        this.lastPongAt = this.now();
+        clearTimer(pongTimer);
+        pongTimer = null;
+        clearTimer(heartbeatTimer);
+        heartbeatTimer = this.timeout(sendPing, this.heartbeatIntervalMs);
+      });
+      socket.on("message", (data) => {
+        this.handleSocketMessage(data, socket)
+          .then((control) => {
+            if (!isCurrent()) return;
+            if (control === "hello") {
+              clearTimer(helloTimer);
+              helloTimer = null;
+              this.connectedAt = this.now();
+              this.setLifecycle("connected");
+              log.info("Slack Socket Mode connected", { accountId: this.options.accountId });
+            } else if (control === "disconnect") {
+              finish("slack_disconnect", true);
+            }
+          })
+          .catch((error) => {
+            log.error("Failed to handle Slack Socket Mode message", { error });
+          });
+      });
+      socket.on("error", (event) => {
+        if (!isCurrent()) return;
+        log.warn("Slack Socket Mode socket error", { event });
+        finish("socket_error", true);
+      });
+      socket.on("close", () => finish("socket_closed", false));
     });
   }
 
-  private async handleSocketMessage(raw: unknown, socket: WebSocket): Promise<void> {
+  private async handleSocketMessage(raw: unknown, socket: NodeWebSocket): Promise<"hello" | "disconnect" | null> {
     const text = typeof raw === "string" ? raw : raw instanceof Buffer ? raw.toString("utf-8") : String(raw);
     const envelope = JSON.parse(text) as SlackSocketEnvelope;
+    if (envelope.type === "hello") return "hello";
+    if (envelope.type === "disconnect") return "disconnect";
     await this.handleEnvelope(envelope, async (envelopeId) => {
       socket.send(JSON.stringify({ envelope_id: envelopeId }));
     });
+    return null;
+  }
+
+  private setLifecycle(state: SlackSocketModeState, reason?: SlackSocketModeReason): void {
+    this.lifecycleState = state;
+    this.lifecycleReason = reason;
+  }
+
+  private async openSocketConnectionUntilStopped(): Promise<string | null> {
+    let resolveStop: ((value: null) => void) | undefined;
+    const stopped = new Promise<null>((resolve) => {
+      resolveStop = resolve;
+    });
+    const interrupt = () => resolveStop?.(null);
+    this.interruptConnectionOpen = interrupt;
+    try {
+      return await Promise.race([this.webClient.openSocketConnection(), stopped]);
+    } finally {
+      if (this.interruptConnectionOpen === interrupt) this.interruptConnectionOpen = null;
+    }
+  }
+
+  private timeout(callback: () => void, ms: number): SocketTimer {
+    const timer = this.scheduleTimeout(callback, ms);
+    timer.unref?.();
+    return timer;
+  }
+
+  private waitForReconnectDelay(): Promise<void> {
+    if (!this.running || this.reconnectDelayMs <= 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      let settled = false;
+      const complete = () => {
+        if (settled) return;
+        settled = true;
+        this.cancelTimeout(timer);
+        if (this.interruptReconnectDelay === complete) this.interruptReconnectDelay = null;
+        resolve();
+      };
+      const timer = this.timeout(complete, this.reconnectDelayMs);
+      this.interruptReconnectDelay = complete;
+    });
+  }
+
+  private terminateSocket(socket: NodeWebSocket | null): void {
+    if (!socket) return;
+    try {
+      socket.terminate();
+    } catch (error) {
+      log.debug("Slack Socket Mode terminate failed", { accountId: this.options.accountId, error });
+    }
   }
 
   private async normalizeEnvelope(envelope: SlackSocketEnvelope): Promise<SlackNormalizedMessage | null> {
@@ -1754,8 +1987,8 @@ function formatSlackPrompt(message: SlackNormalizedMessage, files: readonly Proc
   return `[${parts.join(" ")}]\n<@${message.userId}>: ${formatSlackMessageBody(message, files)}`;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function positiveDuration(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function normalizeSlackFiles(value: unknown): SlackNormalizedFile[] {

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -139,6 +139,16 @@ describe("findTriggeredPrefixes", () => {
     expect(findTriggeredPrefixes(files)).toEqual(["src/devin/", "src/omni/"]);
   });
 
+  it("identifies native channel runner and adapter changes", () => {
+    const files = ["src/channels/runner.ts", "src/channels/slack/socket-mode.ts"];
+
+    expect(findTriggeredPrefixes(files)).toEqual([
+      "src/channels/",
+      "src/channels/runner.ts",
+      "src/channels/slack/socket-mode.ts",
+    ]);
+  });
+
   it("excludes test files from triggering", () => {
     const files = ["src/omni/consumer-context.test.ts"];
     expect(findTriggeredPrefixes(files)).toEqual([]);
@@ -267,6 +277,19 @@ describe("runCoverageGate", () => {
     const result = runCoverageGate(["src/omni/consumer.ts", "src/omni/consumer-context.test.ts"], cwd);
 
     expect(result.ok).toBe(true);
+  });
+
+  it("requires a focused native channel test in the diff", () => {
+    const missing = runCoverageGate(["src/channels/slack/socket-mode.ts"]);
+    const covered = runCoverageGate(["src/channels/slack/socket-mode.ts", "src/channels/slack/socket-mode.test.ts"]);
+    const healthCovered = runCoverageGate(["src/channels/health.ts", "src/channels/health.test.ts"]);
+
+    expect(missing.ok).toBe(false);
+    expect(missing.triggeredPrefixes).toEqual(["src/channels/", "src/channels/slack/socket-mode.ts"]);
+    expect(missing.errors[0]?.message).toContain("src/channels/");
+    expect(covered.ok).toBe(true);
+    expect(covered.triggeredPrefixes).toEqual(["src/channels/", "src/channels/slack/socket-mode.ts"]);
+    expect(healthCovered.ok).toBe(true);
   });
 
   it("passes when the session stream focused test is in the diff", () => {

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -19,6 +19,14 @@ const REQUIRED_COMPANIONS = ["WHY.md", "RUNBOOK.md", "CHECKS.md"] as const;
  * Each prefix maps to a list of known test file glob patterns.
  */
 export const RUNTIME_PATH_MAP: Record<string, string[]> = {
+  "src/channels/health.ts": ["src/channels/health.test.ts"],
+  "src/channels/runner.ts": ["src/channels/runner.test.ts"],
+  "src/channels/slack/socket-mode.ts": ["src/channels/slack/socket-mode.test.ts"],
+  "src/channels/": [
+    "src/channels/health.test.ts",
+    "src/channels/runner.test.ts",
+    "src/channels/slack/socket-mode.test.ts",
+  ],
   "src/omni/": [
     "src/omni/consumer-context.test.ts",
     "src/omni/consumer-policy.test.ts",

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -1,7 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createChannelRunnerHealthSnapshot, type ChannelRunnerRuntimeStatus } from "../../channels/health.js";
 import { dbGetChannel } from "../../router/router-db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
-import { buildRunnerPm2Env, ChannelsCommands } from "./channels.js";
+import {
+  buildChannelsLiveStatusJson,
+  buildRunnerPm2Env,
+  ChannelsCommands,
+  classifyChannelRunnerHealth,
+} from "./channels.js";
 
 const ORIGINAL_ENV = { ...process.env };
 let stateDir: string | null = null;
@@ -81,5 +87,126 @@ describe("channels config commands", () => {
 
     expect(updated.channel.defaults).toEqual({ subscriptionScope: "chat_and_thread" });
     expect(dbGetChannel("ravi-rbbt-slack")?.defaults).toEqual({ subscriptionScope: "chat_and_thread" });
+  });
+});
+
+function liveRunnerStatus(adapterStatus: ChannelRunnerRuntimeStatus["adapters"][number]["status"] = "connected") {
+  return createChannelRunnerHealthSnapshot(
+    {
+      running: true,
+      startedAt: 1_721_563_200_000,
+      pid: 4242,
+      outbound: {
+        stream: "CHANNEL_OUTBOUND",
+        consumer: "ravi-channels-outbound",
+        enabled: true,
+        infrastructureReady: true,
+        consuming: true,
+      },
+      adapters: [
+        {
+          id: "slack:hana-slack",
+          channelId: "slack",
+          status: adapterStatus,
+          reconnectCount: adapterStatus === "reconnecting" ? 1 : 0,
+        },
+      ],
+    },
+    1_721_563_203_000,
+  );
+}
+
+const ONLINE_CHANNELS_PROCESS = {
+  name: "ravi-channels",
+  pm_id: 2,
+  pid: 4242,
+  status: "online",
+  cpu: 0,
+  memory: 64 * 1024 * 1024,
+};
+
+describe("channels live status", () => {
+  it("separates PM2 process liveness from runner and Slack readiness", async () => {
+    const snapshot = liveRunnerStatus();
+    const probe = mock(async () => ({ reachable: true as const, snapshot }));
+
+    const payload = await buildChannelsLiveStatusJson({
+      pm2Available: true,
+      processes: [ONLINE_CHANNELS_PROCESS],
+      probe,
+      now: () => 1_721_563_204_000,
+    });
+
+    expect(payload).toMatchObject({
+      channels: { running: true, status: "online", pid: 4242 },
+      health: { status: "ready", reachable: true, checkedAt: 1_721_563_204_000 },
+      runner: snapshot,
+    });
+    expect(probe).toHaveBeenCalledWith({ pid: 4242 });
+  });
+
+  it("reports a connected process without a health reply as unreachable", async () => {
+    const payload = await buildChannelsLiveStatusJson({
+      pm2Available: true,
+      processes: [ONLINE_CHANNELS_PROCESS],
+      probe: async () => ({ reachable: false, reason: "timeout" }),
+      now: () => 1_721_563_204_000,
+    });
+
+    expect(payload).toMatchObject({
+      channels: { running: true, status: "online" },
+      health: { status: "unreachable", reachable: false, reason: "timeout" },
+      runner: null,
+    });
+  });
+
+  it("retries against a new PM2 PID when the runner restarts during the probe", async () => {
+    const restartedSnapshot = createChannelRunnerHealthSnapshot({
+      ...liveRunnerStatus(),
+      pid: 4343,
+    });
+    const probe = mock(async ({ pid }: { pid: number }) =>
+      pid === 4242
+        ? ({ reachable: false, reason: "no_responders" } as const)
+        : ({ reachable: true, snapshot: restartedSnapshot } as const),
+    );
+    const refreshProcesses = mock(() => [{ ...ONLINE_CHANNELS_PROCESS, pid: 4343 }]);
+
+    const payload = await buildChannelsLiveStatusJson({
+      pm2Available: true,
+      processes: [ONLINE_CHANNELS_PROCESS],
+      refreshProcesses,
+      probe,
+      now: () => 1_721_563_204_000,
+    });
+
+    expect(payload).toMatchObject({
+      channels: { pid: 4343, status: "online" },
+      health: { status: "ready", reachable: true },
+      runner: { pid: 4343 },
+    });
+    expect(probe.mock.calls.map((call) => call[0].pid)).toEqual([4242, 4343]);
+    expect(refreshProcesses).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run a live probe when the PM2 runner is stopped", async () => {
+    const probe = mock(async () => ({ reachable: true as const, snapshot: liveRunnerStatus() }));
+    const payload = await buildChannelsLiveStatusJson({
+      pm2Available: true,
+      processes: [{ ...ONLINE_CHANNELS_PROCESS, status: "stopped", pid: 0 }],
+      probe,
+      now: () => 1_721_563_204_000,
+    });
+
+    expect(payload).toMatchObject({
+      health: { status: "stopped", reachable: false, reason: "not_running" },
+      runner: null,
+    });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("classifies adapter recovery and failure independently from PM2", () => {
+    expect(classifyChannelRunnerHealth(liveRunnerStatus("reconnecting"))).toBe("starting");
+    expect(classifyChannelRunnerHealth(liveRunnerStatus("failed"))).toBe("degraded");
   });
 });

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -5,6 +5,11 @@
 import "reflect-metadata";
 import { spawnSync } from "node:child_process";
 import { z } from "zod";
+import {
+  probeChannelRunnerHealth,
+  type ChannelRunnerHealthProbeResult,
+  type ChannelRunnerHealthSnapshot,
+} from "../../channels/health.js";
 import { ChannelRunner, runChannelRunnerFromEnv } from "../../channels/runner.js";
 import { getCredentialConnection } from "../../credentials/index.js";
 import { nats } from "../../nats.js";
@@ -38,11 +43,54 @@ const pm2ProcessReturnSchema = z
   })
   .strict();
 
+const channelAdapterHealthReturnSchema = z
+  .object({
+    id: z.string(),
+    channelId: z.string(),
+    status: z.enum(["disabled", "starting", "connected", "degraded", "reconnecting", "disconnected", "failed"]),
+    reason: z.string().optional(),
+    connectedAt: z.number().optional(),
+    lastPongAt: z.number().optional(),
+    reconnectCount: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+const channelRunnerHealthSnapshotReturnSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    observedAt: z.number(),
+    running: z.boolean(),
+    startedAt: z.number().nullable(),
+    pid: z.number().int().positive(),
+    outbound: z
+      .object({
+        stream: z.string(),
+        consumer: z.string(),
+        enabled: z.boolean(),
+        infrastructureReady: z.boolean(),
+        consuming: z.boolean(),
+      })
+      .strict(),
+    adapters: z.array(channelAdapterHealthReturnSchema),
+  })
+  .strict();
+
+const channelsHealthReturnSchema = z
+  .object({
+    status: z.enum(["ready", "starting", "degraded", "unreachable", "stopped"]),
+    reachable: z.boolean(),
+    checkedAt: z.number(),
+    reason: z.string().optional(),
+  })
+  .strict();
+
 const channelsStatusReturnSchema = z.object({
   pm2Available: z.boolean(),
   processName: z.string(),
   channels: pm2ProcessReturnSchema,
   processes: z.array(pm2ProcessReturnSchema),
+  health: channelsHealthReturnSchema.optional(),
+  runner: channelRunnerHealthSnapshotReturnSchema.nullable().optional(),
 });
 
 const runtimeTargetReturnSchema = z
@@ -235,9 +283,13 @@ function serializePm2Process(process: ReturnType<typeof getPm2Process>, fallback
   };
 }
 
-function buildChannelsStatusJson(): Record<string, unknown> {
-  const pm2Available = isPm2Available();
-  const processes = pm2Available ? getPm2Processes() : [];
+type Pm2ProcessSnapshot = ReturnType<typeof getPm2Processes>[number];
+
+function buildChannelsStatusJson(
+  options: { pm2Available?: boolean; processes?: Pm2ProcessSnapshot[] } = {},
+): Record<string, unknown> {
+  const pm2Available = options.pm2Available ?? isPm2Available();
+  const processes = options.processes ?? (pm2Available ? getPm2Processes() : []);
   const channels = processes.find((process) => process.name === CHANNELS_PM2_PROCESS_NAME);
 
   return {
@@ -245,6 +297,89 @@ function buildChannelsStatusJson(): Record<string, unknown> {
     processName: CHANNELS_PM2_PROCESS_NAME,
     channels: serializePm2Process(channels, CHANNELS_PM2_PROCESS_NAME),
     processes: processes.map((process) => serializePm2Process(process, process.name)),
+  };
+}
+
+export type ChannelsRunnerHealthState = "ready" | "starting" | "degraded" | "unreachable" | "stopped";
+
+export function classifyChannelRunnerHealth(snapshot: ChannelRunnerHealthSnapshot): ChannelsRunnerHealthState {
+  if (!snapshot.running) return "degraded";
+  if (!snapshot.outbound.infrastructureReady) return "starting";
+
+  if (snapshot.adapters.some((adapter) => ["failed", "degraded", "disconnected"].includes(adapter.status))) {
+    return "degraded";
+  }
+  if (snapshot.adapters.some((adapter) => ["starting", "reconnecting"].includes(adapter.status))) {
+    return "starting";
+  }
+  if (snapshot.outbound.enabled && !snapshot.outbound.consuming) return "starting";
+  return "ready";
+}
+
+export async function buildChannelsLiveStatusJson(
+  options: {
+    pm2Available?: boolean;
+    processes?: Pm2ProcessSnapshot[];
+    refreshProcesses?: () => Pm2ProcessSnapshot[];
+    probe?: (options: { pid: number }) => Promise<ChannelRunnerHealthProbeResult>;
+    now?: () => number;
+  } = {},
+): Promise<Record<string, unknown>> {
+  const pm2Available = options.pm2Available ?? isPm2Available();
+  const processes = options.processes ?? (pm2Available ? getPm2Processes() : []);
+  const refreshProcesses = options.refreshProcesses ?? (options.processes === undefined ? getPm2Processes : undefined);
+  const payload = buildChannelsStatusJson({ pm2Available, processes });
+  const checkedAt = options.now?.() ?? Date.now();
+  const channels = processes.find((process) => process.name === CHANNELS_PM2_PROCESS_NAME);
+
+  if (!pm2Available) {
+    return {
+      ...payload,
+      health: { status: "stopped", reachable: false, checkedAt, reason: "pm2_unavailable" },
+      runner: null,
+    };
+  }
+  if (!channels || channels.status !== "online") {
+    return {
+      ...payload,
+      health: { status: "stopped", reachable: false, checkedAt, reason: "not_running" },
+      runner: null,
+    };
+  }
+  if (!Number.isSafeInteger(channels.pid) || channels.pid <= 0) {
+    return {
+      ...payload,
+      health: { status: "unreachable", reachable: false, checkedAt, reason: "invalid_pid" },
+      runner: null,
+    };
+  }
+
+  const result = await (options.probe ?? probeChannelRunnerHealth)({ pid: channels.pid });
+  if (!result.reachable) {
+    const refreshed = refreshProcesses?.();
+    const refreshedChannels = refreshed?.find((process) => process.name === CHANNELS_PM2_PROCESS_NAME);
+    if (refreshed && (refreshedChannels?.pid !== channels.pid || refreshedChannels?.status !== channels.status)) {
+      return buildChannelsLiveStatusJson({
+        ...options,
+        processes: refreshed,
+        refreshProcesses: undefined,
+      });
+    }
+    return {
+      ...payload,
+      health: { status: "unreachable", reachable: false, checkedAt, reason: result.reason },
+      runner: null,
+    };
+  }
+
+  return {
+    ...payload,
+    health: {
+      status: classifyChannelRunnerHealth(result.snapshot),
+      reachable: true,
+      checkedAt,
+    },
+    runner: result.snapshot,
   };
 }
 
@@ -537,8 +672,8 @@ export class ChannelsCommands {
   @Command({ name: "status", description: "Show channel runner status" })
   @CommandAccess({ kind: "read", resource: "channels", action: "status", risk: "low" })
   @Returns(channelsStatusReturnSchema)
-  status(@Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean) {
-    const payload = buildChannelsStatusJson();
+  async status(@Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean) {
+    const payload = await buildChannelsLiveStatusJson();
     if (asJson) {
       printJson(payload);
       return payload;
@@ -554,6 +689,12 @@ export class ChannelsCommands {
     console.log(
       `  ${CHANNELS_PM2_PROCESS_NAME}: ${String(channels.status)}${channels.pid ? ` (PID ${channels.pid})` : ""}`,
     );
+    const health = payload.health as Record<string, unknown>;
+    console.log(`  health: ${String(health.status)}${health.reason ? ` (${String(health.reason)})` : ""}`);
+    const runner = payload.runner as ChannelRunnerHealthSnapshot | null;
+    for (const adapter of runner?.adapters ?? []) {
+      console.log(`  ${adapter.id}: ${adapter.status}${adapter.reason ? ` (${adapter.reason})` : ""}`);
+    }
     return payload;
   }
 


### PR DESCRIPTION
## Objective

Automatically recover half-open Slack Socket Mode connections and expose real runner and adapter health.

## Problem

- After a local IP or network transition, the TCP/WebSocket connection could remain apparently established while Slack events stopped arriving.
- Ravi only reconnected from the close callback, socket errors only logged, and PM2 online status could look healthy while the adapter was not.

## Solution

- Use WebSocket ping/pong plus bounded Slack hello and pong deadlines.
- Force termination and reconnect without waiting for a close callback.
- Guard stale socket generations and interrupt pending connection-open/reconnect work during shutdown.
- Expose PID-scoped NATS runner health and adapter lifecycle through `ravi channels status`.
- Retry the status probe once if the PM2 PID rotates during inspection.
- Add focused lifecycle, runner, CLI, health, spec, CI coverage, and SDK tests/updates.

## Practical impact

- Quiet workspaces stay covered by transport-level heartbeat.
- A zombie socket is detected within about 15 seconds, followed by the normal reconnect backoff.
- Channel status now distinguishes ready, starting, degraded, unreachable, and stopped.

## What does NOT change

- The daemon and `ravi-channels` remain separate processes; daemon restart does not cascade.
- Slack events missed before reconnection are not replayed.
- Routing and delivery semantics do not change.

## Validation

- Mandatory pre-push hook passed: SDK drift, build, typecheck, and full `bun run test`.
- `bun test src/channels/`: 158 pass, 0 fail.
- Focused Socket Mode suite: 55 pass, 0 fail.
- Channels CLI suite: 9 pass, 0 fail.
- Quality gate passed against `dev`.
- Real NATS health request/reply smoke test passed.

## Risks

- Long event-loop stalls or machine sleep can cause a conservative reconnect.
- Events missed while a connection is dead remain unreplayed.

## Rollback

- Revert this PR and restart `ravi-channels`.

## Follow-ups

- Event replay and daemon-to-channel-runner lifecycle coupling remain intentionally outside this PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/filipexyz/ravi/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->