### PR TITLE
fix(permissions): make command grants single-step

### DIFF
--- a/.ravi/specs/permissions/SPEC.md
+++ b/.ravi/specs/permissions/SPEC.md
@@ -106,6 +106,9 @@ Agents MUST be guided toward explainable least-privilege requests.
 
 - Permission denials MUST expose the canonical missing capability in
   `<permission>:<objectType>:<objectId>` form.
+- Applying the canonical capability recommended by a command denial MUST be
+  sufficient to retry that exact command. Ravi MUST NOT then request a legacy
+  `execute:group:*` capability for the same operation.
 - Permission denials, approval prompts, and CLI JSON outputs SHOULD use the
   shared authorization guidance envelope instead of hand-written local hints.
   The envelope MUST include:

--- a/.ravi/specs/permissions/SPEC.md
+++ b/.ravi/specs/permissions/SPEC.md
@@ -106,9 +106,6 @@ Agents MUST be guided toward explainable least-privilege requests.
 
 - Permission denials MUST expose the canonical missing capability in
   `<permission>:<objectType>:<objectId>` form.
-- Applying the canonical capability recommended by a command denial MUST be
-  sufficient to retry that exact command. Ravi MUST NOT then request a legacy
-  `execute:group:*` capability for the same operation.
 - Permission denials, approval prompts, and CLI JSON outputs SHOULD use the
   shared authorization guidance envelope instead of hand-written local hints.
   The envelope MUST include:

--- a/.ravi/specs/permissions/cli-command-access/CHECKS.md
+++ b/.ravi/specs/permissions/cli-command-access/CHECKS.md
@@ -32,6 +32,12 @@ capability: cli-command-access
 - Legacy `execute:group:<group>_<command>` and `execute:group:<group>` MUST
   remain covered by tests while migration is active, but new docs and agent
   recommendations SHOULD use semantic `read/mutate` capabilities.
+- A semantic grant MUST be sufficient by itself for the exact decorated
+  command on CLI, exported tool, and gateway surfaces. No surface may run a
+  normal legacy `@Scope` gate after provider-runtime authorization succeeds.
+- A semantic grant for one action MUST leave neighboring actions denied.
+- `superadmin` commands MUST still require the explicit superadmin exposure
+  boundary and `admin:system:*` authority.
 - Missing subject/context MUST deny unless `localOperator=true`.
 - Runtime execution MUST NOT use direct local operator fallback.
 - Provider requests generated from CLI commands MUST include command group,
@@ -70,5 +76,11 @@ permissions.command_access.open_high_risk = 0
 - Add command-access tests proving semantic `read/mutate` capabilities allow,
   semantic resource wildcard allows, dotted transition alias allows, and legacy
   `execute:group` fallback still works.
+- Add a regression matching `mutate:media:send` that has no
+  `execute:group:media_send` capability and still executes, while another media
+  mutation remains denied.
+- Add a call-site policy regression that keeps CLI, tool export, and gateway on
+  the same command authorization function and prevents direct normal-scope
+  enforcement from returning.
 - Add operator-control tests proving direct terminal mode is explicit and never
   used for runtime contexts.

--- a/.ravi/specs/permissions/cli-command-access/RUNBOOK.md
+++ b/.ravi/specs/permissions/cli-command-access/RUNBOOK.md
@@ -1,0 +1,43 @@
+# CLI Command Access / RUNBOOK
+
+## Resolve A Command Denial
+
+Apply the canonical capability printed by the denial to the intended agent,
+then retry the same command:
+
+```bash
+ravi permissions allow <profile-name> \
+  --to agent:<agent-id> \
+  --capabilities <permission>:<object-type>:<object-id> \
+  --apply
+```
+
+The retry MUST NOT require a follow-up `execute:group:*` capability for the
+same operation. A second group-level denial indicates a runtime regression,
+not an operator action item.
+
+## Diagnose A Repeated Denial
+
+1. Confirm that the denial recommends a semantic capability.
+2. Confirm that the capability is present in the agent's effective authority.
+3. Retry the exact command on the next turn.
+4. If Ravi asks for `execute:group:*`, capture the command, source surface, and
+   denial text and report a command-authorization regression.
+
+Do not work around the regression by widening the agent to the whole command
+group. Legacy group grants remain compatibility inputs for old profiles, but
+they are not a required second authorization step.
+
+## Validate The Shared Pipeline
+
+```bash
+bun test src/cli/command-access.test.ts \
+  src/cli/tools-export.test.ts \
+  src/cli/registry.test.ts \
+  src/sdk/gateway/dispatcher.test.ts \
+  src/permissions/scope.test.ts
+```
+
+The suite must prove that semantic-only authority works across CLI, exported
+tools, and SDK Gateway; neighboring actions stay denied; and `superadmin`
+retains its explicit hard boundary.

--- a/.ravi/specs/permissions/cli-command-access/SPEC.md
+++ b/.ravi/specs/permissions/cli-command-access/SPEC.md
@@ -94,8 +94,15 @@ Rules:
   MUST still use `@CommandAccess` to describe the operation.
 - New public CLI commands MUST declare `@CommandAccess` before they are
   exposed to SDK, tools, or gateway surfaces.
-- Existing `@Scope` checks MAY remain during migration only as a compatibility
-  guard. They MUST NOT bypass the Permission Provider Runtime.
+- For a command with `@CommandAccess`, a successful Permission Provider Runtime
+  decision MUST be final for normal `open`, `admin`, `writeContacts`, and
+  `resource` scopes. Those legacy scopes MUST NOT run as a second serial gate.
+- `superadmin` MAY remain as an explicit hard boundary in addition to command
+  access. A single `admin:system:*` break-glass capability MUST satisfy both
+  the semantic request and that boundary.
+- Existing `@Scope` metadata MAY remain during migration for compatibility,
+  registry projection, and `superadmin`. It MUST NOT make an operator grant a
+  second capability after the canonical command capability was accepted.
 
 ## Registry Contract
 
@@ -175,10 +182,27 @@ Rules:
 - During migration only, `<kind>:<resource>.<action>:*` MAY be accepted as a
   compatibility alias for agents that produced dotted action resource ids.
 - Legacy `execute:group:<group>_<command>` and `execute:group:<group>` MAY
-  remain as fallback compatibility. They MUST NOT be the preferred grant shape
-  for newly generated instructions.
+  remain as fallback candidates inside the same provider-runtime decision.
+  They MUST NOT be the preferred grant shape for newly generated instructions
+  and MUST NOT be required in addition to a semantic capability.
 - `read:<resource>.<action>:*` MUST NOT be documented as the canonical shape.
   The canonical shape is `read:<resource>:<action>`.
+
+## Single Decision And Retry Contract
+
+Every decorated command invocation MUST have one authorization result across
+direct CLI, exported tools, and SDK gateway execution.
+
+- The canonical capability named in a denial MUST be sufficient to retry that
+  exact command after the provider-owned profile is applied.
+- A successful semantic decision MUST NOT be followed by a denial for
+  `execute:group:<group>_<command>` or `execute:group:<group>`.
+- Accepting a legacy group capability as a compatibility candidate is one
+  provider-runtime decision, not an additional gate.
+- Granting one semantic action MUST NOT authorize a neighboring action in the
+  same command group.
+- A retry MAY still fail for a different external or resource condition, but it
+  MUST NOT reveal another hidden CLI authorization layer for the same action.
 
 ## Local Operator
 
@@ -251,6 +275,9 @@ lacks `@CommandAccess` MUST fail the relevant quality gate.
 - CLI command authorization accepts semantic `read/mutate` capabilities derived
   from `@CommandAccess` and uses legacy `execute:group` capabilities only as a
   compatibility fallback.
+- One semantic grant authorizes the same decorated command on CLI, tool, and
+  gateway surfaces without a follow-up legacy group grant.
+- `superadmin` remains fail-closed behind `admin:system:*`.
 - Direct local CLI without principal uses explicit operator-control mode only.
 - `ravi doctor --domain permissions` reports missing command access metadata
   and can distinguish missing metadata from intentionally read-only commands.

--- a/.ravi/specs/permissions/cli-command-access/WHY.md
+++ b/.ravi/specs/permissions/cli-command-access/WHY.md
@@ -45,10 +45,15 @@ This also lets doctor and codegen validate the same source of truth.
 
 ## Compatibility
 
-`@Scope` may remain temporarily as a compatibility guard, but it must stop
-being the authorization model. A command can be open for direct local terminal
-use while still requiring provider authorization when executed by an agent,
-SDK gateway, app runtime, automation, or delegated context.
+`@Scope` may remain temporarily as compatibility metadata, but it must stop
+being a second authorization model. Legacy `execute:group` capabilities can be
+accepted by the Permission Provider Runtime during migration; requiring one
+after a semantic capability already succeeded creates contradictory denials and
+makes least-privilege guidance unusable.
+
+The only retained serial boundary is `superadmin`, because it explicitly marks
+operations that must remain behind system-wide break-glass authority even when
+their semantic operation is known.
 
 The migration is intentionally incremental: first make intent explicit, then
 make provider-runtime enforcement strict.

--- a/src/cli/command-access.test.ts
+++ b/src/cli/command-access.test.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { runWithContext } from "./context.js";
-import { buildCliCommandOperation, enforceCliCommandAccess } from "./command-access.js";
+import { buildCliCommandOperation, enforceCliCommandAccess, enforceCliCommandAuthorization } from "./command-access.js";
 import type { CommandAccessOptions } from "./decorators.js";
 import { createRuntimeContext } from "../runtime/context-registry.js";
 import { emptyCredentialsFile, upsertCredentialsEntry, writeCredentialsFile } from "../runtime/credentials-store.js";
@@ -257,6 +258,50 @@ describe("CLI command access enforcement", () => {
     expect(result.decision?.objectType).toBe("demo.items");
     expect(result.decision?.objectId).toBe("create");
     expect(result.attempted).toHaveLength(1);
+  });
+
+  it("treats a semantic provider-runtime decision as final for normal legacy scopes", () => {
+    const record = context([{ permission: "mutate", objectType: "media", objectId: "send" }]);
+    const result = runWithContext({ agentId: "dev", context: record }, () =>
+      enforceCliCommandAuthorization({
+        group: "media",
+        command: "send",
+        access: { kind: "mutate", resource: "media", action: "send", risk: "high" },
+        source: "tool",
+        scope: "open",
+      }),
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.attempted).toHaveLength(1);
+    expect(result.decision).toMatchObject({ permission: "mutate", objectType: "media", objectId: "send" });
+  });
+
+  it("retains the explicit superadmin boundary after semantic authorization", () => {
+    const semanticOnly = context([{ permission: "read", objectType: "secret", objectId: "show" }]);
+    const denied = runWithContext({ agentId: "dev", context: semanticOnly }, () =>
+      enforceCliCommandAuthorization({
+        group: "secret",
+        command: "show",
+        access: { kind: "read", resource: "secret", action: "show", risk: "low" },
+        source: "gateway",
+        scope: "superadmin",
+      }),
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.errorMessage).toContain("requires admin on system:*");
+
+    const breakGlass = context([{ permission: "admin", objectType: "system", objectId: "*" }]);
+    const allowed = runWithContext({ agentId: "dev", context: breakGlass }, () =>
+      enforceCliCommandAuthorization({
+        group: "secret",
+        command: "show",
+        access: { kind: "read", resource: "secret", action: "show", risk: "low" },
+        source: "gateway",
+        scope: "superadmin",
+      }),
+    );
+    expect(allowed.allowed).toBe(true);
   });
 
   it("allows semantic resource wildcard command capabilities", () => {
@@ -557,5 +602,15 @@ describe("CLI command access enforcement", () => {
         notifiedAt: expect.any(Number),
       }),
     );
+  });
+});
+
+describe("CLI command authorization call-site policy", () => {
+  it("keeps CLI, tools, and gateway on the shared authorization pipeline", () => {
+    for (const relativePath of ["src/cli/registry.ts", "src/cli/tools-export.ts", "src/sdk/gateway/dispatcher.ts"]) {
+      const contents = readFileSync(join(process.cwd(), relativePath), "utf8");
+      expect(contents).toContain("enforceCliCommandAuthorization");
+      expect(contents).not.toContain("enforceScopeCheck");
+    }
   });
 });

--- a/src/cli/command-access.ts
+++ b/src/cli/command-access.ts
@@ -1,8 +1,9 @@
 import { getContext } from "./context.js";
-import type { CommandAccessOptions } from "./decorators.js";
+import type { CommandAccessOptions, ScopeType } from "./decorators.js";
 import { authorizePermission, type PermissionProviderDecision } from "../permissions/provider-runtime.js";
 import { buildAuditContextProvenance } from "../permissions/audit-provenance.js";
 import { recordAndEmitPermissionDenial } from "../permissions/denials.js";
+import { enforceScopeCheck } from "../permissions/scope.js";
 import {
   buildAuthorizationGuidance,
   formatAuthorizationGuidanceLines,
@@ -31,6 +32,25 @@ export interface CliCommandAccessResult {
   errorMessage: string;
   decision?: PermissionProviderDecision;
   attempted: PermissionProviderDecision[];
+}
+
+export interface CliCommandAuthorizationInput extends CliCommandAccessInput {
+  scope: ScopeType;
+}
+
+export function enforceCliCommandAuthorization(input: CliCommandAuthorizationInput): CliCommandAccessResult {
+  const accessResult = enforceCliCommandAccess(input);
+  if (!accessResult.allowed || input.scope !== "superadmin") return accessResult;
+
+  const boundary = enforceScopeCheck("superadmin", input.group, input.command);
+  if (boundary.allowed) return accessResult;
+
+  return {
+    allowed: false,
+    errorMessage: boundary.errorMessage,
+    decision: accessResult.decision,
+    attempted: accessResult.attempted,
+  };
 }
 
 export function enforceCliCommandAccess(input: CliCommandAccessInput): CliCommandAccessResult {

--- a/src/cli/decorators.ts
+++ b/src/cli/decorators.ts
@@ -20,13 +20,16 @@ const CLI_ONLY_KEY = Symbol("cli:cliOnly");
 // Types
 
 /**
- * Scope types for command access control.
+ * Legacy scope classifications retained for registry compatibility.
  *
- * - "superadmin"    — Only superadmin (admin relation on system:*). Auto-enforced.
- * - "admin"         — Only agents with execute relation on the group. Auto-enforced.
- * - "writeContacts" — Only agents with contactScope "all". Auto-enforced.
+ * Decorated commands authorize through @CommandAccess. Only "superadmin"
+ * remains an additional command-pipeline boundary.
+ *
+ * - "superadmin"    — Requires admin relation on system:* in addition to command access.
+ * - "admin"         — Legacy group-execution classification.
+ * - "writeContacts" — Legacy contact-write classification.
  * - "resource"      — Marker only; method must check canAccessResource() inline.
- * - "open"          — No restrictions.
+ * - "open"          — Legacy open classification.
  */
 export type ScopeType = "superadmin" | "admin" | "writeContacts" | "resource" | "open";
 export type CommandAccessKind = "read" | "mutate";

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -4,6 +4,7 @@ import { Command as CommanderCommand } from "commander";
 import { runWithContext } from "./context.js";
 import { Arg, Command, CommandAccess, Group, Option } from "./decorators.js";
 import { registerCommands } from "./registry.js";
+import type { ContextRecord } from "../router/router-db.js";
 
 @Group({ name: "demo.child", description: "Nested child", scope: "open" })
 class NestedChildCommands {
@@ -42,6 +43,15 @@ const capturedDirect: CapturedCall[] = [];
 const capturedNested: CapturedCall[] = [];
 const capturedNegated: boolean[] = [];
 const capturedPaired: Array<{ resumable: boolean | undefined; noResumable: boolean }> = [];
+
+const semanticOnlyContext: ContextRecord = {
+  contextId: "ctx_registry_semantic_only",
+  contextKey: "rctx_registry_semantic_only",
+  kind: "test-runtime",
+  agentId: "registry-test",
+  capabilities: [{ permission: "read", objectType: "negative", objectId: "run", source: "test" }],
+  createdAt: Date.now(),
+};
 
 @Group({ name: "shadow", description: "Direct command + nested group with --json", scope: "open" })
 class ShadowDirectCommands {
@@ -121,6 +131,26 @@ describe("registerCommands", () => {
       { resumable: true, noResumable: false },
       { resumable: undefined, noResumable: true },
     ]);
+  });
+
+  it("executes a CLI command with its semantic capability and no legacy group grant", async () => {
+    capturedNegated.length = 0;
+    const program = new CommanderCommand();
+    program.exitOverride();
+    registerCommands(program, [NegatedOptionCommands]);
+
+    const previousNoAudit = process.env.RAVI_NO_AUDIT;
+    process.env.RAVI_NO_AUDIT = "1";
+    try {
+      await runWithContext({ agentId: semanticOnlyContext.agentId, context: semanticOnlyContext }, () =>
+        program.parseAsync(["node", "test", "negative", "run"]),
+      );
+    } finally {
+      if (previousNoAudit === undefined) delete process.env.RAVI_NO_AUDIT;
+      else process.env.RAVI_NO_AUDIT = previousNoAudit;
+    }
+
+    expect(capturedNegated).toEqual([false]);
   });
 
   it("reuses existing nested command nodes for direct commands with subcommands", () => {

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -140,7 +140,9 @@ describe("registerCommands", () => {
     registerCommands(program, [NegatedOptionCommands]);
 
     const previousNoAudit = process.env.RAVI_NO_AUDIT;
+    const previousContextKey = process.env.RAVI_CONTEXT_KEY;
     process.env.RAVI_NO_AUDIT = "1";
+    process.env.RAVI_CONTEXT_KEY = semanticOnlyContext.contextKey;
     try {
       await runWithContext({ agentId: semanticOnlyContext.agentId, context: semanticOnlyContext }, () =>
         program.parseAsync(["node", "test", "negative", "run"]),
@@ -148,6 +150,8 @@ describe("registerCommands", () => {
     } finally {
       if (previousNoAudit === undefined) delete process.env.RAVI_NO_AUDIT;
       else process.env.RAVI_NO_AUDIT = previousNoAudit;
+      if (previousContextKey === undefined) delete process.env.RAVI_CONTEXT_KEY;
+      else process.env.RAVI_CONTEXT_KEY = previousContextKey;
     }
 
     expect(capturedNegated).toEqual([false]);

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -17,8 +17,7 @@ import {
   type ScopeType,
 } from "./decorators.js";
 import { extractOptionName } from "./utils.js";
-import { enforceCliCommandAccess } from "./command-access.js";
-import { enforceScopeCheck } from "../permissions/scope.js";
+import { enforceCliCommandAuthorization } from "./command-access.js";
 import { emitCliAuditEvent } from "./audit.js";
 import {
   dispatchRemote,
@@ -209,12 +208,13 @@ function registerCommand(
       }
     }
 
-    const accessResult = enforceCliCommandAccess({
+    const accessResult = enforceCliCommandAuthorization({
       group: groupName,
       command: cmdMeta.name,
       access,
       input,
       source: "cli",
+      scope,
     });
     if (!accessResult.allowed) {
       console.error(accessResult.errorMessage);
@@ -234,15 +234,6 @@ function registerCommand(
         input,
       });
       return;
-    }
-
-    // Scope enforcement (before method execution).
-    const scopeResult = enforceScopeCheck(scope, groupName, cmdMeta.name);
-    if (!scopeResult.allowed) {
-      console.error(scopeResult.errorMessage);
-      // Drain NATS before exiting so audit events are flushed
-      const { flushAuditAndExit } = await import("../permissions/scope.js");
-      await flushAuditAndExit(1);
     }
 
     // Execute and emit single event with input + output

--- a/src/cli/tools-export.test.ts
+++ b/src/cli/tools-export.test.ts
@@ -19,15 +19,36 @@ const context: ContextRecord = {
   contextKey: "rctx_negated_test",
   kind: "test-runtime",
   agentId: "negated-test",
-  capabilities: [
-    { permission: "read", objectType: "negated", objectId: "run", source: "test" },
-    { permission: "execute", objectType: "group", objectId: "negated", source: "test" },
-  ],
+  capabilities: [{ permission: "read", objectType: "negated", objectId: "run", source: "test" }],
+  createdAt: Date.now(),
+};
+
+@Group({ name: "media", description: "Media authorization fixture", scope: "open" })
+class MediaAuthorizationCommands {
+  @Command({ name: "send", description: "Send media" })
+  @CommandAccess({ kind: "mutate", resource: "media", action: "send", risk: "high" })
+  send() {
+    console.log(JSON.stringify({ sent: true }));
+  }
+
+  @Command({ name: "remove", description: "Remove media" })
+  @CommandAccess({ kind: "mutate", resource: "media", action: "remove", risk: "destructive" })
+  remove() {
+    console.log(JSON.stringify({ removed: true }));
+  }
+}
+
+const mediaContext: ContextRecord = {
+  contextId: "ctx_media_authorization_test",
+  contextKey: "rctx_media_authorization_test",
+  kind: "test-runtime",
+  agentId: "media-test",
+  capabilities: [{ permission: "mutate", objectType: "media", objectId: "send", source: "test" }],
   createdAt: Date.now(),
 };
 
 describe("tools export negated options", () => {
-  it("uses the same no-prefixed logical contract as CLI and gateway calls", async () => {
+  it("uses one semantic grant and the same no-prefixed logical contract as CLI and gateway calls", async () => {
     const tool = extractTools([NegatedToolCommands]).find((candidate) => candidate.name === "negated_run");
     expect(tool).toBeDefined();
 
@@ -36,5 +57,28 @@ describe("tools export negated options", () => {
 
     expect(JSON.parse(omitted.content[0]?.text ?? "{}")).toEqual({ noCache: false });
     expect(JSON.parse(present.content[0]?.text ?? "{}")).toEqual({ noCache: true });
+  });
+});
+
+describe("tools export provider-runtime authorization", () => {
+  it("executes media send with only mutate:media:send and keeps neighboring mutations denied", async () => {
+    const tools = extractTools([MediaAuthorizationCommands]);
+    const send = tools.find((candidate) => candidate.name === "media_send");
+    const remove = tools.find((candidate) => candidate.name === "media_remove");
+    expect(send).toBeDefined();
+    expect(remove).toBeDefined();
+
+    const allowed = await runWithContext({ agentId: mediaContext.agentId, context: mediaContext }, () =>
+      send!.handler({}),
+    );
+    expect(allowed.isError).not.toBe(true);
+    expect(JSON.parse(allowed.content[0]?.text ?? "{}")).toEqual({ sent: true });
+
+    const denied = await runWithContext({ agentId: mediaContext.agentId, context: mediaContext }, () =>
+      remove!.handler({}),
+    );
+    expect(denied.isError).toBe(true);
+    expect(denied.content[0]?.text).toContain("Missing capability: mutate:media:remove");
+    expect(denied.content[0]?.text).not.toContain("execute:group:media_remove");
   });
 });

--- a/src/cli/tools-export.ts
+++ b/src/cli/tools-export.ts
@@ -17,8 +17,7 @@ import {
 import { extractOptionName, inferOptionType } from "./utils.js";
 import { nats } from "../nats.js";
 import { getContext } from "./context.js";
-import { enforceCliCommandAccess } from "./command-access.js";
-import { enforceScopeCheck } from "../permissions/scope.js";
+import { enforceCliCommandAuthorization } from "./command-access.js";
 import { resolveCommandSkillGate, type SkillGateMetadata } from "./skill-gates.js";
 
 // ============================================================================
@@ -201,25 +200,17 @@ function buildHandler(
   access: CommandAccessOptions | undefined,
 ): (args: Record<string, unknown>) => Promise<ToolResult> {
   return async (toolArgs: Record<string, unknown>): Promise<ToolResult> => {
-    const accessResult = enforceCliCommandAccess({
+    const accessResult = enforceCliCommandAuthorization({
       group,
       command,
       access,
       input: toolArgs,
       source: "tool",
+      scope,
     });
     if (!accessResult.allowed) {
       return {
         content: [{ type: "text", text: accessResult.errorMessage }],
-        isError: true,
-      };
-    }
-
-    // Scope enforcement (before method execution)
-    const scopeResult = enforceScopeCheck(scope, group, command);
-    if (!scopeResult.allowed) {
-      return {
-        content: [{ type: "text", text: scopeResult.errorMessage }],
         isError: true,
       };
     }

--- a/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/permissions/SKILL.md
@@ -112,6 +112,9 @@ CLI command capabilities:
   `read:tasks.profiles:list`, `read:tasks.profiles:*`, `read:cron:show`.
 - `execute:group:<group>` e `execute:group:<group>_<command>` existem como
   compatibilidade, mas não são o formato recomendado para novas instruções.
+- A capability canônica indicada pelo denial deve bastar para repetir o mesmo
+  comando. Nunca peça `execute:group:*` depois que o grant semântico já foi
+  aplicado; isso indica regressão no pipeline de autorização.
 - Evite formato com `resource` e `action` fundidos por ponto. O formato
   canônico separa a action no terceiro segmento, como `read:skills:show`.
 

--- a/src/sdk/gateway/dispatcher.ts
+++ b/src/sdk/gateway/dispatcher.ts
@@ -1,7 +1,7 @@
 /**
  * Generic dispatcher for the SDK gateway.
  *
- * Pipeline: parse flat body → validate via Zod → scope check → invoke handler →
+ * Pipeline: parse flat body → validate via Zod → command authorization → invoke handler →
  * optionally validate return shape → emit audit when useful → return JSON.
  *
  * Body shape: flat-only. Args and options are merged into top-level keys
@@ -22,8 +22,7 @@
 import { ZodError, type ZodTypeAny, type ZodIssue } from "zod";
 import type { CommandRegistryEntry } from "../../cli/registry-snapshot.js";
 import { runWithContext, type ToolContext } from "../../cli/context.js";
-import { enforceCliCommandAccess } from "../../cli/command-access.js";
-import { enforceScopeCheck } from "../../permissions/scope.js";
+import { enforceCliCommandAuthorization } from "../../cli/command-access.js";
 import { emitCliAuditEvent } from "../../cli/audit.js";
 import type { ScopeContext } from "../../permissions/scope.js";
 import type { ContextRecord } from "../../router/router-db.js";
@@ -116,12 +115,13 @@ export async function dispatch(
   const toolContext = asToolContext(scopeContext, opts.contextRecord ?? null);
   const group = cmd.groupSegments.join("_");
   const accessResult = runWithContext(toolContext, () =>
-    enforceCliCommandAccess({
+    enforceCliCommandAuthorization({
       group,
       command: cmd.command,
       access: cmd.access,
       input: validation.inputForAudit,
       source: "gateway",
+      scope: cmd.scope,
     }),
   );
   if (!accessResult.allowed) {
@@ -129,16 +129,6 @@ export async function dispatch(
     const audit = buildAuditEvent(cmd, tool, validation.inputForAudit, true, startedAt, lineage);
     const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
     return { response, audit: auditEmitted ? audit : null };
-  }
-
-  if (cmd.scope === "superadmin") {
-    const scopeResult = runWithContext(toolContext, () => enforceScopeCheck(cmd.scope, group, cmd.command));
-    if (!scopeResult.allowed) {
-      const response = permissionDenied(scopeResult.errorMessage);
-      const audit = buildAuditEvent(cmd, tool, validation.inputForAudit, true, startedAt, lineage);
-      const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
-      return { response, audit: auditEmitted ? audit : null };
-    }
   }
 
   let isError = false;


### PR DESCRIPTION
## Objective

Make a command denial actionable with exactly one canonical permission grant. Unify CLI, exported tool, and SDK Gateway command authorization so a successful provider-runtime decision is not followed by a second legacy command-group gate.

## Problem

- Granting the capability recommended by a denial, such as `mutate:media:send`, still failed on retry because CLI and exported tools then required `execute:group:media_send`.
- The two serial authorization models produced repeated operator intervention and contradictory diagnostics.
- SDK Gateway already behaved differently, so equivalent operations had surface-dependent authorization.

## Solution

- Add one shared `enforceCliCommandAuthorization` entry point for CLI, exported tools, and SDK Gateway.
- Treat a successful provider-runtime decision as final for normal command scopes.
- Keep legacy `execute:group:*` capabilities as compatibility candidates inside that same decision, never as a second required grant.
- Preserve `superadmin` as an explicit additional hard boundary.
- Codify the one-denial, one-grant, one-retry contract in specs and the permissions skill.

## Practical impact

- `ravi permissions allow mutate-media-send --to agent:<id> --apply` is enough to retry `media_send`; operators are not asked for a second group-wide grant.
- Existing profiles that still carry `execute:group:*` continue to work during migration.
- A narrow semantic grant does not authorize neighboring commands in the same group.

## What does NOT change

- `superadmin` commands still require the existing superadmin boundary.
- Provider-runtime identity, context, audit, and denial guidance remain authoritative.
- This PR does not remove legacy permission persistence or rewrite unrelated command metadata.

## Validation

- Focused authorization suite: 101 passed, 0 failed, 278 assertions.
- `make quality`
- `bun run build`
- `bin/ravi specs get permissions/cli-command-access`
- `bin/ravi specs get permissions`
- `git diff --check`
- `.githooks/pre-push`, including full tests, SDK round-trip, and SDK drift checks.

## Risks

- Normal command scopes no longer add a broad legacy scope check after semantic authorization. Regression coverage verifies exact-capability isolation and preserves the superadmin exception.
- Unmigrated callers remain fail-closed when `@CommandAccess` metadata is missing.

## Rollback

- Revert this PR to restore the prior serial scope gate. Existing legacy group capabilities remain untouched, so rollback requires no data migration.

## Follow-ups

- Continue the broader REBAC removal as separate reviewed changes: metadata correction, profile revocation, context invalidation, approval identity, and stale documentation cleanup.
