### PR TITLE
Fix Claude authority refresh between turns

### DIFF
--- a/.ravi/specs/runtime/providers/claude-code/CHECKS.md
+++ b/.ravi/specs/runtime/providers/claude-code/CHECKS.md
@@ -10,6 +10,9 @@
 - Non-success result maps to recoverable `turn.failed`.
 - Query exception maps to recoverable `turn.failed`.
 - `setModel` updates active query when possible and always affects next query.
+- A live provider session snapshots the current Ravi env for every query: a
+  rotated `RAVI_CONTEXT_KEY` appears on the next turn, removed managed values do
+  not survive, and the Claude session id is still resumed.
 - Resume session id is read from `RuntimeSessionState.params`.
 - Fork is passed only when requested by session continuity.
 

--- a/.ravi/specs/runtime/providers/claude-code/SPEC.md
+++ b/.ravi/specs/runtime/providers/claude-code/SPEC.md
@@ -74,6 +74,10 @@ The Claude Code provider adapts the current default cloud execution bridge into 
 
 - The provider MUST pass Ravi `systemPromptAppend` as additional system instructions.
 - The provider MUST pass Ravi-owned env into the native query environment.
+- The provider MUST snapshot the current Ravi-owned env immediately before each
+  native query. A live provider session MUST observe the newly rotated
+  `RAVI_CONTEXT_KEY` and removal of stale managed `RAVI_*` values on the next
+  turn without resetting conversation history.
 - The provider MUST use Ravi `canUseTool` for tool permission decisions.
 - The provider MUST attach host hooks only when capabilities allow it.
 - The provider MUST attach spec server only for spec-mode agents.
@@ -101,6 +105,9 @@ The Claude Code provider adapts the current default cloud execution bridge into 
 - Host exit-plan logic still reads a provider-specific plan directory; future providers need an explicit plan artifact/control contract instead of host hardcoding.
 - Provider-specific settings files are created during prepare but not captured as explicit runtime bootstrap state.
 - Host hooks are available here but not in Codex, which can hide permission behavior differences.
+- Regressing to a native query environment copied only at provider-session
+  start freezes turn-scoped authority. Grants and revocations then remain stale
+  until the provider session or daemon restarts.
 - Runtime controls are unavailable even though the sessions CLI exposes a generic control surface.
 - Raw events lack consistent thread/turn/item metadata compared with Codex, reducing trace correlation.
 - The model catalog is alias-based and provider-specific instead of a generic provider model registry.

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -295,6 +295,15 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
   });
 
+  it("passes when the Claude provider focused test is in the diff", () => {
+    const cwd = makeWorkspace();
+
+    const result = runCoverageGate(["src/runtime/claude-provider.ts", "src/runtime/claude-provider.test.ts"], cwd);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
+  });
+
   it("passes when the observation plane focused test is in the diff", () => {
     const cwd = makeWorkspace();
 

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -48,6 +48,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/runtime/allowed-skills.test.ts",
     "src/runtime/skill-gate.test.ts",
     "src/runtime/claude-local-skills.test.ts",
+    "src/runtime/claude-provider.test.ts",
   ],
   "src/session-trace/": ["src/session-trace/session-trace.test.ts"],
   "src/triggers/": ["src/triggers/triggers.test.ts"],

--- a/src/runtime/claude-provider.test.ts
+++ b/src/runtime/claude-provider.test.ts
@@ -464,6 +464,51 @@ describe("createClaudeRuntimeProvider", () => {
     expect(queryCalls[1]?.options.model).toBe("model-b");
   });
 
+  it("refreshes Ravi authority env between turns without resetting conversation history", async () => {
+    nextMessages = [{ type: "result", subtype: "success", session_id: "claude-session-authority" }];
+    const env: Record<string, string> = {
+      PATH: "",
+      RAVI_CONTEXT_KEY: "rctx_first",
+      RAVI_TASK_ID: "task_stale",
+    };
+
+    const provider = createClaudeRuntimeProvider();
+    const session = provider.startSession(
+      makeStartRequest(
+        (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "first" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+          env.RAVI_CONTEXT_KEY = "rctx_second";
+          delete env.RAVI_TASK_ID;
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "second" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+        })(),
+        { env },
+      ),
+    );
+
+    const events = await collectEvents(session.events);
+    expect(queryCalls).toHaveLength(2);
+    const firstEnv = queryCalls[0]?.options.env as Record<string, string>;
+    const secondEnv = queryCalls[1]?.options.env as Record<string, string>;
+
+    expect(findEventsByType(events, "turn.complete")).toHaveLength(2);
+    expect(firstEnv.RAVI_CONTEXT_KEY).toBe("rctx_first");
+    expect(firstEnv.RAVI_TASK_ID).toBe("task_stale");
+    expect(secondEnv.RAVI_CONTEXT_KEY).toBe("rctx_second");
+    expect(secondEnv.RAVI_TASK_ID).toBeUndefined();
+    expect(queryCalls[1]?.options.resume).toBe("claude-session-authority");
+    expect(secondEnv).not.toBe(firstEnv);
+  });
+
   it("backfills daemon auth env when the runtime env is partial", async () => {
     const originalToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
     process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-daemon-token";

--- a/src/runtime/claude-provider.ts
+++ b/src/runtime/claude-provider.ts
@@ -153,8 +153,6 @@ export function createClaudeRuntimeProvider(): ClaudeRuntimeProvider {
       // filter — they are its curated arsenal, invisible to the agnostic core.
       const request = withLocalSkillsPreserved(input);
       const resumeSessionId = readRuntimeSessionId(request.resumeSession) ?? request.resume;
-      const env = buildClaudeCodeEnvironment(request.env);
-      const pathToClaudeCodeExecutable = resolveClaudeCodeExecutable(env);
       const skillVisibility = buildPluginSkillVisibilitySnapshot({
         provider: "claude",
         plugins: request.plugins,
@@ -171,8 +169,6 @@ export function createClaudeRuntimeProvider(): ClaudeRuntimeProvider {
         skillVisibility,
         events: runClaudeTurns(request, {
           initialResumeSessionId: resumeSessionId,
-          env,
-          pathToClaudeCodeExecutable,
           skillVisibility,
           getModel: () => currentModel,
           setActiveQuery: (queryResult) => {
@@ -207,8 +203,6 @@ async function* runClaudeTurns(
   input: RuntimeStartRequest,
   runtime: {
     initialResumeSessionId?: string;
-    env: Record<string, string>;
-    pathToClaudeCodeExecutable?: string;
     skillVisibility?: RuntimeSkillVisibilitySnapshot;
     getModel(): string;
     setActiveQuery(queryResult: Query | null): void;
@@ -227,12 +221,15 @@ async function* runClaudeTurns(
       continue;
     }
 
+    // The host rotates `input.env` before yielding each turn. Snapshot it here
+    // so authority changes apply between queries, never during an active one.
+    const env = buildClaudeCodeEnvironment(input.env);
     const queryResult = query({
       prompt,
-      options: buildClaudeQueryOptions({ ...input, model: runtime.getModel() }, runtime.env, {
+      options: buildClaudeQueryOptions({ ...input, model: runtime.getModel() }, env, {
         resumeSessionId,
         forkSession: useForkSession,
-        pathToClaudeCodeExecutable: runtime.pathToClaudeCodeExecutable,
+        pathToClaudeCodeExecutable: resolveClaudeCodeExecutable(env),
       }),
     });
     runtime.setActiveQuery(queryResult);


### PR DESCRIPTION
## Objective

Refresh Claude's Ravi-owned authority environment between turns while preserving the same native Claude conversation. Permission grants and revocations should become effective on the next turn without requiring a session reset.

## Problem

The Claude provider copied `request.env` once when its provider session started. Ravi rotates `RAVI_CONTEXT_KEY` and other managed authority values at turn boundaries, but later Claude queries continued using the original environment snapshot.

## Solution

- Snapshot the current Ravi-owned environment immediately before every native Claude query.
- Resolve the Claude executable from that current environment.
- Continue resuming the same native Claude session id.
- Recognize the provider-specific regression as focused runtime coverage in the CI Quality Gate.

## Practical impact

Live Claude sessions observe permission grants and revocations on their next turn. Operators no longer need to reset conversation history merely to refresh the session authority ceiling.

## What does NOT change

The active native query is never widened or revoked mid-turn. The broader provider-runtime migration, legacy REBAC removal, permission profile model, and non-Claude providers remain outside this PR.

## Validation

- `bun test src/runtime/claude-provider.test.ts`
- `bun test src/runtime/runtime-request-context.test.ts`
- `bun test src/runtime/provider-contract.test.ts`
- `bun test src/runtime/claude-local-skills.test.ts`
- `bun test src/ci/quality-gate.test.ts`
- `ravi specs get runtime/providers/claude-code`
- `make quality`
- `bun run build`
- full repository pre-push checks

## Risks

Resolving the current environment for every query adds a small amount of setup work at each turn. The snapshot is intentionally taken only after the previous query completes, preserving turn-level authority isolation.

## Rollback

Revert the commits in this PR to restore the previous provider-session environment behavior. No database migration or persisted state rollback is required.

## Follow-ups

The canonical provider-runtime migration and removal of legacy REBAC enforcement are tracked separately so this urgent Claude fix can be reviewed and released independently.