### PR TITLE
fix(channels): make native Slack outbound durable

### DIFF
--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -13171,6 +13171,69 @@ export const ChannelsRestartReturnSchema = {
                     "infrastructureReady": {
                       "type": "boolean"
                     },
+                    "lastError": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "at": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "phase": {
+                          "const": "consume_loop",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "phase",
+                        "message",
+                        "at"
+                      ],
+                      "type": "object"
+                    },
+                    "lastMessageAt": {
+                      "type": "number"
+                    },
+                    "publishOutbox": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "lastError": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "at": {
+                              "type": "number"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "message",
+                            "at"
+                          ],
+                          "type": "object"
+                        },
+                        "lastPublishedAt": {
+                          "type": "number"
+                        },
+                        "nextAttemptAt": {
+                          "type": "number"
+                        },
+                        "oldestPendingAt": {
+                          "type": "number"
+                        },
+                        "pendingCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "pendingCount"
+                      ],
+                      "type": "object"
+                    },
                     "stream": {
                       "type": "string"
                     }
@@ -13798,6 +13861,69 @@ export const ChannelsStartReturnSchema = {
                     "infrastructureReady": {
                       "type": "boolean"
                     },
+                    "lastError": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "at": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "phase": {
+                          "const": "consume_loop",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "phase",
+                        "message",
+                        "at"
+                      ],
+                      "type": "object"
+                    },
+                    "lastMessageAt": {
+                      "type": "number"
+                    },
+                    "publishOutbox": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "lastError": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "at": {
+                              "type": "number"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "message",
+                            "at"
+                          ],
+                          "type": "object"
+                        },
+                        "lastPublishedAt": {
+                          "type": "number"
+                        },
+                        "nextAttemptAt": {
+                          "type": "number"
+                        },
+                        "oldestPendingAt": {
+                          "type": "number"
+                        },
+                        "pendingCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "pendingCount"
+                      ],
+                      "type": "object"
+                    },
                     "stream": {
                       "type": "string"
                     }
@@ -14162,6 +14288,69 @@ export const ChannelsStatusReturnSchema = {
                 },
                 "infrastructureReady": {
                   "type": "boolean"
+                },
+                "lastError": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "at": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "phase": {
+                      "const": "consume_loop",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "phase",
+                    "message",
+                    "at"
+                  ],
+                  "type": "object"
+                },
+                "lastMessageAt": {
+                  "type": "number"
+                },
+                "publishOutbox": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "lastError": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "at": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "message",
+                        "at"
+                      ],
+                      "type": "object"
+                    },
+                    "lastPublishedAt": {
+                      "type": "number"
+                    },
+                    "nextAttemptAt": {
+                      "type": "number"
+                    },
+                    "oldestPendingAt": {
+                      "type": "number"
+                    },
+                    "pendingCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "pendingCount"
+                  ],
+                  "type": "object"
                 },
                 "stream": {
                   "type": "string"
@@ -14539,6 +14728,69 @@ export const ChannelsStopReturnSchema = {
                     },
                     "infrastructureReady": {
                       "type": "boolean"
+                    },
+                    "lastError": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "at": {
+                          "type": "number"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "phase": {
+                          "const": "consume_loop",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "phase",
+                        "message",
+                        "at"
+                      ],
+                      "type": "object"
+                    },
+                    "lastMessageAt": {
+                      "type": "number"
+                    },
+                    "publishOutbox": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "lastError": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "at": {
+                              "type": "number"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "message",
+                            "at"
+                          ],
+                          "type": "object"
+                        },
+                        "lastPublishedAt": {
+                          "type": "number"
+                        },
+                        "nextAttemptAt": {
+                          "type": "number"
+                        },
+                        "oldestPendingAt": {
+                          "type": "number"
+                        },
+                        "pendingCount": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "pendingCount"
+                      ],
+                      "type": "object"
                     },
                     "stream": {
                       "type": "string"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -2356,6 +2356,22 @@ export type ChannelsRestartReturn = {
         consuming: boolean;
         enabled: boolean;
         infrastructureReady: boolean;
+        lastError?: {
+          at: number;
+          message: string;
+          phase: "consume_loop";
+        };
+        lastMessageAt?: number;
+        publishOutbox?: {
+          lastError?: {
+            at: number;
+            message: string;
+          };
+          lastPublishedAt?: number;
+          nextAttemptAt?: number;
+          oldestPendingAt?: number;
+          pendingCount: number;
+        };
         stream: string;
       };
       pid: number;
@@ -2473,6 +2489,22 @@ export type ChannelsStartReturn = {
         consuming: boolean;
         enabled: boolean;
         infrastructureReady: boolean;
+        lastError?: {
+          at: number;
+          message: string;
+          phase: "consume_loop";
+        };
+        lastMessageAt?: number;
+        publishOutbox?: {
+          lastError?: {
+            at: number;
+            message: string;
+          };
+          lastPublishedAt?: number;
+          nextAttemptAt?: number;
+          oldestPendingAt?: number;
+          pendingCount: number;
+        };
         stream: string;
       };
       pid: number;
@@ -2539,6 +2571,22 @@ export type ChannelsStatusReturn = {
       consuming: boolean;
       enabled: boolean;
       infrastructureReady: boolean;
+      lastError?: {
+        at: number;
+        message: string;
+        phase: "consume_loop";
+      };
+      lastMessageAt?: number;
+      publishOutbox?: {
+        lastError?: {
+          at: number;
+          message: string;
+        };
+        lastPublishedAt?: number;
+        nextAttemptAt?: number;
+        oldestPendingAt?: number;
+        pendingCount: number;
+      };
       stream: string;
     };
     pid: number;
@@ -2608,6 +2656,22 @@ export type ChannelsStopReturn = {
         consuming: boolean;
         enabled: boolean;
         infrastructureReady: boolean;
+        lastError?: {
+          at: number;
+          message: string;
+          phase: "consume_loop";
+        };
+        lastMessageAt?: number;
+        publishOutbox?: {
+          lastError?: {
+            at: number;
+            message: string;
+          };
+          lastPublishedAt?: number;
+          nextAttemptAt?: number;
+          oldestPendingAt?: number;
+          pendingCount: number;
+        };
         stream: string;
       };
       pid: number;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:593c8a5800d290268a78d35e472fcdf4c4945c11034b8223ad3d52511a7627d8";
+export const REGISTRY_HASH = "sha256:83ff189849c415304f184ef094b1516a1271e87086bd14e090b9d2f152874db9";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "98ae95bdd4f3";
+export const GIT_SHA = "d7ec87b162fd";

--- a/src/channels/health.test.ts
+++ b/src/channels/health.test.ts
@@ -4,6 +4,7 @@ import {
   CHANNEL_RUNNER_HEALTH_SCHEMA_VERSION,
   channelRunnerHealthSubject,
   createChannelRunnerHealthSnapshot,
+  isChannelRunnerHealthSnapshot,
   probeChannelRunnerHealth,
   startChannelRunnerHealthResponder,
   type ChannelRunnerHealthMessage,
@@ -86,6 +87,51 @@ describe("channel runner health contract", () => {
     });
     status.adapters[0]!.status = "failed";
     expect(snapshot.adapters[0]?.status).toBe("connected");
+  });
+
+  it("validates outbound consumer and publish outbox telemetry", () => {
+    const snapshot = createChannelRunnerHealthSnapshot({
+      ...runtimeStatus(),
+      outbound: {
+        ...runtimeStatus().outbound,
+        lastMessageAt: 1_721_563_202_500,
+        lastError: {
+          phase: "consume_loop",
+          message: "temporary consumer failure",
+          at: 1_721_563_202_600,
+        },
+        publishOutbox: {
+          pendingCount: 2,
+          oldestPendingAt: 1_721_563_200_500,
+          nextAttemptAt: 1_721_563_204_000,
+          lastPublishedAt: 1_721_563_202_000,
+          lastError: {
+            message: "temporary publish failure",
+            at: 1_721_563_202_700,
+          },
+        },
+      },
+    });
+
+    expect(isChannelRunnerHealthSnapshot(snapshot)).toBe(true);
+    expect(
+      isChannelRunnerHealthSnapshot({
+        ...snapshot,
+        outbound: {
+          ...snapshot.outbound,
+          publishOutbox: { ...snapshot.outbound.publishOutbox, pendingCount: -1 },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isChannelRunnerHealthSnapshot({
+        ...snapshot,
+        outbound: {
+          ...snapshot.outbound,
+          lastError: { ...snapshot.outbound.lastError, phase: "publish" },
+        },
+      }),
+    ).toBe(false);
   });
 
   it("responds with the current snapshot and stops the subscription", async () => {

--- a/src/channels/health.ts
+++ b/src/channels/health.ts
@@ -33,6 +33,22 @@ export interface ChannelRunnerRuntimeStatus {
     enabled: boolean;
     infrastructureReady: boolean;
     consuming: boolean;
+    lastMessageAt?: number;
+    lastError?: {
+      phase: "consume_loop";
+      message: string;
+      at: number;
+    };
+    publishOutbox?: {
+      pendingCount: number;
+      oldestPendingAt?: number;
+      nextAttemptAt?: number;
+      lastPublishedAt?: number;
+      lastError?: {
+        message: string;
+        at: number;
+      };
+    };
   };
   adapters: ChannelAdapterHealth[];
 }
@@ -188,7 +204,37 @@ export function isChannelRunnerHealthSnapshot(value: unknown): value is ChannelR
   if (typeof value.outbound.enabled !== "boolean") return false;
   if (typeof value.outbound.infrastructureReady !== "boolean") return false;
   if (typeof value.outbound.consuming !== "boolean") return false;
+  if (value.outbound.lastMessageAt !== undefined && !isFiniteNumber(value.outbound.lastMessageAt)) return false;
+  if (value.outbound.lastError !== undefined && !isOutboundLastError(value.outbound.lastError)) return false;
+  if (value.outbound.publishOutbox !== undefined && !isOutboundPublishOutbox(value.outbound.publishOutbox))
+    return false;
   if (!Array.isArray(value.adapters) || !value.adapters.every(isChannelAdapterHealth)) return false;
+  return true;
+}
+
+function isOutboundLastError(
+  value: unknown,
+): value is NonNullable<ChannelRunnerRuntimeStatus["outbound"]["lastError"]> {
+  if (!isRecord(value)) return false;
+  if (value.phase !== "consume_loop") return false;
+  if (typeof value.message !== "string") return false;
+  if (!isFiniteNumber(value.at)) return false;
+  return true;
+}
+
+function isOutboundPublishOutbox(
+  value: unknown,
+): value is NonNullable<ChannelRunnerRuntimeStatus["outbound"]["publishOutbox"]> {
+  if (!isRecord(value)) return false;
+  if (typeof value.pendingCount !== "number" || value.pendingCount < 0) return false;
+  if (value.oldestPendingAt !== undefined && !isFiniteNumber(value.oldestPendingAt)) return false;
+  if (value.nextAttemptAt !== undefined && !isFiniteNumber(value.nextAttemptAt)) return false;
+  if (value.lastPublishedAt !== undefined && !isFiniteNumber(value.lastPublishedAt)) return false;
+  if (value.lastError !== undefined) {
+    if (!isRecord(value.lastError)) return false;
+    if (typeof value.lastError.message !== "string") return false;
+    if (!isFiniteNumber(value.lastError.at)) return false;
+  }
   return true;
 }
 

--- a/src/channels/outbound-consumer.test.ts
+++ b/src/channels/outbound-consumer.test.ts
@@ -3,7 +3,9 @@ import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-
 import type { NativeTextDelivery } from "./native/types.js";
 import {
   type ChannelOutboundConsumerOptions,
+  acknowledgeChannelOutboundMessage,
   channelOutboundRequestFingerprint,
+  missingAdapterRetryDelayMs,
   persistDeliveredMessage,
   processChannelOutboundJob as processChannelOutboundJobWithNats,
 } from "./outbound-consumer.js";
@@ -69,26 +71,71 @@ describe("channel outbound consumer", () => {
     );
   });
 
-  it("acks terminal missing-adapter failures", async () => {
+  it("naks missing-adapter failures with bounded backoff instead of acknowledging terminal loss", async () => {
     const emitEvent = mock(async () => {});
     const result = await processChannelOutboundJob(makeJob(), {
       deliveries: [],
       emitEvent,
       persistDelivery: false,
+      deliveryAttempt: 2,
     });
 
     expect(result).toMatchObject({
-      disposition: "ack",
+      disposition: "nak",
       status: "failed",
-      retryable: false,
+      retryable: true,
+      phase: "adapter_lookup",
+      nakDelayMs: 60_000,
     });
     expect(emitEvent).toHaveBeenCalledWith(
       "ravi.session.ravi-channels.delivery",
       expect.objectContaining({
         status: "failed",
         reason: "missing_adapter",
+        retryable: true,
+        retryDelayMs: 60_000,
+        deliveryAttempt: 2,
       }),
     );
+  });
+
+  it("recovers a missing-adapter redelivery when the matching adapter appears later", async () => {
+    const emitEvent = mock(async () => {});
+    const missing = await processChannelOutboundJob(makeJob(), {
+      deliveries: [],
+      emitEvent,
+      persistDelivery: false,
+      deliveryAttempt: 1,
+    });
+    const delivery = makeDelivery();
+    const delivered = await processChannelOutboundJob(makeJob(), {
+      deliveries: [delivery],
+      emitEvent,
+      persistDelivery: false,
+      deliveryAttempt: 2,
+    });
+
+    expect(missing).toMatchObject({
+      disposition: "nak",
+      retryable: true,
+      nakDelayMs: 30_000,
+    });
+    expect(delivered).toEqual({ disposition: "ack", status: "delivered", retryable: false });
+    expect(delivery.deliverText).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the retry delay to JetStream NAKs", () => {
+    const ack = mock(() => {});
+    const nak = mock((_delayMs?: number) => {});
+
+    acknowledgeChannelOutboundMessage(
+      { ack, nak },
+      { disposition: "nak", status: "failed", retryable: true, nakDelayMs: 120_000 },
+    );
+
+    expect(ack).not.toHaveBeenCalled();
+    expect(nak).toHaveBeenCalledWith(120_000);
+    expect(missingAdapterRetryDelayMs(10)).toBe(300_000);
   });
 
   it("naks retryable adapter send failures", async () => {

--- a/src/channels/outbound-consumer.ts
+++ b/src/channels/outbound-consumer.ts
@@ -28,15 +28,19 @@ import {
 const log = logger.child("channels:outbound-consumer");
 const sc = StringCodec();
 const CONSUMER_RETRY_DELAY_MS = 2_000;
+export const CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_BASE_MS = 30_000;
+export const CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_MAX_MS = 5 * 60_000;
 
 export type ChannelOutboundJobDisposition = "ack" | "nak";
+export type ChannelOutboundProcessingPhase = ChannelOutboundReceiptErrorPhase | "adapter_lookup" | "send";
 
 export interface ChannelOutboundProcessingResult {
   disposition: ChannelOutboundJobDisposition;
   status: "delivered" | "failed" | "dropped";
   retryable: boolean;
   error?: string;
-  phase?: ChannelOutboundReceiptErrorPhase | "send";
+  phase?: ChannelOutboundProcessingPhase;
+  nakDelayMs?: number;
 }
 
 export interface PersistedOutboundMessage {
@@ -56,6 +60,7 @@ export interface ChannelOutboundConsumerOptions {
   emitEvent?: typeof nats.emit;
   flushNats?: typeof flushNatsConnection;
   isRunning?: () => boolean;
+  deliveryAttempt?: number;
   persistDelivery?: boolean;
   receiptStore?: ChannelOutboundReceiptStore;
   persistDeliveredMessage?: PersistDeliveredMessage;
@@ -63,9 +68,25 @@ export interface ChannelOutboundConsumerOptions {
   claimLeaseMs?: number;
 }
 
+export interface ChannelOutboundConsumerRuntimeStatus {
+  lastMessageAt?: number;
+  lastError?: {
+    phase: "consume_loop";
+    message: string;
+    at: number;
+  };
+}
+
+export interface AckableChannelOutboundMessage {
+  ack(): void;
+  nak(delayMs?: number): void;
+}
+
 export class ChannelOutboundConsumer {
   private running = false;
   private loopPromise: Promise<void> | null = null;
+  private lastMessageAt: number | undefined;
+  private lastError: ChannelOutboundConsumerRuntimeStatus["lastError"] | undefined;
 
   constructor(private readonly options: ChannelOutboundConsumerOptions) {}
 
@@ -87,6 +108,13 @@ export class ChannelOutboundConsumer {
     return this.running;
   }
 
+  status(): ChannelOutboundConsumerRuntimeStatus {
+    return {
+      ...(this.lastMessageAt !== undefined ? { lastMessageAt: this.lastMessageAt } : {}),
+      ...(this.lastError ? { lastError: { ...this.lastError } } : {}),
+    };
+  }
+
   private shouldContinue(): boolean {
     return this.running && (this.options.isRunning?.() ?? true);
   }
@@ -102,12 +130,14 @@ export class ChannelOutboundConsumer {
           expires: 2_000,
           abort_on_missing_resource: true,
         });
+        this.lastError = undefined;
 
         for await (const msg of messages) {
           if (!this.shouldContinue()) {
-            msg.nak();
+            msg.nak(CONSUMER_RETRY_DELAY_MS);
             break;
           }
+          this.lastMessageAt = Date.now();
 
           let job: ChannelOutboundJob;
           try {
@@ -118,17 +148,35 @@ export class ChannelOutboundConsumer {
             continue;
           }
 
-          const result = await processChannelOutboundJob(job, this.options);
-          if (result.disposition === "ack") msg.ack();
-          else msg.nak();
+          const result = await processChannelOutboundJob(job, {
+            ...this.options,
+            deliveryAttempt: msg.info.deliveryCount,
+          });
+          acknowledgeChannelOutboundMessage(msg, result);
         }
       } catch (error) {
         if (!this.shouldContinue()) break;
+        this.lastError = {
+          phase: "consume_loop",
+          message: errorMessage(error),
+          at: Date.now(),
+        };
         log.warn("Channel outbound consume loop failed; retrying", { error });
         await delay(CONSUMER_RETRY_DELAY_MS);
       }
     }
   }
+}
+
+export function acknowledgeChannelOutboundMessage(
+  msg: AckableChannelOutboundMessage,
+  result: ChannelOutboundProcessingResult,
+): void {
+  if (result.disposition === "ack") {
+    msg.ack();
+    return;
+  }
+  msg.nak(result.retryable ? (result.nakDelayMs ?? missingAdapterRetryDelayMs(undefined)) : result.nakDelayMs);
 }
 
 export async function processChannelOutboundJob(
@@ -143,6 +191,7 @@ export async function processChannelOutboundJob(
   const emitId = job.request.origin.emitId;
   const target = job.request.target;
   const text = job.request.content.text;
+  const deliveryAttempt = options.deliveryAttempt;
 
   if (job.request.content.type !== "text") {
     const error = `Unsupported outbound content type: ${job.request.content.type}`;
@@ -161,7 +210,7 @@ export async function processChannelOutboundJob(
 
   const adapter = options.deliveries.find((candidate) => candidate.supports(target));
   if (options.persistDelivery === false) {
-    if (!adapter) return emitMissingAdapter(emitEvent, recordTrace, job, t0);
+    if (!adapter) return emitMissingAdapter(emitEvent, recordTrace, job, t0, deliveryAttempt);
     return processWithoutReceiptLedger(job, adapter, emitEvent, recordTrace, t0);
   }
 
@@ -199,13 +248,27 @@ export async function processChannelOutboundJob(
   let claimOwner: string | undefined;
   if (!receipt || receipt.state === "claimed") {
     if (!adapter) {
-      if (!receipt) return emitMissingAdapter(emitEvent, recordTrace, job, t0);
+      if (!receipt) return emitMissingAdapter(emitEvent, recordTrace, job, t0, deliveryAttempt);
+      const delayMs = missingAdapterRetryDelayMs(deliveryAttempt);
+      try {
+        receiptStore.recordError(
+          job.request.idempotencyKey,
+          "adapter_lookup",
+          `No native delivery adapter registered for claimed channel: ${job.request.channelId}`,
+        );
+      } catch (error) {
+        log.warn("Failed to record missing adapter against native outbound receipt", {
+          jobId: job.jobId,
+          error: errorMessage(error),
+        });
+      }
       return {
         disposition: "nak",
         status: "failed",
         retryable: true,
         error: `No native delivery adapter registered for claimed channel: ${job.request.channelId}`,
-        phase: "receipt_claim",
+        phase: "adapter_lookup",
+        nakDelayMs: delayMs,
       };
     }
 
@@ -595,19 +658,43 @@ async function emitMissingAdapter(
   recordTrace: typeof recordDeliveryTrace,
   job: ChannelOutboundJob,
   t0: number,
+  deliveryAttempt?: number,
 ): Promise<ChannelOutboundProcessingResult> {
   const error = `No native delivery adapter registered for channel: ${job.request.channelId}`;
+  const retryDelayMs = missingAdapterRetryDelayMs(deliveryAttempt);
   await emitDelivery(emitEvent, recordTrace, job, {
     status: "failed",
     reason: "missing_adapter",
     error,
+    retryable: true,
+    retryDelayMs,
+    ...(deliveryAttempt !== undefined ? { deliveryAttempt } : {}),
     target: job.request.target,
     emitId: job.request.origin.emitId,
     idempotencyKey: job.request.idempotencyKey,
     textLen: job.request.content.text.length,
     durationMs: Date.now() - t0,
   });
-  return { disposition: "ack", status: "failed", retryable: false, error };
+  return {
+    disposition: "nak",
+    status: "failed",
+    retryable: true,
+    error,
+    phase: "adapter_lookup",
+    nakDelayMs: retryDelayMs,
+  };
+}
+
+export function missingAdapterRetryDelayMs(deliveryAttempt: number | undefined): number {
+  const attempt =
+    typeof deliveryAttempt === "number" && Number.isSafeInteger(deliveryAttempt) && deliveryAttempt > 0
+      ? deliveryAttempt
+      : 1;
+  const exponent = Math.min(attempt - 1, 4);
+  return Math.min(
+    CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_BASE_MS * 2 ** exponent,
+    CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_MAX_MS,
+  );
 }
 
 function deliveryResultFromReceipt(receipt: ChannelOutboundReceipt): NativeTextDeliveryResult {

--- a/src/channels/outbound-publish-outbox.test.ts
+++ b/src/channels/outbound-publish-outbox.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import {
+  CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS,
+  getChannelOutboundPublishJob,
+  markChannelOutboundPublishJobPublished,
+  prunePublishedChannelOutboundPublishJobs,
+  saveChannelOutboundPublishJob,
+} from "./outbound-publish-outbox.js";
+import type { ChannelOutboundJob } from "./outbound-stream.js";
+
+let stateDir: string | null = null;
+
+beforeEach(async () => {
+  stateDir = await createIsolatedRaviState("ravi-channel-publish-outbox-");
+});
+
+afterEach(async () => {
+  await cleanupIsolatedRaviState(stateDir);
+  stateDir = null;
+});
+
+describe("channel outbound publish outbox retention", () => {
+  it("removes expired published jobs while preserving old pending jobs", () => {
+    const now = Date.UTC(2026, 6, 22);
+    const expired = now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS - 1;
+    const pendingKey = "runtime:ravi-channels:pending-old:slack:T1:C123:root";
+    const publishedKey = "runtime:ravi-channels:published-old:slack:T1:C123:root";
+
+    saveChannelOutboundPublishJob(makeJob(pendingKey, "pending-old"), expired);
+    saveChannelOutboundPublishJob(makeJob(publishedKey, "published-old"), expired);
+    markChannelOutboundPublishJobPublished(publishedKey, expired);
+
+    expect(prunePublishedChannelOutboundPublishJobs(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now)).toBe(1);
+
+    expect(getChannelOutboundPublishJob(publishedKey)).toBeNull();
+    expect(getChannelOutboundPublishJob(pendingKey)).toMatchObject({
+      idempotencyKey: pendingKey,
+      status: "pending",
+      createdAt: expired,
+    });
+  });
+
+  it("preserves published jobs inside the retention window", () => {
+    const now = Date.UTC(2026, 6, 22);
+    const recent = now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS + 1;
+    const recentKey = "runtime:ravi-channels:published-recent:slack:T1:C123:root";
+
+    saveChannelOutboundPublishJob(makeJob(recentKey, "published-recent"), recent);
+    markChannelOutboundPublishJobPublished(recentKey, recent);
+
+    expect(prunePublishedChannelOutboundPublishJobs(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now)).toBe(0);
+    expect(getChannelOutboundPublishJob(recentKey)).toMatchObject({
+      idempotencyKey: recentKey,
+      status: "published",
+      publishedAt: recent,
+    });
+  });
+});
+
+function makeJob(idempotencyKey: string, emitId: string): ChannelOutboundJob {
+  return {
+    jobId: `runtime:ravi-channels:${emitId}`,
+    status: "queued",
+    attemptCount: 0,
+    createdAt: 1782920000000,
+    updatedAt: 1782920000000,
+    request: {
+      requestId: `runtime:ravi-channels:${emitId}`,
+      channelId: "slack",
+      instanceId: "slack-main",
+      accountId: "T1",
+      targetChatId: "C123",
+      origin: {
+        sessionName: "ravi-channels",
+        emitId,
+      },
+      content: {
+        type: "text",
+        text: "hello Slack",
+      },
+      idempotencyKey,
+      target: {
+        channel: "slack",
+        accountId: "T1",
+        instanceId: "slack-main",
+        chatId: "C123",
+      },
+    },
+  };
+}

--- a/src/channels/outbound-publish-outbox.ts
+++ b/src/channels/outbound-publish-outbox.ts
@@ -1,0 +1,506 @@
+import { createHash } from "node:crypto";
+import { getDb } from "../router/router-db.js";
+import { nats } from "../nats.js";
+import { logger } from "../utils/logger.js";
+import { CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS } from "./outbound-receipts.js";
+import { type ChannelOutboundJob, publishChannelOutboundJob } from "./outbound-stream.js";
+
+const log = logger.child("channels:outbound-publish-outbox");
+
+export const CHANNEL_OUTBOUND_PUBLISH_RETRY_BASE_MS = 30_000;
+export const CHANNEL_OUTBOUND_PUBLISH_RETRY_MAX_MS = 5 * 60_000;
+export const CHANNEL_OUTBOUND_PUBLISH_RECONCILE_INTERVAL_MS = 30_000;
+export const CHANNEL_OUTBOUND_PUBLISH_RECONCILE_LIMIT = 25;
+export const CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS = CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS;
+
+export type ChannelOutboundPublishStatus = "pending" | "published";
+
+export interface ChannelOutboundPublishRecord {
+  idempotencyKey: string;
+  requestFingerprint: string;
+  jobId: string;
+  sessionName: string;
+  channelId: string;
+  status: ChannelOutboundPublishStatus;
+  job: ChannelOutboundJob;
+  attemptCount: number;
+  nextAttemptAt: number;
+  lastErrorMessage?: string;
+  lastErrorAt?: number;
+  publishedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ChannelOutboundPublishOutboxSummary {
+  pendingCount: number;
+  oldestPendingAt?: number;
+  nextAttemptAt?: number;
+  lastPublishedAt?: number;
+  lastError?: {
+    message: string;
+    at: number;
+  };
+}
+
+interface ChannelOutboundPublishRow {
+  idempotency_key: string;
+  request_fingerprint: string;
+  job_id: string;
+  session_name: string;
+  channel_id: string;
+  status: ChannelOutboundPublishStatus;
+  payload_json: string;
+  attempt_count: number;
+  next_attempt_at: number;
+  last_error_message: string | null;
+  last_error_at: number | null;
+  published_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export type ChannelOutboundPublisher = (job: ChannelOutboundJob) => Promise<void>;
+
+export type ChannelOutboundPublishResult =
+  | {
+      ok: true;
+      record: ChannelOutboundPublishRecord;
+      publishedNow: boolean;
+    }
+  | {
+      ok: false;
+      record: ChannelOutboundPublishRecord;
+      error: unknown;
+      nextAttemptAt: number;
+    };
+
+export interface ChannelOutboundPublishOutboxStore {
+  save(job: ChannelOutboundJob, now?: number): ChannelOutboundPublishRecord;
+  get(idempotencyKey: string): ChannelOutboundPublishRecord | null;
+  listDue(options?: { now?: number; limit?: number }): ChannelOutboundPublishRecord[];
+  markPublished(idempotencyKey: string, publishedAt?: number): ChannelOutboundPublishRecord;
+  recordFailure(idempotencyKey: string, error: unknown, failedAt?: number): ChannelOutboundPublishRecord;
+  prunePublished(cutoff: number, now?: number): number;
+  summary(now?: number): ChannelOutboundPublishOutboxSummary;
+}
+
+export const sqliteChannelOutboundPublishOutboxStore: ChannelOutboundPublishOutboxStore = {
+  save: saveChannelOutboundPublishJob,
+  get: getChannelOutboundPublishJob,
+  listDue: listDueChannelOutboundPublishJobs,
+  markPublished: markChannelOutboundPublishJobPublished,
+  recordFailure: recordChannelOutboundPublishJobFailure,
+  prunePublished: prunePublishedChannelOutboundPublishJobs,
+  summary: getChannelOutboundPublishOutboxSummary,
+};
+
+export function saveChannelOutboundPublishJob(job: ChannelOutboundJob, now = Date.now()): ChannelOutboundPublishRecord {
+  ensureChannelOutboundPublishOutboxSchema();
+  const key = requireText(job.request.idempotencyKey, "idempotencyKey");
+  const payloadJson = JSON.stringify(job);
+  const requestFingerprint = channelOutboundPublishRequestFingerprint(job);
+  const database = getDb();
+
+  return database.transaction(() => {
+    database
+      .prepare(
+        `INSERT OR IGNORE INTO channel_outbound_publish_jobs (
+           idempotency_key, request_fingerprint, job_id, session_name, channel_id,
+           status, payload_json, attempt_count, next_attempt_at, last_error_message,
+           last_error_at, published_at, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, 'pending', ?, 0, 0, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        key,
+        requestFingerprint,
+        requireText(job.jobId, "jobId"),
+        requireText(job.request.origin.sessionName, "sessionName"),
+        requireText(job.request.channelId, "channelId"),
+        payloadJson,
+        now,
+        now,
+      );
+
+    const record = requireChannelOutboundPublishJob(key);
+    if (record.requestFingerprint !== requestFingerprint) {
+      throw new Error(`Channel outbound publish job conflict for idempotency key: ${key}`);
+    }
+    return record;
+  })();
+}
+
+export function getChannelOutboundPublishJob(idempotencyKey: string): ChannelOutboundPublishRecord | null {
+  ensureChannelOutboundPublishOutboxSchema();
+  const row = selectChannelOutboundPublishRow(requireText(idempotencyKey, "idempotencyKey"));
+  return row ? rowToPublishRecord(row) : null;
+}
+
+export function listDueChannelOutboundPublishJobs(
+  options: { now?: number; limit?: number } = {},
+): ChannelOutboundPublishRecord[] {
+  ensureChannelOutboundPublishOutboxSchema();
+  const now = finiteNumber(options.now) ?? Date.now();
+  const limit = Math.max(
+    1,
+    Math.min(Math.trunc(finiteNumber(options.limit) ?? CHANNEL_OUTBOUND_PUBLISH_RECONCILE_LIMIT), 100),
+  );
+  const rows = getDb()
+    .prepare(
+      `SELECT *
+         FROM channel_outbound_publish_jobs
+        WHERE status = 'pending'
+          AND next_attempt_at <= ?
+        ORDER BY next_attempt_at ASC, created_at ASC
+        LIMIT ?`,
+    )
+    .all(now, limit) as ChannelOutboundPublishRow[];
+  return rows.map(rowToPublishRecord);
+}
+
+export function markChannelOutboundPublishJobPublished(
+  idempotencyKey: string,
+  publishedAt = Date.now(),
+): ChannelOutboundPublishRecord {
+  ensureChannelOutboundPublishOutboxSchema();
+  const key = requireText(idempotencyKey, "idempotencyKey");
+  const now = finiteNumber(publishedAt) ?? Date.now();
+  const result = getDb()
+    .prepare(
+      `UPDATE channel_outbound_publish_jobs
+          SET status = 'published',
+              published_at = COALESCE(published_at, ?),
+              last_error_message = NULL,
+              last_error_at = NULL,
+              updated_at = ?
+        WHERE idempotency_key = ?`,
+    )
+    .run(now, now, key);
+  if (result.changes === 0) throw new Error(`Channel outbound publish job not found: ${key}`);
+  return requireChannelOutboundPublishJob(key);
+}
+
+export function recordChannelOutboundPublishJobFailure(
+  idempotencyKey: string,
+  error: unknown,
+  failedAt = Date.now(),
+): ChannelOutboundPublishRecord {
+  ensureChannelOutboundPublishOutboxSchema();
+  const key = requireText(idempotencyKey, "idempotencyKey");
+  const existing = requireChannelOutboundPublishJob(key);
+  if (existing.status === "published") return existing;
+  const now = finiteNumber(failedAt) ?? Date.now();
+  const attemptCount = existing.attemptCount + 1;
+  const nextAttemptAt = now + channelOutboundPublishRetryDelayMs(attemptCount);
+  getDb()
+    .prepare(
+      `UPDATE channel_outbound_publish_jobs
+          SET status = 'pending',
+              attempt_count = ?,
+              next_attempt_at = ?,
+              last_error_message = ?,
+              last_error_at = ?,
+              updated_at = ?
+        WHERE idempotency_key = ?
+          AND status = 'pending'`,
+    )
+    .run(attemptCount, nextAttemptAt, errorMessage(error), now, now, key);
+  return requireChannelOutboundPublishJob(key);
+}
+
+export function getChannelOutboundPublishOutboxSummary(_now = Date.now()): ChannelOutboundPublishOutboxSummary {
+  ensureChannelOutboundPublishOutboxSchema();
+  const row = getDb()
+    .prepare(
+      `SELECT COUNT(CASE WHEN status = 'pending' THEN 1 END) AS pending_count,
+              MIN(CASE WHEN status = 'pending' THEN created_at END) AS oldest_pending_at,
+              MIN(CASE WHEN status = 'pending' THEN next_attempt_at END) AS next_attempt_at,
+              MAX(published_at) AS last_published_at
+         FROM channel_outbound_publish_jobs`,
+    )
+    .get() as {
+    pending_count: number;
+    oldest_pending_at: number | null;
+    next_attempt_at: number | null;
+    last_published_at: number | null;
+  };
+  const errorRow = getDb()
+    .prepare(
+      `SELECT last_error_message, last_error_at
+         FROM channel_outbound_publish_jobs
+        WHERE last_error_at IS NOT NULL
+        ORDER BY last_error_at DESC
+        LIMIT 1`,
+    )
+    .get() as { last_error_message: string | null; last_error_at: number | null } | undefined;
+
+  return {
+    pendingCount: Number(row?.pending_count ?? 0),
+    ...(row?.oldest_pending_at !== null && row?.oldest_pending_at !== undefined
+      ? { oldestPendingAt: row.oldest_pending_at }
+      : {}),
+    ...(row?.next_attempt_at !== null && row?.next_attempt_at !== undefined
+      ? { nextAttemptAt: row.next_attempt_at }
+      : {}),
+    ...(row?.last_published_at !== null && row?.last_published_at !== undefined
+      ? { lastPublishedAt: row.last_published_at }
+      : {}),
+    ...(errorRow?.last_error_at !== null && errorRow?.last_error_at !== undefined
+      ? { lastError: { message: errorRow.last_error_message ?? "unknown publish error", at: errorRow.last_error_at } }
+      : {}),
+  };
+}
+
+export function prunePublishedChannelOutboundPublishJobs(cutoff: number, now = Date.now()): number {
+  ensureChannelOutboundPublishOutboxSchema();
+  const normalizedCutoff = finiteNumber(cutoff);
+  if (normalizedCutoff === null) throw new Error("cutoff must be a finite number");
+  const normalizedNow = finiteNumber(now);
+  if (normalizedNow === null) throw new Error("now must be a finite number");
+  if (normalizedCutoff > normalizedNow) throw new Error("cutoff must not be in the future");
+  return getDb()
+    .prepare(
+      `DELETE FROM channel_outbound_publish_jobs
+       WHERE status = 'published'
+         AND published_at IS NOT NULL
+         AND published_at <= ?`,
+    )
+    .run(normalizedCutoff).changes;
+}
+
+export async function publishChannelOutboundJobDurably(
+  job: ChannelOutboundJob,
+  options: {
+    store?: ChannelOutboundPublishOutboxStore;
+    publisher?: ChannelOutboundPublisher;
+    now?: () => number;
+  } = {},
+): Promise<ChannelOutboundPublishResult> {
+  const store = options.store ?? sqliteChannelOutboundPublishOutboxStore;
+  const now = options.now ?? Date.now;
+  const saved = store.save(job, now());
+  if (saved.status === "published") {
+    return { ok: true, record: saved, publishedNow: false };
+  }
+
+  try {
+    await (options.publisher ?? publishChannelOutboundJob)(saved.job);
+    const published = store.markPublished(saved.idempotencyKey, now());
+    return { ok: true, record: published, publishedNow: true };
+  } catch (error) {
+    const failed = store.recordFailure(saved.idempotencyKey, error, now());
+    return {
+      ok: false,
+      record: failed,
+      error,
+      nextAttemptAt: failed.nextAttemptAt,
+    };
+  }
+}
+
+export async function reconcileDueChannelOutboundPublishes(
+  options: {
+    store?: ChannelOutboundPublishOutboxStore;
+    publisher?: ChannelOutboundPublisher;
+    emitEvent?: typeof nats.emit;
+    now?: () => number;
+    limit?: number;
+  } = {},
+): Promise<{ attempted: number; published: number; failed: number }> {
+  const store = options.store ?? sqliteChannelOutboundPublishOutboxStore;
+  const now = options.now ?? Date.now;
+  const due = store.listDue({ now: now(), limit: options.limit });
+  let published = 0;
+  let failed = 0;
+
+  for (const record of due) {
+    try {
+      await (options.publisher ?? publishChannelOutboundJob)(record.job);
+      const updated = store.markPublished(record.idempotencyKey, now());
+      published++;
+      await emitQueuedDelivery(updated.job, options.emitEvent ?? nats.emit, "native_channel_outbound_reconciled").catch(
+        (error) => {
+          log.warn("Failed to emit reconciled native outbound queued delivery", {
+            jobId: updated.jobId,
+            error,
+          });
+        },
+      );
+    } catch (error) {
+      failed++;
+      const updated = store.recordFailure(record.idempotencyKey, error, now());
+      log.warn("Deferred channel outbound publish; will retry", {
+        jobId: updated.jobId,
+        attemptCount: updated.attemptCount,
+        nextAttemptAt: updated.nextAttemptAt,
+        error,
+      });
+    }
+  }
+
+  return { attempted: due.length, published, failed };
+}
+
+export class ChannelOutboundPublishReconciler {
+  private running = false;
+  private loopPromise: Promise<void> | null = null;
+
+  constructor(
+    private readonly options: {
+      store?: ChannelOutboundPublishOutboxStore;
+      publisher?: ChannelOutboundPublisher;
+      emitEvent?: typeof nats.emit;
+      isRunning?: () => boolean;
+      intervalMs?: number;
+      limit?: number;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.loopPromise = this.runLoop();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    await this.loopPromise?.catch((error) => {
+      log.debug("Channel outbound publish reconciler stopped after loop error", { error });
+    });
+    this.loopPromise = null;
+  }
+
+  status(): ChannelOutboundPublishOutboxSummary {
+    return (this.options.store ?? sqliteChannelOutboundPublishOutboxStore).summary(this.options.now?.() ?? Date.now());
+  }
+
+  private shouldContinue(): boolean {
+    return this.running && (this.options.isRunning?.() ?? true);
+  }
+
+  private async runLoop(): Promise<void> {
+    const intervalMs = this.options.intervalMs ?? CHANNEL_OUTBOUND_PUBLISH_RECONCILE_INTERVAL_MS;
+    while (this.shouldContinue()) {
+      try {
+        await reconcileDueChannelOutboundPublishes(this.options);
+      } catch (error) {
+        log.warn("Channel outbound publish reconcile loop failed; retrying", { error });
+      }
+      await delayWhileRunning(intervalMs, () => this.shouldContinue());
+    }
+  }
+}
+
+export function channelOutboundPublishRetryDelayMs(attemptCount: number): number {
+  const attempt =
+    typeof attemptCount === "number" && Number.isSafeInteger(attemptCount) && attemptCount > 0 ? attemptCount : 1;
+  const exponent = Math.min(attempt - 1, 4);
+  return Math.min(CHANNEL_OUTBOUND_PUBLISH_RETRY_BASE_MS * 2 ** exponent, CHANNEL_OUTBOUND_PUBLISH_RETRY_MAX_MS);
+}
+
+function ensureChannelOutboundPublishOutboxSchema(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS channel_outbound_publish_jobs (
+      idempotency_key      TEXT PRIMARY KEY,
+      request_fingerprint  TEXT NOT NULL,
+      job_id               TEXT NOT NULL,
+      session_name         TEXT NOT NULL,
+      channel_id           TEXT NOT NULL,
+      status               TEXT NOT NULL CHECK(status IN ('pending','published')),
+      payload_json         TEXT NOT NULL,
+      attempt_count        INTEGER NOT NULL DEFAULT 0,
+      next_attempt_at      INTEGER NOT NULL DEFAULT 0,
+      last_error_message   TEXT,
+      last_error_at        INTEGER,
+      published_at         INTEGER,
+      created_at           INTEGER NOT NULL,
+      updated_at           INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_channel_outbound_publish_jobs_status_next
+      ON channel_outbound_publish_jobs(status, next_attempt_at, created_at);
+    CREATE INDEX IF NOT EXISTS idx_channel_outbound_publish_jobs_published_retention
+      ON channel_outbound_publish_jobs(status, published_at);
+    CREATE INDEX IF NOT EXISTS idx_channel_outbound_publish_jobs_error
+      ON channel_outbound_publish_jobs(last_error_at);
+  `);
+}
+
+function selectChannelOutboundPublishRow(idempotencyKey: string): ChannelOutboundPublishRow | null {
+  return (
+    (getDb().prepare("SELECT * FROM channel_outbound_publish_jobs WHERE idempotency_key = ?").get(idempotencyKey) as
+      | ChannelOutboundPublishRow
+      | undefined) ?? null
+  );
+}
+
+function requireChannelOutboundPublishJob(idempotencyKey: string): ChannelOutboundPublishRecord {
+  const row = selectChannelOutboundPublishRow(idempotencyKey);
+  if (!row) throw new Error(`Channel outbound publish job not found: ${idempotencyKey}`);
+  return rowToPublishRecord(row);
+}
+
+function rowToPublishRecord(row: ChannelOutboundPublishRow): ChannelOutboundPublishRecord {
+  const parsed = JSON.parse(row.payload_json) as ChannelOutboundJob;
+  return {
+    idempotencyKey: row.idempotency_key,
+    requestFingerprint: row.request_fingerprint,
+    jobId: row.job_id,
+    sessionName: row.session_name,
+    channelId: row.channel_id,
+    status: row.status,
+    job: parsed,
+    attemptCount: row.attempt_count,
+    nextAttemptAt: row.next_attempt_at,
+    ...(row.last_error_message ? { lastErrorMessage: row.last_error_message } : {}),
+    ...(row.last_error_at !== null ? { lastErrorAt: row.last_error_at } : {}),
+    ...(row.published_at !== null ? { publishedAt: row.published_at } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function channelOutboundPublishRequestFingerprint(job: ChannelOutboundJob): string {
+  return createHash("sha256").update(JSON.stringify(job.request)).digest("hex");
+}
+
+async function emitQueuedDelivery(
+  job: ChannelOutboundJob,
+  emitEvent: typeof nats.emit,
+  reason: "native_channel_outbound" | "native_channel_outbound_reconciled",
+): Promise<void> {
+  await emitEvent(`ravi.session.${job.request.origin.sessionName}.delivery`, {
+    status: "queued",
+    reason,
+    jobId: job.jobId,
+    target: job.request.target,
+    textLen: job.request.content.text.length,
+  });
+}
+
+function requireText(value: string, label: string): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function finiteNumber(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function delayWhileRunning(ms: number, shouldContinue: () => boolean): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (shouldContinue()) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    await delay(Math.min(remaining, 1_000));
+  }
+}

--- a/src/channels/outbound-receipts.ts
+++ b/src/channels/outbound-receipts.ts
@@ -7,6 +7,7 @@ export const CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS = 14 * DAY_MS;
 
 export type ChannelOutboundReceiptState = "claimed" | "sent" | "persisted" | "complete";
 export type ChannelOutboundReceiptErrorPhase =
+  | "adapter_lookup"
   | "send"
   | "receipt_read"
   | "receipt_claim"

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, mock } from "bun:test";
+import { CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS } from "./outbound-publish-outbox.js";
 import { CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS } from "./outbound-receipts.js";
 import {
   CHANNEL_OUTBOUND_RECEIPT_PRUNE_INTERVAL_MS,
+  pruneChannelOutboundPublishOutbox,
   pruneChannelOutboundReceiptLedger,
+  runChannelOutboundLedgerMaintenance,
   slackAdapterHealth,
   startChannelOutboundReceiptPruner,
 } from "./runner.js";
@@ -17,8 +20,33 @@ describe("channel runner outbound receipt maintenance", () => {
     expect(CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS).toBe(14 * 24 * 60 * 60 * 1_000);
   });
 
+  it("prunes published outbox jobs using the same 14-day safety window", () => {
+    const prunePublished = mock(() => 4);
+    const now = Date.UTC(2026, 6, 21);
+
+    expect(pruneChannelOutboundPublishOutbox(now, { prunePublished })).toBe(4);
+    expect(prunePublished).toHaveBeenCalledWith(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now);
+    expect(CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS).toBe(CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS);
+  });
+
+  it("runs receipt and publish outbox pruning in the same maintenance pass", () => {
+    const pruneExpired = mock(() => 2);
+    const prunePublished = mock(() => 1);
+    const now = Date.UTC(2026, 6, 21);
+
+    expect(
+      runChannelOutboundLedgerMaintenance(now, {
+        receiptStore: { pruneExpired },
+        publishOutboxStore: { prunePublished },
+      }),
+    ).toEqual({ receipts: 2, publishJobs: 1 });
+    expect(pruneExpired).toHaveBeenCalledWith(now - CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS, now);
+    expect(prunePublished).toHaveBeenCalledWith(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now);
+  });
+
   it("runs periodic pruning on an unref timer and clears it when stopped", () => {
     const pruneExpired = mock(() => 2);
+    const prunePublished = mock(() => 1);
     const unref = mock(() => {});
     const timer = { unref } as unknown as ReturnType<typeof setInterval>;
     let callback: (() => void) | undefined;
@@ -33,6 +61,7 @@ describe("channel runner outbound receipt maintenance", () => {
     const stop = startChannelOutboundReceiptPruner({
       now: () => now,
       store: { pruneExpired },
+      publishOutboxStore: { prunePublished },
       setInterval: setIntervalForTest,
       clearInterval: clearIntervalForTest,
     });
@@ -40,8 +69,10 @@ describe("channel runner outbound receipt maintenance", () => {
     expect(setIntervalForTest).toHaveBeenCalledTimes(1);
     expect(unref).toHaveBeenCalledTimes(1);
     expect(pruneExpired).not.toHaveBeenCalled();
+    expect(prunePublished).not.toHaveBeenCalled();
     callback?.();
     expect(pruneExpired).toHaveBeenCalledWith(now - CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS, now);
+    expect(prunePublished).toHaveBeenCalledWith(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now);
 
     stop();
     expect(clearIntervalForTest).toHaveBeenCalledWith(timer);

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -11,6 +11,14 @@ import {
 import type { NativePresenceDelivery, NativeTextDelivery } from "./native/types.js";
 import { ChannelOutboundConsumer } from "./outbound-consumer.js";
 import {
+  ChannelOutboundPublishReconciler,
+  CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS,
+  getChannelOutboundPublishOutboxSummary,
+  sqliteChannelOutboundPublishOutboxStore,
+  type ChannelOutboundPublishOutboxStore,
+  type ChannelOutboundPublishOutboxSummary,
+} from "./outbound-publish-outbox.js";
+import {
   CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS,
   type ChannelOutboundReceiptStore,
   sqliteChannelOutboundReceiptStore,
@@ -37,6 +45,7 @@ export interface ChannelOutboundReceiptPrunerOptions {
   intervalMs?: number;
   now?: () => number;
   store?: Pick<ChannelOutboundReceiptStore, "pruneExpired">;
+  publishOutboxStore?: Pick<ChannelOutboundPublishOutboxStore, "prunePublished">;
   setInterval?: (callback: () => void, intervalMs: number) => ReceiptPruneTimer;
   clearInterval?: (timer: ReceiptPruneTimer) => void;
 }
@@ -55,6 +64,7 @@ export class ChannelRunner {
   private running = false;
   private startedAt: number | null = null;
   private outboundInfrastructureReady = false;
+  private outboundPublishReconciler: ChannelOutboundPublishReconciler | null = null;
   private outboundConsumer: ChannelOutboundConsumer | null = null;
   private presenceConsumer: ChannelPresenceConsumer | null = null;
   private deliveries: NativeTextDelivery[] = [];
@@ -83,14 +93,7 @@ export class ChannelRunner {
     });
     await configStore.startRefresh();
     await ensureChannelOutboundInfrastructure();
-    try {
-      const prunedReceipts = pruneChannelOutboundReceiptLedger();
-      if (prunedReceipts > 0) {
-        log.info("Pruned expired channel outbound receipts", { count: prunedReceipts });
-      }
-    } catch (error) {
-      log.warn("Failed to prune expired channel outbound receipts", { error });
-    }
+    runChannelOutboundLedgerMaintenance();
     this.stopReceiptPruner = startChannelOutboundReceiptPruner();
 
     this.outboundInfrastructureReady = true;
@@ -105,6 +108,11 @@ export class ChannelRunner {
     await this.startSlack(env);
 
     if (this.options.consumeOutbound !== false) {
+      this.outboundPublishReconciler = new ChannelOutboundPublishReconciler({
+        isRunning: () => this.running,
+      });
+      this.outboundPublishReconciler.start();
+
       this.outboundConsumer = new ChannelOutboundConsumer({
         deliveries: this.deliveries,
         isRunning: () => this.running,
@@ -135,6 +143,8 @@ export class ChannelRunner {
     this.stopReceiptPruner?.();
     this.stopReceiptPruner = null;
     log.info("Stopping channel runner", { pid: process.pid });
+    await this.outboundPublishReconciler?.stop();
+    this.outboundPublishReconciler = null;
     await this.outboundConsumer?.stop();
     this.outboundConsumer = null;
     await this.presenceConsumer?.stop();
@@ -165,6 +175,8 @@ export class ChannelRunner {
         enabled: this.options.consumeOutbound !== false,
         infrastructureReady: this.outboundInfrastructureReady,
         consuming: this.outboundConsumer?.isConsuming() ?? false,
+        publishOutbox: this.outboundPublishOutboxStatus(),
+        ...this.outboundConsumer?.status(),
       },
       adapters: this.currentAdapterStatuses(),
     };
@@ -173,7 +185,18 @@ export class ChannelRunner {
   private async startSlack(env: NodeJS.ProcessEnv): Promise<void> {
     this.markAdapter("slack", "slack", "starting");
     try {
-      const runtimes = await createSlackNativeRuntimesFromEnv(env);
+      const runtimes = await createSlackNativeRuntimesFromEnv(env, {
+        onRuntimeDisabled: (channel, reason) => {
+          this.markAdapter(`slack:${channel.name}`, "slack", "failed", reason);
+        },
+        onRuntimeError: (channel, error) => {
+          this.markAdapter(`slack:${channel.name}`, "slack", "failed", "startup_failed");
+          log.error("Failed to start configured Slack native runtime", {
+            channel: channel.name,
+            error,
+          });
+        },
+      });
       this.adapterStatuses.delete("slack");
       if (!runtimes.length) {
         this.markAdapter("slack", "slack", "disabled", "not_configured");
@@ -200,6 +223,20 @@ export class ChannelRunner {
       statuses.set(`slack:${runtime.accountId}`, slackAdapterHealth(runtime.accountId, socketStatus));
     }
     return Array.from(statuses.values()).sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  private outboundPublishOutboxStatus(): ChannelOutboundPublishOutboxSummary {
+    try {
+      return this.outboundPublishReconciler?.status() ?? getChannelOutboundPublishOutboxSummary();
+    } catch (error) {
+      return {
+        pendingCount: 0,
+        lastError: {
+          message: error instanceof Error ? error.message : String(error),
+          at: Date.now(),
+        },
+      };
+    }
   }
 
   private markAdapter(id: string, channelId: string, status: AdapterStatus["status"], reason?: string): void {
@@ -239,6 +276,43 @@ export function pruneChannelOutboundReceiptLedger(
   return store.pruneExpired(now - CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS, now);
 }
 
+export function pruneChannelOutboundPublishOutbox(
+  now = Date.now(),
+  store: Pick<ChannelOutboundPublishOutboxStore, "prunePublished"> = sqliteChannelOutboundPublishOutboxStore,
+): number {
+  return store.prunePublished(now - CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS, now);
+}
+
+export function runChannelOutboundLedgerMaintenance(
+  now = Date.now(),
+  stores: {
+    receiptStore?: Pick<ChannelOutboundReceiptStore, "pruneExpired">;
+    publishOutboxStore?: Pick<ChannelOutboundPublishOutboxStore, "prunePublished">;
+  } = {},
+): { receipts: number; publishJobs: number } {
+  let receipts = 0;
+  try {
+    receipts = pruneChannelOutboundReceiptLedger(now, stores.receiptStore);
+    if (receipts > 0) {
+      log.info("Pruned expired channel outbound receipts", { count: receipts });
+    }
+  } catch (error) {
+    log.warn("Failed to prune expired channel outbound receipts", { error });
+  }
+
+  let publishJobs = 0;
+  try {
+    publishJobs = pruneChannelOutboundPublishOutbox(now, stores.publishOutboxStore);
+    if (publishJobs > 0) {
+      log.info("Pruned expired channel outbound publish jobs", { count: publishJobs });
+    }
+  } catch (error) {
+    log.warn("Failed to prune expired channel outbound publish jobs", { error });
+  }
+
+  return { receipts, publishJobs };
+}
+
 export function startChannelOutboundReceiptPruner(options: ChannelOutboundReceiptPrunerOptions = {}): () => void {
   const intervalMs = options.intervalMs ?? CHANNEL_OUTBOUND_RECEIPT_PRUNE_INTERVAL_MS;
   if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
@@ -247,17 +321,11 @@ export function startChannelOutboundReceiptPruner(options: ChannelOutboundReceip
 
   const now = options.now ?? Date.now;
   const store = options.store ?? sqliteChannelOutboundReceiptStore;
+  const publishOutboxStore = options.publishOutboxStore ?? sqliteChannelOutboundPublishOutboxStore;
   const scheduleInterval = options.setInterval ?? setInterval;
   const cancelInterval = options.clearInterval ?? clearInterval;
   const timer = scheduleInterval(() => {
-    try {
-      const prunedReceipts = pruneChannelOutboundReceiptLedger(now(), store);
-      if (prunedReceipts > 0) {
-        log.info("Pruned expired channel outbound receipts", { count: prunedReceipts });
-      }
-    } catch (error) {
-      log.warn("Failed to prune expired channel outbound receipts", { error });
-    }
+    runChannelOutboundLedgerMaintenance(now(), { receiptStore: store, publishOutboxStore });
   }, intervalMs);
   timer.unref?.();
 

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { EventEmitter } from "node:events";
+import { configStore } from "../../config-store.js";
 import {
   createContact,
   ensureContactFromInbound,
@@ -22,6 +23,7 @@ import {
   dbGetContext,
   dbListChatParticipants,
   dbUpsertChat,
+  dbUpsertInstance,
   getDb,
 } from "../../router/router-db.js";
 import type { InstanceConfig } from "../../router/router-db.js";
@@ -150,6 +152,7 @@ describe("Slack Socket Mode routing", () => {
   beforeEach(async () => {
     stateDir = await createIsolatedRaviState("ravi-slack-socket-mode-");
     seedAgent("ravi-hil", "/tmp/ravi-hil");
+    configStore.refresh();
   });
 
   afterEach(async () => {
@@ -157,27 +160,87 @@ describe("Slack Socket Mode routing", () => {
     stateDir = null;
   });
 
-  it("scopes native text delivery to the configured Slack workspace", () => {
+  it("scopes native text delivery to explicit Slack workspace aliases", () => {
+    const slug = "ravi-rbbt-slack";
+    const uuid = "0bc9635c-1ee9-42e3-9112-95be9cdb0334";
+    const otherUuid = "11111111-2222-3333-4444-555555555555";
     const delivery = new SlackTextDelivery({} as never, {} as never, {
-      accountId: "ravi-rbbt-slack",
-      routeAccountId: "ravi-rbbt-slack",
-      instanceId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
-      connection: "ravi-rbbt-slack",
+      accountId: slug,
+      routeAccountId: slug,
+      instanceId: slug,
+      connection: slug,
+      instanceAliases: [uuid, slug],
     });
 
     expect(
       delivery.supports({
         channel: "slack",
-        accountId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
-        instanceId: "0bc9635c-1ee9-42e3-9112-95be9cdb0334",
+        accountId: uuid,
+        instanceId: uuid,
         chatId: "C123",
       }),
     ).toBe(true);
     expect(
       delivery.supports({
         channel: "slack",
-        accountId: "hana-slack",
-        instanceId: "hana-slack",
+        accountId: otherUuid,
+        instanceId: otherUuid,
+        chatId: "C456",
+      }),
+    ).toBe(false);
+    expect(
+      delivery.supports({
+        channel: "slack",
+        accountId: slug,
+        instanceId: otherUuid,
+        chatId: "C456",
+      }),
+    ).toBe(false);
+  });
+
+  it("loads explicit Slack instance UUID aliases into outbound runtime scope", async () => {
+    const slug = "ravi-rbbt-slack";
+    const uuid = "0bc9635c-1ee9-42e3-9112-95be9cdb0334";
+    const otherUuid = "11111111-2222-3333-4444-555555555555";
+    dbUpsertInstance({ name: slug, instanceId: uuid, channel: "slack" });
+    dbUpsertInstance({ name: "hana-slack", instanceId: otherUuid, channel: "slack" });
+    configStore.refresh();
+
+    const runtimes = await createSlackNativeRuntimesFromEnv({} as NodeJS.ProcessEnv, {
+      resolveSecret: mock(async () => ({
+        secret: JSON.stringify({ appToken: "xapp-rbbt", botToken: "xoxb-rbbt" }),
+        connection: { connection: slug },
+      })),
+      channels: {
+        [slug]: slackChannel({ name: slug, credentialConnection: slug }),
+      },
+    });
+
+    expect(runtimes).toHaveLength(1);
+    const runtime = runtimes[0]!;
+    expect(runtime.accountId).toBe(slug);
+    expect(runtime.instanceId).toBe(slug);
+    expect(
+      runtime.delivery.supports({
+        channel: "slack",
+        accountId: uuid,
+        instanceId: uuid,
+        chatId: "C123",
+      }),
+    ).toBe(true);
+    expect(
+      runtime.delivery.supports({
+        channel: "slack",
+        accountId: otherUuid,
+        instanceId: otherUuid,
+        chatId: "C456",
+      }),
+    ).toBe(false);
+    expect(
+      runtime.delivery.supports({
+        channel: "slack",
+        accountId: slug,
+        instanceId: otherUuid,
         chatId: "C456",
       }),
     ).toBe(false);
@@ -251,6 +314,42 @@ describe("Slack Socket Mode routing", () => {
     expect(resolveSecret.mock.calls.map((call) => call[0].connection)).toEqual(["hana-secret", "rbbt-secret"]);
     expect(runtimes.map((runtime) => runtime.accountId)).toEqual(["hana-slack", "ravi-rbbt-slack"]);
     expect(runtimes.map((runtime) => runtime.connection)).toEqual(["hana-secret", "rbbt-secret"]);
+  });
+
+  it("isolates one Slack account startup failure from other configured accounts", async () => {
+    const errors: string[] = [];
+    const disabled: string[] = [];
+    const resolveSecret = mock(async ({ connection }: { connection: string }) => {
+      if (connection === "bad-secret") throw new Error("credential backend unavailable");
+      return {
+        secret: JSON.stringify({
+          appToken: `xapp-${connection}`,
+          botToken: `xoxb-${connection}`,
+        }),
+        connection: { connection },
+      };
+    });
+
+    const runtimes = await createSlackNativeRuntimesFromEnv({} as NodeJS.ProcessEnv, {
+      resolveSecret,
+      onRuntimeDisabled: (channel, reason) => disabled.push(`${channel.name}:${reason}`),
+      onRuntimeError: (channel, error) =>
+        errors.push(`${channel.name}:${error instanceof Error ? error.message : String(error)}`),
+      channels: {
+        "bad-slack": slackChannel({
+          name: "bad-slack",
+          credentialConnection: "bad-secret",
+        }),
+        "hana-slack": slackChannel({
+          name: "hana-slack",
+          credentialConnection: "hana-secret",
+        }),
+      },
+    });
+
+    expect(runtimes.map((runtime) => runtime.accountId)).toEqual(["hana-slack"]);
+    expect(errors).toEqual(["bad-slack:credential backend unavailable"]);
+    expect(disabled).toEqual([]);
   });
 
   it("keeps bot alias defaults isolated per configured Slack account", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -170,6 +170,7 @@ export interface SlackTargetScope {
   readonly routeAccountId?: string;
   readonly instanceId?: string;
   readonly connection?: string;
+  readonly instanceAliases?: readonly string[];
 }
 
 class RecentIdCache {
@@ -198,8 +199,15 @@ function supportsSlackTarget(target: MessageTarget, scope?: SlackTargetScope): b
   if (!scope) return true;
 
   const targetIds = normalizeSlackTargetIds([target.accountId, target.instanceId]);
-  const scopeIds = normalizeSlackTargetIds([scope.accountId, scope.routeAccountId, scope.instanceId, scope.connection]);
-  return targetIds.some((id) => scopeIds.includes(id));
+  const scopeIds = normalizeSlackTargetIds([
+    scope.accountId,
+    scope.routeAccountId,
+    scope.instanceId,
+    scope.connection,
+    ...(scope.instanceAliases ?? []),
+  ]);
+  if (targetIds.length === 0 || scopeIds.length === 0) return false;
+  return targetIds.every((id) => scopeIds.includes(id));
 }
 
 function normalizeSlackTargetIds(values: Array<string | undefined>): string[] {
@@ -1841,9 +1849,11 @@ export async function createSlackNativeRuntimeFromEnv(
     channel?: ChannelConfig;
     channels?: Record<string, ChannelConfig>;
     resolveSecret?: SlackCredentialResolver;
+    onRuntimeDisabled?: (channel: ChannelConfig, reason: "missing_credentials") => void;
   } = {},
 ): Promise<SlackNativeRuntime | null> {
-  const channels = options.channels ?? configStore.getConfig().channels ?? {};
+  const routerConfig = configStore.getConfig();
+  const channels = options.channels ?? routerConfig.channels ?? {};
   const credentials = await resolveSlackCredentialConfigFromEnv(env, {
     channels,
     channel: options.channel,
@@ -1851,14 +1861,17 @@ export async function createSlackNativeRuntimeFromEnv(
   });
   if (!credentials) {
     log.warn("Slack native runtime disabled: configure a Slack channel with brokered credentials");
+    if (options.channel) options.onRuntimeDisabled?.(options.channel, "missing_credentials");
     return null;
   }
 
+  const instanceAliases = resolveSlackInstanceAliases(routerConfig, credentials.instanceId);
   const scope: SlackTargetScope = {
     accountId: credentials.accountId,
     routeAccountId: credentials.routeAccountId,
     instanceId: credentials.instanceId,
     connection: credentials.connection,
+    instanceAliases: instanceAliases.scopedAliases,
   };
   const routingPolicy = slackRoutingPolicyFromChannelDefaults(options.channel?.defaults, env);
   const webClient = new SlackWebApiClient({
@@ -1921,18 +1934,25 @@ export async function createSlackNativeRuntimesFromEnv(
   options: {
     channels?: Record<string, ChannelConfig>;
     resolveSecret?: SlackCredentialResolver;
+    onRuntimeDisabled?: (channel: ChannelConfig, reason: "missing_credentials") => void;
+    onRuntimeError?: (channel: ChannelConfig, error: unknown) => void;
   } = {},
 ): Promise<SlackNativeRuntime[]> {
   const channels = options.channels ?? configStore.getConfig().channels ?? {};
   const configuredChannels = enabledSlackChannels(channels);
   const runtimes: SlackNativeRuntime[] = [];
   for (const channel of configuredChannels) {
-    const runtime = await createSlackNativeRuntimeFromEnv(env, {
-      channels,
-      channel,
-      resolveSecret: options.resolveSecret,
-    });
-    if (runtime) runtimes.push(runtime);
+    try {
+      const runtime = await createSlackNativeRuntimeFromEnv(env, {
+        channels,
+        channel,
+        resolveSecret: options.resolveSecret,
+        onRuntimeDisabled: options.onRuntimeDisabled,
+      });
+      if (runtime) runtimes.push(runtime);
+    } catch (error) {
+      options.onRuntimeError?.(channel, error);
+    }
   }
   return runtimes;
 }

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createChannelRunnerHealthSnapshot, type ChannelRunnerRuntimeStatus } from "../../channels/health.js";
 import { dbGetChannel } from "../../router/router-db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
@@ -7,9 +10,11 @@ import {
   buildRunnerPm2Env,
   ChannelsCommands,
   classifyChannelRunnerHealth,
+  validateChannelRunnerRuntimeTarget,
 } from "./channels.js";
 
 const ORIGINAL_ENV = { ...process.env };
+const tempDirs: string[] = [];
 let stateDir: string | null = null;
 
 beforeEach(async () => {
@@ -20,6 +25,10 @@ afterEach(async () => {
   await cleanupIsolatedRaviState(stateDir);
   stateDir = null;
   process.env = { ...ORIGINAL_ENV };
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 describe("channels command runner env", () => {
@@ -208,5 +217,102 @@ describe("channels live status", () => {
   it("classifies adapter recovery and failure independently from PM2", () => {
     expect(classifyChannelRunnerHealth(liveRunnerStatus("reconnecting"))).toBe("starting");
     expect(classifyChannelRunnerHealth(liveRunnerStatus("failed"))).toBe("degraded");
+  });
+
+  it("classifies outbound consumer loop errors as degraded", () => {
+    const snapshot = createChannelRunnerHealthSnapshot({
+      ...liveRunnerStatus(),
+      outbound: {
+        ...liveRunnerStatus().outbound,
+        lastError: {
+          phase: "consume_loop",
+          message: "JetStream consumer unavailable",
+          at: 1_721_563_204_000,
+        },
+      },
+    });
+
+    expect(classifyChannelRunnerHealth(snapshot)).toBe("degraded");
+  });
+
+  it("classifies native publish outbox failures as degraded", () => {
+    const snapshot = createChannelRunnerHealthSnapshot({
+      ...liveRunnerStatus(),
+      outbound: {
+        ...liveRunnerStatus().outbound,
+        publishOutbox: {
+          pendingCount: 1,
+          nextAttemptAt: 1_721_563_234_000,
+          lastError: {
+            message: "503 no space left on device",
+            at: 1_721_563_204_000,
+          },
+        },
+      },
+    });
+
+    expect(classifyChannelRunnerHealth(snapshot)).toBe("degraded");
+  });
+});
+
+describe("channels runner runtime target parity", () => {
+  it("accepts the daemon-authoritative bundle", () => {
+    const root = mkdtempSync(join(tmpdir(), "ravi-channels-target-"));
+    tempDirs.push(root);
+    const bundlePath = join(root, "dist", "bundle", "index.js");
+    mkdirSync(join(bundlePath, ".."), { recursive: true });
+    writeFileSync(bundlePath, "", "utf8");
+
+    const validation = validateChannelRunnerRuntimeTarget(
+      { bundlePath, cwd: root },
+      {
+        inspectRuntimeTarget: () =>
+          ({
+            daemon: {
+              online: true,
+              execPath: bundlePath,
+              cwd: root,
+              matchesCli: true,
+            },
+          }) as never,
+      },
+    );
+
+    expect(validation).toEqual({ ok: true });
+  });
+
+  it("rejects a channel runner bundle that diverges from the live daemon", () => {
+    const root = mkdtempSync(join(tmpdir(), "ravi-channels-target-mismatch-"));
+    tempDirs.push(root);
+    const daemonBundle = join(root, "daemon", "dist", "bundle", "index.js");
+    const targetBundle = join(root, "stale", "dist", "bundle", "index.js");
+    mkdirSync(join(daemonBundle, ".."), { recursive: true });
+    mkdirSync(join(targetBundle, ".."), { recursive: true });
+    writeFileSync(daemonBundle, "", "utf8");
+    writeFileSync(targetBundle, "", "utf8");
+
+    const validation = validateChannelRunnerRuntimeTarget(
+      { bundlePath: targetBundle, cwd: join(root, "stale") },
+      {
+        inspectRuntimeTarget: () =>
+          ({
+            daemon: {
+              online: true,
+              execPath: daemonBundle,
+              cwd: join(root, "daemon"),
+              matchesCli: false,
+            },
+          }) as never,
+      },
+    );
+
+    expect(validation).toMatchObject({
+      ok: false,
+      targetBundle: realpathSync(targetBundle).toLowerCase(),
+      daemonBundle: realpathSync(daemonBundle).toLowerCase(),
+    });
+    if (!validation.ok) {
+      expect(validation.message).toContain("Refusing to start channel runner");
+    }
   });
 });

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -4,6 +4,7 @@
 
 import "reflect-metadata";
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { z } from "zod";
 import {
   probeChannelRunnerHealth,
@@ -27,6 +28,7 @@ import { Arg, CliOnly, Command, CommandAccess, Group, Option, Returns, Scope } f
 import { fail } from "../context.js";
 import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
 import { jsonObjectSchema, strictCliOffsetPaginationSchema } from "../return-schemas.js";
+import { inspectCliRuntimeTarget, type CliRuntimeTargetSummary } from "../runtime-target.js";
 import { resolveDaemonRuntimeTarget, type DaemonRuntimeTarget } from "./daemon.js";
 
 const pm2ProcessReturnSchema = z
@@ -69,6 +71,31 @@ const channelRunnerHealthSnapshotReturnSchema = z
         enabled: z.boolean(),
         infrastructureReady: z.boolean(),
         consuming: z.boolean(),
+        lastMessageAt: z.number().optional(),
+        lastError: z
+          .object({
+            phase: z.literal("consume_loop"),
+            message: z.string(),
+            at: z.number(),
+          })
+          .strict()
+          .optional(),
+        publishOutbox: z
+          .object({
+            pendingCount: z.number().int().nonnegative(),
+            oldestPendingAt: z.number().optional(),
+            nextAttemptAt: z.number().optional(),
+            lastPublishedAt: z.number().optional(),
+            lastError: z
+              .object({
+                message: z.string(),
+                at: z.number(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict(),
     adapters: z.array(channelAdapterHealthReturnSchema),
@@ -305,6 +332,8 @@ export type ChannelsRunnerHealthState = "ready" | "starting" | "degraded" | "unr
 export function classifyChannelRunnerHealth(snapshot: ChannelRunnerHealthSnapshot): ChannelsRunnerHealthState {
   if (!snapshot.running) return "degraded";
   if (!snapshot.outbound.infrastructureReady) return "starting";
+  if (snapshot.outbound.lastError) return "degraded";
+  if (snapshot.outbound.publishOutbox?.lastError && snapshot.outbound.publishOutbox.pendingCount > 0) return "degraded";
 
   if (snapshot.adapters.some((adapter) => ["failed", "degraded", "disconnected"].includes(adapter.status))) {
     return "degraded";
@@ -394,7 +423,64 @@ function requireRuntimeTarget(build?: boolean): DaemonRuntimeTarget {
   if (!target) {
     fail("Could not resolve Ravi runtime bundle. Use --build from the source repo or set RAVI_BUNDLE.");
   }
+  const validation = validateChannelRunnerRuntimeTarget(target);
+  if (!validation.ok) fail(validation.message);
   return target;
+}
+
+export type ChannelRunnerRuntimeTargetValidation =
+  | { ok: true }
+  | {
+      ok: false;
+      message: string;
+      targetBundle: string;
+      daemonBundle: string | null;
+    };
+
+export function validateChannelRunnerRuntimeTarget(
+  target: DaemonRuntimeTarget,
+  options: { inspectRuntimeTarget?: () => CliRuntimeTargetSummary } = {},
+): ChannelRunnerRuntimeTargetValidation {
+  const summary = (options.inspectRuntimeTarget ?? inspectCliRuntimeTarget)();
+  if (!summary.daemon.online) return { ok: true };
+
+  const targetBundle = normalizeComparablePath(target.bundlePath) ?? target.bundlePath.toLowerCase();
+  const daemonBundle = normalizeComparablePath(summary.daemon.execPath);
+  if (!daemonBundle) {
+    return {
+      ok: false,
+      targetBundle,
+      daemonBundle,
+      message: [
+        "Cannot start channel runner because the live daemon bundle is unknown.",
+        `Target bundle: ${target.bundlePath}`,
+        "Run `ravi daemon status --json` and restart channels only from the daemon-authoritative runtime.",
+      ].join("\n"),
+    };
+  }
+  if (targetBundle === daemonBundle) return { ok: true };
+
+  return {
+    ok: false,
+    targetBundle,
+    daemonBundle,
+    message: [
+      "Refusing to start channel runner from a bundle that diverges from the live daemon.",
+      `Target bundle: ${target.bundlePath}`,
+      `Daemon bundle: ${summary.daemon.execPath ?? "-"}`,
+      "Use the same repo/runtime as the live daemon, or restart the daemon first with the intended bundle.",
+    ].join("\n"),
+  };
+}
+
+function normalizeComparablePath(path: string | null | undefined): string | null {
+  const trimmed = path?.trim();
+  if (!trimmed) return null;
+  try {
+    return realpathSync(trimmed).toLowerCase();
+  } catch {
+    return trimmed.toLowerCase();
+  }
 }
 
 @Group({
@@ -638,6 +724,7 @@ export class ChannelsCommands {
   ) {
     requirePm2();
     const runnerEnv = buildRunnerPm2Env();
+    const target = requireRuntimeTarget(build);
 
     if (isPm2ProcessRunning(CHANNELS_PM2_PROCESS_NAME)) {
       const stopped = asJson
@@ -646,7 +733,6 @@ export class ChannelsCommands {
       if (stopped.status !== 0) fail("Failed to stop channel runner before restart");
     }
 
-    const target = requireRuntimeTarget(build);
     const args = ["start", "bun", "--name", CHANNELS_PM2_PROCESS_NAME, "--", target.bundlePath, "channels", "run"];
     const { status } = asJson
       ? runPm2Quiet(args, { cwd: target.cwd, envOverrides: runnerEnv })

--- a/src/gateway-native-delivery.test.ts
+++ b/src/gateway-native-delivery.test.ts
@@ -105,6 +105,18 @@ async function createGateway() {
   return { gateway, emitted, omniSend };
 }
 
+async function getPublishOutboxJob(idempotencyKey: string) {
+  const { getChannelOutboundPublishJob } = await import("./channels/outbound-publish-outbox.js");
+  return getChannelOutboundPublishJob(idempotencyKey);
+}
+
+async function reconcilePublishOutbox(
+  options: { now?: () => number; emitEvent?: (topic: string, payload: Record<string, unknown>) => Promise<void> } = {},
+) {
+  const { reconcileDueChannelOutboundPublishes } = await import("./channels/outbound-publish-outbox.js");
+  return reconcileDueChannelOutboundPublishes(options);
+}
+
 async function handleResponse(gateway: unknown, sessionName: string, response: ResponseMessage): Promise<void> {
   await (
     gateway as {
@@ -173,6 +185,11 @@ describe("Gateway native channel outbound queue", () => {
       reason: "native_channel_outbound",
       jobId: "runtime:main-slack:emit-1",
     });
+    const record = await getPublishOutboxJob(publishedJobs[0]!.request.idempotencyKey);
+    expect(record).toMatchObject({
+      jobId: "runtime:main-slack:emit-1",
+      status: "published",
+    });
   });
 
   it("retries JetStream publish ack timeouts with an idempotent msgID before marking queued", async () => {
@@ -222,11 +239,21 @@ describe("Gateway native channel outbound queue", () => {
     expect(emitted[0]?.[1]).toMatchObject({
       status: "failed",
       reason: "queue_error",
+      jobId: "runtime:main-slack:emit-timeout-fail",
       error: "TIMEOUT",
+      retryable: true,
+    });
+    expect(emitted[0]?.[1]).toHaveProperty("nextAttemptAt");
+    const record = await getPublishOutboxJob("runtime:main-slack:emit-timeout-fail:slack:slack:C123:root");
+    expect(record).toMatchObject({
+      jobId: "runtime:main-slack:emit-timeout-fail",
+      status: "pending",
+      attemptCount: 1,
+      lastErrorMessage: "TIMEOUT",
     });
   });
 
-  it("emits delivery.failed for non-timeout native queue errors", async () => {
+  it("persists and later republishes non-timeout native queue errors without duplicate provider sends", async () => {
     publishBehavior = "failBeforePublish";
     const { gateway, emitted } = await createGateway();
 
@@ -246,8 +273,44 @@ describe("Gateway native channel outbound queue", () => {
     expect(emitted[0]?.[1]).toMatchObject({
       status: "failed",
       reason: "queue_error",
+      jobId: "runtime:main-slack:emit-fail",
       error: "stream unavailable",
+      retryable: true,
     });
+    const idempotencyKey = "runtime:main-slack:emit-fail:slack:slack:C123:root";
+    expect(await getPublishOutboxJob(idempotencyKey)).toMatchObject({
+      status: "pending",
+      attemptCount: 1,
+      lastErrorMessage: "stream unavailable",
+    });
+
+    publishBehavior = "ok";
+    const reconciled = await reconcilePublishOutbox({
+      now: () => Date.now() + 60_000,
+      emitEvent: async (topic, payload) => {
+        emitted.push([topic, payload]);
+      },
+    });
+
+    expect(reconciled).toEqual({ attempted: 1, published: 1, failed: 0 });
+    expect(publishedJobs).toHaveLength(1);
+    expect(publishedJobs[0]?.jobId).toBe("runtime:main-slack:emit-fail");
+    const publishedRecord = await getPublishOutboxJob(idempotencyKey);
+    expect(publishedRecord).toMatchObject({
+      status: "published",
+      attemptCount: 1,
+    });
+    expect(publishedRecord?.lastErrorMessage).toBeUndefined();
+    expect(emitted[1]?.[0]).toBe("ravi.session.main-slack.delivery");
+    expect(emitted[1]?.[1]).toMatchObject({
+      status: "queued",
+      reason: "native_channel_outbound_reconciled",
+      jobId: "runtime:main-slack:emit-fail",
+    });
+
+    const second = await reconcilePublishOutbox({ now: () => Date.now() + 120_000 });
+    expect(second).toEqual({ attempted: 0, published: 0, failed: 0 });
+    expect(publishedJobs).toHaveLength(1);
   });
 
   it("publishes Slack typing presence through the native channel presence topic", async () => {

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -31,7 +31,8 @@ import type { OmniSender } from "./omni/sender.js";
 import type { OmniConsumer } from "./omni/consumer.js";
 import { getAgentPlatformIdentity, recordOutbound } from "./contacts.js";
 import { assertChannelSupportsStickers } from "./channels/capabilities.js";
-import { buildChannelOutboundJobFromResponse, publishChannelOutboundJob } from "./channels/outbound-stream.js";
+import { publishChannelOutboundJobDurably } from "./channels/outbound-publish-outbox.js";
+import { buildChannelOutboundJobFromResponse } from "./channels/outbound-stream.js";
 import { subjectForChannelPresence } from "./channels/presence-consumer.js";
 import type { StickerSendEvent } from "./stickers/send.js";
 import { getSessionByName } from "./router/index.js";
@@ -883,21 +884,36 @@ export class Gateway {
         return;
       }
       try {
-        await publishChannelOutboundJob(built.job);
-        await emitDelivery({
-          status: "queued",
-          reason: "native_channel_outbound",
-          jobId: built.job.jobId,
-          target,
-          textLen: text.length,
-        });
+        const published = await publishChannelOutboundJobDurably(built.job);
+        if (published.ok) {
+          await emitDelivery({
+            status: "queued",
+            reason: "native_channel_outbound",
+            jobId: built.job.jobId,
+            target,
+            textLen: text.length,
+          });
+        } else {
+          await emitDelivery({
+            status: "failed",
+            reason: "queue_error",
+            jobId: built.job.jobId,
+            target,
+            textLen: text.length,
+            error: published.error instanceof Error ? published.error.message : String(published.error),
+            retryable: true,
+            nextAttemptAt: published.nextAttemptAt,
+          });
+        }
       } catch (error) {
         await emitDelivery({
           status: "failed",
-          reason: "queue_error",
+          reason: "local_outbox_error",
+          jobId: built.job.jobId,
           target,
           textLen: text.length,
           error: error instanceof Error ? error.message : String(error),
+          retryable: false,
         });
       }
       return;


### PR DESCRIPTION
## Objective

Restore reliable native Slack outbound delivery and make the delivery path durable across temporary JetStream failures, runner restarts, and equivalent Slack instance identifiers.

## Problem

Slack inbound reached the Ravi session and the agent generated replies, but outbound delivery failed with `missing_adapter`. The incident combined bundle divergence, terminal acknowledgement of recoverable adapter misses, loss of pre-publish intent during a damaged empty stream, and UUID-versus-slug instance addressing.

## Solution

This change adds a durable SQLite pre-publish outbox with reconciliation, retries `missing_adapter` using bounded NAK backoff, isolates partial Slack adapter startup failures, exposes outbound consumer and outbox health, rejects daemon/runner bundle divergence, and accepts only explicitly equivalent UUID/slug aliases. Published outbox rows are pruned after fourteen days while pending rows are retained.

## Practical impact

Replies survive transient publish failures and channel-runner restarts instead of disappearing silently. Operators can see whether outbound infrastructure, consumption, and local publish recovery are healthy, and UUID-targeted Slack jobs reach the correct adapter without allowing cross-instance delivery.

## What does NOT change

Inbound routing, chat/session ownership, contact identity semantics, and the default fail-closed isolation between Slack instances remain unchanged. This PR does not alter the separate session-event retention/export-cursor lifecycle or resolve host disk pressure.

## Validation

Focused channel coverage previously passed with 102 tests and 506 assertions. The new health-contract test passes 7 tests with 20 assertions and explicitly validates consumer/outbox telemetry. Typecheck, build, generated SDK drift checks, and Biome passed on the implementation. Live proof delivered three naturally retried UUID-targeted jobs visibly in Slack with complete receipts, canonical message rows, zero ACK pending, zero redeliveries, zero consumer pending, and zero publish-outbox pending.

## Risks

The durable outbox adds local SQLite state and maintenance work, so regressions could delay retries or leave pending rows visible until reconciliation succeeds. Alias matching is intentionally conservative; ambiguous or foreign-instance identifiers still fail closed. The host remains under critical disk pressure, which can independently disrupt broad local test runs.

## Rollback

Revert this PR and rebuild the daemon/channel-runner bundle from the previous `dev` revision. If rollback is required after jobs have entered the new outbox, inspect and preserve pending rows before reverting so delivery intent is not discarded.

## Operational note

The empty damaged `CHANNEL_OUTBOUND` stream was recreated only after confirming that it contained no messages. This was an incident repair; the application-level durability in this PR is the lasting protection.