### PR TITLE
Fix native Slack media uploads

### DIFF
--- a/src/channels/slack/media.test.ts
+++ b/src/channels/slack/media.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChannelConfig } from "../../router/router-db.js";
+import { resolveSlackMediaChannel, sendSlackMedia } from "./media.js";
+
+function slackChannel(overrides: Partial<ChannelConfig> = {}): ChannelConfig {
+  return {
+    name: "hana-slack",
+    provider: "slack",
+    enabled: true,
+    credentialConnection: "hana-slack-credentials",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("resolveSlackMediaChannel", () => {
+  it("matches native Slack accounts by channel name or credential connection", () => {
+    const channels = {
+      hana: slackChannel(),
+    };
+
+    expect(resolveSlackMediaChannel(channels, "HANA-SLACK")?.name).toBe("hana-slack");
+    expect(resolveSlackMediaChannel(channels, "hana-slack-credentials")?.name).toBe("hana-slack");
+    expect(resolveSlackMediaChannel(channels, "missing")).toBeUndefined();
+  });
+});
+
+describe("sendSlackMedia", () => {
+  it("uploads bytes and completes a channel-thread share with a caption", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-slack-media-"));
+    const filePath = join(dir, "sample.png");
+    writeFileSync(filePath, Buffer.from("png-bytes"));
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      if (String(url).endsWith("/files.getUploadURLExternal")) {
+        return Response.json({
+          ok: true,
+          upload_url: "https://files.slack.test/upload/v1/ticket",
+          file_id: "F123",
+        });
+      }
+      if (String(url) === "https://files.slack.test/upload/v1/ticket") {
+        return new Response("OK - 9", { status: 200 });
+      }
+      if (String(url).endsWith("/files.completeUploadExternal")) {
+        return Response.json({
+          ok: true,
+          files: [
+            {
+              id: "F123",
+              shares: {
+                public: {
+                  C123: [{ ts: "1784000000.000100" }],
+                },
+              },
+            },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const result = await sendSlackMedia(
+        {
+          accountId: "hana-slack",
+          chatId: "C123",
+          threadId: "1783999999.000099",
+          filePath,
+          filename: "sample.png",
+          caption: "caption",
+        },
+        {
+          channels: { hana: slackChannel() },
+          resolveSecret: async () => ({
+            secret: JSON.stringify({ appToken: "xapp-test", botToken: "xoxb-test" }),
+          }),
+          fetchImpl,
+          apiBaseUrl: "https://slack.test/api/",
+        },
+      );
+
+      expect(result).toMatchObject({
+        transport: "slack-native",
+        provider: "slack",
+        success: true,
+        status: "sent",
+        fileId: "F123",
+        messageId: "1784000000.000100",
+      });
+      expect(requests.map((request) => request.url)).toEqual([
+        "https://slack.test/api/files.getUploadURLExternal",
+        "https://files.slack.test/upload/v1/ticket",
+        "https://slack.test/api/files.completeUploadExternal",
+      ]);
+
+      const uploadUrlBody = new URLSearchParams(String(requests[0]?.init?.body));
+      expect(uploadUrlBody.get("filename")).toBe("sample.png");
+      expect(uploadUrlBody.get("length")).toBe("9");
+      expect(requests[1]?.init?.body).toEqual(Buffer.from("png-bytes"));
+
+      const completionBody = new URLSearchParams(String(requests[2]?.init?.body));
+      expect(JSON.parse(completionBody.get("files") ?? "[]")).toEqual([{ id: "F123", title: "sample.png" }]);
+      expect(completionBody.get("channel_id")).toBe("C123");
+      expect(completionBody.get("thread_ts")).toBe("1783999999.000099");
+      expect(completionBody.get("initial_comment")).toBe("caption");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces Slack API errors without falling back to Omni", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-slack-media-"));
+    const filePath = join(dir, "sample.pdf");
+    writeFileSync(filePath, "pdf");
+
+    try {
+      await expect(
+        sendSlackMedia(
+          {
+            accountId: "hana-slack",
+            chatId: "C123",
+            filePath,
+            filename: "sample.pdf",
+          },
+          {
+            channels: { hana: slackChannel() },
+            resolveSecret: async () => ({
+              secret: JSON.stringify({ appToken: "xapp-test", botToken: "xoxb-test" }),
+            }),
+            fetchImpl: (async () => Response.json({ ok: false, error: "missing_scope" })) as unknown as typeof fetch,
+          },
+        ),
+      ).rejects.toThrow("Slack files.getUploadURLExternal failed: missing_scope");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+import { configStore } from "../../config-store.js";
+import type { ChannelConfig } from "../../router/router-db.js";
+import { resolveSlackCredentialConfigFromEnv, type SlackCredentialResolver } from "./credentials.js";
+
+const DEFAULT_SLACK_API_BASE_URL = "https://slack.com/api";
+const SLACK_UPLOAD_TIMEOUT_MS = 120_000;
+
+interface SlackApiResponse {
+  readonly ok?: boolean;
+  readonly error?: string;
+  readonly [key: string]: unknown;
+}
+
+interface SlackUploadUrlResponse extends SlackApiResponse {
+  readonly upload_url?: string;
+  readonly file_id?: string;
+}
+
+interface SlackCompleteUploadResponse extends SlackApiResponse {
+  readonly files?: readonly unknown[];
+}
+
+export interface SlackMediaSendInput {
+  readonly accountId: string;
+  readonly chatId: string;
+  readonly filePath: string;
+  readonly filename: string;
+  readonly caption?: string;
+  readonly threadId?: string;
+}
+
+export interface SlackMediaSendDependencies {
+  readonly channels?: Record<string, ChannelConfig>;
+  readonly resolveSecret?: SlackCredentialResolver;
+  readonly fetchImpl?: typeof fetch;
+  readonly apiBaseUrl?: string;
+}
+
+export interface SlackNativeMediaDelivery {
+  readonly transport: "slack-native";
+  readonly provider: "slack";
+  readonly success: true;
+  readonly status: "sent";
+  readonly fileId: string;
+  readonly messageId?: string;
+  readonly raw: Record<string, unknown>;
+}
+
+export function resolveSlackMediaChannel(
+  channels: Record<string, ChannelConfig>,
+  accountId: string,
+): ChannelConfig | undefined {
+  const normalizedAccountId = accountId.trim().toLowerCase();
+  if (!normalizedAccountId) return undefined;
+
+  return Object.values(channels).find((channel) => {
+    if (channel.enabled === false || channel.provider.toLowerCase() !== "slack") return false;
+    return [channel.name, channel.credentialConnection]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .some((value) => value.trim().toLowerCase() === normalizedAccountId);
+  });
+}
+
+export async function sendSlackMedia(
+  input: SlackMediaSendInput,
+  dependencies: SlackMediaSendDependencies = {},
+): Promise<SlackNativeMediaDelivery> {
+  const channels = dependencies.channels ?? configStore.getConfig().channels ?? {};
+  const channel = resolveSlackMediaChannel(channels, input.accountId);
+  if (!channel) {
+    throw new Error(`Slack channel not configured for account "${input.accountId}".`);
+  }
+
+  const credentials = await resolveSlackCredentialConfigFromEnv(process.env, {
+    action: "files.getUploadURLExternal",
+    channel,
+    channels,
+    resolveSecret: dependencies.resolveSecret,
+  });
+  if (!credentials) {
+    throw new Error(`Slack credentials not configured for channel "${channel.name}".`);
+  }
+
+  const bytes = await readFile(input.filePath);
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const apiBaseUrl = (dependencies.apiBaseUrl ?? DEFAULT_SLACK_API_BASE_URL).replace(/\/+$/, "");
+
+  const uploadTicket = await slackFormRequest<SlackUploadUrlResponse>({
+    fetchImpl,
+    apiBaseUrl,
+    method: "files.getUploadURLExternal",
+    botToken: credentials.botToken,
+    body: {
+      filename: input.filename,
+      length: String(bytes.byteLength),
+    },
+  });
+  const uploadUrl = uploadTicket.upload_url;
+  const ticketFileId = uploadTicket.file_id;
+  if (!uploadUrl || !ticketFileId) {
+    throw new Error("Slack files.getUploadURLExternal did not return upload_url and file_id.");
+  }
+
+  const uploadResponse = await fetchImpl(uploadUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/octet-stream",
+    },
+    body: bytes,
+    signal: AbortSignal.timeout(SLACK_UPLOAD_TIMEOUT_MS),
+  });
+  if (!uploadResponse.ok) {
+    throw new Error(`Slack file content upload failed: ${uploadResponse.status} ${uploadResponse.statusText}`.trim());
+  }
+
+  const completion = await slackFormRequest<SlackCompleteUploadResponse>({
+    fetchImpl,
+    apiBaseUrl,
+    method: "files.completeUploadExternal",
+    botToken: credentials.botToken,
+    body: {
+      files: JSON.stringify([{ id: ticketFileId, title: input.filename }]),
+      channel_id: input.chatId,
+      ...(input.caption ? { initial_comment: input.caption } : {}),
+      ...(input.threadId ? { thread_ts: input.threadId } : {}),
+    },
+  });
+  const completedFile = firstRecord(completion.files);
+  const fileId = firstString(completedFile?.id) ?? ticketFileId;
+  const messageId = findSlackFileShareTs(completedFile, input.chatId);
+
+  return {
+    transport: "slack-native",
+    provider: "slack",
+    success: true,
+    status: "sent",
+    fileId,
+    ...(messageId ? { messageId } : {}),
+    raw: completion,
+  };
+}
+
+async function slackFormRequest<T extends SlackApiResponse>(input: {
+  readonly fetchImpl: typeof fetch;
+  readonly apiBaseUrl: string;
+  readonly method: string;
+  readonly botToken: string;
+  readonly body: Record<string, string>;
+}): Promise<T> {
+  const response = await input.fetchImpl(`${input.apiBaseUrl}/${input.method}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.botToken}`,
+      "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+    },
+    body: new URLSearchParams(input.body).toString(),
+    signal: AbortSignal.timeout(SLACK_UPLOAD_TIMEOUT_MS),
+  });
+  const text = await response.text();
+  let payload: T;
+  try {
+    payload = JSON.parse(text) as T;
+  } catch {
+    throw new Error(`Slack ${input.method} returned a non-JSON response.`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Slack ${input.method} failed: ${response.status} ${response.statusText}`.trim());
+  }
+  if (payload.ok !== true) {
+    throw new Error(`Slack ${input.method} failed: ${payload.error || "unknown_error"}`);
+  }
+  return payload;
+}
+
+function firstRecord(values: readonly unknown[] | undefined): Record<string, unknown> | undefined {
+  const first = values?.[0];
+  return first && typeof first === "object" && !Array.isArray(first) ? (first as Record<string, unknown>) : undefined;
+}
+
+function firstString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function findSlackFileShareTs(file: Record<string, unknown> | undefined, chatId: string): string | undefined {
+  const shares = file?.shares;
+  if (!shares || typeof shares !== "object" || Array.isArray(shares)) return undefined;
+
+  for (const scope of Object.values(shares as Record<string, unknown>)) {
+    if (!scope || typeof scope !== "object" || Array.isArray(scope)) continue;
+    const entries = (scope as Record<string, unknown>)[chatId];
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+      const ts = firstString((entry as Record<string, unknown>).ts);
+      if (ts) return ts;
+    }
+  }
+  return undefined;
+}

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -283,6 +283,7 @@ describe("runCoverageGate", () => {
     const missing = runCoverageGate(["src/channels/slack/socket-mode.ts"]);
     const covered = runCoverageGate(["src/channels/slack/socket-mode.ts", "src/channels/slack/socket-mode.test.ts"]);
     const healthCovered = runCoverageGate(["src/channels/health.ts", "src/channels/health.test.ts"]);
+    const mediaCovered = runCoverageGate(["src/channels/slack/media.ts", "src/channels/slack/media.test.ts"]);
 
     expect(missing.ok).toBe(false);
     expect(missing.triggeredPrefixes).toEqual(["src/channels/", "src/channels/slack/socket-mode.ts"]);
@@ -290,6 +291,8 @@ describe("runCoverageGate", () => {
     expect(covered.ok).toBe(true);
     expect(covered.triggeredPrefixes).toEqual(["src/channels/", "src/channels/slack/socket-mode.ts"]);
     expect(healthCovered.ok).toBe(true);
+    expect(mediaCovered.ok).toBe(true);
+    expect(mediaCovered.triggeredPrefixes).toEqual(["src/channels/"]);
   });
 
   it("passes when the session stream focused test is in the diff", () => {

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -25,6 +25,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
   "src/channels/": [
     "src/channels/health.test.ts",
     "src/channels/runner.test.ts",
+    "src/channels/slack/media.test.ts",
     "src/channels/slack/socket-mode.test.ts",
   ],
   "src/omni/": [

--- a/src/cli/commands/audio.ts
+++ b/src/cli/commands/audio.ts
@@ -158,7 +158,7 @@ export class AudioCommands {
         voiceNote: boolean;
       };
       sent?: {
-        transport: "omni-send";
+        transport: "omni-send" | "slack-native";
         channel?: string;
         accountId: string;
         instanceId: string;

--- a/src/cli/commands/image.ts
+++ b/src/cli/commands/image.ts
@@ -656,7 +656,7 @@ export class ImageCommands {
         outputDir?: string;
       };
       sent: Array<{
-        transport: "omni-send";
+        transport: "omni-send" | "slack-native";
         channel?: string;
         accountId: string;
         instanceId: string;

--- a/src/cli/media-send.test.ts
+++ b/src/cli/media-send.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 mock.module("../config-store.js", () => ({
   configStore: {
-    resolveInstanceId: (accountId: string) => accountId,
+    resolveInstanceId: (accountId: string) => (accountId === "hana-slack" ? undefined : accountId),
   },
 }));
 
@@ -78,6 +78,65 @@ printf '{"success":true,"message":"Media sent","data":{"messageId":"msg-test","s
       message: "Media sent",
       messageId: "msg-test",
       status: "sent",
+    });
+  });
+
+  it("uses native Slack delivery when the source channel is Slack", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-media-send-"));
+    tempDirs.push(dir);
+    const mediaPath = join(dir, "sample.png");
+    writeFileSync(mediaPath, "image");
+    const slackCalls: unknown[] = [];
+
+    const result = await sendMediaWithOmniCli(
+      {
+        filePath: mediaPath,
+        caption: "native upload",
+        target: {
+          channel: "slack",
+          accountId: "hana-slack",
+          chatId: "C123",
+          threadId: "1783999999.000099",
+        },
+      },
+      {
+        sendSlackMedia: async (input) => {
+          slackCalls.push(input);
+          return {
+            transport: "slack-native",
+            provider: "slack",
+            success: true,
+            status: "sent",
+            fileId: "F123",
+            messageId: "1784000000.000100",
+            raw: { ok: true },
+          };
+        },
+      },
+    );
+
+    expect(slackCalls).toEqual([
+      {
+        accountId: "hana-slack",
+        chatId: "C123",
+        filePath: mediaPath,
+        filename: "sample.png",
+        caption: "native upload",
+        threadId: "1783999999.000099",
+      },
+    ]);
+    expect(result.target).toEqual({
+      channel: "slack",
+      accountId: "hana-slack",
+      instanceId: "hana-slack",
+      chatId: "C123",
+      threadId: "1783999999.000099",
+    });
+    expect(result.delivery).toMatchObject({
+      transport: "slack-native",
+      provider: "slack",
+      fileId: "F123",
+      messageId: "1784000000.000100",
     });
   });
 });

--- a/src/cli/media-send.ts
+++ b/src/cli/media-send.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { resolve, basename, extname } from "node:path";
 import { getContext } from "./context.js";
 import { configStore } from "../config-store.js";
+import { sendSlackMedia, type SlackMediaSendInput, type SlackNativeMediaDelivery } from "../channels/slack/media.js";
 
 const MIME_MAP: Record<string, string> = {
   ".jpg": "image/jpeg",
@@ -47,6 +48,12 @@ export interface OmniSendExecution {
   messageId?: string;
   status?: string;
   raw?: unknown;
+}
+
+export type MediaSendExecution = OmniSendExecution | SlackNativeMediaDelivery;
+
+export interface MediaSendDependencies {
+  sendSlackMedia?: (input: SlackMediaSendInput) => Promise<SlackNativeMediaDelivery>;
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
@@ -98,7 +105,7 @@ export function resolveMediaSendTarget(input: MediaSendTargetInput = {}): Resolv
     throw new Error("No target context available — use --account and --to, or run from a chat session.");
   }
 
-  const instanceId = configStore.resolveInstanceId(accountId);
+  const instanceId = channel?.toLowerCase() === "slack" ? accountId : configStore.resolveInstanceId(accountId);
   if (!instanceId) {
     throw new Error(`No omni instance mapped for account "${accountId}".`);
   }
@@ -112,20 +119,23 @@ export function resolveMediaSendTarget(input: MediaSendTargetInput = {}): Resolv
   };
 }
 
-export async function sendMediaWithOmniCli(args: {
-  filePath: string;
-  caption?: string;
-  type?: MediaType;
-  filename?: string;
-  voiceNote?: boolean;
-  target?: MediaSendTargetInput;
-}): Promise<{
+export async function sendMediaWithOmniCli(
+  args: {
+    filePath: string;
+    caption?: string;
+    type?: MediaType;
+    filename?: string;
+    voiceNote?: boolean;
+    target?: MediaSendTargetInput;
+  },
+  dependencies: MediaSendDependencies = {},
+): Promise<{
   filePath: string;
   filename: string;
   mimeType: string;
   type: MediaType;
   target: ResolvedMediaSendTarget;
-  delivery: OmniSendExecution;
+  delivery: MediaSendExecution;
 }> {
   const absPath = resolve(args.filePath);
   if (!existsSync(absPath)) {
@@ -136,6 +146,25 @@ export async function sendMediaWithOmniCli(args: {
   const type = args.type ?? inferMediaType(mimeType);
   const filename = args.filename ?? basename(absPath);
   const target = resolveMediaSendTarget(args.target);
+
+  if (target.channel?.toLowerCase() === "slack") {
+    const delivery = await (dependencies.sendSlackMedia ?? sendSlackMedia)({
+      accountId: target.accountId,
+      chatId: target.chatId,
+      filePath: absPath,
+      filename,
+      ...(args.caption ? { caption: args.caption } : {}),
+      ...(target.threadId ? { threadId: target.threadId } : {}),
+    });
+    return {
+      filePath: absPath,
+      filename,
+      mimeType,
+      type,
+      target,
+      delivery,
+    };
+  }
 
   const omniArgs = ["send", "--instance", target.instanceId, "--to", target.chatId, "--media", absPath];
 


### PR DESCRIPTION
## Objective

Enable agents to send local media through native Slack channel contexts using `ravi media send`. This removes the accidental dependency on a legacy Omni instance for Slack while preserving existing behavior for legacy channel adapters.

## Problem

Native Slack accounts such as `hana-slack` do not have Omni instance mappings. The media target resolver nevertheless required an Omni instance for every channel, so media sends failed with `No omni instance mapped for account "hana-slack"` even though native Slack delivery and `files:write` credentials were available.

## Solution

Route Slack media targets to a new native uploader that uses `files.getUploadURLExternal`, uploads the bytes to Slack's returned URL, and completes the share with `files.completeUploadExternal`. Resolve credentials through the existing broker, preserve captions and thread IDs, and retain the Omni path for non-Slack channels.

## Practical impact

Agents can send images, documents, video, and audio files to their current Slack channel context through the same `ravi media send` action. Image and document delivery were both verified in the live Slack channel after rebuilding and restarting the daemon.

## What does NOT change

WhatsApp and other legacy adapters continue using the existing Omni send path. Slack text delivery, routing, credential storage, inbound media handling, and channel permissions are unchanged.

## Validation

- Reproduced the live pre-fix failure.
- Sent and verified a 1.49 MB PNG after restart.
- Sent and verified a Markdown document after restart.
- `bun run typecheck`
- Biome check for all changed files.
- Focused media, image, JSON, and CI quality-gate tests.
- Repository pre-push build, full test suite, SDK drift, and SDK checks.

## Risks

The uploader reads the file into memory before sending it, matching the current CLI's local-file workflow but potentially increasing memory usage for very large files. Slack API or credential errors are surfaced without falling back to Omni, preventing accidental duplicate or cross-transport sends.

## Rollback

Revert the native Slack media commits and rebuild and restart the daemon. Slack media sends will return to the previous failure mode, while text delivery and legacy Omni media delivery remain unaffected.
