### PR TITLE
fix(runtime): preserve Codex session continuity across subagents

### DIFF
--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -327,6 +327,15 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
   });
 
+  it("passes when the Codex provider focused test is in the diff", () => {
+    const cwd = makeWorkspace();
+
+    const result = runCoverageGate(["src/runtime/codex-provider.ts", "src/runtime/codex-provider.test.ts"], cwd);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
+  });
+
   it("accepts approval service focused tests for approval service changes", () => {
     const cwd = makeWorkspace();
 

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -57,6 +57,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/runtime/skill-gate.test.ts",
     "src/runtime/claude-local-skills.test.ts",
     "src/runtime/claude-provider.test.ts",
+    "src/runtime/codex-provider.test.ts",
   ],
   "src/session-trace/": ["src/session-trace/session-trace.test.ts"],
   "src/triggers/": ["src/triggers/triggers.test.ts"],

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -402,6 +402,156 @@ rl.on("line", (line) => {
     ).toBe(true);
   });
 
+  it("keeps multi-agent child notifications from replacing the top-level thread", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-sub-agent-notifications-"));
+    const command = join(cwd, "fake-codex-app-server.mjs");
+    const requestsPath = join(cwd, "requests.jsonl");
+
+    writeFileSync(
+      command,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const requestsPath = ${JSON.stringify(requestsPath)};
+const rl = createInterface({ input: process.stdin });
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+let threadStartCount = 0;
+let acceptedTurnCount = 0;
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id && message.method === "initialize") {
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "initialized") return;
+  if (message.id && message.method === "thread/start") {
+    threadStartCount += 1;
+    const threadId = threadStartCount === 1 ? "thread_main" : "thread_recovered";
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    send({ id: message.id, result: { thread: { id: threadId }, model: "gpt-5", modelProvider: "openai" } });
+    return;
+  }
+  if (message.id && message.method === "turn/start") {
+    appendFileSync(requestsPath, JSON.stringify({ method: message.method, params: message.params }) + "\\n");
+    if (message.params.threadId === "thread_child") {
+      send({
+        id: message.id,
+        error: { code: -32600, message: "direct app-server input is not allowed for multi-agent v2 sub-agents" },
+      });
+      return;
+    }
+
+    acceptedTurnCount += 1;
+    const threadId = message.params.threadId;
+    const turnId = \`turn_\${acceptedTurnCount}\`;
+    send({ id: message.id, result: {} });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId, turn: { id: turnId, status: "inProgress" } },
+    });
+
+    if (acceptedTurnCount === 1) {
+      send({
+        jsonrpc: "2.0",
+        method: "thread/started",
+        params: { thread: { id: "thread_child", title: "Explorer" } },
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: { threadId: "thread_child", turn: { id: "turn_child", status: "inProgress" } },
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread_child",
+          turnId: "turn_child",
+          tokenUsage: { last: { inputTokens: 999, cachedInputTokens: 999, outputTokens: 999 } },
+        },
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread_child", turnId: "turn_child", itemId: "message_child", delta: "child" },
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "thread_child",
+          turnId: "turn_child",
+          item: { id: "message_child", type: "agentMessage", text: "child", status: "completed" },
+        },
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: { threadId: "thread_child", turn: { id: "turn_child", status: "completed" } },
+      });
+    }
+
+    send({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId,
+        turnId,
+        item: {
+          id: \`message_\${acceptedTurnCount}\`,
+          type: "agentMessage",
+          text: \`root_\${acceptedTurnCount}\`,
+          status: "completed",
+        },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId,
+        turnId,
+        tokenUsage: { last: { inputTokens: acceptedTurnCount, cachedInputTokens: 0, outputTokens: 1 } },
+      },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId, turn: { id: turnId, status: "completed" } },
+    });
+  }
+});
+`,
+    );
+    chmodSync(command, 0o755);
+
+    const provider = createCodexRuntimeProvider({ command, defaultModel: "gpt-5" });
+    const session = provider.startSession(makeStartRequest(["first", "second"], { cwd }));
+
+    const events = await collectEvents(session.events);
+    const requests = readFileSync(requestsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const turnStarts = requests.filter((request) => request.method === "turn/start");
+    const completions = findEventsByType(events, "turn.complete");
+    const assistantMessages = findEventsByType(events, "assistant.message");
+
+    expect(requests.filter((request) => request.method === "thread/start")).toHaveLength(1);
+    expect(turnStarts.map((request) => request.params.threadId)).toEqual(["thread_main", "thread_main"]);
+    expect(completions.map((event) => event.providerSessionId)).toEqual(["thread_main", "thread_main"]);
+    expect(assistantMessages.map((event) => event.text)).toEqual(["root_1", "root_2"]);
+    expect(completions[0]?.usage.inputTokens).toBe(1);
+    expect(
+      findEventsByType(events, "provider.raw").some(
+        (event) => (event.rawEvent as { type?: string })?.type === "thread.resume_recovered",
+      ),
+    ).toBe(false);
+  });
+
   it("forks an app-server thread before the first turn when forkSession is requested", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-fork-appserver-"));
     const command = join(cwd, "fake-codex-app-server.mjs");
@@ -516,8 +666,8 @@ rl.on("line", (line) => {
   }
   if (message.id && message.method === "turn/start") {
     send({ id: message.id, result: {} });
-    send({ jsonrpc: "2.0", method: "turn/started", params: { threadId: "thread_effort", turn: { id: "turn_effort", status: "inProgress" } } });
-    send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: "thread_effort", turn: { id: "turn_effort", status: "completed" } } });
+    send({ jsonrpc: "2.0", method: "turn/started", params: { threadId: message.params.threadId, turn: { id: "turn_effort", status: "inProgress" } } });
+    send({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: "turn_effort", status: "completed" } } });
   }
 });
 `,

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -916,6 +916,30 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
   let intentionalChildRestart = false;
   let closePromise: Promise<void> | null = null;
 
+  // The app-server broadcasts notifications for the top-level turn and every
+  // multi-agent child over the same connection. Child events must never mutate
+  // or complete the canonical Ravi turn that owns provider session continuity.
+  const notificationThreadId = (params: Record<string, unknown>): string | undefined =>
+    firstString(params.threadId, params.thread_id);
+
+  const notificationTurnId = (params: Record<string, unknown>): string | undefined =>
+    firstString(params.turnId, params.turn_id, asRecord(params.turn)?.id);
+
+  const notificationMatchesActiveTurn = (turn: AppServerTurnState, params: Record<string, unknown>): boolean => {
+    const eventThreadId = notificationThreadId(params);
+    const activeThreadId = turn.threadId ?? currentThreadId;
+    if (eventThreadId && activeThreadId && eventThreadId !== activeThreadId) {
+      return false;
+    }
+
+    const eventTurnId = notificationTurnId(params);
+    if (eventTurnId && turn.turnId && eventTurnId !== turn.turnId) {
+      return false;
+    }
+
+    return true;
+  };
+
   const clearForcedKillTimer = () => {
     if (forcedKillTimer) {
       clearTimeout(forcedKillTimer);
@@ -1401,7 +1425,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
 
     switch (method) {
       case "error": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           turn.queue.push({
             type: "error",
             message: extractAppServerErrorMessage(params) ?? "Codex app-server error",
@@ -1413,6 +1437,10 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         const thread = normalizeAppServerThread(params.thread);
         const threadId = thread?.id;
         if (threadId) {
+          const activeThreadId = turn?.threadId ?? currentThreadId;
+          if (activeThreadId && threadId !== activeThreadId) {
+            break;
+          }
           currentThreadId = threadId;
           if (turn) {
             turn.threadId = threadId;
@@ -1430,7 +1458,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "turn/started": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           const startedTurn = normalizeAppServerTurn(params.turn);
           turn.threadId = firstString(params.threadId, turn.threadId, currentThreadId);
           turn.turnId = firstString(startedTurn?.id, turn.turnId);
@@ -1448,23 +1476,25 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "item/started": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           const item = normalizeAppServerItem(params.item);
           if (item) {
+            const threadId = firstString(notificationThreadId(params), turn.threadId, currentThreadId);
+            const turnId = firstString(notificationTurnId(params), turn.turnId);
             if (item.type === "context_compaction") {
               turn.queue.push({
                 type: "thread.compaction.started",
                 source: "codex.app-server",
-                thread_id: turn.threadId ?? currentThreadId,
-                turn_id: turn.turnId,
+                thread_id: threadId,
+                turn_id: turnId,
                 item,
               });
             }
             turn.queue.push({
               type: "item.started",
               source: "codex.app-server",
-              thread_id: turn.threadId ?? currentThreadId,
-              turn_id: turn.turnId,
+              thread_id: threadId,
+              turn_id: turnId,
               item,
             });
           }
@@ -1472,22 +1502,24 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "item/completed": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           const item = applyPendingDynamicToolResult(normalizeAppServerItem(params.item), pendingDynamicToolResults);
           if (item) {
+            const threadId = firstString(notificationThreadId(params), turn.threadId, currentThreadId);
+            const turnId = firstString(notificationTurnId(params), turn.turnId);
             turn.queue.push({
               type: "item.completed",
               source: "codex.app-server",
-              thread_id: turn.threadId ?? currentThreadId,
-              turn_id: turn.turnId,
+              thread_id: threadId,
+              turn_id: turnId,
               item,
             });
             if (item.type === "context_compaction") {
               turn.queue.push({
                 type: "thread.compacted",
                 source: "codex.app-server",
-                thread_id: turn.threadId ?? currentThreadId,
-                turn_id: turn.turnId,
+                thread_id: threadId,
+                turn_id: turnId,
                 item,
               });
             }
@@ -1496,14 +1528,14 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "item/agentMessage/delta": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           const delta = firstString(params.delta);
           if (delta) {
             turn.queue.push({
               type: "agent_message.delta",
               source: "codex.app-server",
-              thread_id: turn.threadId ?? currentThreadId,
-              turn_id: turn.turnId,
+              thread_id: firstString(notificationThreadId(params), turn.threadId, currentThreadId),
+              turn_id: firstString(notificationTurnId(params), turn.turnId),
               delta,
               item_id: firstString(params.itemId),
             });
@@ -1512,36 +1544,38 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         break;
       }
       case "thread/tokenUsage/updated": {
-        if (turn) {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
           turn.lastUsage = extractAppServerUsage(params.tokenUsage);
         }
         break;
       }
       case "thread/compacted": {
-        if (turn) {
-          const threadId = firstString(params.threadId, params.thread_id, turn.threadId, currentThreadId);
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
+          const threadId = firstString(notificationThreadId(params), turn.threadId, currentThreadId);
           turn.queue.push({
             type: "thread.compacted",
             source: "codex.app-server",
             thread_id: threadId,
-            turn_id: turn.turnId,
+            turn_id: firstString(notificationTurnId(params), turn.turnId),
           });
         }
         break;
       }
       case "turn/completed": {
-        if (!turn) {
+        if (!turn || !notificationMatchesActiveTurn(turn, params)) {
           break;
         }
 
         const completedTurn = asRecord(params.turn);
+        const threadId = firstString(notificationThreadId(params), turn.threadId, currentThreadId);
+        const turnId = firstString(notificationTurnId(params), turn.turnId);
         const status = typeof completedTurn?.status === "string" ? completedTurn.status : "completed";
         if (status === "completed") {
           turn.queue.push({
             type: "turn.completed",
             source: "codex.app-server",
-            thread_id: turn.threadId ?? currentThreadId,
-            turn_id: turn.turnId,
+            thread_id: threadId,
+            turn_id: turnId,
             turn: normalizeAppServerTurn(completedTurn),
             usage: turn.lastUsage ?? {},
             model: resolvedModel,
@@ -1552,16 +1586,16 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
           turn.queue.push({
             type: "turn.interrupted",
             source: "codex.app-server",
-            thread_id: turn.threadId ?? currentThreadId,
-            turn_id: turn.turnId,
+            thread_id: threadId,
+            turn_id: turnId,
             turn: normalizeAppServerTurn(completedTurn),
           });
         } else {
           turn.queue.push({
             type: "turn.failed",
             source: "codex.app-server",
-            thread_id: turn.threadId ?? currentThreadId,
-            turn_id: turn.turnId,
+            thread_id: threadId,
+            turn_id: turnId,
             turn: normalizeAppServerTurn(completedTurn),
             error: extractAppServerTurnError(completedTurn) ?? `Codex turn ${status}`,
           });


### PR DESCRIPTION
## Objective

Preserve the canonical Codex conversation history when a top-level Ravi turn spawns subagents on the same app-server connection.

## Problem

Codex app-server multiplexes notifications from the parent turn and its child agents over one connection. The adapter treated every `thread/started` and `turn/started` event as canonical, so a child thread could replace the persisted provider session. On the next message, Ravi attempted to resume that child, recovery created a fresh thread, and the prior conversation history appeared lost.

## Solution

Scope lifecycle handling to the active top-level thread and turn. Child notifications can no longer replace persisted thread state, emit assistant output into the parent, overwrite usage or compaction state, surface child errors as parent errors, or finish the canonical turn. Add a regression test that reproduces child-thread takeover and verifies the next prompt resumes the original root thread.

## Practical impact

Sessions that use explorers or other Codex subagents retain their original provider conversation history across subsequent user messages.

## What does NOT change

Slack routing, Ravi session storage schemas, provider selection, and ordinary single-agent turns are unchanged. No migration or configuration update is required.

## Validation

- `bun test src/runtime/codex-provider.test.ts` — 38 passed
- provider contract, model-switch, and index tests — 13 passed
- runtime guards and delivery-barrier tests — 12 passed
- `bun run typecheck`
- `bun run lint` — 919 files checked
- `bun run build`
- repository pre-push checks, including the full test and SDK suites

## Risks

The filtering depends on the thread and turn identifiers emitted by Codex app-server. The regression suite covers interleaved parent and child notifications, parent completion, usage isolation, and continuity on the following prompt.

## Rollback

Revert commit `759f290b` or close this PR. The change has no data migration, schema change, or persistent-state rewrite to undo.
