### PR TITLE
Fix Slack Connect audio transcription

### DIFF
--- a/src/channels/slack/client.test.ts
+++ b/src/channels/slack/client.test.ts
@@ -69,6 +69,39 @@ describe("Slack Web API client", () => {
     });
   });
 
+  it("hydrates Slack Connect file metadata through files.info", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return jsonResponse({
+        ok: true,
+        file: {
+          id: "F123",
+          name: "audio_message.m4a",
+          mimetype: "audio/mp4",
+          url_private_download: "https://files.slack.test/private/F123",
+        },
+      });
+    }) as unknown as typeof fetch;
+    const client = new SlackWebApiClient({
+      appToken: "xapp-secret",
+      botToken: "xoxb-secret",
+      fetchImpl,
+    });
+
+    await expect(client.filesInfo({ file: "F123" })).resolves.toMatchObject({
+      file: { id: "F123", mimetype: "audio/mp4" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://slack.com/api/files.info");
+    expect(calls[0]?.init.headers).toMatchObject({
+      authorization: "Bearer xoxb-secret",
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    expect(formBody(calls[0]?.init.body)).toEqual({ file: "F123" });
+  });
+
   it("creates, renames and invites to conversations through explicit methods", async () => {
     const methods: string[] = [];
     const requests: Array<{ method: string; body: Record<string, unknown> }> = [];

--- a/src/channels/slack/client.ts
+++ b/src/channels/slack/client.ts
@@ -142,6 +142,10 @@ export interface SlackFilesListInput {
   readonly tsTo?: string;
 }
 
+export interface SlackFileInfoInput {
+  readonly file: string;
+}
+
 export interface SlackCanvasCreateInput {
   readonly title?: string;
   readonly markdown?: string;
@@ -287,6 +291,10 @@ export interface SlackFilesListResponse extends SlackApiResponse {
   readonly files?: unknown[];
   readonly paging?: unknown;
   readonly response_metadata?: SlackCursorPaging;
+}
+
+export interface SlackFileInfoResponse extends SlackApiResponse {
+  readonly file?: unknown;
 }
 
 export interface SlackCanvasCreateResponse extends SlackApiResponse {
@@ -615,6 +623,12 @@ export class SlackWebApiClient {
         ts_to: input.tsTo,
       }),
     );
+  }
+
+  async filesInfo(input: SlackFileInfoInput): Promise<SlackFileInfoResponse> {
+    return this.apiRequest<SlackFileInfoResponse>("files.info", this.botToken, {
+      file: input.file,
+    });
   }
 
   async canvasesCreate(input: SlackCanvasCreateInput): Promise<SlackCanvasCreateResponse> {

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1258,12 +1258,13 @@ describe("Slack Socket Mode routing", () => {
     ]);
   });
 
-  it("routes Slack audio file_share events as media prompts", async () => {
+  it("hydrates Slack Connect audio metadata before downloading and transcribing", async () => {
+    const audioAgentCwd = stateDir!;
     const config: RouterConfig = {
       agents: {
         "ravi-hil": {
           id: "ravi-hil",
-          cwd: "/tmp/ravi-hil",
+          cwd: audioAgentCwd,
           dmScope: "per-peer",
         },
       },
@@ -1285,6 +1286,28 @@ describe("Slack Socket Mode routing", () => {
       instances: {},
     };
     const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const filesInfo = mock(async () => ({
+      ok: true,
+      file: {
+        id: "F123",
+        name: "audio_message.m4a",
+        title: "audio_message.m4a",
+        mimetype: "audio/mp4",
+        filetype: "m4a",
+        size: 2_558_655,
+        media_display_type: "audio",
+        url_private_download: "https://files.slack.test/private/F123",
+      },
+    }));
+    const downloadFile = mock(async () => ({
+      buffer: Buffer.from("audio-bytes"),
+      contentType: "audio/mp4",
+    }));
+    const transcribe = mock(async () => ({
+      text: "fala transcrita",
+      provider: "groq",
+      model: "whisper-large-v3-turbo",
+    }));
     const service = new SlackSocketModeService({
       appToken: "xapp-test",
       botToken: "xoxb-test",
@@ -1295,7 +1318,8 @@ describe("Slack Socket Mode routing", () => {
       publishPrompt: async (sessionName, payload) => {
         published.push({ sessionName, payload });
       },
-      webClient: {} as never,
+      webClient: { filesInfo, downloadFile } as never,
+      transcribeAudio: transcribe,
     });
     const envelope: SlackSocketEnvelope = {
       envelope_id: "env-audio-1",
@@ -1305,7 +1329,6 @@ describe("Slack Socket Mode routing", () => {
         event_time: 1_713_000_010,
         event: {
           type: "message",
-          subtype: "file_share",
           channel: "C123",
           channel_type: "channel",
           user: "U123",
@@ -1314,13 +1337,9 @@ describe("Slack Socket Mode routing", () => {
           files: [
             {
               id: "F123",
-              name: "audio_message.m4a",
-              title: "audio_message.m4a",
-              mimetype: "audio/mp4",
+              mode: "file_access",
+              file_access: "check_file_info",
               filetype: "m4a",
-              size: 2_558_655,
-              media_display_type: "audio",
-              url_private_download: "https://files.slack.test/private/F123",
             },
           ],
         },
@@ -1329,9 +1348,16 @@ describe("Slack Socket Mode routing", () => {
 
     await service.handleEnvelope(envelope);
 
+    expect(filesInfo).toHaveBeenCalledWith({ file: "F123" });
+    expect(downloadFile).toHaveBeenCalledWith({
+      url: "https://files.slack.test/private/F123",
+      maxBytes: 20 * 1024 * 1024,
+    });
+    expect(transcribe).toHaveBeenCalledWith(Buffer.from("audio-bytes"), "audio/mp4");
     expect(published).toHaveLength(1);
     expect(String(published[0]?.payload.prompt)).toContain("[Audio: audio_message.m4a, audio/mp4, 2.4 MB]");
-    expect(String(published[0]?.payload.prompt)).toContain("Transcript: unavailable");
+    expect(String(published[0]?.payload.prompt)).toContain("Transcript:\nfala transcrita");
+    expect(String(published[0]?.payload.prompt)).toContain(`file: ${audioAgentCwd}/attachments/`);
 
     const canonicalChatId = (published[0]?.payload.source as { canonicalChatId?: string } | undefined)?.canonicalChatId;
     expect(typeof canonicalChatId).toBe("string");
@@ -1347,9 +1373,16 @@ describe("Slack Socket Mode routing", () => {
       files: [
         {
           id: "F123",
+          mode: "file_access",
+          fileAccess: "check_file_info",
           name: "audio_message.m4a",
           mimeType: "audio/mp4",
           mediaDisplayType: "audio",
+          transcript: "fala transcrita",
+          transcriptionProvider: "groq",
+          transcriptionModel: "whisper-large-v3-turbo",
+          downloadError: null,
+          transcriptionError: null,
         },
       ],
     });

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -74,6 +74,7 @@ const DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS = 5_000;
 const DEFAULT_SLACK_HEARTBEAT_INTERVAL_MS = 10_000;
 const DEFAULT_SLACK_PONG_TIMEOUT_MS = 5_000;
 const DEFAULT_SLACK_HELLO_TIMEOUT_MS = 10_000;
+const SLACK_FILE_INFO_RETRY_DELAYS_MS = [0, 250, 750, 1_500] as const;
 
 type PublishPrompt = typeof publishSessionPrompt;
 type PublishInteraction = (topic: string, payload: Record<string, unknown>) => Promise<void>;
@@ -153,6 +154,7 @@ export interface SlackSocketModeServiceOptions {
   readonly authTestTimeoutMs?: number;
   /** Clock injection for bounded auth.test retry tests. */
   readonly now?: () => number;
+  readonly transcribeAudio?: typeof transcribeAudio;
 }
 
 export interface SlackNativeRuntime {
@@ -1365,22 +1367,32 @@ export class SlackSocketModeService {
     index: number,
     agentCwd: string,
   ): Promise<ProcessedSlackFile> {
-    const downloadUrl = file.privateDownloadUrl ?? file.privateUrl;
-    if (!downloadUrl) return file;
+    const hydrated = await this.hydrateFileMetadata(file);
+    const resolvedFile = hydrated.file;
+    const downloadUrl = slackFileDownloadUrl(resolvedFile);
+    if (!downloadUrl) {
+      const downloadError = hydrated.error ?? "Slack file metadata did not include a private download URL";
+      log.warn("Slack file metadata unavailable", {
+        fileId: resolvedFile.id,
+        fileAccess: resolvedFile.fileAccess,
+        error: downloadError,
+      });
+      return { ...resolvedFile, downloadError };
+    }
 
-    const isAudio = isSlackAudioFile(file);
+    const isAudio = isSlackAudioFile(resolvedFile);
     const maxBytes = isAudio ? MAX_AUDIO_BYTES : MAX_MEDIA_BYTES;
     try {
       const download = await this.webClient.downloadFile({ url: downloadUrl, maxBytes });
-      const mimeType = file.mimeType ?? download.contentType ?? "application/octet-stream";
-      const messageId = `${message.ts}-${file.id || index}`;
+      const mimeType = resolvedFile.mimeType ?? download.contentType ?? "application/octet-stream";
+      const messageId = `${message.ts}-${resolvedFile.id || index}`;
       const localPath = await saveToAgentAttachments(download.buffer, agentCwd, messageId, mimeType);
-      if (!isAudio) return { ...file, mimeType, localPath };
+      if (!isAudio) return { ...resolvedFile, mimeType, localPath };
 
       try {
-        const transcription = await transcribeAudio(download.buffer, mimeType);
+        const transcription = await (this.options.transcribeAudio ?? transcribeAudio)(download.buffer, mimeType);
         return {
-          ...file,
+          ...resolvedFile,
           mimeType,
           localPath,
           transcript: transcription.text,
@@ -1389,12 +1401,12 @@ export class SlackSocketModeService {
         };
       } catch (error) {
         log.warn("Slack audio transcription failed", {
-          fileId: file.id,
+          fileId: resolvedFile.id,
           mimeType,
           error: error instanceof Error ? error.message : String(error),
         });
         return {
-          ...file,
+          ...resolvedFile,
           mimeType,
           localPath,
           transcriptionError: error instanceof Error ? error.message : String(error),
@@ -1402,16 +1414,54 @@ export class SlackSocketModeService {
       }
     } catch (error) {
       log.warn("Slack file download failed", {
-        fileId: file.id,
-        mimeType: file.mimeType,
-        sizeBytes: file.sizeBytes,
+        fileId: resolvedFile.id,
+        mimeType: resolvedFile.mimeType,
+        sizeBytes: resolvedFile.sizeBytes,
         error: error instanceof Error ? error.message : String(error),
       });
       return {
-        ...file,
+        ...resolvedFile,
         downloadError: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  private async hydrateFileMetadata(
+    file: SlackNormalizedFile,
+  ): Promise<{ readonly file: SlackNormalizedFile; readonly error?: string }> {
+    if (slackFileDownloadUrl(file)) return { file };
+    if (!file.id || file.id.startsWith("file-")) {
+      return { file, error: "Slack file metadata is missing a stable file ID" };
+    }
+
+    const filesInfo = (this.webClient as Partial<SlackWebApiClient>).filesInfo;
+    if (typeof filesInfo !== "function") {
+      return { file, error: "Slack Web API client cannot hydrate file metadata" };
+    }
+
+    let hydrated = file;
+    let lastError = "Slack files.info returned no private download URL";
+    for (const [attempt, delayMs] of SLACK_FILE_INFO_RETRY_DELAYS_MS.entries()) {
+      if (delayMs > 0) await delay(delayMs);
+      try {
+        const response = await filesInfo.call(this.webClient, { file: file.id });
+        const resolved = normalizeSlackFile(response.file, 0);
+        if (resolved) hydrated = { ...hydrated, ...resolved, id: file.id };
+        if (slackFileDownloadUrl(hydrated)) {
+          log.info("Slack file metadata hydrated", {
+            fileId: file.id,
+            fileAccess: file.fileAccess,
+            attempts: attempt + 1,
+          });
+          return { file: hydrated };
+        }
+        lastError = "Slack files.info returned no private download URL";
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    return { file: hydrated, error: lastError };
   }
 }
 
@@ -2011,6 +2061,10 @@ function positiveDuration(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function normalizeSlackFiles(value: unknown): SlackNormalizedFile[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -2024,6 +2078,8 @@ function normalizeSlackFile(value: unknown, index: number): SlackNormalizedFile 
   const id = firstString(record.id) ?? `file-${index}`;
   return {
     id,
+    ...(firstString(record.mode) ? { mode: firstString(record.mode) } : {}),
+    ...(firstString(record.file_access) ? { fileAccess: firstString(record.file_access) } : {}),
     ...(firstString(record.name) ? { name: firstString(record.name) } : {}),
     ...(firstString(record.title) ? { title: firstString(record.title) } : {}),
     ...(firstString(record.mimetype) ? { mimeType: firstString(record.mimetype) } : {}),
@@ -2070,6 +2126,8 @@ function buildSlackMessageContent(
 function publicSlackFileMetadata(file: ProcessedSlackFile): Record<string, unknown> {
   return {
     id: file.id,
+    mode: file.mode ?? null,
+    fileAccess: file.fileAccess ?? null,
     name: file.name ?? null,
     title: file.title ?? null,
     mimeType: file.mimeType ?? null,
@@ -2080,6 +2138,8 @@ function publicSlackFileMetadata(file: ProcessedSlackFile): Record<string, unkno
     transcript: file.transcript ?? null,
     transcriptionProvider: file.transcriptionProvider ?? null,
     transcriptionModel: file.transcriptionModel ?? null,
+    downloadError: file.downloadError ?? null,
+    transcriptionError: file.transcriptionError ?? null,
   };
 }
 
@@ -2132,4 +2192,8 @@ function isSlackAudioFile(file: Pick<SlackNormalizedFile, "mimeType" | "fileType
       fileType === "wav" ||
       fileType === "webm",
   );
+}
+
+function slackFileDownloadUrl(file: SlackNormalizedFile): string | undefined {
+  return file.privateDownloadUrl ?? file.privateUrl;
 }

--- a/src/channels/slack/types.ts
+++ b/src/channels/slack/types.ts
@@ -67,6 +67,8 @@ export interface SlackEventPayload {
 
 export interface SlackFilePayload {
   readonly id?: string;
+  readonly mode?: string;
+  readonly file_access?: string;
   readonly name?: string;
   readonly title?: string;
   readonly mimetype?: string;
@@ -80,6 +82,8 @@ export interface SlackFilePayload {
 
 export interface SlackNormalizedFile {
   readonly id: string;
+  readonly mode?: string;
+  readonly fileAccess?: string;
   readonly name?: string;
   readonly title?: string;
   readonly mimeType?: string;


### PR DESCRIPTION
## Objective

Restore automatic transcription for audio messages received through Slack Connect.

## Problem

Slack Connect may emit file placeholders with `mode=file_access` and `file_access=check_file_info`, but without a private download URL or complete media metadata. The adapter returned before download, so transcription never ran.

## Solution

Hydrate incomplete file payloads through `files.info`, retry briefly while Slack makes the file available, and then feed the resolved download and MIME metadata into the existing attachment and transcription pipeline. The change also records safe processing diagnostics and adds focused coverage.

## Practical impact

Slack Connect audio messages can now be downloaded, saved in the receiving agent's attachments directory, transcribed automatically, and included in the prompt with the transcript.

## What does NOT change

Direct Slack audio files that already contain download metadata keep using the existing path. The transcription provider selection, size limits, routing behavior, and outbound Slack behavior are unchanged.

## Validation

- `bun test src/channels/slack/client.test.ts src/channels/slack/socket-mode.test.ts` — 67 passed
- `bun run typecheck`
- Biome check on all five changed files
- `bun run build:cli`
- full repository pre-push checks passed, including build, complete test suite, SDK checks, and generated-artifact drift checks

## Risks

Hydration can add up to four `files.info` calls and a short bounded delay when Slack initially withholds file metadata. Failures remain non-fatal and are recorded as download diagnostics.

## Rollback

Revert commit `586338cf` to restore the previous early-return behavior for files without private download URLs.
