### PR TITLE
Harden release workflows for PR-only publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,68 +1,946 @@
-name: Release
+name: Create GitHub Release
 
-on:
-  push:
-    tags:
-      - "v3.*"
+"on":
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release, e.g. v3.260418.1"
+        description: "Existing published tag (v<version> or ravi-os-sdk-v<version>)"
         required: true
         type: string
 
 permissions:
-  contents: write
+  actions: read
+  contents: read
+  pull-requests: read
+
+# Different releases never share a pending slot. A rerun for the same tag is
+# serialized and is safe because existing release state is checked exactly.
+concurrency:
+  group: ravi-github-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  NPM_REGISTRY: https://registry.npmjs.org/
 
 jobs:
-  github-release:
-    name: GitHub Release
+  verify:
+    name: Verify Exact Published Tag
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      base: ${{ steps.tag.outputs.base }}
+      current_base_sha: ${{ steps.tag.outputs.current_base_sha }}
+      immutable_npm_tag: ${{ steps.tag.outputs.immutable_npm_tag }}
+      integrity: ${{ steps.tag.outputs.integrity }}
+      package_name: ${{ steps.tag.outputs.package_name }}
+      package_path: ${{ steps.tag.outputs.package_path }}
+      pr_number: ${{ steps.tag.outputs.pr_number }}
+      tag: ${{ steps.tag.outputs.tag }}
+      target_sha: ${{ steps.tag.outputs.target_sha }}
+      version: ${{ steps.tag.outputs.version }}
 
+    # No release job checks out or executes repository code.
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
+          node-version: "24"
+          registry-url: https://registry.npmjs.org/
 
-      - name: Resolve tag
+      - name: Verify full published tag provenance
         id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Determine release channel
-        id: channel
-        run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          git fetch origin main --tags
-          git fetch origin dev --tags || true
-          if git branch -r --contains "$TAG" | grep -q "origin/main"; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists"
+          set -euo pipefail
+          export LC_ALL=C
+
+          semver_valid() {
+            [[ "$1" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]]
+          }
+          semver_gt() {
+            local newer="$1" older="$2" left right
+            local newer_a newer_b newer_c older_a older_b older_c
+            semver_valid "$newer" && semver_valid "$older" || return 1
+            IFS=. read -r newer_a newer_b newer_c <<<"$newer"
+            IFS=. read -r older_a older_b older_c <<<"$older"
+            for pair in "$newer_a:$older_a" "$newer_b:$older_b" "$newer_c:$older_c"; do
+              left="${pair%%:*}"; right="${pair#*:}"
+              if [ "${#left}" -gt "${#right}" ]; then return 0; fi
+              if [ "${#left}" -lt "${#right}" ]; then return 1; fi
+              if [[ "$left" > "$right" ]]; then return 0; fi
+              if [[ "$left" < "$right" ]]; then return 1; fi
+            done
+            return 1
+          }
+
+          TAG="$REQUESTED_TAG"
+          case "$TAG" in
+            v*)
+              if [[ ! "$TAG" =~ ^v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$ ]]; then
+                echo "Root release tag '${TAG}' is invalid." >&2
+                exit 1
+              fi
+              VERSION="${BASH_REMATCH[1]}"
+              DATE_PART="${BASH_REMATCH[3]}"
+              PACKAGE_PATH="package.json"
+              EXPECTED_PACKAGE="ravi.bot"
+              PUBLISH_WORKFLOW="version.yml"
+              RELEASE_KIND="root"
+              ;;
+            ravi-os-sdk-v*)
+              if [[ ! "$TAG" =~ ^ravi-os-sdk-v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$ ]]; then
+                echo "SDK release tag '${TAG}' is invalid." >&2
+                exit 1
+              fi
+              VERSION="${BASH_REMATCH[1]}"
+              DATE_PART="${BASH_REMATCH[3]}"
+              PACKAGE_PATH="packages/ravi-os-sdk/package.json"
+              EXPECTED_PACKAGE="@ravi-os/sdk"
+              PUBLISH_WORKFLOW="sdk-release.yml"
+              RELEASE_KIND="sdk"
+              ;;
+            *)
+              echo "Tag '${TAG}' is outside the release namespaces." >&2
+              exit 1
+              ;;
+          esac
+          NORMALIZED_DATE="$(
+            date -u \
+              -d "20${DATE_PART:0:2}-${DATE_PART:2:2}-${DATE_PART:4:2}" \
+              +%y%m%d 2>/dev/null
+          )" || {
+            echo "Version date '${DATE_PART}' is not a real UTC calendar date." >&2
+            exit 1
+          }
+          if [ "$NORMALIZED_DATE" != "$DATE_PART" ]; then
+            echo "Version date '${DATE_PART}' is not a real UTC calendar date." >&2
+            exit 1
+          fi
+
+          REF_JSON="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/tags/${TAG}" \
+            '.ref == $ref and .object.type == "commit" and (.object.sha | test("^[0-9a-f]{40}$"))' \
+            >/dev/null \
+            <<<"$REF_JSON"; then
+            echo "Tag '${TAG}' must be an existing lightweight commit tag." >&2
+            exit 1
+          fi
+          TARGET_SHA="$(jq -er '.object.sha' <<<"$REF_JSON")"
+
+          TARGET_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${TARGET_SHA}"
+          )"
+          if ! jq -e \
+            '.type == "file" and .encoding == "base64" and (.content | type == "string")' \
+            >/dev/null \
+            <<<"$TARGET_CONTENT"; then
+            echo "Tagged package manifest response is ambiguous." >&2
+            exit 1
+          fi
+          TARGET_MANIFEST="${RUNNER_TEMP}/release-target-manifest.json"
+          jq -er '.content' <<<"$TARGET_CONTENT" | tr -d '\n' | base64 --decode > "$TARGET_MANIFEST"
+          if [ "$(jq -er '.name' "$TARGET_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            [ "$(jq -er '.version' "$TARGET_MANIFEST")" != "$VERSION" ]; then
+            echo "Tag does not target the expected package version." >&2
+            exit 1
+          fi
+
+          ASSOCIATED_PRS="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}/pulls?per_page=100"
+          )"
+          if ! jq -e \
+            'type == "array" and all(.[]; type == "array" and all(.[]; type == "object"))' \
+            >/dev/null \
+            <<<"$ASSOCIATED_PRS"; then
+            echo "Associated PR response is ambiguous." >&2
+            exit 1
+          fi
+          MATCHING_PRS="$(
+            jq -c \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg sha "$TARGET_SHA" \
+              '[
+                (add // [])[]
+                | select(
+                    .merged_at != null
+                    and .merge_commit_sha == $sha
+                    and .head.repo.full_name == $repo
+                    and .base.repo.full_name == $repo
+                    and (.base.ref == "dev" or .base.ref == "main")
+                    and (.number | type == "number")
+                  )
+              ]' \
+              <<<"$ASSOCIATED_PRS"
+          )"
+          if [ "$(jq -er 'length' <<<"$MATCHING_PRS")" -ne 1 ]; then
+            echo "Expected one same-repository merged PR for the exact tag target." >&2
+            exit 1
+          fi
+          BASE="$(jq -er '.[0].base.ref' <<<"$MATCHING_PRS")"
+          PR_NUMBER="$(jq -er '.[0].number | tostring' <<<"$MATCHING_PRS")"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]]; then
+            echo "Associated PR number is invalid." >&2
+            exit 1
+          fi
+
+          PR_JSON="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          )"
+          if ! jq -e \
+            --argjson number "$PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$BASE" \
+            --arg target "$TARGET_SHA" \
+            '
+              .number == $number
+              and .merged_at != null
+              and .merge_commit_sha == $target
+              and .head.repo.full_name == $repo
+              and .base.repo.full_name == $repo
+              and .base.ref == $base
+            ' \
+            >/dev/null \
+            <<<"$PR_JSON"; then
+            echo "Merged PR provenance is ambiguous." >&2
+            exit 1
+          fi
+
+          # Full paginated files, not historical base metadata, are the reviewed delta.
+          PR_FILE_PAGES="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100"
+          )"
+          if ! jq -e \
+            --arg path "$PACKAGE_PATH" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ((add // []) | length) == 1
+              and (add // [])[0].filename == $path
+              and (add // [])[0].status == "modified"
+              and ((add // [])[0].previous_filename == null)
+            ' \
+            >/dev/null \
+            <<<"$PR_FILE_PAGES"; then
+            echo "Release PR must modify only the package manifest." >&2
+            exit 1
+          fi
+
+          BRANCH_REF="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/heads/${BASE}" \
+            '.ref == $ref and .object.type == "commit" and (.object.sha | test("^[0-9a-f]{40}$"))' \
+            >/dev/null \
+            <<<"$BRANCH_REF"; then
+            echo "Current base branch ref is ambiguous." >&2
+            exit 1
+          fi
+          CURRENT_BASE_SHA="$(jq -er '.object.sha' <<<"$BRANCH_REF")"
+          REACHABILITY="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/compare/${TARGET_SHA}...${CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            --arg target "$TARGET_SHA" \
+            --arg current "$CURRENT_BASE_SHA" \
+            '
+              .base_commit.sha == $target
+              and .merge_base_commit.sha == $target
+              and .head_commit.sha == $current
+              and (.status == "ahead" or .status == "identical")
+            ' \
+            >/dev/null \
+            <<<"$REACHABILITY"; then
+            echo "Tagged commit is not reachable from the current base tip." >&2
+            exit 1
+          fi
+
+          CURRENT_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            '.type == "file" and .encoding == "base64" and (.content | type == "string")' \
+            >/dev/null \
+            <<<"$CURRENT_CONTENT"; then
+            echo "Current base manifest response is ambiguous." >&2
+            exit 1
+          fi
+          CURRENT_MANIFEST="${RUNNER_TEMP}/release-current-manifest.json"
+          jq -er '.content' <<<"$CURRENT_CONTENT" | tr -d '\n' | base64 --decode > "$CURRENT_MANIFEST"
+          if [ "$(jq -er '.name' "$CURRENT_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            ! diff -u \
+              <(jq -S 'del(.version)' "$TARGET_MANIFEST") \
+              <(jq -S 'del(.version)' "$CURRENT_MANIFEST"); then
+            echo "Current base manifest diverges outside version." >&2
+            exit 1
+          fi
+          CURRENT_VERSION="$(jq -er '.version' "$CURRENT_MANIFEST")"
+          if ! semver_valid "$CURRENT_VERSION" ||
+            { [ "$CURRENT_VERSION" != "$VERSION" ] && ! semver_gt "$CURRENT_VERSION" "$VERSION"; }; then
+            echo "Current base version is older than the published target." >&2
+            exit 1
+          fi
+
+          case "$BASE" in
+            dev) IMMUTABLE_NPM_TAG="next-v${VERSION//./-}" ;;
+            main) IMMUTABLE_NPM_TAG="stable-v${VERSION//./-}" ;;
+            *)
+              echo "Unsupported release base." >&2
+              exit 1
+              ;;
+          esac
+
+          validate_tar_layout() {
+            local tarball="$1"
+            local listing="$2"
+            local verbose="$3"
+            local manifest_entries manifest_regular_entries
+            tar -tzf "$tarball" > "$listing"
+            tar -tvzf "$tarball" > "$verbose"
+            if grep -Eq '(^$|^/|//|(^|/)\.\.?(/|$)|\\)' "$listing" ||
+              [ "$(sort "$listing" | uniq -d | wc -l | tr -d ' ')" -ne 0 ]; then
+              echo "Published provenance tarball has a duplicate or ambiguous path." >&2
+              return 1
+            fi
+            if awk '$1 !~ /^[-d]/ { unsafe=1 } END { exit !unsafe }' "$verbose"; then
+              echo "Published provenance tarball contains a link or special entry." >&2
+              return 1
+            fi
+            manifest_entries="$(
+              awk '$0 == "package/package.json" { count++ } END { print count + 0 }' "$listing"
+            )"
+            manifest_regular_entries="$(
+              awk '
+                $1 ~ /^-/ && $NF == "package\/package.json" { count++ }
+                END { print count + 0 }
+              ' "$verbose"
+            )"
+            if [ "$manifest_entries" -ne 1 ] || [ "$manifest_regular_entries" -ne 1 ]; then
+              echo "Published provenance must contain exactly one regular package/package.json." >&2
+              return 1
+            fi
+          }
+
+          ssri_sha512() {
+            printf 'sha512-%s\n' "$(
+              openssl dgst -sha512 -binary "$1" | openssl base64 -A
+            )"
+          }
+
+          # Recover the immutable v4 artifact from a successful tag-push run.
+          # The requested tag supplies no digest; the downloaded sealed bytes do.
+          WORKFLOW_RUN_PAGES="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${PUBLISH_WORKFLOW}/runs?event=push&status=completed&head_sha=${TARGET_SHA}&per_page=100"
+          )"
+          if ! jq -e '
+            type == "array"
+            and all(.[];
+              type == "object"
+              and (.workflow_runs | type == "array")
+              and all(.workflow_runs[]; type == "object")
+            )
+          ' >/dev/null <<<"$WORKFLOW_RUN_PAGES"; then
+            echo "Publishing workflow-run response is ambiguous." >&2
+            exit 1
+          fi
+          CANDIDATE_RUNS="${RUNNER_TEMP}/publish-run-candidates.tsv"
+          jq -r \
+            --arg sha "$TARGET_SHA" \
+            '
+              [
+                .[].workflow_runs[]
+                | select(
+                    .event == "push"
+                    and .status == "completed"
+                    and .conclusion == "success"
+                    and .head_sha == $sha
+                    and (.id | type == "number")
+                    and (.run_attempt | type == "number" and . >= 1)
+                  )
+              ]
+              | unique_by(.id)
+              | sort_by(.id)
+              | reverse[]
+              | [.id, .run_attempt]
+              | @tsv
+            ' \
+            <<<"$WORKFLOW_RUN_PAGES" > "$CANDIDATE_RUNS"
+
+          PROVENANCE_ROOT="${RUNNER_TEMP}/published-provenance"
+          mkdir -p "$PROVENANCE_ROOT"
+          FOUND_PROVENANCE=0
+          EXPECTED_INTEGRITY=""
+          while IFS=$'\t' read -r RUN_ID RUN_ATTEMPT; do
+            [ -n "$RUN_ID" ] || continue
+            if [[ ! "$RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] ||
+              [[ ! "$RUN_ATTEMPT" =~ ^[1-9][0-9]{0,9}$ ]]; then
+              echo "Publishing workflow run identity is invalid." >&2
+              exit 1
+            fi
+            ARTIFACT_NAME="ravi-${RELEASE_KIND}-package-${RUN_ID}-${RUN_ATTEMPT}"
+            ARTIFACT_INDEX_PAGES="$(
+              gh api --paginate --slurp \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?per_page=100"
+            )"
+            if ! ARTIFACT_INDEX="$(
+              jq -ce '
+                if type != "array" or length == 0 then
+                  error("missing artifact pages")
+                elif (all(.[]; type == "object") | not) then
+                  error("invalid artifact page")
+                elif (all(.[];
+                  (.total_count
+                    | type == "number"
+                    and . >= 0
+                    and floor == .
+                  )
+                ) | not) then
+                  error("invalid artifact total")
+                elif (all(.[]; (.artifacts | type == "array")) | not) then
+                  error("invalid artifact collection")
+                elif (all(.[].artifacts[];
+                  type == "object"
+                  and (.name | type == "string")
+                  and (.expired | type == "boolean")
+                ) | not) then
+                  error("invalid artifact")
+                elif ([.[].total_count] | unique | length) != 1 then
+                  error("artifact totals disagree")
+                elif ([.[].artifacts[]] | length) != .[0].total_count then
+                  error("artifact total is incomplete")
+                else
+                  {
+                    totalCount: .[0].total_count,
+                    artifacts: [.[].artifacts[]]
+                  }
+                end
+              ' <<<"$ARTIFACT_INDEX_PAGES"
+            )"; then
+              echo "Publishing artifact pages are incomplete or ambiguous." >&2
+              exit 1
+            fi
+            if ! jq -e \
+              --arg name "$ARTIFACT_NAME" \
+              '
+                type == "object"
+                and (.artifacts | type == "array")
+                and ([.artifacts[] | select(.name == $name)] | length) <= 1
+              ' \
+              >/dev/null \
+              <<<"$ARTIFACT_INDEX"; then
+              echo "Publishing artifact index is ambiguous." >&2
+              exit 1
+            fi
+            if [ "$(
+              jq -r \
+                --arg name "$ARTIFACT_NAME" \
+                '[.artifacts[] | select(.name == $name and .expired == false)] | length' \
+                <<<"$ARTIFACT_INDEX"
+            )" -eq 0 ]; then
+              continue
+            fi
+
+            CANDIDATE_DIR="${PROVENANCE_ROOT}/${RUN_ID}-${RUN_ATTEMPT}"
+            mkdir -p "$CANDIDATE_DIR"
+            if ! gh run download "$RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "$ARTIFACT_NAME" \
+              --dir "$CANDIDATE_DIR"; then
+              echo "Failed to download authoritative publishing provenance." >&2
+              exit 1
+            fi
+            CANDIDATE_METADATA="${CANDIDATE_DIR}/metadata.json"
+            if [ -L "$CANDIDATE_DIR" ] ||
+              [ ! -f "$CANDIDATE_METADATA" ] ||
+              [ -L "$CANDIDATE_METADATA" ] ||
+              [ "$(find "$CANDIDATE_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')" -ne 2 ] ||
+              [ "$(find "$CANDIDATE_DIR" -mindepth 1 -maxdepth 1 -type f -links 1 -print | wc -l | tr -d ' ')" -ne 2 ]; then
+              echo "Downloaded publishing provenance layout is unsafe." >&2
+              exit 1
+            fi
+            if ! jq -e \
+              --arg artifact "$ARTIFACT_NAME" \
+              --arg base "$BASE" \
+              --arg npmTag "$IMMUTABLE_NPM_TAG" \
+              --arg name "$EXPECTED_PACKAGE" \
+              --arg path "$PACKAGE_PATH" \
+              --arg pr "$PR_NUMBER" \
+              --arg registry "$NPM_REGISTRY" \
+              --arg tag "$TAG" \
+              --arg sha "$TARGET_SHA" \
+              --arg version "$VERSION" \
+              '
+                type == "object"
+                and .schema == 2
+                and .artifactName == $artifact
+                and .base == $base
+                and (.currentBaseSha | type == "string" and test("^[0-9a-f]{40}$"))
+                and .immutableNpmTag == $npmTag
+                and .packageName == $name
+                and .packagePath == $path
+                and .prNumber == $pr
+                and .registry == $registry
+                and .tag == $tag
+                and .targetSha == $sha
+                and .version == $version
+                and (.tarball | type == "string" and test("^[A-Za-z0-9._-]+[.]tgz$"))
+                and (.tarballIntegrity | type == "string" and test("^sha512-[A-Za-z0-9+/]{86}==$"))
+                and (.tarballSha512 | type == "string" and test("^[0-9a-f]{128}$"))
+              ' \
+              "$CANDIDATE_METADATA" >/dev/null; then
+              echo "Downloaded publishing provenance does not bind the requested release." >&2
+              exit 1
+            fi
+            CANDIDATE_TARBALL="$(
+              jq -er --arg dir "$CANDIDATE_DIR" '$dir + "/" + .tarball' "$CANDIDATE_METADATA"
+            )"
+            CANDIDATE_INTEGRITY="$(jq -er '.tarballIntegrity' "$CANDIDATE_METADATA")"
+            if [ ! -f "$CANDIDATE_TARBALL" ] || [ -L "$CANDIDATE_TARBALL" ] ||
+              [ "$(sha512sum "$CANDIDATE_TARBALL" | awk '{print $1}')" != "$(jq -er '.tarballSha512' "$CANDIDATE_METADATA")" ] ||
+              [ "$(ssri_sha512 "$CANDIDATE_TARBALL")" != "$CANDIDATE_INTEGRITY" ]; then
+              echo "Downloaded publishing provenance digest is invalid." >&2
+              exit 1
+            fi
+            if ! validate_tar_layout \
+              "$CANDIDATE_TARBALL" \
+              "${CANDIDATE_DIR}/tar-files.txt" \
+              "${CANDIDATE_DIR}/tar-verbose.txt"; then
+              exit 1
+            fi
+            CANDIDATE_MANIFEST="${CANDIDATE_DIR}/package.json"
+            tar -xOf "$CANDIDATE_TARBALL" package/package.json > "$CANDIDATE_MANIFEST"
+            if ! jq -e -s \
+              --arg name "$EXPECTED_PACKAGE" \
+              --arg version "$VERSION" \
+              --arg sha "$TARGET_SHA" \
+              '
+                length == 1
+                and .[0].name == $name
+                and .[0].version == $version
+                and .[0].gitHead == $sha
+                and .[0].publishConfig == {"access":"public"}
+              ' \
+              "$CANDIDATE_MANIFEST" >/dev/null; then
+              echo "Downloaded publishing manifest is not exactly one bound JSON document." >&2
+              exit 1
+            fi
+            if [ -n "$EXPECTED_INTEGRITY" ] &&
+              [ "$CANDIDATE_INTEGRITY" != "$EXPECTED_INTEGRITY" ]; then
+              echo "Successful publishing runs disagree on sealed package integrity." >&2
+              exit 1
+            fi
+            EXPECTED_INTEGRITY="$CANDIDATE_INTEGRITY"
+            FOUND_PROVENANCE=$((FOUND_PROVENANCE + 1))
+          done < "$CANDIDATE_RUNS"
+          if [ "$FOUND_PROVENANCE" -eq 0 ] || [ -z "$EXPECTED_INTEGRITY" ]; then
+            echo "No unexpired successful tag-push artifact proves the published tarball." >&2
+            exit 1
+          fi
+
+          REGISTRY_METADATA="$(
+            npm view \
+              "${EXPECTED_PACKAGE}@${VERSION}" \
+              version gitHead dist.integrity --json \
+              --registry="$NPM_REGISTRY"
+          )"
+          DIST_TAGS="$(
+            npm view "$EXPECTED_PACKAGE" dist-tags --json \
+              --registry="$NPM_REGISTRY"
+          )"
+          if ! jq -e \
+            --arg version "$VERSION" \
+            --arg sha "$TARGET_SHA" \
+            --arg integrity "$EXPECTED_INTEGRITY" \
+            '
+              .version == $version
+              and .gitHead == $sha
+              and .["dist.integrity"] == $integrity
+            ' \
+            >/dev/null \
+            <<<"$REGISTRY_METADATA" ||
+            [ "$(jq -r --arg tag "$IMMUTABLE_NPM_TAG" '.[$tag] // empty' <<<"$DIST_TAGS")" != "$VERSION" ]; then
+            echo "Published version, integrity, gitHead, or immutable dist-tag does not match sealed provenance." >&2
+            exit 1
+          fi
+
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "current_base_sha=${CURRENT_BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "immutable_npm_tag=${IMMUTABLE_NPM_TAG}" >> "$GITHUB_OUTPUT"
+          echo "integrity=${EXPECTED_INTEGRITY}" >> "$GITHUB_OUTPUT"
+          echo "package_name=${EXPECTED_PACKAGE}" >> "$GITHUB_OUTPUT"
+          echo "package_path=${PACKAGE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  create:
+    name: Revalidate Published SHA And Create Release
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: read
+
+    # The only write-capable job also has no checkout or repository execution.
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org/
+
+      - name: Revalidate published artifact and create GitHub Release
+        env:
+          EXPECTED_BASE: ${{ needs.verify.outputs.base }}
+          EXPECTED_CURRENT_BASE_SHA: ${{ needs.verify.outputs.current_base_sha }}
+          EXPECTED_IMMUTABLE_NPM_TAG: ${{ needs.verify.outputs.immutable_npm_tag }}
+          EXPECTED_INTEGRITY: ${{ needs.verify.outputs.integrity }}
+          EXPECTED_PACKAGE: ${{ needs.verify.outputs.package_name }}
+          EXPECTED_PACKAGE_PATH: ${{ needs.verify.outputs.package_path }}
+          EXPECTED_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
+          EXPECTED_TAG: ${{ needs.verify.outputs.tag }}
+          EXPECTED_TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          EXPECTED_VERSION: ${{ needs.verify.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          TAG="$EXPECTED_TAG"
+          TARGET_SHA="$EXPECTED_TARGET_SHA"
+          VERSION="$EXPECTED_VERSION"
+          case "$TAG" in
+            v*)
+              [[ "$TAG" =~ ^v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$ ]] || exit 1
+              DERIVED_VERSION="${BASH_REMATCH[1]}"
+              DATE_PART="${BASH_REMATCH[3]}"
+              PACKAGE_PATH="package.json"
+              PACKAGE_NAME="ravi.bot"
+              ;;
+            ravi-os-sdk-v*)
+              [[ "$TAG" =~ ^ravi-os-sdk-v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$ ]] || exit 1
+              DERIVED_VERSION="${BASH_REMATCH[1]}"
+              DATE_PART="${BASH_REMATCH[3]}"
+              PACKAGE_PATH="packages/ravi-os-sdk/package.json"
+              PACKAGE_NAME="@ravi-os/sdk"
+              ;;
+            *) exit 1 ;;
+          esac
+          NORMALIZED_DATE="$(
+            date -u \
+              -d "20${DATE_PART:0:2}-${DATE_PART:2:2}-${DATE_PART:4:2}" \
+              +%y%m%d 2>/dev/null
+          )" || {
+            echo "Release date is not a real UTC calendar date." >&2
+            exit 1
+          }
+          if [ "$NORMALIZED_DATE" != "$DATE_PART" ] ||
+            [ "$DERIVED_VERSION" != "$VERSION" ] ||
+            [ "$PACKAGE_PATH" != "$EXPECTED_PACKAGE_PATH" ] ||
+            [ "$PACKAGE_NAME" != "$EXPECTED_PACKAGE" ] ||
+            [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ ! "$EXPECTED_CURRENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ ! "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]]; then
+            echo "Verified release outputs are malformed." >&2
+            exit 1
+          fi
+          case "$EXPECTED_BASE" in
+            dev)
+              EXPECTED_PRERELEASE=true
+              EXPECTED_NPM_TAG="next-v${VERSION//./-}"
+              RELEASE_FLAGS=(--prerelease --latest=false)
+              ;;
+            main)
+              EXPECTED_PRERELEASE=false
+              EXPECTED_NPM_TAG="stable-v${VERSION//./-}"
+              RELEASE_FLAGS=(--latest=false)
+              ;;
+            *) exit 1 ;;
+          esac
+          if [ "$EXPECTED_NPM_TAG" != "$EXPECTED_IMMUTABLE_NPM_TAG" ]; then
+            echo "Immutable npm tag output is inconsistent." >&2
+            exit 1
+          fi
+
+          revalidate_published_authorities() {
+            local phase="$1"
+            local ref_json branch_ref reachability registry_metadata dist_tags
+
+            ref_json="$(
+              gh api -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}"
+            )"
+            if ! jq -e \
+              --arg ref "refs/tags/${TAG}" \
+              --arg sha "$TARGET_SHA" \
+              '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+              >/dev/null \
+              <<<"$ref_json"; then
+              echo "Tag changed ${phase}." >&2
+              exit 1
+            fi
+
+            branch_ref="$(
+              gh api -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/git/ref/heads/${EXPECTED_BASE}"
+            )"
+            if ! jq -e \
+              --arg ref "refs/heads/${EXPECTED_BASE}" \
+              --arg sha "$EXPECTED_CURRENT_BASE_SHA" \
+              '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+              >/dev/null \
+              <<<"$branch_ref"; then
+              echo "Base branch moved ${phase}; fail closed." >&2
+              exit 1
+            fi
+            reachability="$(
+              gh api -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/compare/${TARGET_SHA}...${EXPECTED_CURRENT_BASE_SHA}"
+            )"
+            if ! jq -e \
+              --arg target "$TARGET_SHA" \
+              --arg current "$EXPECTED_CURRENT_BASE_SHA" \
+              '
+                .base_commit.sha == $target
+                and .merge_base_commit.sha == $target
+                and .head_commit.sha == $current
+                and (.status == "ahead" or .status == "identical")
+              ' \
+              >/dev/null \
+              <<<"$reachability"; then
+              echo "Target is no longer reachable from the sealed current base ${phase}." >&2
+              exit 1
+            fi
+
+            registry_metadata="$(
+              npm view \
+                "${EXPECTED_PACKAGE}@${VERSION}" \
+                version gitHead dist.integrity --json \
+                --registry="$NPM_REGISTRY"
+            )"
+            dist_tags="$(
+              npm view "$EXPECTED_PACKAGE" dist-tags --json \
+                --registry="$NPM_REGISTRY"
+            )"
+            if ! jq -e \
+              --arg version "$VERSION" \
+              --arg sha "$TARGET_SHA" \
+              --arg integrity "$EXPECTED_INTEGRITY" \
+              '
+                .version == $version
+                and .gitHead == $sha
+                and .["dist.integrity"] == $integrity
+              ' \
+              >/dev/null \
+              <<<"$registry_metadata" ||
+              [ "$(jq -r --arg tag "$EXPECTED_IMMUTABLE_NPM_TAG" '.[$tag] // empty' <<<"$dist_tags")" != "$VERSION" ]; then
+              echo "Exact published version no longer has the required integrity, gitHead, or immutable dist-tag ${phase}." >&2
+              exit 1
+            fi
+          }
+
+          revalidate_pr_authority() {
+            local phase="$1"
+            local associated_pr_pages eligible_prs
+
+            associated_pr_pages="$(
+              gh api --paginate --slurp \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}/pulls?per_page=100"
+            )"
+            if ! jq -e \
+              'type == "array" and all(.[]; type == "array" and all(.[]; type == "object"))' \
+              >/dev/null \
+              <<<"$associated_pr_pages"; then
+              echo "Associated PR pages became ambiguous ${phase}." >&2
+              exit 1
+            fi
+            eligible_prs="$(
+              jq -c \
+                --arg repo "$GITHUB_REPOSITORY" \
+                --arg sha "$TARGET_SHA" \
+                '[
+                  (add // [])[]
+                  | select(
+                      .merged_at != null
+                      and .merge_commit_sha == $sha
+                      and .head.repo.full_name == $repo
+                      and .base.repo.full_name == $repo
+                      and (.base.ref == "dev" or .base.ref == "main")
+                      and (.number | type == "number")
+                    )
+                ]' \
+                <<<"$associated_pr_pages"
+            )"
+            if [ "$(jq -er 'length' <<<"$eligible_prs")" -ne 1 ]; then
+              echo "Associated PR authority is not unique ${phase}." >&2
+              exit 1
+            fi
+            if ! jq -e \
+              --argjson number "$EXPECTED_PR_NUMBER" \
+              --arg base "$EXPECTED_BASE" \
+              '.[0].number == $number and .[0].base.ref == $base' \
+              >/dev/null \
+              <<<"$eligible_prs"; then
+              echo "Associated PR authority does not match sealed provenance ${phase}." >&2
+              exit 1
+            fi
+          }
+
+          revalidate_published_authorities "after verification"
+          revalidate_pr_authority "after verification"
+
+          PR_JSON="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}"
+          )"
+          if ! jq -e \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$EXPECTED_BASE" \
+            --arg target "$TARGET_SHA" \
+            '
+              .number == $number
+              and .merged_at != null
+              and .merge_commit_sha == $target
+              and .head.repo.full_name == $repo
+              and .base.repo.full_name == $repo
+              and .base.ref == $base
+            ' \
+            >/dev/null \
+            <<<"$PR_JSON"; then
+            echo "PR provenance changed after verification." >&2
+            exit 1
+          fi
+          PR_FILE_PAGES="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}/files?per_page=100"
+          )"
+          if ! jq -e \
+            --arg path "$PACKAGE_PATH" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ((add // []) | length) == 1
+              and (add // [])[0].filename == $path
+              and (add // [])[0].status == "modified"
+              and ((add // [])[0].previous_filename == null)
+            ' \
+            >/dev/null \
+            <<<"$PR_FILE_PAGES"; then
+            echo "Full paginated PR delta changed after verification." >&2
+            exit 1
+          fi
+
+          TARGET_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${TARGET_SHA}"
+          )"
+          CURRENT_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${EXPECTED_CURRENT_BASE_SHA}"
+          )"
+          for response in "$TARGET_CONTENT" "$CURRENT_CONTENT"; do
+            jq -e '.type == "file" and .encoding == "base64" and (.content | type == "string")' \
+              >/dev/null <<<"$response" || {
+              echo "Manifest response became ambiguous." >&2
+              exit 1
+            }
+          done
+          TARGET_MANIFEST="${RUNNER_TEMP}/release-write-target.json"
+          CURRENT_MANIFEST="${RUNNER_TEMP}/release-write-current.json"
+          jq -er '.content' <<<"$TARGET_CONTENT" | tr -d '\n' | base64 --decode > "$TARGET_MANIFEST"
+          jq -er '.content' <<<"$CURRENT_CONTENT" | tr -d '\n' | base64 --decode > "$CURRENT_MANIFEST"
+          if [ "$(jq -er '.name' "$TARGET_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            [ "$(jq -er '.version' "$TARGET_MANIFEST")" != "$VERSION" ] ||
+            [ "$(jq -er '.name' "$CURRENT_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            ! diff -u \
+              <(jq -S 'del(.version)' "$TARGET_MANIFEST") \
+              <(jq -S 'del(.version)' "$CURRENT_MANIFEST"); then
+            echo "Package manifest invariant changed." >&2
+            exit 1
+          fi
+
+          validate_release() {
+            local file="$1"
+            jq -e \
+              --arg tag "$TAG" \
+              --arg title "$TAG" \
+              --arg target "$TARGET_SHA" \
+              --argjson prerelease "$EXPECTED_PRERELEASE" \
+              '
+                .tag_name == $tag
+                and .name == $title
+                and .draft == false
+                and .prerelease == $prerelease
+                and .target_commitish == $target
+              ' \
+              "$file" >/dev/null
+          }
+
+          RELEASE_JSON="${RUNNER_TEMP}/existing-release.json"
+          RELEASE_ERROR="${RUNNER_TEMP}/existing-release.err"
+          set +e
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            > "$RELEASE_JSON" 2> "$RELEASE_ERROR"
+          LOOKUP_STATUS=$?
+          set -e
+          if [ "$LOOKUP_STATUS" -eq 0 ]; then
+            if ! validate_release "$RELEASE_JSON"; then
+              echo "Existing GitHub Release metadata does not exactly match the request." >&2
+              exit 1
+            fi
             exit 0
           fi
-
-          FLAGS=""
-          if [ "${{ steps.channel.outputs.prerelease }}" = "true" ]; then
-            FLAGS="--prerelease"
+          if ! grep -Eq '(^|[^0-9])404([^0-9]|$)' "$RELEASE_ERROR"; then
+            echo "GitHub Release lookup failed ambiguously." >&2
+            cat "$RELEASE_ERROR" >&2
+            exit 1
           fi
 
-          gh release create "${TAG}" \
-            --title "${TAG}" \
+          # A failed create can be an ambiguous network response. Re-read the
+          # canonical API object and accept only an exact match.
+          set +e
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --target "$TARGET_SHA" \
+            --title "$TAG" \
             --generate-notes \
-            ${FLAGS}
+            "${RELEASE_FLAGS[@]}"
+          CREATE_STATUS=$?
+          set -e
+          if ! gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            > "$RELEASE_JSON"; then
+            echo "GitHub Release is absent after create attempt (status ${CREATE_STATUS})." >&2
+            exit 1
+          fi
+          if ! validate_release "$RELEASE_JSON"; then
+            echo "Created GitHub Release metadata does not exactly match the request." >&2
+            exit 1
+          fi
+          revalidate_published_authorities "after GitHub Release create attempt"
+          revalidate_pr_authority "after GitHub Release create attempt"

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,144 +1,29 @@
-name: SDK Release
+name: Publish Ravi SDK
 
-on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to release the SDK from"
-        required: true
-        type: choice
-        options: [main, dev]
-        default: main
-      prefix:
-        description: "Version major prefix (defaults to current package.json major)"
-        required: false
-        type: string
-        default: ""
+"on":
+  push:
+    tags:
+      - "ravi-os-sdk-v*"
 
+# The reusable implementation fails closed unless the caller is a tag event in
+# this exact namespace. Keeping the SDK trigger as a tiny wrapper prevents the
+# root and SDK security contracts from drifting.
 permissions:
-  contents: write
+  contents: read
+  pull-requests: read
 
 concurrency:
-  group: sdk-release-${{ github.event.inputs.branch }}
+  group: ravi-sdk-package-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Version And Publish SDK
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    env:
-      SDK_PACKAGE_PATH: packages/ravi-os-sdk/package.json
-      SDK_DIR: packages/ravi-os-sdk
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.inputs.branch }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.11"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Resolve prefix
-        id: prefix
-        run: |
-          PREFIX="${{ github.event.inputs.prefix }}"
-          if [ -z "$PREFIX" ]; then
-            PREFIX=$(jq -r '.version | split(".") | .[0]' "$SDK_PACKAGE_PATH")
-          fi
-          if ! echo "$PREFIX" | grep -Eq '^[0-9]+$'; then
-            echo "Resolved prefix '$PREFIX' is not numeric" >&2
-            exit 1
-          fi
-          echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"
-          echo "Resolved prefix: ${PREFIX}"
-
-      - name: Derive version
-        id: version
-        env:
-          PREFIX: ${{ steps.prefix.outputs.prefix }}
-        run: |
-          set -euo pipefail
-          PACKAGE=$(jq -r '.name' "$SDK_PACKAGE_PATH")
-          TODAY=$(date -u +%y%m%d)
-          PATTERN="${PREFIX}.${TODAY}."
-
-          VERSIONS_JSON=$(npm view "$PACKAGE" versions --json 2>/dev/null || echo '[]')
-          if [ -z "$VERSIONS_JSON" ]; then
-            VERSIONS_JSON='[]'
-          fi
-          EXISTING=$(echo "$VERSIONS_JSON" | jq --arg p "$PATTERN" '
-            if type == "string"
-            then (if startswith($p) then 1 else 0 end)
-            else [.[] | select(startswith($p))] | length
-            end
-          ')
-          BUILD_NUMBER=$((EXISTING + 1))
-          VERSION="${PREFIX}.${TODAY}.${BUILD_NUMBER}"
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "Derived SDK version: ${VERSION} (existing today: ${EXISTING})"
-
-      - name: Sync SDK version
-        env:
-          RAVI_PACKAGE_PATH: ${{ env.SDK_PACKAGE_PATH }}
-          RAVI_VERSION_PREFIX: ${{ steps.prefix.outputs.prefix }}
-          RAVI_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
-          RAVI_VERSION: ${{ steps.version.outputs.version }}
-        run: bun run version
-
-      - name: Regenerate SDK client (live registry → typed client)
-        run: bun run sdk:generate
-
-      - name: Commit SDK version bump
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="${{ github.event.inputs.branch }}"
-
-          git add "$SDK_PACKAGE_PATH" packages/ravi-os-sdk/src
-          if git diff --cached --quiet; then
-            echo "No version changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore(sdk-version): bump to ${VERSION} [skip ci]"
-          git push origin "HEAD:refs/heads/${BRANCH}"
-
-      - name: Build SDK
-        working-directory: ${{ env.SDK_DIR }}
-        run: bun run build
-
-      - name: Publish to npm
-        working-directory: ${{ env.SDK_DIR }}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "NPM_TOKEN not set; cannot publish SDK" >&2
-            exit 1
-          fi
-
-          PACKAGE=$(jq -r '.name' package.json)
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-
-          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${VERSION} already exists; moving dist-tag latest"
-            npm dist-tag add "${PACKAGE}@${VERSION}" latest
-          else
-            bun publish --access public --tag latest
-          fi
+  publish:
+    name: Verify And Publish Exact SDK Tag
+    uses: ./.github/workflows/version.yml
+    with:
+      release_kind: sdk
+      expected_package: "@ravi-os/sdk"
+      package_path: packages/ravi-os-sdk/package.json
+      package_dir: packages/ravi-os-sdk
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,169 +1,1338 @@
-name: Version And Publish
+name: Publish Ravi Package
 
-on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main, dev]
-  workflow_dispatch:
+"on":
+  push:
+    tags:
+      - "v*"
+  workflow_call:
     inputs:
-      branch:
-        description: "Branch to version and publish"
+      release_kind:
         required: true
-        type: choice
-        options: [dev, main]
-        default: dev
+        type: string
+      expected_package:
+        required: true
+        type: string
+      package_path:
+        required: true
+        type: string
+      package_dir:
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
 
+# Version changes are ordinary reviewed PRs. An operator pushes a lightweight
+# v<version> tag only after merge. Distinct tags deliberately use distinct
+# concurrency groups: GitHub keeps at most one pending run per group, so a
+# package-global group can silently discard the middle of three rapid tags.
 permissions:
-  contents: write
+  contents: read
+  pull-requests: read
 
 concurrency:
-  group: version-${{ github.event.workflow_run.head_branch || github.event.inputs.branch || 'manual' }}
+  group: ravi-package-${{ github.ref_name }}
   cancel-in-progress: false
 
-jobs:
-  check-changes:
-    name: Check For Publishable Changes
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        !contains(github.event.workflow_run.head_commit.message, '[skip ci]')
-      )
-    outputs:
-      should_publish: ${{ steps.filter.outputs.publish }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.branch }}
-          fetch-depth: 0
+env:
+  RELEASE_KIND: ${{ inputs.release_kind || 'root' }}
+  EXPECTED_PACKAGE: ${{ inputs.expected_package || 'ravi.bot' }}
+  PACKAGE_PATH: ${{ inputs.package_path || 'package.json' }}
+  PACKAGE_DIR: ${{ inputs.package_dir || '.' }}
+  NPM_REGISTRY: https://registry.npmjs.org/
 
-      - name: Detect publishable changes
-        id: filter
-        shell: bash
+jobs:
+  verify:
+    name: Verify, Test, And Seal Exact Tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      artifact_name: ${{ steps.seal.outputs.artifact_name }}
+      base: ${{ steps.provenance.outputs.base }}
+      current_base_sha: ${{ steps.provenance.outputs.current_base_sha }}
+      immutable_npm_tag: ${{ steps.provenance.outputs.immutable_npm_tag }}
+      pr_number: ${{ steps.provenance.outputs.pr_number }}
+      tag: ${{ steps.provenance.outputs.tag }}
+      target_sha: ${{ steps.provenance.outputs.target_sha }}
+      version: ${{ steps.provenance.outputs.version }}
+
+    # This is the only job that checks out or executes repository code. It has
+    # no npm credential in its job, step, config, or generated npmrc.
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org/
+
+      - name: Resolve trusted npm before repository code
+        id: npm
         run: |
           set -euo pipefail
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "Manual dispatch: publish forced."
-            exit 0
+          NPM_BIN="$(realpath "$(command -v npm)")"
+          NODE_BIN="$(realpath "$(command -v node)")"
+          TOOLCHAIN_DIR="$(dirname "$NODE_BIN")"
+          TOOLCHAIN_ROOT="$(dirname "$TOOLCHAIN_DIR")"
+          case "$NPM_BIN" in
+            "$TOOLCHAIN_ROOT"/*) ;;
+            *)
+              echo "npm is outside the freshly configured Node toolchain." >&2
+              exit 1
+              ;;
+          esac
+          if [ ! -x "$NPM_BIN" ] || [ ! -x "$NODE_BIN" ]; then
+            echo "Trusted Node toolchain is not executable." >&2
+            exit 1
           fi
-
-          BASE="$(git describe --tags --match 'v*' --abbrev=0 HEAD^ 2>/dev/null || true)"
-          if [ -z "$BASE" ]; then
-            BASE="$(git rev-list --max-parents=0 HEAD)"
-          fi
-
-          echo "Detecting publishable changes between ${BASE} and HEAD"
-          CHANGED_FILES="$(mktemp)"
-          git diff --name-only "${BASE}"..HEAD | tee "$CHANGED_FILES"
-
-          if grep -Eq '^(src/|bin/|scripts/|package\.json$|bun\.lock$|tsconfig\.json$)' "$CHANGED_FILES"; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "Publishable changes detected."
-          else
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "No publishable changes detected."
-          fi
-
-  version-and-publish:
-    name: Version And Publish
-    runs-on: ubuntu-latest
-    needs: check-changes
-    timeout-minutes: 15
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      needs.check-changes.outputs.should_publish == 'true'
-
-    steps:
-      - name: Resolve target
-        id: target
-        run: |
-          BRANCH="${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}"
-          if [ "$BRANCH" = "main" ]; then
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "branch=dev" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
-          fi
-          echo "prefix=3" >> "$GITHUB_OUTPUT"
+          echo "binary=${NPM_BIN}" >> "$GITHUB_OUTPUT"
+          echo "path=${TOOLCHAIN_DIR}:/usr/bin:/bin" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v5
         with:
-          ref: ${{ steps.target.outputs.branch }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Verify tag, reviewed PR delta, and current base
+        id: provenance
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_REF_NAME: ${{ github.ref_name }}
+          EVENT_REF_TYPE: ${{ github.ref_type }}
+          EVENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+          TRUSTED_PATH: ${{ steps.npm.outputs.path }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          export PATH="$TRUSTED_PATH"
+
+          semver_valid() {
+            [[ "$1" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]]
+          }
+
+          semver_gt() {
+            local newer="$1"
+            local older="$2"
+            local newer_a newer_b newer_c older_a older_b older_c left right
+            semver_valid "$newer" && semver_valid "$older" || return 1
+            IFS=. read -r newer_a newer_b newer_c <<<"$newer"
+            IFS=. read -r older_a older_b older_c <<<"$older"
+            for pair in \
+              "$newer_a:$older_a" \
+              "$newer_b:$older_b" \
+              "$newer_c:$older_c"; do
+              left="${pair%%:*}"
+              right="${pair#*:}"
+              if [ "${#left}" -gt "${#right}" ]; then return 0; fi
+              if [ "${#left}" -lt "${#right}" ]; then return 1; fi
+              if [[ "$left" > "$right" ]]; then return 0; fi
+              if [[ "$left" < "$right" ]]; then return 1; fi
+            done
+            return 1
+          }
+
+          case "$RELEASE_KIND" in
+            root)
+              if [ "$EXPECTED_PACKAGE" != "ravi.bot" ] ||
+                [ "$PACKAGE_PATH" != "package.json" ] ||
+                [ "$PACKAGE_DIR" != "." ]; then
+                echo "Root release inputs are outside the fixed package contract." >&2
+                exit 1
+              fi
+              TAG_PATTERN='^v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$'
+              ;;
+            sdk)
+              if [ "$EXPECTED_PACKAGE" != "@ravi-os/sdk" ] ||
+                [ "$PACKAGE_PATH" != "packages/ravi-os-sdk/package.json" ] ||
+                [ "$PACKAGE_DIR" != "packages/ravi-os-sdk" ]; then
+                echo "SDK release inputs are outside the fixed package contract." >&2
+                exit 1
+              fi
+              TAG_PATTERN='^ravi-os-sdk-v((0|[1-9][0-9]{0,8})\.([0-9]{6})\.([1-9][0-9]{0,8}))$'
+              ;;
+            *)
+              echo "Release kind '${RELEASE_KIND}' is invalid." >&2
+              exit 1
+              ;;
+          esac
+
+          TAG="$EVENT_REF_NAME"
+          if [ "$EVENT_NAME" != "push" ] ||
+            [ "$EVENT_REF_TYPE" != "tag" ] ||
+            [ "$EVENT_REF" != "refs/tags/${TAG}" ]; then
+            echo "This workflow accepts tag push events only." >&2
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ $TAG_PATTERN ]]; then
+            echo "Tag '${TAG}' does not match the bounded ${RELEASE_KIND} release namespace." >&2
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}"
+          DATE_PART="${BASH_REMATCH[3]}"
+          NORMALIZED_DATE="$(
+            date -u \
+              -d "20${DATE_PART:0:2}-${DATE_PART:2:2}-${DATE_PART:4:2}" \
+              +%y%m%d 2>/dev/null
+          )" || {
+            echo "Version date '${DATE_PART}' is not a real UTC calendar date." >&2
+            exit 1
+          }
+          if [ "$NORMALIZED_DATE" != "$DATE_PART" ]; then
+            echo "Version date '${DATE_PART}' is not a real UTC calendar date." >&2
+            exit 1
+          fi
+
+          if [[ ! "$EVENT_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            [ "$(git cat-file -t "refs/tags/${TAG}")" != "commit" ]; then
+            echo "The event must identify a full SHA and a lightweight commit tag." >&2
+            exit 1
+          fi
+          TAG_SHA="$(git rev-parse "refs/tags/${TAG}")"
+          if [ "$TAG_SHA" != "$EVENT_SHA" ] || [ "$(git rev-parse HEAD)" != "$EVENT_SHA" ]; then
+            echo "Tag, event, and checkout do not resolve to the same commit." >&2
+            exit 1
+          fi
+
+          if [ "$(git ls-files -- '.npmrc' '*/.npmrc' | wc -l | tr -d ' ')" -ne 0 ]; then
+            echo "Repository-controlled .npmrc files are forbidden in a release payload." >&2
+            exit 1
+          fi
+          if [ "$(jq -er '.name' "$PACKAGE_PATH")" != "$EXPECTED_PACKAGE" ] ||
+            [ "$(jq -er '.version' "$PACKAGE_PATH")" != "$VERSION" ] ||
+            ! jq -e '
+              (.publishConfig // {}) == {"access":"public"}
+              and (.gitHead == null)
+            ' "$PACKAGE_PATH" >/dev/null; then
+            echo "Package identity or publishConfig is outside the release contract." >&2
+            exit 1
+          fi
+
+          REMOTE_REF="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/tags/${TAG}" \
+            --arg sha "$TAG_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$REMOTE_REF"; then
+            echo "Remote tag '${TAG}' does not target the event commit." >&2
+            exit 1
+          fi
+
+          ASSOCIATED_PRS="$(
+            gh api \
+              --paginate \
+              --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${TAG_SHA}/pulls?per_page=100"
+          )"
+          if ! jq -e \
+            'type == "array" and all(.[]; type == "array" and all(.[]; type == "object"))' \
+            >/dev/null \
+            <<<"$ASSOCIATED_PRS"; then
+            echo "Associated pull request response was ambiguous." >&2
+            exit 1
+          fi
+          MATCHING_PRS="$(
+            jq -c \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg sha "$TAG_SHA" \
+              '[
+                (add // [])[]
+                | select(
+                    .merged_at != null
+                    and .merge_commit_sha == $sha
+                    and .head.repo.full_name == $repo
+                    and .base.repo.full_name == $repo
+                    and (.base.ref == "dev" or .base.ref == "main")
+                    and (.number | type == "number")
+                  )
+              ]' \
+              <<<"$ASSOCIATED_PRS"
+          )"
+          if [ "$(jq -er 'length' <<<"$MATCHING_PRS")" -ne 1 ]; then
+            echo "Expected one same-repository merged PR for exact tag target ${TAG_SHA}." >&2
+            exit 1
+          fi
+          BASE="$(jq -er '.[0].base.ref' <<<"$MATCHING_PRS")"
+          PR_NUMBER="$(jq -er '.[0].number | tostring' <<<"$MATCHING_PRS")"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]]; then
+            echo "Associated pull request number is invalid." >&2
+            exit 1
+          fi
+
+          PR_JSON="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          )"
+          if ! jq -e \
+            --argjson number "$PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$BASE" \
+            --arg target "$TAG_SHA" \
+            '
+              .number == $number
+              and .merged_at != null
+              and .merge_commit_sha == $target
+              and .head.repo.full_name == $repo
+              and .base.repo.full_name == $repo
+              and .base.ref == $base
+            ' \
+            >/dev/null \
+            <<<"$PR_JSON"; then
+            echo "Merged pull request provenance is ambiguous." >&2
+            exit 1
+          fi
+
+          # The fully paginated PR file list is the reviewed-delta authority.
+          # Historical PR base metadata is not treated as a merge base.
+          PR_FILE_PAGES="$(
+            gh api \
+              --paginate \
+              --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100"
+          )"
+          if ! jq -e \
+            --arg path "$PACKAGE_PATH" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ((add // []) | length) == 1
+              and (add // [])[0].filename == $path
+              and (add // [])[0].status == "modified"
+              and ((add // [])[0].previous_filename == null)
+            ' \
+            >/dev/null \
+            <<<"$PR_FILE_PAGES"; then
+            echo "Release PR must modify only ${PACKAGE_PATH} across its full paginated delta." >&2
+            exit 1
+          fi
+
+          BRANCH_REF="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/heads/${BASE}" \
+            '.ref == $ref and .object.type == "commit" and (.object.sha | test("^[0-9a-f]{40}$"))' \
+            >/dev/null \
+            <<<"$BRANCH_REF"; then
+            echo "Current base branch ref is ambiguous." >&2
+            exit 1
+          fi
+          CURRENT_BASE_SHA="$(jq -er '.object.sha' <<<"$BRANCH_REF")"
+          REACHABILITY="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/compare/${TAG_SHA}...${CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            --arg target "$TAG_SHA" \
+            --arg current "$CURRENT_BASE_SHA" \
+            '
+              .base_commit.sha == $target
+              and .merge_base_commit.sha == $target
+              and .head_commit.sha == $current
+              and (.status == "ahead" or .status == "identical")
+            ' \
+            >/dev/null \
+            <<<"$REACHABILITY"; then
+            echo "Tagged commit is not reachable from the current ${BASE} tip." >&2
+            exit 1
+          fi
+
+          CURRENT_CONTENT="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            '.type == "file" and .encoding == "base64" and (.content | type == "string")' \
+            >/dev/null \
+            <<<"$CURRENT_CONTENT"; then
+            echo "Current base manifest response is ambiguous." >&2
+            exit 1
+          fi
+          CURRENT_MANIFEST="${RUNNER_TEMP}/current-base-package.json"
+          jq -er '.content' <<<"$CURRENT_CONTENT" \
+            | tr -d '\n' \
+            | base64 --decode > "$CURRENT_MANIFEST"
+          if ! jq -e 'type == "object"' "$CURRENT_MANIFEST" >/dev/null ||
+            [ "$(jq -er '.name' "$CURRENT_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            ! diff -u \
+              <(jq -S 'del(.version)' "$PACKAGE_PATH") \
+              <(jq -S 'del(.version)' "$CURRENT_MANIFEST"); then
+            echo "Current base manifest diverges outside the reviewed version field." >&2
+            exit 1
+          fi
+          CURRENT_VERSION="$(jq -er '.version' "$CURRENT_MANIFEST")"
+          if ! semver_valid "$CURRENT_VERSION" ||
+            { [ "$CURRENT_VERSION" != "$VERSION" ] && ! semver_gt "$CURRENT_VERSION" "$VERSION"; }; then
+            echo "Current base version must be equal to or newer than the tagged version." >&2
+            exit 1
+          fi
+
+          case "$BASE" in
+            dev) CHANNEL_PREFIX="next" ;;
+            main) CHANNEL_PREFIX="stable" ;;
+            *)
+              echo "Unsupported release base '${BASE}'." >&2
+              exit 1
+              ;;
+          esac
+          # A version-qualified immutable dist-tag cannot be downgraded by an
+          # inverted publication order. No run mutates shared latest/next.
+          IMMUTABLE_NPM_TAG="${CHANNEL_PREFIX}-v${VERSION//./-}"
+
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "current_base_sha=${CURRENT_BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "immutable_npm_tag=${IMMUTABLE_NPM_TAG}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "target_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Registry monotonicity and retry preflight
+        env:
+          TARGET_SHA: ${{ steps.provenance.outputs.target_sha }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+          TRUSTED_PATH: ${{ steps.npm.outputs.path }}
+          VERSION: ${{ steps.provenance.outputs.version }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          export PATH="$TRUSTED_PATH"
+
+          semver_valid() {
+            [[ "$1" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]]
+          }
+
+          SAFE_NPMRC="${RUNNER_TEMP}/verify-read-only.npmrc"
+          printf 'registry=%s\nignore-scripts=true\n' "$NPM_REGISTRY" > "$SAFE_NPMRC"
+          REGISTRY_VERSIONS="${RUNNER_TEMP}/registry-versions.json"
+          NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+            NPM_CONFIG_GLOBALCONFIG=/dev/null \
+            "$TRUSTED_NPM" view "$EXPECTED_PACKAGE" versions --json \
+            --registry="$NPM_REGISTRY" > "$REGISTRY_VERSIONS"
+          if ! jq -e '
+            (if type == "string" then [.] elif type == "array" then . else error("invalid registry response") end)
+            | length > 0 and all(.[]; type == "string")
+          ' "$REGISTRY_VERSIONS" >/dev/null; then
+            echo "Registry versions are empty or ambiguous." >&2
+            exit 1
+          fi
+
+          VERSION_EXISTS=false
+          while IFS= read -r REGISTRY_VERSION; do
+            if ! semver_valid "$REGISTRY_VERSION"; then
+              echo "Registry version '${REGISTRY_VERSION}' is not bounded stable semver." >&2
+              exit 1
+            fi
+            if [ "$REGISTRY_VERSION" = "$VERSION" ]; then VERSION_EXISTS=true; fi
+          done < <(jq -er 'if type == "string" then . else .[] end' "$REGISTRY_VERSIONS")
+
+          # An existing version is only a retry candidate here. It is not
+          # accepted until the sealed tarball exists and its authoritative
+          # SSRI can be compared with npm's dist.integrity in the publish job.
+          # An absent version remains publishable even when newer versions
+          # already exist because every run uses a version-qualified immutable
+          # dist-tag and never mutates shared latest/next state.
+          echo "version_exists=${VERSION_EXISTS}"
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
-      - name: Install dependencies
+      - name: Install dependencies without publish credentials
         run: bun install --frozen-lockfile
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Derive version
-        id: version
-        run: |
-          PREFIX="${{ steps.target.outputs.prefix }}"
-          TODAY=$(date -u +%y%m%d)
-          EXISTING=$(git tag --list "v${PREFIX}.${TODAY}.*" | wc -l | tr -d ' ')
-          BUILD_NUMBER=$((EXISTING + 1))
-          VERSION="${PREFIX}.${TODAY}.${BUILD_NUMBER}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "Derived version: ${VERSION}"
-
-      - name: Sync version files
-        run: bun run version
-        env:
-          RAVI_VERSION_PREFIX: ${{ steps.target.outputs.prefix }}
-          RAVI_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
-
-      - name: Commit and tag version
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="${{ steps.target.outputs.branch }}"
-
-          git add package.json
-          if git diff --cached --quiet; then
-            echo "No version changes to commit"
-          else
-            git commit -m "chore(version): bump to ${VERSION} [skip ci]"
-          fi
-
-          git tag "v${VERSION}"
-          git push --atomic origin "HEAD:refs/heads/${BRANCH}" "refs/tags/v${VERSION}"
-
-      - name: Build package
+      - name: Build exact tagged SHA without publish credentials
         run: bun run build
 
-      - name: Publish to npm
+      - name: Typecheck exact tagged SHA without publish credentials
+        run: bun run typecheck
+
+      - name: Test exact tagged SHA without publish credentials
+        run: bun run test
+
+      - name: Seal immutable inspected tarball and metadata
+        id: seal
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TAG: ${{ steps.target.outputs.npm_tag }}
-          VERSION: ${{ steps.version.outputs.version }}
+          BASE: ${{ steps.provenance.outputs.base }}
+          CURRENT_BASE_SHA: ${{ steps.provenance.outputs.current_base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          IMMUTABLE_NPM_TAG: ${{ steps.provenance.outputs.immutable_npm_tag }}
+          PR_NUMBER: ${{ steps.provenance.outputs.pr_number }}
+          TAG: ${{ steps.provenance.outputs.tag }}
+          TARGET_SHA: ${{ steps.provenance.outputs.target_sha }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+          TRUSTED_PATH: ${{ steps.npm.outputs.path }}
+          VERSION: ${{ steps.provenance.outputs.version }}
         run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "NPM_TOKEN not set; skipping npm publish"
-            exit 0
+          set -euo pipefail
+          export LC_ALL=C
+          export PATH="$TRUSTED_PATH"
+
+          validate_tar_layout() {
+            local tarball="$1"
+            local listing="$2"
+            local verbose="$3"
+            local manifest_entries manifest_regular_entries
+            tar -tzf "$tarball" > "$listing"
+            tar -tvzf "$tarball" > "$verbose"
+            if grep -Eq '(^$|^/|//|(^|/)\.\.?(/|$)|\\)' "$listing" ||
+              [ "$(sort "$listing" | uniq -d | wc -l | tr -d ' ')" -ne 0 ]; then
+              echo "Packed payload contains a duplicate or ambiguous path." >&2
+              return 1
+            fi
+            if awk '$1 !~ /^[-d]/ { unsafe=1 } END { exit !unsafe }' "$verbose"; then
+              echo "Packed payload contains a link or special entry." >&2
+              return 1
+            fi
+            manifest_entries="$(
+              awk '$0 == "package/package.json" { count++ } END { print count + 0 }' "$listing"
+            )"
+            manifest_regular_entries="$(
+              awk '
+                $1 ~ /^-/ && $NF == "package\/package.json" { count++ }
+                END { print count + 0 }
+              ' "$verbose"
+            )"
+            if [ "$manifest_entries" -ne 1 ] || [ "$manifest_regular_entries" -ne 1 ]; then
+              echo "Packed payload must contain exactly one regular package/package.json." >&2
+              return 1
+            fi
+          }
+
+          ssri_sha512() {
+            printf 'sha512-%s\n' "$(
+              openssl dgst -sha512 -binary "$1" | openssl base64 -A
+            )"
+          }
+
+          if [ "$(git rev-parse HEAD)" != "$TARGET_SHA" ] ||
+            [ "$(git rev-parse "refs/tags/${TAG}")" != "$TARGET_SHA" ]; then
+            echo "Checkout or local tag changed before packaging." >&2
+            exit 1
+          fi
+          if find "$GITHUB_WORKSPACE" \
+            -path "$GITHUB_WORKSPACE/.git" -prune -o \
+            -path "$GITHUB_WORKSPACE/node_modules" -prune -o \
+            -name .npmrc -type f -print -quit | grep -q .; then
+            echo "A repository-controlled .npmrc appeared before packaging." >&2
+            exit 1
           fi
 
-          PACKAGE=$(jq -r '.name' package.json)
-          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${VERSION} already exists. Moving dist-tag ${NPM_TAG}."
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-            npm dist-tag add "${PACKAGE}@${VERSION}" "${NPM_TAG}"
+          BRANCH_REF="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/heads/${BASE}" \
+            --arg sha "$CURRENT_BASE_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$BRANCH_REF"; then
+            echo "Base branch moved while the tagged SHA was being tested; rerun explicitly." >&2
+            exit 1
+          fi
+
+          WORK_DIR="${RUNNER_TEMP}/pack-work"
+          FIRST_DIR="${WORK_DIR}/first"
+          STAGE_DIR="${WORK_DIR}/stage"
+          PAYLOAD_DIR="${RUNNER_TEMP}/release-payload"
+          mkdir -p "$FIRST_DIR" "$STAGE_DIR" "$PAYLOAD_DIR"
+          SAFE_NPMRC="${RUNNER_TEMP}/pack-read-only.npmrc"
+          printf 'registry=%s\nignore-scripts=true\n' "$NPM_REGISTRY" > "$SAFE_NPMRC"
+
+          NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+            NPM_CONFIG_GLOBALCONFIG=/dev/null \
+            "$TRUSTED_NPM" pack "$PACKAGE_DIR" \
+            --json \
+            --ignore-scripts \
+            --pack-destination "$FIRST_DIR" \
+            --registry="$NPM_REGISTRY" > "${WORK_DIR}/first-pack.json"
+          FIRST_NAME="$(jq -er 'if type == "array" and length == 1 then .[0].filename else error("ambiguous pack") end' "${WORK_DIR}/first-pack.json")"
+          FIRST_TARBALL="${FIRST_DIR}/${FIRST_NAME}"
+          if [ "$(basename "$FIRST_TARBALL")" != "$FIRST_NAME" ] || [ ! -f "$FIRST_TARBALL" ]; then
+            echo "npm pack returned an unsafe tarball name." >&2
+            exit 1
+          fi
+          if ! validate_tar_layout \
+            "$FIRST_TARBALL" \
+            "${WORK_DIR}/first-files.txt" \
+            "${WORK_DIR}/first-verbose.txt" ||
+            grep -Eq '(^|/)\.npmrc$' "${WORK_DIR}/first-files.txt"; then
+            echo "Initial packed payload is unsafe." >&2
+            exit 1
+          fi
+          tar -xzf "$FIRST_TARBALL" -C "$STAGE_DIR"
+
+          STAGED_MANIFEST="${STAGE_DIR}/package/package.json"
+          if ! jq -e -s \
+            --arg name "$EXPECTED_PACKAGE" \
+            --arg version "$VERSION" \
+            '
+              length == 1
+              and .[0].name == $name
+              and .[0].version == $version
+              and (.[0].publishConfig // {}) == {"access":"public"}
+              and (.[0].gitHead == null)
+            ' \
+            "$STAGED_MANIFEST" >/dev/null; then
+            echo "Packed manifest must be one JSON document inside the release contract." >&2
+            exit 1
+          fi
+          jq --arg sha "$TARGET_SHA" '.gitHead = $sha' "$STAGED_MANIFEST" \
+            > "${STAGED_MANIFEST}.tmp"
+          mv "${STAGED_MANIFEST}.tmp" "$STAGED_MANIFEST"
+
+          NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+            NPM_CONFIG_GLOBALCONFIG=/dev/null \
+            "$TRUSTED_NPM" pack "${STAGE_DIR}/package" \
+            --json \
+            --ignore-scripts \
+            --pack-destination "$PAYLOAD_DIR" \
+            --registry="$NPM_REGISTRY" > "${WORK_DIR}/final-pack.json"
+          TARBALL_NAME="$(jq -er 'if type == "array" and length == 1 then .[0].filename else error("ambiguous pack") end' "${WORK_DIR}/final-pack.json")"
+          TARBALL="${PAYLOAD_DIR}/${TARBALL_NAME}"
+          if [ "$(basename "$TARBALL")" != "$TARBALL_NAME" ] ||
+            [[ ! "$TARBALL_NAME" =~ ^[A-Za-z0-9._-]+\.tgz$ ]] ||
+            [ ! -f "$TARBALL" ]; then
+            echo "Final tarball name is unsafe or missing." >&2
+            exit 1
+          fi
+          if ! validate_tar_layout \
+            "$TARBALL" \
+            "${WORK_DIR}/final-files.txt" \
+            "${WORK_DIR}/final-verbose.txt" ||
+            grep -Eq '(^|/)\.npmrc$' "${WORK_DIR}/final-files.txt"; then
+            echo "Final tarball is unsafe." >&2
+            exit 1
+          fi
+          tar -xOf "$TARBALL" package/package.json > "${WORK_DIR}/final-manifest.json"
+          if ! jq -e -s \
+            --arg name "$EXPECTED_PACKAGE" \
+            --arg version "$VERSION" \
+            --arg sha "$TARGET_SHA" \
+            '
+              length == 1
+              and .[0].name == $name
+              and .[0].version == $version
+              and .[0].gitHead == $sha
+              and .[0].publishConfig == {"access":"public"}
+            ' \
+            "${WORK_DIR}/final-manifest.json" >/dev/null; then
+            echo "Final tarball must contain one JSON manifest binding package, version, and gitHead." >&2
+            exit 1
+          fi
+
+          TARBALL_SHA512="$(sha512sum "$TARBALL" | awk '{print $1}')"
+          TARBALL_INTEGRITY="$(ssri_sha512 "$TARBALL")"
+          if [[ ! "$TARBALL_INTEGRITY" =~ ^sha512-[A-Za-z0-9+/]{86}==$ ]]; then
+            echo "Sealed tarball SSRI is malformed." >&2
+            exit 1
+          fi
+          ARTIFACT_NAME="ravi-${RELEASE_KIND}-package-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          jq -n \
+            --arg artifactName "$ARTIFACT_NAME" \
+            --arg base "$BASE" \
+            --arg currentBaseSha "$CURRENT_BASE_SHA" \
+            --arg immutableNpmTag "$IMMUTABLE_NPM_TAG" \
+            --arg packageName "$EXPECTED_PACKAGE" \
+            --arg packagePath "$PACKAGE_PATH" \
+            --arg prNumber "$PR_NUMBER" \
+            --arg registry "$NPM_REGISTRY" \
+            --arg tag "$TAG" \
+            --arg targetSha "$TARGET_SHA" \
+            --arg tarball "$TARBALL_NAME" \
+            --arg tarballIntegrity "$TARBALL_INTEGRITY" \
+            --arg tarballSha512 "$TARBALL_SHA512" \
+            --arg version "$VERSION" \
+            '{
+              schema: 2,
+              artifactName: $artifactName,
+              base: $base,
+              currentBaseSha: $currentBaseSha,
+              immutableNpmTag: $immutableNpmTag,
+              packageName: $packageName,
+              packagePath: $packagePath,
+              prNumber: $prNumber,
+              registry: $registry,
+              tag: $tag,
+              targetSha: $targetSha,
+              tarball: $tarball,
+              tarballIntegrity: $tarballIntegrity,
+              tarballSha512: $tarballSha512,
+              version: $version
+            }' > "${PAYLOAD_DIR}/metadata.json"
+          echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable inspected release payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.seal.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-payload
+          if-no-files-found: error
+          compression-level: 0
+          overwrite: false
+          retention-days: 90
+
+  publish:
+    name: Revalidate And Publish Sealed Tarball
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # This fresh job has no checkout and executes no repository code. It sees
+    # only the immutable inspected tarball plus declarative metadata.
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org/
+
+      - name: Resolve fresh trusted npm and isolated config
+        id: npm
+        run: |
+          set -euo pipefail
+          NPM_BIN="$(realpath "$(command -v npm)")"
+          NODE_BIN="$(realpath "$(command -v node)")"
+          TOOLCHAIN_DIR="$(dirname "$NODE_BIN")"
+          TOOLCHAIN_ROOT="$(dirname "$TOOLCHAIN_DIR")"
+          case "$NPM_BIN" in
+            "$TOOLCHAIN_ROOT"/*) ;;
+            *)
+              echo "npm is outside the fresh Node toolchain." >&2
+              exit 1
+              ;;
+          esac
+          SAFE_HOME="${RUNNER_TEMP}/npm-home"
+          SAFE_NPMRC="${RUNNER_TEMP}/publish.npmrc"
+          mkdir -p "$SAFE_HOME"
+          chmod 700 "$SAFE_HOME"
+          umask 077
+          {
+            printf 'registry=%s\n' "$NPM_REGISTRY"
+            printf 'ignore-scripts=true\n'
+            printf 'access=public\n'
+            printf '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\n'
+          } > "$SAFE_NPMRC"
+          echo "binary=${NPM_BIN}" >> "$GITHUB_OUTPUT"
+          echo "home=${SAFE_HOME}" >> "$GITHUB_OUTPUT"
+          echo "npmrc=${SAFE_NPMRC}" >> "$GITHUB_OUTPUT"
+          echo "path=${TOOLCHAIN_DIR}:/usr/bin:/bin" >> "$GITHUB_OUTPUT"
+
+      - name: Download exact sealed release payload
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.verify.outputs.artifact_name }}
+          path: ${{ runner.temp }}/release-payload
+
+      - name: Revalidate artifact, tag, current base, PR files, and registry
+        id: revalidate
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.verify.outputs.artifact_name }}
+          EXPECTED_BASE: ${{ needs.verify.outputs.base }}
+          EXPECTED_CURRENT_BASE_SHA: ${{ needs.verify.outputs.current_base_sha }}
+          EXPECTED_IMMUTABLE_NPM_TAG: ${{ needs.verify.outputs.immutable_npm_tag }}
+          EXPECTED_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
+          EXPECTED_TAG: ${{ needs.verify.outputs.tag }}
+          EXPECTED_TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          EXPECTED_VERSION: ${{ needs.verify.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          SAFE_HOME: ${{ steps.npm.outputs.home }}
+          SAFE_NPMRC: ${{ steps.npm.outputs.npmrc }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+          TRUSTED_PATH: ${{ steps.npm.outputs.path }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          export PATH="$TRUSTED_PATH"
+          export HOME="$SAFE_HOME"
+
+          semver_valid() {
+            [[ "$1" =~ ^(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})$ ]]
+          }
+          semver_gt() {
+            local newer="$1" older="$2" left right
+            local newer_a newer_b newer_c older_a older_b older_c
+            semver_valid "$newer" && semver_valid "$older" || return 1
+            IFS=. read -r newer_a newer_b newer_c <<<"$newer"
+            IFS=. read -r older_a older_b older_c <<<"$older"
+            for pair in "$newer_a:$older_a" "$newer_b:$older_b" "$newer_c:$older_c"; do
+              left="${pair%%:*}"; right="${pair#*:}"
+              if [ "${#left}" -gt "${#right}" ]; then return 0; fi
+              if [ "${#left}" -lt "${#right}" ]; then return 1; fi
+              if [[ "$left" > "$right" ]]; then return 0; fi
+              if [[ "$left" < "$right" ]]; then return 1; fi
+            done
+            return 1
+          }
+
+          validate_tar_layout() {
+            local tarball="$1"
+            local listing="$2"
+            local verbose="$3"
+            local manifest_entries manifest_regular_entries
+            tar -tzf "$tarball" > "$listing"
+            tar -tvzf "$tarball" > "$verbose"
+            if grep -Eq '(^$|^/|//|(^|/)\.\.?(/|$)|\\)' "$listing" ||
+              [ "$(sort "$listing" | uniq -d | wc -l | tr -d ' ')" -ne 0 ]; then
+              echo "Sealed tarball contains a duplicate or ambiguous path." >&2
+              return 1
+            fi
+            if awk '$1 !~ /^[-d]/ { unsafe=1 } END { exit !unsafe }' "$verbose"; then
+              echo "Sealed tarball contains a link or special entry." >&2
+              return 1
+            fi
+            manifest_entries="$(
+              awk '$0 == "package/package.json" { count++ } END { print count + 0 }' "$listing"
+            )"
+            manifest_regular_entries="$(
+              awk '
+                $1 ~ /^-/ && $NF == "package\/package.json" { count++ }
+                END { print count + 0 }
+              ' "$verbose"
+            )"
+            if [ "$manifest_entries" -ne 1 ] || [ "$manifest_regular_entries" -ne 1 ]; then
+              echo "Sealed tarball must contain exactly one regular package/package.json." >&2
+              return 1
+            fi
+          }
+
+          ssri_sha512() {
+            printf 'sha512-%s\n' "$(
+              openssl dgst -sha512 -binary "$1" | openssl base64 -A
+            )"
+          }
+
+          PAYLOAD_DIR="${RUNNER_TEMP}/release-payload"
+          METADATA="${PAYLOAD_DIR}/metadata.json"
+          if [ -L "$PAYLOAD_DIR" ] || [ ! -f "$METADATA" ] || [ -L "$METADATA" ]; then
+            echo "Release artifact layout is unsafe." >&2
+            exit 1
+          fi
+          if [ "$(find "$PAYLOAD_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')" -ne 2 ] ||
+            [ "$(find "$PAYLOAD_DIR" -mindepth 1 -maxdepth 1 -type f -links 1 -print | wc -l | tr -d ' ')" -ne 2 ] ||
+            ! jq -e 'type == "object" and .schema == 2' "$METADATA" >/dev/null; then
+            echo "Release artifact must contain exactly two unlinked regular files and schema-2 metadata." >&2
+            exit 1
+          fi
+
+          if ! jq -e \
+            --arg artifact "$EXPECTED_ARTIFACT_NAME" \
+            --arg base "$EXPECTED_BASE" \
+            --arg current "$EXPECTED_CURRENT_BASE_SHA" \
+            --arg npmTag "$EXPECTED_IMMUTABLE_NPM_TAG" \
+            --arg name "$EXPECTED_PACKAGE" \
+            --arg path "$PACKAGE_PATH" \
+            --arg pr "$EXPECTED_PR_NUMBER" \
+            --arg registry "$NPM_REGISTRY" \
+            --arg tag "$EXPECTED_TAG" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            --arg version "$EXPECTED_VERSION" \
+            '
+              .artifactName == $artifact
+              and .base == $base
+              and .currentBaseSha == $current
+              and .immutableNpmTag == $npmTag
+              and .packageName == $name
+              and .packagePath == $path
+              and .prNumber == $pr
+              and .registry == $registry
+              and .tag == $tag
+              and .targetSha == $sha
+              and .version == $version
+              and (.tarball | type == "string" and test("^[A-Za-z0-9._-]+[.]tgz$"))
+              and (.tarballIntegrity | type == "string" and test("^sha512-[A-Za-z0-9+/]{86}==$"))
+              and (.tarballSha512 | type == "string" and test("^[0-9a-f]{128}$"))
+            ' \
+            "$METADATA" >/dev/null; then
+            echo "Release metadata does not match verified job outputs." >&2
+            exit 1
+          fi
+          TARBALL_NAME="$(jq -er '.tarball' "$METADATA")"
+          TARBALL="${PAYLOAD_DIR}/${TARBALL_NAME}"
+          EXPECTED_TARBALL_INTEGRITY="$(jq -er '.tarballIntegrity' "$METADATA")"
+          if [ ! -f "$TARBALL" ] || [ -L "$TARBALL" ] ||
+            [ "$(sha512sum "$TARBALL" | awk '{print $1}')" != "$(jq -er '.tarballSha512' "$METADATA")" ] ||
+            [ "$(ssri_sha512 "$TARBALL")" != "$EXPECTED_TARBALL_INTEGRITY" ]; then
+            echo "Sealed tarball is missing, linked, or has the wrong hex/SSRI digest." >&2
+            exit 1
+          fi
+          if ! validate_tar_layout \
+            "$TARBALL" \
+            "${RUNNER_TEMP}/publish-files.txt" \
+            "${RUNNER_TEMP}/publish-verbose.txt" ||
+            grep -Eq '(^|/)\.npmrc$' "${RUNNER_TEMP}/publish-files.txt"; then
+            echo "Sealed tarball layout is unsafe." >&2
+            exit 1
+          fi
+          tar -xOf "$TARBALL" package/package.json > "${RUNNER_TEMP}/publish-manifest.json"
+          if ! jq -e -s \
+            --arg name "$EXPECTED_PACKAGE" \
+            --arg version "$EXPECTED_VERSION" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '
+              length == 1
+              and .[0].name == $name
+              and .[0].version == $version
+              and .[0].gitHead == $sha
+              and .[0].publishConfig == {"access":"public"}
+            ' \
+            "${RUNNER_TEMP}/publish-manifest.json" >/dev/null; then
+            echo "Sealed manifest must be one JSON document binding the target SHA." >&2
+            exit 1
+          fi
+
+          REMOTE_REF="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${EXPECTED_TAG}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/tags/${EXPECTED_TAG}" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$REMOTE_REF"; then
+            echo "Remote tag changed after artifact sealing." >&2
+            exit 1
+          fi
+
+          ASSOCIATED_PRS="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${EXPECTED_TARGET_SHA}/pulls?per_page=100"
+          )"
+          if ! jq -e \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$EXPECTED_BASE" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ([
+                (add // [])[]
+                | select(
+                    .merged_at != null
+                    and .merge_commit_sha == $sha
+                    and .head.repo.full_name == $repo
+                    and .base.repo.full_name == $repo
+                    and (.base.ref == "dev" or .base.ref == "main")
+                    and (.number | type == "number")
+                  )
+              ] |
+                length == 1
+                and .[0].number == $number
+                and .[0].base.ref == $base
+              )
+            ' \
+            >/dev/null \
+            <<<"$ASSOCIATED_PRS"; then
+            echo "Associated PR provenance changed after artifact sealing." >&2
+            exit 1
+          fi
+          PR_JSON="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}"
+          )"
+          if ! jq -e \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$EXPECTED_BASE" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '
+              .number == $number
+              and .merged_at != null
+              and .merge_commit_sha == $sha
+              and .head.repo.full_name == $repo
+              and .base.repo.full_name == $repo
+              and .base.ref == $base
+            ' \
+            >/dev/null \
+            <<<"$PR_JSON"; then
+            echo "PR provenance changed after artifact sealing." >&2
+            exit 1
+          fi
+          PR_FILE_PAGES="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}/files?per_page=100"
+          )"
+          if ! jq -e \
+            --arg path "$PACKAGE_PATH" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ((add // []) | length) == 1
+              and (add // [])[0].filename == $path
+              and (add // [])[0].status == "modified"
+              and ((add // [])[0].previous_filename == null)
+            ' \
+            >/dev/null \
+            <<<"$PR_FILE_PAGES"; then
+            echo "Full paginated PR delta changed after artifact sealing." >&2
+            exit 1
+          fi
+
+          BRANCH_REF="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${EXPECTED_BASE}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/heads/${EXPECTED_BASE}" \
+            --arg sha "$EXPECTED_CURRENT_BASE_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$BRANCH_REF"; then
+            echo "Base branch moved after artifact sealing; fail closed and rerun." >&2
+            exit 1
+          fi
+          REACHABILITY="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/compare/${EXPECTED_TARGET_SHA}...${EXPECTED_CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            --arg target "$EXPECTED_TARGET_SHA" \
+            --arg current "$EXPECTED_CURRENT_BASE_SHA" \
+            '
+              .base_commit.sha == $target
+              and .merge_base_commit.sha == $target
+              and .head_commit.sha == $current
+              and (.status == "ahead" or .status == "identical")
+            ' \
+            >/dev/null \
+            <<<"$REACHABILITY"; then
+            echo "Tagged target is no longer reachable from the sealed base tip." >&2
+            exit 1
+          fi
+
+          TARGET_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${EXPECTED_TARGET_SHA}"
+          )"
+          CURRENT_CONTENT="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/contents/${PACKAGE_PATH}?ref=${EXPECTED_CURRENT_BASE_SHA}"
+          )"
+          for response in "$TARGET_CONTENT" "$CURRENT_CONTENT"; do
+            if ! jq -e \
+              '.type == "file" and .encoding == "base64" and (.content | type == "string")' \
+              >/dev/null \
+              <<<"$response"; then
+              echo "Target or current-base manifest response is ambiguous." >&2
+              exit 1
+            fi
+          done
+          TARGET_MANIFEST="${RUNNER_TEMP}/target-manifest.json"
+          CURRENT_MANIFEST="${RUNNER_TEMP}/current-manifest.json"
+          jq -er '.content' <<<"$TARGET_CONTENT" | tr -d '\n' | base64 --decode > "$TARGET_MANIFEST"
+          jq -er '.content' <<<"$CURRENT_CONTENT" | tr -d '\n' | base64 --decode > "$CURRENT_MANIFEST"
+          if [ "$(jq -er '.name' "$TARGET_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            [ "$(jq -er '.version' "$TARGET_MANIFEST")" != "$EXPECTED_VERSION" ] ||
+            [ "$(jq -er '.name' "$CURRENT_MANIFEST")" != "$EXPECTED_PACKAGE" ] ||
+            ! diff -u \
+              <(jq -S 'del(.version)' "$TARGET_MANIFEST") \
+              <(jq -S 'del(.version)' "$CURRENT_MANIFEST"); then
+            echo "Target/current-base manifest invariant changed." >&2
+            exit 1
+          fi
+          CURRENT_VERSION="$(jq -er '.version' "$CURRENT_MANIFEST")"
+          if ! semver_valid "$CURRENT_VERSION" ||
+            { [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ] && ! semver_gt "$CURRENT_VERSION" "$EXPECTED_VERSION"; }; then
+            echo "Current base version is older than the target." >&2
+            exit 1
+          fi
+
+          REGISTRY_VERSIONS="${RUNNER_TEMP}/publish-registry-versions.json"
+          NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+            NPM_CONFIG_GLOBALCONFIG=/dev/null \
+            "$TRUSTED_NPM" view "$EXPECTED_PACKAGE" versions --json \
+            --registry="$NPM_REGISTRY" > "$REGISTRY_VERSIONS"
+          if ! jq -e '
+            (if type == "string" then [.] elif type == "array" then . else error("invalid registry response") end)
+            | length > 0 and all(.[]; type == "string")
+          ' "$REGISTRY_VERSIONS" >/dev/null; then
+            echo "Registry versions are empty or ambiguous." >&2
+            exit 1
+          fi
+          VERSION_EXISTS=false
+          while IFS= read -r REGISTRY_VERSION; do
+            if ! semver_valid "$REGISTRY_VERSION"; then
+              echo "Registry version '${REGISTRY_VERSION}' is invalid." >&2
+              exit 1
+            fi
+            if [ "$REGISTRY_VERSION" = "$EXPECTED_VERSION" ]; then VERSION_EXISTS=true; fi
+          done < <(jq -er 'if type == "string" then . else .[] end' "$REGISTRY_VERSIONS")
+
+          DIST_TAGS="$(
+            NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+              NPM_CONFIG_GLOBALCONFIG=/dev/null \
+              "$TRUSTED_NPM" view "$EXPECTED_PACKAGE" dist-tags --json \
+              --registry="$NPM_REGISTRY"
+          )"
+          if ! jq -e 'type == "object" and all(to_entries[]; .value | type == "string")' \
+            >/dev/null <<<"$DIST_TAGS"; then
+            echo "Registry dist-tags are ambiguous." >&2
+            exit 1
+          fi
+
+          if [ "$VERSION_EXISTS" = true ]; then
+            REGISTRY_METADATA="$(
+              NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+                NPM_CONFIG_GLOBALCONFIG=/dev/null \
+                "$TRUSTED_NPM" view \
+                "${EXPECTED_PACKAGE}@${EXPECTED_VERSION}" \
+                version gitHead dist.integrity --json \
+                --registry="$NPM_REGISTRY"
+            )"
+            if ! jq -e \
+              --arg version "$EXPECTED_VERSION" \
+              --arg sha "$EXPECTED_TARGET_SHA" \
+              --arg integrity "$EXPECTED_TARBALL_INTEGRITY" \
+              '
+                .version == $version
+                and .gitHead == $sha
+                and .["dist.integrity"] == $integrity
+              ' \
+              >/dev/null \
+              <<<"$REGISTRY_METADATA"; then
+              echo "Existing package version has mismatched gitHead or dist.integrity." >&2
+              exit 1
+            fi
+            if [ "$(jq -r --arg tag "$EXPECTED_IMMUTABLE_NPM_TAG" '.[$tag] // empty' <<<"$DIST_TAGS")" != "$EXPECTED_VERSION" ]; then
+              echo "Existing package has a missing or mismatched immutable dist-tag." >&2
+              exit 1
+            fi
+            ALREADY_PUBLISHED=true
           else
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-            bun publish --access public --tag "${NPM_TAG}"
+            if jq -e --arg tag "$EXPECTED_IMMUTABLE_NPM_TAG" 'has($tag)' >/dev/null <<<"$DIST_TAGS"; then
+              echo "Immutable dist-tag already exists without its package version." >&2
+              exit 1
+            fi
+            # Publication order is intentionally irrelevant. The immutable,
+            # version-qualified tag cannot move a shared channel backward.
+            ALREADY_PUBLISHED=false
+          fi
+
+          echo "already_published=${ALREADY_PUBLISHED}" >> "$GITHUB_OUTPUT"
+          echo "integrity=${EXPECTED_TARBALL_INTEGRITY}" >> "$GITHUB_OUTPUT"
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+          echo "tarball_sha512=$(jq -er '.tarballSha512' "$METADATA")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish immutable inspected tarball
+        id: publish
+        if: steps.revalidate.outputs.already_published == 'false'
+        continue-on-error: true
+        env:
+          HOME: ${{ steps.npm.outputs.home }}
+          IMMUTABLE_NPM_TAG: ${{ needs.verify.outputs.immutable_npm_tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_GLOBALCONFIG: /dev/null
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          NPM_CONFIG_USERCONFIG: ${{ steps.npm.outputs.npmrc }}
+          PATH: ${{ steps.npm.outputs.path }}
+          TARBALL: ${{ steps.revalidate.outputs.tarball }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+        run: '"$TRUSTED_NPM" publish "$TARBALL" --ignore-scripts --access public --tag "$IMMUTABLE_NPM_TAG" --registry="https://registry.npmjs.org/"'
+
+      - name: Verify exact registry result after publish or retry
+        if: always() && steps.revalidate.outcome == 'success'
+        env:
+          EXPECTED_BASE: ${{ needs.verify.outputs.base }}
+          EXPECTED_CURRENT_BASE_SHA: ${{ needs.verify.outputs.current_base_sha }}
+          EXPECTED_IMMUTABLE_NPM_TAG: ${{ needs.verify.outputs.immutable_npm_tag }}
+          EXPECTED_INTEGRITY: ${{ steps.revalidate.outputs.integrity }}
+          EXPECTED_PR_NUMBER: ${{ needs.verify.outputs.pr_number }}
+          EXPECTED_TAG: ${{ needs.verify.outputs.tag }}
+          EXPECTED_TARBALL_SHA512: ${{ steps.revalidate.outputs.tarball_sha512 }}
+          EXPECTED_TARGET_SHA: ${{ needs.verify.outputs.target_sha }}
+          EXPECTED_VERSION: ${{ needs.verify.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          HOME: ${{ steps.npm.outputs.home }}
+          SAFE_NPMRC: ${{ steps.npm.outputs.npmrc }}
+          TARBALL: ${{ steps.revalidate.outputs.tarball }}
+          TRUSTED_NPM: ${{ steps.npm.outputs.binary }}
+          TRUSTED_PATH: ${{ steps.npm.outputs.path }}
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          export PATH="$TRUSTED_PATH"
+
+          ssri_sha512() {
+            printf 'sha512-%s\n' "$(
+              openssl dgst -sha512 -binary "$1" | openssl base64 -A
+            )"
+          }
+
+          if [ ! -f "$TARBALL" ] || [ -L "$TARBALL" ] ||
+            [ "$(sha512sum "$TARBALL" | awk '{print $1}')" != "$EXPECTED_TARBALL_SHA512" ] ||
+            [ "$(ssri_sha512 "$TARBALL")" != "$EXPECTED_INTEGRITY" ]; then
+            echo "Sealed tarball digest changed during publication." >&2
+            exit 1
+          fi
+
+          REMOTE_REF="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${EXPECTED_TAG}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/tags/${EXPECTED_TAG}" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$REMOTE_REF"; then
+            echo "Remote tag diverged during publication." >&2
+            exit 1
+          fi
+
+          ASSOCIATED_PRS="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${EXPECTED_TARGET_SHA}/pulls?per_page=100"
+          )"
+          if ! jq -e \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$EXPECTED_BASE" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ([
+                (add // [])[]
+                | select(
+                    .merged_at != null
+                    and .merge_commit_sha == $sha
+                    and .head.repo.full_name == $repo
+                    and .base.repo.full_name == $repo
+                    and (.base.ref == "dev" or .base.ref == "main")
+                    and (.number | type == "number")
+                  )
+              ] |
+                length == 1
+                and .[0].number == $number
+                and .[0].base.ref == $base
+              )
+            ' \
+            >/dev/null \
+            <<<"$ASSOCIATED_PRS"; then
+            echo "Associated PR provenance diverged during publication." >&2
+            exit 1
+          fi
+          PR_JSON="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}"
+          )"
+          if ! jq -e \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg base "$EXPECTED_BASE" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            '
+              .number == $number
+              and .merged_at != null
+              and .merge_commit_sha == $sha
+              and .head.repo.full_name == $repo
+              and .base.repo.full_name == $repo
+              and .base.ref == $base
+            ' \
+            >/dev/null \
+            <<<"$PR_JSON"; then
+            echo "PR provenance diverged during publication." >&2
+            exit 1
+          fi
+          PR_FILE_PAGES="$(
+            gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${EXPECTED_PR_NUMBER}/files?per_page=100"
+          )"
+          if ! jq -e \
+            --arg path "$PACKAGE_PATH" \
+            '
+              type == "array"
+              and all(.[]; type == "array" and all(.[]; type == "object"))
+              and ((add // []) | length) == 1
+              and (add // [])[0].filename == $path
+              and (add // [])[0].status == "modified"
+              and ((add // [])[0].previous_filename == null)
+            ' \
+            >/dev/null \
+            <<<"$PR_FILE_PAGES"; then
+            echo "Reviewed PR delta diverged during publication." >&2
+            exit 1
+          fi
+
+          BRANCH_REF="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${EXPECTED_BASE}"
+          )"
+          if ! jq -e \
+            --arg ref "refs/heads/${EXPECTED_BASE}" \
+            --arg sha "$EXPECTED_CURRENT_BASE_SHA" \
+            '.ref == $ref and .object.type == "commit" and .object.sha == $sha' \
+            >/dev/null \
+            <<<"$BRANCH_REF"; then
+            echo "Base branch diverged during publication." >&2
+            exit 1
+          fi
+          REACHABILITY="$(
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/compare/${EXPECTED_TARGET_SHA}...${EXPECTED_CURRENT_BASE_SHA}"
+          )"
+          if ! jq -e \
+            --arg target "$EXPECTED_TARGET_SHA" \
+            --arg current "$EXPECTED_CURRENT_BASE_SHA" \
+            '
+              .base_commit.sha == $target
+              and .merge_base_commit.sha == $target
+              and .head_commit.sha == $current
+              and (.status == "ahead" or .status == "identical")
+            ' \
+            >/dev/null \
+            <<<"$REACHABILITY"; then
+            echo "Base reachability diverged during publication." >&2
+            exit 1
+          fi
+
+          REGISTRY_METADATA="$(
+            NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+              NPM_CONFIG_GLOBALCONFIG=/dev/null \
+              "$TRUSTED_NPM" view \
+              "${EXPECTED_PACKAGE}@${EXPECTED_VERSION}" \
+              version gitHead dist.integrity --json \
+              --registry="$NPM_REGISTRY"
+          )"
+          DIST_TAGS="$(
+            NPM_CONFIG_USERCONFIG="$SAFE_NPMRC" \
+              NPM_CONFIG_GLOBALCONFIG=/dev/null \
+              "$TRUSTED_NPM" view "$EXPECTED_PACKAGE" dist-tags --json \
+              --registry="$NPM_REGISTRY"
+          )"
+          if ! jq -e \
+            --arg version "$EXPECTED_VERSION" \
+            --arg sha "$EXPECTED_TARGET_SHA" \
+            --arg integrity "$EXPECTED_INTEGRITY" \
+            '
+              .version == $version
+              and .gitHead == $sha
+              and .["dist.integrity"] == $integrity
+            ' \
+            >/dev/null \
+            <<<"$REGISTRY_METADATA" ||
+            [ "$(jq -r --arg tag "$EXPECTED_IMMUTABLE_NPM_TAG" '.[$tag] // empty' <<<"$DIST_TAGS")" != "$EXPECTED_VERSION" ]; then
+            echo "npm publish was unsuccessful or produced mismatched integrity, gitHead, or dist-tag." >&2
+            exit 1
           fi

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -11,6 +11,7 @@ import {
   runQualityGate,
   runSpecGate,
 } from "./quality-gate.js";
+import "./release-workflow-security.test.js";
 
 const tempRoots: string[] = [];
 let isolatedStateDir: string | null = null;

--- a/src/ci/release-workflow-fixture.ts
+++ b/src/ci/release-workflow-fixture.ts
@@ -1,0 +1,259 @@
+import { spawnSync } from "node:child_process";
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { delimiter, isAbsolute, join, relative, sep } from "node:path";
+
+export type ReleaseWorkflowFixtureResult = {
+  commandLog: string;
+  context: ReleaseWorkflowFixtureContext;
+  githubOutput: string;
+  status: number;
+  stderr: string;
+  stdout: string;
+};
+
+export type ReleaseWorkflowFixtureContext = {
+  binDir: string;
+  fixtureRoot: string;
+  gitHooksDir: string;
+  gitTemplateDir: string;
+  homeDir: string;
+  runnerTemp: string;
+  temporaryDir: string;
+  xdgCacheDir: string;
+  xdgConfigDir: string;
+  xdgDataDir: string;
+};
+
+/**
+ * Repository-local variables reported by `git rev-parse --local-env-vars`.
+ * Keep this static so sanitizing a child Git process never recursively invokes
+ * Git under the potentially hostile repository context it is meant to remove.
+ */
+const gitRepositoryLocalEnvironmentVariables = Object.freeze([
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CONFIG",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_COUNT",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_GRAFT_FILE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_PREFIX",
+  "GIT_SHALLOW_FILE",
+  "GIT_COMMON_DIR",
+] as const);
+
+const allowedParentEnvironmentVariables = Object.freeze([] as const);
+const safeSystemPathEntries = Object.freeze([
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+]);
+const safeSystemPath = safeSystemPathEntries.join(delimiter);
+
+export type ReleaseWorkflowFixtureEnvironment = {
+  context: ReleaseWorkflowFixtureContext;
+  environment: NodeJS.ProcessEnv;
+};
+
+export function createReleaseWorkflowFixtureEnvironment(options: {
+  cwd: string;
+  env?: Readonly<NodeJS.ProcessEnv>;
+  fixtureRoot: string;
+  includeFixtureBin?: boolean;
+  parentEnvironment?: Readonly<NodeJS.ProcessEnv>;
+}): ReleaseWorkflowFixtureEnvironment {
+  assertPathWithin(options.cwd, options.fixtureRoot);
+  const context: ReleaseWorkflowFixtureContext = {
+    binDir: join(options.fixtureRoot, "bin"),
+    fixtureRoot: options.fixtureRoot,
+    gitHooksDir: join(options.fixtureRoot, "git-hooks"),
+    gitTemplateDir: join(options.fixtureRoot, "git-template"),
+    homeDir: join(options.fixtureRoot, "home"),
+    runnerTemp: join(options.fixtureRoot, "runner-temp"),
+    temporaryDir: join(options.fixtureRoot, "tmp"),
+    xdgCacheDir: join(options.fixtureRoot, "xdg-cache"),
+    xdgConfigDir: join(options.fixtureRoot, "xdg-config"),
+    xdgDataDir: join(options.fixtureRoot, "xdg-data"),
+  };
+  for (const directory of Object.values(context)) {
+    mkdirSync(directory, { recursive: true });
+  }
+  chmodSync(context.homeDir, 0o700);
+
+  const environment: NodeJS.ProcessEnv = {};
+  const parentEnvironment = options.parentEnvironment ?? {};
+  for (const variable of allowedParentEnvironmentVariables) {
+    const value = parentEnvironment[variable];
+    if (value !== undefined) environment[variable] = value;
+  }
+  for (const [variable, value] of Object.entries(options.env ?? {})) {
+    if (value !== undefined && !isBlockedFixtureEnvironmentVariable(variable)) environment[variable] = value;
+  }
+
+  environment.LANG = "C";
+  environment.LC_ALL = "C";
+  environment.TZ = "UTC";
+  environment.PATH = [options.includeFixtureBin ? context.binDir : undefined, safeSystemPath]
+    .filter(Boolean)
+    .join(delimiter);
+  environment.HOME = context.homeDir;
+  environment.XDG_CACHE_HOME = context.xdgCacheDir;
+  environment.XDG_CONFIG_HOME = context.xdgConfigDir;
+  environment.XDG_DATA_HOME = context.xdgDataDir;
+  environment.TMPDIR = context.temporaryDir;
+  environment.TMP = context.temporaryDir;
+  environment.TEMP = context.temporaryDir;
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = "/dev/null";
+  environment.GIT_CONFIG_SYSTEM = "/dev/null";
+  environment.GIT_TEMPLATE_DIR = context.gitTemplateDir;
+  environment.NPM_CONFIG_USERCONFIG = "/dev/null";
+  environment.NPM_CONFIG_GLOBALCONFIG = "/dev/null";
+  environment.RAVI_RELEASE_FIXTURE_GIT_BINARY = findSafeExecutable("git");
+  environment.RAVI_RELEASE_FIXTURE_GIT_HOOKS_DIR = context.gitHooksDir;
+
+  return { context, environment };
+}
+
+export function runReleaseWorkflowFixture(options: {
+  commands?: Record<string, string>;
+  cwd: string;
+  env?: Record<string, string>;
+  parentEnvironment?: Readonly<NodeJS.ProcessEnv>;
+  prepare?: (context: ReleaseWorkflowFixtureContext) => void;
+  script: string;
+}): ReleaseWorkflowFixtureResult {
+  const fixtureRoot = mkdtempSync(join(options.cwd, ".ravi-release-workflow-"));
+  const { context, environment } = createReleaseWorkflowFixtureEnvironment({
+    cwd: options.cwd,
+    env: Object.fromEntries(
+      Object.entries(options.env ?? {}).map(([key, value]) => [
+        key,
+        value.replaceAll("__FIXTURE_BIN__", join(fixtureRoot, "bin")).replaceAll("__SYSTEM_PATH__", safeSystemPath),
+      ]),
+    ),
+    fixtureRoot,
+    includeFixtureBin: true,
+    parentEnvironment: options.parentEnvironment,
+  });
+  const { binDir, runnerTemp } = context;
+  const commandLogPath = join(fixtureRoot, "commands.log");
+  const githubOutputPath = join(fixtureRoot, "github-output");
+  writeFileSync(commandLogPath, "");
+  writeFileSync(githubOutputPath, "");
+
+  if (Object.hasOwn(options.commands ?? {}, "git")) {
+    throw new Error("The fixture Git wrapper is reserved by the hermetic harness.");
+  }
+  for (const [name, body] of Object.entries(options.commands ?? {})) {
+    const commandPath = join(binDir, name);
+    writeFileSync(commandPath, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`);
+    chmodSync(commandPath, 0o755);
+  }
+  const gitWrapperPath = join(binDir, "git");
+  writeFileSync(
+    gitWrapperPath,
+    [
+      "#!/bin/sh",
+      'exec "$RAVI_RELEASE_FIXTURE_GIT_BINARY" \\',
+      '  -c "core.hooksPath=$RAVI_RELEASE_FIXTURE_GIT_HOOKS_DIR" "$@"',
+      "",
+    ].join("\n"),
+  );
+  chmodSync(gitWrapperPath, 0o755);
+  options.prepare?.(context);
+
+  environment.FIXTURE_COMMAND_LOG = commandLogPath;
+  environment.GITHUB_OUTPUT = githubOutputPath;
+  environment.RUNNER_TEMP = runnerTemp;
+  const result = spawnSync("/bin/bash", ["-c", options.script], {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: environment,
+  });
+
+  return {
+    commandLog: readFileSync(commandLogPath, "utf8"),
+    context,
+    githubOutput: readFileSync(githubOutputPath, "utf8"),
+    status: result.status ?? 1,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function isBlockedFixtureEnvironmentVariable(variable: string): boolean {
+  const upperVariable = variable.toUpperCase();
+  return (
+    gitRepositoryLocalEnvironmentVariables.includes(
+      variable as (typeof gitRepositoryLocalEnvironmentVariables)[number],
+    ) ||
+    upperVariable.startsWith("GIT_") ||
+    upperVariable.startsWith("BASH_FUNC_") ||
+    upperVariable.startsWith("DYLD_") ||
+    upperVariable.startsWith("LD_") ||
+    upperVariable === "BASH_ENV" ||
+    upperVariable === "ENV" ||
+    upperVariable === "CDPATH" ||
+    upperVariable === "SHELLOPTS" ||
+    upperVariable === "BASHOPTS" ||
+    upperVariable === "PROMPT_COMMAND" ||
+    upperVariable === "PS4" ||
+    upperVariable === "PATH" ||
+    upperVariable === "HOME" ||
+    upperVariable === "XDG_CONFIG_HOME" ||
+    upperVariable === "XDG_CACHE_HOME" ||
+    upperVariable === "XDG_DATA_HOME" ||
+    upperVariable === "TMPDIR" ||
+    upperVariable === "TMP" ||
+    upperVariable === "TEMP" ||
+    upperVariable === "NPM_CONFIG_USERCONFIG" ||
+    upperVariable === "NPM_CONFIG_GLOBALCONFIG" ||
+    upperVariable === "NODE_OPTIONS" ||
+    upperVariable === "NODE_PATH" ||
+    upperVariable === "TAR_OPTIONS" ||
+    upperVariable === "GZIP" ||
+    upperVariable === "GZIP_OPT" ||
+    upperVariable === "BZIP" ||
+    upperVariable === "BZIP2" ||
+    upperVariable === "XZ_DEFAULTS" ||
+    upperVariable === "XZ_OPT"
+  );
+}
+
+function findSafeExecutable(name: string): string {
+  for (const directory of safeSystemPathEntries) {
+    const candidate = join(directory, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Continue through the fixed, parent-independent path.
+    }
+  }
+  throw new Error(`Required executable is absent from the safe system path: ${name}`);
+}
+
+function assertPathWithin(root: string, candidate: string): void {
+  const relativePath = relative(realpathSync(root), realpathSync(candidate));
+  if (isAbsolute(relativePath) || relativePath === ".." || relativePath.startsWith(`..${sep}`)) {
+    throw new Error(`Fixture environment path must remain within its cwd: ${candidate}`);
+  }
+}

--- a/src/ci/release-workflow-security.test.ts
+++ b/src/ci/release-workflow-security.test.ts
@@ -1,0 +1,2252 @@
+import { describe, expect, it } from "bun:test";
+import { YAML } from "bun";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, isAbsolute, join, relative, sep } from "node:path";
+import ts from "typescript";
+import { createReleaseWorkflowFixtureEnvironment, runReleaseWorkflowFixture } from "./release-workflow-fixture.js";
+
+type WorkflowStep = {
+  "continue-on-error"?: boolean;
+  env?: Record<string, unknown>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  needs?: string | string[];
+  outputs?: Record<string, unknown>;
+  permissions?: Record<string, string>;
+  secrets?: Record<string, unknown> | "inherit";
+  steps?: WorkflowStep[];
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  concurrency?: {
+    "cancel-in-progress"?: boolean;
+    group?: string;
+  };
+  env?: Record<string, unknown>;
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    push?: { tags?: string[] };
+    workflow_call?: unknown;
+    workflow_dispatch?: unknown;
+  };
+  permissions?: Record<string, string>;
+};
+
+const repositoryRoot = join(import.meta.dir, "../..");
+const dollarSign = "$";
+const workflowPaths = [
+  ".github/workflows/version.yml",
+  ".github/workflows/sdk-release.yml",
+  ".github/workflows/release.yml",
+] as const;
+
+function readWorkflow(relativePath: (typeof workflowPaths)[number]): {
+  config: Workflow;
+  text: string;
+} {
+  const text = readFileSync(join(repositoryRoot, relativePath), "utf8");
+  return { config: YAML.parse(text) as Workflow, text };
+}
+
+function steps(workflow: Workflow): WorkflowStep[] {
+  return Object.values(workflow.jobs ?? {}).flatMap((job) => job.steps ?? []);
+}
+
+function scripts(workflow: Workflow): string {
+  return steps(workflow)
+    .map((step) => step.run ?? "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function namedStep(workflow: Workflow, name: string): WorkflowStep {
+  const step = steps(workflow).find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+type ReleaseFixture = {
+  baseSha: string;
+  currentBaseSha: string;
+  cwd: string;
+  hermeticProcess: HermeticFixtureProcess;
+  packageName: string;
+  packagePath: string;
+  prNumber: string;
+  repository: string;
+  tarball: string;
+  tarballIntegrity: string;
+  tarballName: string;
+  tarballSha512: string;
+  tag: string;
+  targetSha: string;
+  version: string;
+};
+
+const dateCommand = [
+  `printf 'date %s\\n' "$*" >> "$FIXTURE_COMMAND_LOG"`,
+  `if [ "\${FIXTURE_DATE_FAIL:-0}" = "1" ]; then exit 1; fi`,
+  `printf '%s\\n' "$FIXTURE_DATE_RESULT"`,
+].join("\n");
+
+const ghCommand = [
+  `printf 'gh %s\\n' "$*" >> "$FIXTURE_COMMAND_LOG"`,
+  `release_attempted="$RUNNER_TEMP/fixture-release-create-attempted"`,
+  `if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "download" ]; then`,
+  `  destination=""`,
+  `  while [ "$#" -gt 0 ]; do`,
+  `    if [ "$1" = "--dir" ]; then destination="$2"; shift 2; else shift; fi`,
+  `  done`,
+  `  [ -n "$destination" ] || exit 95`,
+  `  mkdir -p "$destination"`,
+  `  cp "$FIXTURE_PROVENANCE_TARBALL" "$destination/$FIXTURE_TARBALL_NAME"`,
+  `  printf '%s\\n' "$FIXTURE_PROVENANCE_METADATA_JSON" > "$destination/metadata.json"`,
+  `  exit "\${FIXTURE_RUN_DOWNLOAD_EXIT:-0}"`,
+  `fi`,
+  `if [ "\${1:-}" = "release" ] && [ "\${2:-}" = "create" ]; then`,
+  `  : > "$release_attempted"`,
+  `  exit "\${FIXTURE_RELEASE_CREATE_EXIT:-0}"`,
+  `fi`,
+  `request="\${!#}"`,
+  `case "$request" in`,
+  `  *"/releases/tags/"*)`,
+  `    lookup_mode="\${FIXTURE_RELEASE_LOOKUP_MODE:-existing}"`,
+  `    release_json="$FIXTURE_RELEASE_JSON"`,
+  `    if [ -f "$release_attempted" ]; then`,
+  `      lookup_mode="\${FIXTURE_RELEASE_REREAD_MODE:-existing}"`,
+  `      release_json="\${FIXTURE_RELEASE_REREAD_JSON:-$FIXTURE_RELEASE_JSON}"`,
+  `    fi`,
+  `    if [ "$lookup_mode" = "missing" ]; then`,
+  `      echo "HTTP 404: Not Found" >&2`,
+  `      exit 22`,
+  `    elif [ "$lookup_mode" != "existing" ]; then`,
+  `      echo "Unexpected release lookup mode" >&2`,
+  `      exit 98`,
+  `    fi`,
+  `    printf '%s\\n' "$release_json"`,
+  `    ;;`,
+  `  *"/git/ref/tags/"*)`,
+  `    if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_TAG_REF_JSON:-}" ]; then`,
+  `      printf '%s\\n' "$FIXTURE_POST_CREATE_TAG_REF_JSON"`,
+  `    else`,
+  `      printf '%s\\n' "$FIXTURE_TAG_REF_JSON"`,
+  `    fi`,
+  `    ;;`,
+  `  *"/git/ref/heads/"*)`,
+  `    if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_BRANCH_REF_JSON:-}" ]; then`,
+  `      printf '%s\\n' "$FIXTURE_POST_CREATE_BRANCH_REF_JSON"`,
+  `    else`,
+  `      printf '%s\\n' "$FIXTURE_BRANCH_REF_JSON"`,
+  `    fi`,
+  `    ;;`,
+  `  *"/actions/workflows/"*"/runs?"*) printf '%s\\n' "$FIXTURE_WORKFLOW_RUNS_JSON" ;;`,
+  `  *"/actions/runs/"*"/artifacts?"*) printf '%s\\n' "$FIXTURE_ARTIFACT_INDEX_JSON" ;;`,
+  `  *"/commits/"*"/pulls?per_page=100")`,
+  `    if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_ASSOCIATED_PRS_JSON:-}" ]; then`,
+  `      printf '%s\\n' "$FIXTURE_POST_CREATE_ASSOCIATED_PRS_JSON"`,
+  `    else`,
+  `      printf '%s\\n' "$FIXTURE_ASSOCIATED_PRS_JSON"`,
+  `    fi`,
+  `    ;;`,
+  `  *"/pulls/"*"/files?per_page=100") printf '%s\\n' "$FIXTURE_PR_FILES_JSON" ;;`,
+  `  *"/pulls/"*) printf '%s\\n' "$FIXTURE_PR_JSON" ;;`,
+  `  *"/compare/"*)`,
+  `    if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_REACHABILITY_JSON:-}" ]; then`,
+  `      printf '%s\\n' "$FIXTURE_POST_CREATE_REACHABILITY_JSON"`,
+  `    else`,
+  `      printf '%s\\n' "$FIXTURE_REACHABILITY_JSON"`,
+  `    fi`,
+  `    ;;`,
+  `  *"/contents/"*) printf '%s\\n' "$FIXTURE_CONTENT_JSON" ;;`,
+  `  *) echo "Unexpected gh request: $request" >&2; exit 97 ;;`,
+  `esac`,
+].join("\n");
+
+const npmCommand = [
+  `printf 'npm %s\\n' "$*" >> "$FIXTURE_COMMAND_LOG"`,
+  `release_attempted="$RUNNER_TEMP/fixture-release-create-attempted"`,
+  `if [ "\${1:-}" = "view" ] && [[ "$*" == *" versions --json"* ]]; then`,
+  `  printf '%s\\n' "$FIXTURE_REGISTRY_VERSIONS_JSON"`,
+  `elif [ "\${1:-}" = "view" ] && [[ "$*" == *" version gitHead dist.integrity --json"* ]]; then`,
+  `  if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_REGISTRY_METADATA_JSON:-}" ]; then`,
+  `    printf '%s\\n' "$FIXTURE_POST_CREATE_REGISTRY_METADATA_JSON"`,
+  `  else`,
+  `    printf '%s\\n' "$FIXTURE_REGISTRY_METADATA_JSON"`,
+  `  fi`,
+  `elif [ "\${1:-}" = "view" ] && [[ "$*" == *" dist-tags --json"* ]]; then`,
+  `  if [ -f "$release_attempted" ] && [ -n "\${FIXTURE_POST_CREATE_DIST_TAGS_JSON:-}" ]; then`,
+  `    printf '%s\\n' "$FIXTURE_POST_CREATE_DIST_TAGS_JSON"`,
+  `  else`,
+  `    printf '%s\\n' "$FIXTURE_DIST_TAGS_JSON"`,
+  `  fi`,
+  `elif [ "\${1:-}" = "publish" ]; then`,
+  `  exit "\${FIXTURE_PUBLISH_EXIT:-0}"`,
+  `else`,
+  `  echo "Unexpected npm request: $*" >&2`,
+  `  exit 96`,
+  `fi`,
+].join("\n");
+
+type HermeticFixtureProcess = ReturnType<typeof createReleaseWorkflowFixtureEnvironment> & {
+  cwd: string;
+};
+
+function createHermeticFixtureProcess(
+  cwd: string,
+  options: {
+    env?: Readonly<NodeJS.ProcessEnv>;
+    parentEnvironment?: Readonly<NodeJS.ProcessEnv>;
+  } = {},
+): HermeticFixtureProcess {
+  const fixtureRoot = mkdtempSync(join(cwd, ".ravi-command-environment-"));
+  return {
+    cwd,
+    ...createReleaseWorkflowFixtureEnvironment({
+      cwd,
+      env: options.env,
+      fixtureRoot,
+      parentEnvironment: options.parentEnvironment,
+    }),
+  };
+}
+
+function execHermeticFixtureCommand(
+  child: HermeticFixtureProcess,
+  executable: string,
+  args: readonly string[],
+  options: { input?: string } = {},
+): string {
+  return execFileSync(executable, args, {
+    cwd: child.cwd,
+    encoding: "utf8",
+    env: child.environment,
+    input: options.input,
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function createFixtureGit(
+  cwd: string,
+  options: {
+    env?: Readonly<NodeJS.ProcessEnv>;
+    parentEnvironment?: Readonly<NodeJS.ProcessEnv>;
+  } = {},
+) {
+  const child = createHermeticFixtureProcess(cwd, options);
+  const gitExecutable = child.environment.RAVI_RELEASE_FIXTURE_GIT_BINARY;
+  if (!gitExecutable) throw new Error("Hermetic fixture Git executable is unavailable.");
+  const git = (...args: string[]): string =>
+    execHermeticFixtureCommand(child, gitExecutable, ["-c", `core.hooksPath=${child.context.gitHooksDir}`, ...args]);
+  return Object.assign(git, { child });
+}
+
+function manifest(name: string, version: string): string {
+  return `${JSON.stringify(
+    {
+      name,
+      private: false,
+      publishConfig: { access: "public" },
+      version,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function sealedManifest(name: string, version: string, gitHead: string): string {
+  return `${JSON.stringify(
+    {
+      gitHead,
+      name,
+      private: false,
+      publishConfig: { access: "public" },
+      version,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function sha512(path: string): { integrity: string; hex: string } {
+  const digest = createHash("sha512").update(readFileSync(path)).digest();
+  return {
+    hex: digest.toString("hex"),
+    integrity: `sha512-${digest.toString("base64")}`,
+  };
+}
+
+function contentResponse(name: string, version: string): string {
+  return JSON.stringify({
+    content: Buffer.from(manifest(name, version)).toString("base64"),
+    encoding: "base64",
+    type: "file",
+  });
+}
+
+function createFixture(
+  options: {
+    gitEnvironment?: NodeJS.ProcessEnv;
+    gitParentEnvironment?: NodeJS.ProcessEnv;
+    trackedNpmrc?: boolean;
+    version?: string;
+  } = {},
+): ReleaseFixture {
+  const cwd = mkdtempSync(join(tmpdir(), "ravi-release-security-"));
+  const packageName = "ravi.bot";
+  const packagePath = "package.json";
+  const version = options.version ?? "3.260723.5";
+  const tag = `v${version}`;
+  const repository = "filipexyz/ravi";
+  const prNumber = "332";
+  const git = createFixtureGit(cwd, {
+    env: options.gitEnvironment,
+    parentEnvironment: options.gitParentEnvironment,
+  });
+
+  writeFileSync(join(cwd, packagePath), manifest(packageName, "3.260723.4"));
+  git("init", "-q");
+  git("config", "user.email", "release-fixture@example.invalid");
+  git("config", "user.name", "Release Fixture");
+  git("add", packagePath);
+  git("commit", "-q", "-m", "base");
+  const baseSha = git("rev-parse", "HEAD");
+
+  writeFileSync(join(cwd, packagePath), manifest(packageName, version));
+  if (options.trackedNpmrc) {
+    writeFileSync(join(cwd, ".npmrc"), "registry=https://attacker.invalid/\n");
+    git("add", ".npmrc");
+  }
+  git("add", packagePath);
+  git("commit", "-q", "-m", "release version");
+  git("tag", tag);
+  const targetSha = git("rev-parse", "HEAD");
+  const tarballName = `ravi.bot-${version}.tgz`;
+  const tarball = join(cwd, tarballName);
+  const tarRoot = join(cwd, ".sealed-tar");
+  mkdirSync(join(tarRoot, "package"), { recursive: true });
+  writeFileSync(join(tarRoot, "package/package.json"), sealedManifest(packageName, version, targetSha));
+  execHermeticFixtureCommand(git.child, "/usr/bin/tar", ["-czf", tarball, "-C", tarRoot, "package"]);
+  const tarballDigest = sha512(tarball);
+
+  return {
+    baseSha,
+    currentBaseSha: targetSha,
+    cwd,
+    hermeticProcess: git.child,
+    packageName,
+    packagePath,
+    prNumber,
+    repository,
+    tarball,
+    tarballIntegrity: tarballDigest.integrity,
+    tarballName,
+    tarballSha512: tarballDigest.hex,
+    tag,
+    targetSha,
+    version,
+  };
+}
+
+function artifactMetadata(fixture: ReleaseFixture, tarball = fixture.tarball): Record<string, unknown> {
+  const digest = sha512(tarball);
+  return {
+    artifactName: "ravi-root-package-42-1",
+    base: "main",
+    currentBaseSha: fixture.currentBaseSha,
+    immutableNpmTag: `stable-v${fixture.version.replaceAll(".", "-")}`,
+    packageName: fixture.packageName,
+    packagePath: fixture.packagePath,
+    prNumber: fixture.prNumber,
+    registry: "https://registry.npmjs.org/",
+    schema: 2,
+    tag: fixture.tag,
+    tarball: basename(tarball),
+    tarballIntegrity: digest.integrity,
+    tarballSha512: digest.hex,
+    targetSha: fixture.targetSha,
+    version: fixture.version,
+  };
+}
+
+function createAdversarialTarball(fixture: ReleaseFixture, kind: "duplicate" | "multi-json" | "symlink"): string {
+  const root = join(fixture.cwd, `.adversarial-${kind}`);
+  const packageDir = join(root, "package");
+  const tarball = join(fixture.cwd, `adversarial-${kind}.tgz`);
+  mkdirSync(packageDir, { recursive: true });
+  const valid = sealedManifest(fixture.packageName, fixture.version, fixture.targetSha);
+
+  if (kind === "symlink") {
+    writeFileSync(join(root, "package.json.target"), valid);
+    symlinkSync("../package.json.target", join(packageDir, "package.json"));
+  } else {
+    writeFileSync(join(packageDir, "package.json"), kind === "multi-json" ? `${valid}${valid}` : valid);
+  }
+
+  const members = kind === "duplicate" ? ["package/package.json", "package/package.json"] : ["package"];
+  execHermeticFixtureCommand(fixture.hermeticProcess, "/usr/bin/tar", ["-czf", tarball, "-C", root, ...members]);
+  return tarball;
+}
+
+function preparePublishPayload(runnerTemp: string, fixture: ReleaseFixture, tarball: string): void {
+  const payloadDir = join(runnerTemp, "release-payload");
+  mkdirSync(payloadDir, { recursive: true });
+  copyFileSync(tarball, join(payloadDir, basename(tarball)));
+  writeFileSync(join(payloadDir, "metadata.json"), `${JSON.stringify(artifactMetadata(fixture, tarball))}\n`);
+}
+
+function associatedPullRequest(fixture: ReleaseFixture, options: { base?: "dev" | "main"; number?: number } = {}) {
+  return {
+    base: {
+      ref: options.base ?? "main",
+      repo: { full_name: fixture.repository },
+      // Deliberately stale: workflows must not use this as a merge base.
+      sha: "f".repeat(40),
+    },
+    head: { repo: { full_name: fixture.repository } },
+    merge_commit_sha: fixture.targetSha,
+    merged_at: "2026-07-23T20:00:00Z",
+    number: options.number ?? Number(fixture.prNumber),
+  };
+}
+
+function fixtureEnv(fixture: ReleaseFixture, overrides: Record<string, string> = {}): Record<string, string> {
+  const immutableTag = `stable-v${fixture.version.replaceAll(".", "-")}`;
+  const artifactName = "ravi-root-package-42-1";
+  const pr = associatedPullRequest(fixture);
+
+  return {
+    EVENT_NAME: "push",
+    EVENT_REF: `refs/tags/${fixture.tag}`,
+    EVENT_REF_NAME: fixture.tag,
+    EVENT_REF_TYPE: "tag",
+    EVENT_SHA: fixture.targetSha,
+    EXPECTED_BASE: "main",
+    EXPECTED_ARTIFACT_NAME: artifactName,
+    EXPECTED_CURRENT_BASE_SHA: fixture.currentBaseSha,
+    EXPECTED_IMMUTABLE_NPM_TAG: immutableTag,
+    EXPECTED_INTEGRITY: fixture.tarballIntegrity,
+    EXPECTED_PACKAGE: fixture.packageName,
+    EXPECTED_PACKAGE_PATH: fixture.packagePath,
+    EXPECTED_PR_NUMBER: fixture.prNumber,
+    EXPECTED_TAG: fixture.tag,
+    EXPECTED_TARBALL_SHA512: fixture.tarballSha512,
+    EXPECTED_TARGET_SHA: fixture.targetSha,
+    EXPECTED_VERSION: fixture.version,
+    FIXTURE_ASSOCIATED_PRS_JSON: JSON.stringify([[pr]]),
+    FIXTURE_ARTIFACT_INDEX_JSON: JSON.stringify([
+      {
+        artifacts: [{ expired: false, name: artifactName }],
+        total_count: 1,
+      },
+    ]),
+    FIXTURE_BASE: "main",
+    FIXTURE_BRANCH_REF_JSON: JSON.stringify({
+      object: { sha: fixture.currentBaseSha, type: "commit" },
+      ref: "refs/heads/main",
+    }),
+    FIXTURE_CONTENT_JSON: contentResponse(fixture.packageName, fixture.version),
+    FIXTURE_DATE_RESULT: "260723",
+    FIXTURE_DIST_TAGS_JSON: JSON.stringify({ [immutableTag]: fixture.version }),
+    FIXTURE_PR_FILES_JSON: JSON.stringify([
+      [{ filename: fixture.packagePath, previous_filename: null, status: "modified" }],
+    ]),
+    FIXTURE_PR_JSON: JSON.stringify(pr),
+    FIXTURE_PROVENANCE_METADATA_JSON: JSON.stringify(artifactMetadata(fixture)),
+    FIXTURE_PROVENANCE_TARBALL: fixture.tarball,
+    FIXTURE_REACHABILITY_JSON: JSON.stringify({
+      base_commit: { sha: fixture.targetSha },
+      head_commit: { sha: fixture.currentBaseSha },
+      merge_base_commit: { sha: fixture.targetSha },
+      status: "identical",
+    }),
+    FIXTURE_REGISTRY_METADATA_JSON: JSON.stringify({
+      "dist.integrity": fixture.tarballIntegrity,
+      gitHead: fixture.targetSha,
+      version: fixture.version,
+    }),
+    FIXTURE_REGISTRY_VERSIONS_JSON: JSON.stringify(["3.260723.4"]),
+    FIXTURE_RELEASE_JSON: JSON.stringify({
+      draft: false,
+      name: fixture.tag,
+      prerelease: false,
+      tag_name: fixture.tag,
+      target_commitish: fixture.targetSha,
+    }),
+    FIXTURE_TAG_REF_JSON: JSON.stringify({
+      object: { sha: fixture.targetSha, type: "commit" },
+      ref: `refs/tags/${fixture.tag}`,
+    }),
+    FIXTURE_TARGET_SHA: fixture.targetSha,
+    FIXTURE_TARBALL_NAME: fixture.tarballName,
+    FIXTURE_WORKFLOW_RUNS_JSON: JSON.stringify([
+      {
+        workflow_runs: [
+          {
+            conclusion: "success",
+            event: "push",
+            head_sha: fixture.targetSha,
+            id: 42,
+            run_attempt: 1,
+            status: "completed",
+          },
+        ],
+      },
+    ]),
+    GH_TOKEN: "fixture-github-token",
+    GITHUB_REPOSITORY: fixture.repository,
+    GITHUB_RUN_ATTEMPT: "1",
+    GITHUB_RUN_ID: "42",
+    GITHUB_WORKSPACE: fixture.cwd,
+    IMMUTABLE_NPM_TAG: immutableTag,
+    NPM_REGISTRY: "https://registry.npmjs.org/",
+    PACKAGE_DIR: ".",
+    PACKAGE_PATH: fixture.packagePath,
+    PR_NUMBER: fixture.prNumber,
+    RELEASE_KIND: "root",
+    REQUESTED_TAG: fixture.tag,
+    SAFE_HOME: fixture.cwd,
+    SAFE_NPMRC: "/dev/null",
+    TAG: fixture.tag,
+    TARGET_SHA: fixture.targetSha,
+    TARBALL: fixture.tarball,
+    TRUSTED_NPM: "__FIXTURE_BIN__/npm",
+    TRUSTED_PATH: "__FIXTURE_BIN__:__SYSTEM_PATH__",
+    VERSION: fixture.version,
+    ...overrides,
+  };
+}
+
+function runFixtureStep(step: WorkflowStep, fixture: ReleaseFixture, overrides: Record<string, string> = {}) {
+  return runReleaseWorkflowFixture({
+    commands: { date: dateCommand, gh: ghCommand, npm: npmCommand },
+    cwd: fixture.cwd,
+    env: fixtureEnv(fixture, overrides),
+    script: step.run ?? "",
+  });
+}
+
+function runPublishRevalidation(
+  step: WorkflowStep,
+  fixture: ReleaseFixture,
+  tarball: string,
+  overrides: Record<string, string> = {},
+) {
+  return runReleaseWorkflowFixture({
+    commands: { date: dateCommand, gh: ghCommand, npm: npmCommand },
+    cwd: fixture.cwd,
+    env: fixtureEnv(fixture, overrides),
+    prepare: ({ runnerTemp }) => preparePublishPayload(runnerTemp, fixture, tarball),
+    script: step.run ?? "",
+  });
+}
+
+function commandCount(commandLog: string, fragment: string): number {
+  return commandLog.split("\n").filter((line) => line.includes(fragment)).length;
+}
+
+function runtimeGitLocalEnvironmentVariables(git: (...args: string[]) => string): string[] {
+  return git("rev-parse", "--local-env-vars").split("\n").filter(Boolean);
+}
+
+function expectPathWithin(root: string, candidate: string): void {
+  const relativePath = relative(realpathSync(root), realpathSync(candidate));
+  expect(isAbsolute(relativePath), candidate).toBe(false);
+  expect(relativePath === ".." || relativePath.startsWith(`..${sep}`), candidate).toBe(false);
+}
+
+type ChildProcessAstInventory = {
+  calls: Array<{ hasExplicitEnv: boolean; name: string }>;
+  imports: string[];
+  violations: string[];
+};
+
+function inspectChildProcessAst(
+  sourcePath: string,
+  source = readFileSync(sourcePath, "utf8"),
+): ChildProcessAstInventory {
+  const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const canonicalChildProcessModule = ["node", ["child", "process"].join("_")].join(":");
+  const legacyChildProcessModule = ["child", "process"].join("_");
+  const childProcessApis = new Set(["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"]);
+  const inventory: ChildProcessAstInventory = { calls: [], imports: [], violations: [] };
+  const allowedImportIdentifiers = new Set<ts.Identifier>();
+  const allowedLocalNames = new Set<string>();
+  const location = (node: ts.Node): string => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    return `${sourcePath}:${line + 1}`;
+  };
+  const isChildProcessModuleText = (text: string): boolean =>
+    text === canonicalChildProcessModule || text === legacyChildProcessModule;
+  const propertyName = (name: ts.PropertyName): string | undefined =>
+    ts.isIdentifier(name) || ts.isStringLiteral(name) ? name.text : undefined;
+  const hasExplicitEnv = (node: ts.CallExpression): boolean => {
+    const options = node.arguments[2];
+    return Boolean(
+      options &&
+        ts.isObjectLiteralExpression(options) &&
+        options.properties.some(
+          (property) => ts.isPropertyAssignment(property) && propertyName(property.name) === "env",
+        ),
+    );
+  };
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== canonicalChildProcessModule
+    ) {
+      continue;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      if (!element.propertyName && childProcessApis.has(element.name.text)) {
+        allowedImportIdentifiers.add(element.name);
+        allowedLocalNames.add(element.name.text);
+      }
+    }
+  }
+
+  const visit = (node: ts.Node): void => {
+    if ((ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) && isChildProcessModuleText(node.text)) {
+      const canonicalImport =
+        ts.isStringLiteral(node) &&
+        ts.isImportDeclaration(node.parent) &&
+        node.parent.moduleSpecifier === node &&
+        node.text === canonicalChildProcessModule;
+      if (!canonicalImport) {
+        inventory.violations.push(`${location(node)} child_process module literal outside canonical import`);
+      }
+    }
+
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isChildProcessModuleText(node.moduleSpecifier.text)
+    ) {
+      if (node.moduleSpecifier.text !== canonicalChildProcessModule) {
+        inventory.violations.push(`${location(node)} non-canonical child_process module specifier`);
+      }
+      const clause = node.importClause;
+      if (!clause || clause.name) {
+        inventory.violations.push(`${location(node)} child_process default or side-effect import`);
+      }
+      if (!clause?.namedBindings || !ts.isNamedImports(clause.namedBindings)) {
+        inventory.violations.push(`${location(node)} child_process namespace import`);
+      } else {
+        for (const element of clause.namedBindings.elements) {
+          if (element.propertyName) {
+            inventory.violations.push(`${location(element)} aliased child_process import`);
+          }
+          inventory.imports.push((element.propertyName ?? element.name).text);
+        }
+      }
+    }
+
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      node.moduleSpecifier.text === "bun"
+    ) {
+      const clause = node.importClause;
+      if (clause?.name || (clause?.namedBindings && ts.isNamespaceImport(clause.namedBindings))) {
+        inventory.violations.push(`${location(node)} Bun default or namespace import`);
+      }
+      if (clause?.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) {
+          const importedName = (element.propertyName ?? element.name).text;
+          if (["$", "spawn", "spawnSync"].includes(importedName)) {
+            inventory.violations.push(`${location(element)} Bun child-process import`);
+          }
+        }
+      }
+    }
+
+    if (ts.isIdentifier(node) && allowedLocalNames.has(node.text)) {
+      const directImport = allowedImportIdentifiers.has(node);
+      const directCall = ts.isCallExpression(node.parent) && node.parent.expression === node;
+      if (!directImport && !directCall) {
+        inventory.violations.push(`${location(node)} indirect reference to imported ${node.text}`);
+      }
+    }
+
+    if (ts.isIdentifier(node) && node.text === "Bun") {
+      inventory.violations.push(`${location(node)} Bun reference`);
+    }
+    if (ts.isIdentifier(node) && node.text === "$") {
+      inventory.violations.push(`${location(node)} shell $ reference`);
+    }
+
+    if (ts.isCallExpression(node)) {
+      if (ts.isIdentifier(node.expression) && childProcessApis.has(node.expression.text)) {
+        if (!allowedLocalNames.has(node.expression.text)) {
+          inventory.violations.push(`${location(node)} unimported or forbidden child_process call`);
+        }
+        inventory.calls.push({
+          hasExplicitEnv: hasExplicitEnv(node),
+          name: node.expression.text,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return inventory;
+}
+
+describe("release workflow fixture Git isolation", () => {
+  it("excludes parent secrets and blocks shell startup injection for bash and its children", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-hermetic-shell-"));
+    const poisonMarker = join(cwd, "bash-env-ran");
+    const poisonScript = join(cwd, "poison-bash-env.sh");
+    writeFileSync(poisonScript, `#!/bin/sh\n: > "${poisonMarker}"\n`);
+    chmodSync(poisonScript, 0o755);
+
+    const parentEnvironment: NodeJS.ProcessEnv = {
+      BASH_ENV: poisonScript,
+      GITHUB_TOKEN: "parent-token-must-not-cross",
+      HOME: join(cwd, "hostile-home"),
+      NODE_OPTIONS: `--require=${poisonScript}`,
+      PATH: join(cwd, "hostile-bin"),
+      RELEASE_PARENT_SECRET: "parent-secret-must-not-cross",
+    };
+    const result = runReleaseWorkflowFixture({
+      cwd,
+      env: {
+        BASH_ENV: poisonScript,
+        CDPATH: cwd,
+        ENV: poisonScript,
+        EXPLICIT_FIXTURE_VAR: "preserved",
+        GITHUB_REPOSITORY: "fixture/repository",
+        NODE_OPTIONS: `--require=${poisonScript}`,
+        POISON_MARKER: poisonMarker,
+      },
+      parentEnvironment,
+      script: [
+        `[ "$EXPLICIT_FIXTURE_VAR" = "preserved" ]`,
+        `[ "$GITHUB_REPOSITORY" = "fixture/repository" ]`,
+        `[ "$LANG" = "C" ] && [ "$LC_ALL" = "C" ] && [ "$TZ" = "UTC" ]`,
+        `[ -z "\${RELEASE_PARENT_SECRET+x}" ]`,
+        `[ -z "\${GITHUB_TOKEN+x}" ]`,
+        `[ -z "\${BASH_ENV+x}" ] && [ -z "\${ENV+x}" ] && [ -z "\${CDPATH+x}" ]`,
+        `[ -z "\${NODE_OPTIONS+x}" ]`,
+        `[ ! -e "$POISON_MARKER" ]`,
+        `/bin/sh -c '[ -z "\${RELEASE_PARENT_SECRET+x}" ] && [ -z "\${GITHUB_TOKEN+x}" ] && [ -z "\${BASH_ENV+x}" ]'`,
+      ].join("\n"),
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(poisonMarker)).toBe(false);
+    for (const path of Object.values(result.context)) expectPathWithin(cwd, path);
+
+    const gitRoot = mkdtempSync(join(tmpdir(), "ravi-hermetic-git-child-"));
+    const git = createFixtureGit(gitRoot, {
+      env: { BASH_ENV: poisonScript, NODE_OPTIONS: `--require=${poisonScript}` },
+      parentEnvironment,
+    });
+    git("init", "-q");
+    git(
+      "config",
+      "alias.assert-hermetic",
+      `!f() { test -z "\${RELEASE_PARENT_SECRET+x}" && test -z "\${GITHUB_TOKEN+x}" && test -z "\${BASH_ENV+x}"; }; f`,
+    );
+    expect(git("assert-hermetic")).toBe("");
+    expect(existsSync(poisonMarker)).toBe(false);
+  });
+
+  it("drops imported Bash functions for every security-sensitive fixture command", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-bash-function-poison-"));
+    const marker = join(cwd, "imported-function-ran");
+    const commandNames = ["git", "gh", "npm", "jq", "date", "tar"] as const;
+    const functionPoison = Object.fromEntries(
+      commandNames.map((name) => [`BASH_FUNC_${name}%%`, `() { : > "${marker}"; }`]),
+    );
+    const result = runReleaseWorkflowFixture({
+      commands: {
+        date: "exit 0",
+        gh: "exit 0",
+        jq: "exit 0",
+        npm: "exit 0",
+      },
+      cwd,
+      env: {
+        ...functionPoison,
+        FUNCTION_MARKER: marker,
+      },
+      parentEnvironment: functionPoison,
+      script: [
+        "set -euo pipefail",
+        "function_seen=0",
+        "for name in git gh npm jq date tar; do",
+        '  [ "$(type -t "$name" || true)" != "function" ] || function_seen=1',
+        '  "$name" --version >/dev/null 2>&1 || true',
+        "done",
+        '[ "$function_seen" = "0" ]',
+        '[ ! -e "$FUNCTION_MARKER" ]',
+      ].join("\n"),
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("drops explicit native loader poisons from the builder and an executable child", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-loader-poison-"));
+    const childScript = join(cwd, "assert-loader-environment.sh");
+    const poisonEnvironment = {
+      DYLD_INSERT_LIBRARIES: join(cwd, "synthetic-dyld-insert.dylib"),
+      DYLD_LIBRARY_PATH: join(cwd, "synthetic-dyld-library-path"),
+      EXPLICIT_FIXTURE_VAR: "preserved",
+      LD_AUDIT: join(cwd, "synthetic-ld-audit.so"),
+      LD_LIBRARY_PATH: join(cwd, "synthetic-ld-library-path"),
+      LD_PRELOAD: join(cwd, "synthetic-ld-preload.so"),
+    };
+    writeFileSync(
+      childScript,
+      [
+        "#!/bin/sh",
+        '[ "$EXPLICIT_FIXTURE_VAR" = "preserved" ]',
+        `[ -z "\${LD_PRELOAD+x}" ]`,
+        `[ -z "\${LD_LIBRARY_PATH+x}" ]`,
+        `[ -z "\${LD_AUDIT+x}" ]`,
+        `[ -z "\${DYLD_INSERT_LIBRARIES+x}" ]`,
+        `[ -z "\${DYLD_LIBRARY_PATH+x}" ]`,
+        'printf "loader-env-clean\\n"',
+        "",
+      ].join("\n"),
+    );
+    chmodSync(childScript, 0o755);
+    const child = createHermeticFixtureProcess(cwd, {
+      env: poisonEnvironment,
+      parentEnvironment: poisonEnvironment,
+    });
+
+    expect(child.environment.EXPLICIT_FIXTURE_VAR).toBe("preserved");
+    for (const variable of [
+      "LD_PRELOAD",
+      "LD_LIBRARY_PATH",
+      "LD_AUDIT",
+      "DYLD_INSERT_LIBRARIES",
+      "DYLD_LIBRARY_PATH",
+    ]) {
+      expect(child.environment[variable], variable).toBeUndefined();
+    }
+    expect(execHermeticFixtureCommand(child, childScript, [])).toBe("loader-env-clean");
+  });
+
+  it("blocks tar startup options from changing an archive", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-tar-options-poison-"));
+    const packageDir = join(cwd, "package");
+    const tarball = join(cwd, "payload.tgz");
+    mkdirSync(packageDir);
+    writeFileSync(join(packageDir, "package.json"), '{"name":"hermetic-tar"}\n');
+    const poisonEnvironment = {
+      BZIP2: "--help",
+      GZIP: "--help",
+      TAR_OPTIONS: "--exclude=package/package.json",
+      XZ_OPT: "--help",
+    };
+    const child = createHermeticFixtureProcess(cwd, {
+      env: poisonEnvironment,
+      parentEnvironment: poisonEnvironment,
+    });
+
+    expect(child.environment.TAR_OPTIONS).toBeUndefined();
+    expect(child.environment.GZIP).toBeUndefined();
+    expect(child.environment.BZIP2).toBeUndefined();
+    expect(child.environment.XZ_OPT).toBeUndefined();
+    execHermeticFixtureCommand(child, "/usr/bin/tar", ["-czf", tarball, "-C", cwd, "package"]);
+    const listing = execHermeticFixtureCommand(child, "/usr/bin/tar", ["-tzf", tarball]);
+    expect(listing.split("\n")).toContain("package/package.json");
+  });
+
+  it("removes every runtime-reported local Git variable without mutating poison inputs", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-runtime-git-env-"));
+    const git = createFixtureGit(cwd);
+    git("init", "-q");
+    const runtimeVariables = runtimeGitLocalEnvironmentVariables(git);
+    expect(new Set(runtimeVariables).size).toBe(15);
+
+    const localPoison = Object.fromEntries(runtimeVariables.map((variable) => [variable, `synthetic-${variable}`]));
+    const fixtureEnvironment = {
+      ...localPoison,
+      BASH_ENV: join(cwd, "poison"),
+      PATH: join(cwd, "hostile-bin"),
+      RELEASE_FIXTURE_NON_GIT: "preserved",
+    };
+    const parentEnvironment = {
+      ...localPoison,
+      RELEASE_PARENT_SECRET: "not-inherited",
+    };
+    const fixtureSnapshot = { ...fixtureEnvironment };
+    const parentSnapshot = { ...parentEnvironment };
+    const fixtureRoot = mkdtempSync(join(cwd, ".ravi-environment-builder-"));
+    const built = createReleaseWorkflowFixtureEnvironment({
+      cwd,
+      env: fixtureEnvironment,
+      fixtureRoot,
+      includeFixtureBin: true,
+      parentEnvironment,
+    });
+
+    expect(built.environment.RELEASE_FIXTURE_NON_GIT).toBe("preserved");
+    expect(built.environment.RELEASE_PARENT_SECRET).toBeUndefined();
+    expect(built.environment.BASH_ENV).toBeUndefined();
+    expect(built.environment.PATH).not.toContain(join(cwd, "hostile-bin"));
+    for (const variable of runtimeVariables) {
+      expect(built.environment[variable], variable).toBeUndefined();
+    }
+    expect(built.environment.GIT_CONFIG_NOSYSTEM).toBe("1");
+    expect(built.environment.GIT_CONFIG_GLOBAL).toBe("/dev/null");
+    expect(built.environment.GIT_CONFIG_SYSTEM).toBe("/dev/null");
+    expect(built.environment.GIT_TEMPLATE_DIR).toBe(built.context.gitTemplateDir);
+    expect(fixtureEnvironment).toEqual(fixtureSnapshot);
+    expect(parentEnvironment).toEqual(parentSnapshot);
+    for (const path of Object.values(built.context)) expectPathWithin(cwd, path);
+  });
+
+  it("ignores hostile home, global Git config, templates, and hooks during fixture creation", () => {
+    const poisonRoot = mkdtempSync(join(tmpdir(), "ravi-hostile-git-home-"));
+    const poisonHome = join(poisonRoot, "home");
+    const poisonHooks = join(poisonRoot, "hooks");
+    const poisonTemplate = join(poisonRoot, "template");
+    const poisonTemplateHooks = join(poisonTemplate, "hooks");
+    const hookMarker = join(poisonRoot, "external-hook-ran");
+    const templateMarker = join(poisonRoot, "external-template-hook-ran");
+    const globalConfig = join(poisonRoot, "hostile.gitconfig");
+    mkdirSync(poisonHome, { recursive: true });
+    mkdirSync(poisonHooks, { recursive: true });
+    mkdirSync(poisonTemplateHooks, { recursive: true });
+    writeFileSync(join(poisonHooks, "post-commit"), `#!/bin/sh\n: > "${hookMarker}"\n`);
+    writeFileSync(join(poisonTemplateHooks, "post-commit"), `#!/bin/sh\n: > "${templateMarker}"\n`);
+    chmodSync(join(poisonHooks, "post-commit"), 0o755);
+    chmodSync(join(poisonTemplateHooks, "post-commit"), 0o755);
+    writeFileSync(
+      globalConfig,
+      [
+        "[core]",
+        `\thooksPath = ${poisonHooks}`,
+        "[init]",
+        `\ttemplateDir = ${poisonTemplate}`,
+        "[user]",
+        "\tname = Hostile Global User",
+        "\temail = hostile-global@example.invalid",
+        "",
+      ].join("\n"),
+    );
+    copyFileSync(globalConfig, join(poisonHome, ".gitconfig"));
+    const poisonEnvironment: NodeJS.ProcessEnv = {
+      GIT_CONFIG_GLOBAL: globalConfig,
+      GIT_CONFIG_SYSTEM: globalConfig,
+      GIT_TEMPLATE_DIR: poisonTemplate,
+      HOME: poisonHome,
+      XDG_CONFIG_HOME: poisonHome,
+    };
+
+    const fixture = createFixture({
+      gitEnvironment: poisonEnvironment,
+      gitParentEnvironment: poisonEnvironment,
+    });
+    const fixtureGit = createFixtureGit(fixture.cwd);
+    expect(fixtureGit("config", "--local", "user.name")).toBe("Release Fixture");
+    expect(fixtureGit("config", "--local", "user.email")).toBe("release-fixture@example.invalid");
+    expect(existsSync(hookMarker)).toBe(false);
+    expect(existsSync(templateMarker)).toBe(false);
+    expect(existsSync(join(fixture.cwd, ".git", "hooks", "post-commit"))).toBe(false);
+  });
+
+  it("keeps synthetic hook Git context isolated from fixture creation and scripts", () => {
+    const sentinelRoot = mkdtempSync(join(tmpdir(), "ravi-git-env-sentinel-"));
+    const sentinelGit = createFixtureGit(sentinelRoot);
+    sentinelGit("init", "-q");
+    sentinelGit("config", "--local", "core.bare", "false");
+    sentinelGit("config", "--local", "user.name", "Sentinel Owner");
+    sentinelGit("config", "--local", "user.email", "sentinel@example.invalid");
+    sentinelGit("config", "--local", "fixture.sentinel", "unchanged");
+
+    const sentinelGitDir = join(sentinelRoot, ".git");
+    const sentinelConfig = join(sentinelGitDir, "config");
+    const sentinelConfigHash = createHash("sha256").update(readFileSync(sentinelConfig)).digest("hex");
+    const runtimeVariables = runtimeGitLocalEnvironmentVariables(sentinelGit);
+    const runtimePoison = Object.fromEntries(
+      runtimeVariables.map((variable) => [variable, join(sentinelGitDir, `synthetic-${variable}`)]),
+    );
+    const gitOverrides: Record<string, string> = {
+      ...runtimePoison,
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: join(sentinelGitDir, "objects"),
+      GIT_COMMON_DIR: sentinelGitDir,
+      GIT_CONFIG: sentinelConfig,
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "user.name",
+      GIT_CONFIG_PARAMETERS: "'fixture.parameter'='synthetic'",
+      GIT_CONFIG_VALUE_0: "Injected Name",
+      GIT_DIR: sentinelGitDir,
+      GIT_GRAFT_FILE: join(sentinelGitDir, "info", "grafts"),
+      GIT_IMPLICIT_WORK_TREE: "0",
+      GIT_INDEX_FILE: join(sentinelGitDir, "index"),
+      GIT_NO_REPLACE_OBJECTS: "1",
+      GIT_OBJECT_DIRECTORY: join(sentinelGitDir, "objects"),
+      GIT_PREFIX: "synthetic/",
+      GIT_REPLACE_REF_BASE: "refs/replace/",
+      GIT_SHALLOW_FILE: join(sentinelGitDir, "shallow"),
+      GIT_WORK_TREE: sentinelRoot,
+      RELEASE_FIXTURE_NON_GIT: "preserved",
+    };
+
+    const fixture = createFixture({
+      gitEnvironment: gitOverrides,
+      gitParentEnvironment: gitOverrides,
+    });
+    const fixtureGit = createFixtureGit(fixture.cwd, {
+      env: gitOverrides,
+      parentEnvironment: gitOverrides,
+    });
+    const fixtureTopLevel = realpathSync(fixture.cwd);
+    expect(fixtureGit("rev-parse", "--show-toplevel")).toBe(fixtureTopLevel);
+    expect(fixtureGit("config", "--local", "user.name")).toBe("Release Fixture");
+    expect(fixtureGit("config", "--local", "user.email")).toBe("release-fixture@example.invalid");
+
+    const runner = runReleaseWorkflowFixture({
+      cwd: fixture.cwd,
+      env: {
+        ...gitOverrides,
+        FIXTURE_EXPECTED_ROOT: fixtureTopLevel,
+      },
+      parentEnvironment: gitOverrides,
+      script: [
+        `[ "$(git rev-parse --show-toplevel)" = "$FIXTURE_EXPECTED_ROOT" ]`,
+        `[ "$(git config --local user.name)" = "Release Fixture" ]`,
+        `[ "$RELEASE_FIXTURE_NON_GIT" = "preserved" ]`,
+      ].join("\n"),
+    });
+    expect(runner.status, runner.stderr).toBe(0);
+    for (const path of Object.values(runner.context)) expectPathWithin(fixture.cwd, path);
+
+    expect(createHash("sha256").update(readFileSync(sentinelConfig)).digest("hex")).toBe(sentinelConfigHash);
+    expect(sentinelGit("config", "--local", "core.bare")).toBe("false");
+    expect(sentinelGit("config", "--local", "user.name")).toBe("Sentinel Owner");
+    expect(sentinelGit("config", "--local", "user.email")).toBe("sentinel@example.invalid");
+    expect(sentinelGit("config", "--local", "fixture.sentinel")).toBe("unchanged");
+  });
+
+  it("keeps an AST-audited child-process inventory on explicit hermetic environments", () => {
+    const expectedInventory = [
+      {
+        api: "spawnSync",
+        sourcePath: join(import.meta.dir, "release-workflow-fixture.ts"),
+      },
+      {
+        api: "execFileSync",
+        sourcePath: join(import.meta.dir, "release-workflow-security.test.ts"),
+      },
+    ] as const;
+
+    for (const expected of expectedInventory) {
+      const inventory = inspectChildProcessAst(expected.sourcePath);
+      expect(inventory.violations, expected.sourcePath).toEqual([]);
+      expect(inventory.imports, expected.sourcePath).toEqual([expected.api]);
+      expect(inventory.calls, expected.sourcePath).toEqual([
+        {
+          hasExplicitEnv: true,
+          name: expected.api,
+        },
+      ]);
+    }
+  });
+
+  it("rejects AST mutations that alias process launchers or load them dynamically", () => {
+    const canonicalModule = ["node", ["child", "process"].join("_")].join(":");
+    const canonicalSources = [
+      {
+        api: "execFileSync",
+        name: "security test helper",
+        source: `import { execFileSync } from "${canonicalModule}";
+execFileSync("git", [], { env: {} });`,
+      },
+      {
+        api: "spawnSync",
+        name: "fixture helper",
+        source: `import { spawnSync } from "${canonicalModule}";
+spawnSync("/bin/bash", [], { env: {} });`,
+      },
+    ] as const;
+
+    for (const canonical of canonicalSources) {
+      const inventory = inspectChildProcessAst(`<canonical:${canonical.name}>`, canonical.source);
+      expect(inventory.violations, canonical.name).toEqual([]);
+      expect(inventory.imports, canonical.name).toEqual([canonical.api]);
+      expect(inventory.calls, canonical.name).toEqual([
+        {
+          hasExplicitEnv: true,
+          name: canonical.api,
+        },
+      ]);
+    }
+
+    const execFileImport = `import { execFileSync } from "${canonicalModule}";`;
+    const mutations = [
+      {
+        name: "bind alias",
+        source: `${execFileImport}
+const run = execFileSync.bind(undefined);`,
+      },
+      {
+        name: "direct identifier alias",
+        source: `${execFileImport}
+const run = execFileSync;`,
+      },
+      {
+        name: "Bun.spawn alias",
+        source: "const run = Bun.spawn;",
+      },
+      {
+        name: "Bun element access",
+        source: 'const run = Bun["spawn"];',
+      },
+      {
+        name: "destructured Bun",
+        source: "const { spawn: run } = Bun;",
+      },
+      {
+        name: "Bun.$ tagged alias",
+        source: "const shell = Bun.$;\nshell`echo mutation`;",
+      },
+      {
+        name: "assignment after declaration",
+        source: `${execFileImport}
+let run;
+run = execFileSync;`,
+      },
+      {
+        name: "identifier passed as argument",
+        source: `${execFileImport}
+consume(execFileSync);`,
+      },
+      {
+        name: "identifier returned",
+        source: `${execFileImport}
+function runner() { return execFileSync; }`,
+      },
+      {
+        name: "identifier stored in array",
+        source: `${execFileImport}
+const runners = [execFileSync];`,
+      },
+      {
+        name: "identifier stored in object",
+        source: `${execFileImport}
+const runners = { execFileSync };`,
+      },
+      {
+        name: "comma expression callee",
+        source: `${execFileImport}
+(0, execFileSync)("git", [], { env: {} });`,
+      },
+      {
+        name: "parenthesized callee",
+        source: `${execFileImport}
+(execFileSync)("git", [], { env: {} });`,
+      },
+      {
+        name: "aliased require",
+        source: `const load = require;
+load("${canonicalModule}");`,
+      },
+      {
+        name: "aliased dynamic import string",
+        source: `const moduleName = "${canonicalModule}";
+import(moduleName);`,
+      },
+      {
+        name: "getBuiltinModule",
+        source: `process.getBuiltinModule("${canonicalModule}");`,
+      },
+      {
+        name: "call alias",
+        source: `${execFileImport}
+execFileSync.call(undefined, "git", [], { env: {} });`,
+      },
+      {
+        name: "apply alias",
+        source: `${execFileImport}
+execFileSync.apply(undefined, ["git", [], { env: {} }]);`,
+      },
+      {
+        name: "Bun.spawnSync alias",
+        source: "const run = Bun.spawnSync;",
+      },
+      {
+        name: "Bun shell import alias",
+        source: 'import { $ as shell } from "bun";\nshell`echo mutation`;',
+      },
+      {
+        name: "bare shell alias",
+        source: "const $ = () => undefined;\n$`echo mutation`;",
+      },
+    ] as const;
+
+    for (const mutation of mutations) {
+      const inventory = inspectChildProcessAst(`<mutation:${mutation.name}>`, mutation.source);
+      expect(inventory.violations.length, mutation.name).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("release workflow security contract", () => {
+  it("keeps tag-only root and SDK entrypoints and never mutates branches or tags", () => {
+    const root = readWorkflow(".github/workflows/version.yml");
+    const sdk = readWorkflow(".github/workflows/sdk-release.yml");
+
+    expect(root.config.on?.push).toEqual({ tags: ["v*"] });
+    expect(root.config.on?.workflow_call).toBeTruthy();
+    expect(sdk.config.on?.push).toEqual({ tags: ["ravi-os-sdk-v*"] });
+    expect(sdk.config.jobs?.publish?.uses).toBe("./.github/workflows/version.yml");
+    expect(sdk.config.jobs?.publish?.with).toEqual({
+      release_kind: "sdk",
+      expected_package: "@ravi-os/sdk",
+      package_path: "packages/ravi-os-sdk/package.json",
+      package_dir: "packages/ravi-os-sdk",
+    });
+    expect(sdk.config.jobs?.publish?.secrets).toEqual({
+      NPM_TOKEN: `${dollarSign}{{ secrets.NPM_TOKEN }}`,
+    });
+    const provenance = namedStep(root.config, "Verify tag, reviewed PR delta, and current base");
+    expect(provenance.env?.EVENT_NAME).toBe(`${dollarSign}{{ github.event_name }}`);
+    expect(provenance.run).toContain('[ "$EVENT_NAME" != "push" ]');
+
+    for (const { config, text } of [root, sdk]) {
+      expect(config.permissions).toEqual({
+        contents: "read",
+        "pull-requests": "read",
+      });
+      expect(scripts(config)).not.toMatch(/\bgit\s+(?:commit|push|switch|tag)\b/);
+      expect(scripts(config)).not.toMatch(/\bgh\s+pr\s+create\b/);
+      expect(text).not.toContain("contents: write");
+      expect(text).not.toContain("workflow_run:");
+    }
+  });
+
+  it("uses per-tag concurrency so three rapid distinct tags retain three runs", () => {
+    const root = readWorkflow(".github/workflows/version.yml").config;
+    const sdk = readWorkflow(".github/workflows/sdk-release.yml").config;
+    const release = readWorkflow(".github/workflows/release.yml").config;
+
+    expect(root.concurrency).toEqual({
+      group: `ravi-package-${dollarSign}{{ github.ref_name }}`,
+      "cancel-in-progress": false,
+    });
+    expect(sdk.concurrency).toEqual({
+      group: `ravi-sdk-package-${dollarSign}{{ github.ref_name }}`,
+      "cancel-in-progress": false,
+    });
+    expect(release.concurrency).toEqual({
+      group: `ravi-github-release-${dollarSign}{{ inputs.tag }}`,
+      "cancel-in-progress": false,
+    });
+
+    const rapidTags = ["v3.260723.5", "v3.260723.6", "v3.260723.7"];
+    const groups = rapidTags.map((tag) => `ravi-package-${tag}`);
+    expect(new Set(groups).size).toBe(3);
+  });
+
+  it("isolates checkout/build/package from the only npm secret", () => {
+    const { config, text } = readWorkflow(".github/workflows/version.yml");
+    const verify = config.jobs?.verify;
+    const publish = config.jobs?.publish;
+    const verifyText = JSON.stringify(verify);
+    const publishText = JSON.stringify(publish);
+
+    expect(verify?.steps?.filter((step) => step.uses === "actions/checkout@v5")).toHaveLength(1);
+    expect(verifyText).not.toContain("secrets.NPM_TOKEN");
+    expect(verifyText).not.toContain("NODE_AUTH_TOKEN");
+    expect(publish?.needs).toBe("verify");
+    expect(publish?.steps?.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+    expect(publishText).not.toMatch(/bun (?:install|run)/);
+    expect(text.match(/\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/g) ?? []).toHaveLength(1);
+
+    const tokenSteps = publish?.steps?.filter((step) => JSON.stringify(step).includes("secrets.NPM_TOKEN"));
+    expect(tokenSteps).toHaveLength(1);
+    expect(tokenSteps?.[0]?.name).toBe("Publish immutable inspected tarball");
+    expect(tokenSteps?.[0]?.run).toBe(
+      '"$TRUSTED_NPM" publish "$TARBALL" --ignore-scripts --access public --tag "$IMMUTABLE_NPM_TAG" --registry="https://registry.npmjs.org/"',
+    );
+    expect(tokenSteps?.[0]?.["continue-on-error"]).toBe(true);
+  });
+
+  it("uploads a sealed real tarball and revalidates it in a fresh no-checkout job", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const seal = namedStep(config, "Seal immutable inspected tarball and metadata").run ?? "";
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry").run ?? "";
+    const upload = namedStep(config, "Upload immutable inspected release payload");
+    const download = namedStep(config, "Download exact sealed release payload");
+
+    expect(seal).toContain('"$TRUSTED_NPM" pack "$PACKAGE_DIR"');
+    expect(seal).not.toContain("npm pack --dry-run");
+    expect(seal).toContain("sha512sum");
+    expect(seal).toContain("ssri_sha512");
+    expect(seal).toContain("tarballIntegrity");
+    expect(seal).toContain("exactly one regular package/package.json");
+    expect(seal).toContain("length == 1");
+    expect(seal).toContain(".gitHead = $sha");
+    expect(upload.uses).toBe("actions/upload-artifact@v4");
+    expect(upload.with?.overwrite).toBe(false);
+    expect(upload.with?.["retention-days"]).toBe(90);
+    expect(download.uses).toBe("actions/download-artifact@v5");
+    expect(revalidate).toContain("sha512sum");
+    expect(revalidate).toContain("ssri_sha512");
+    expect(revalidate).toContain(".schema == 2");
+    expect(revalidate).toContain("dist.integrity");
+    expect(revalidate).toContain("length == 1");
+    expect(revalidate).toContain("package/package.json");
+    expect(revalidate).toContain('.publishConfig == {"access":"public"}');
+    expect(revalidate).toContain(".gitHead == $sha");
+  });
+
+  it("uses PR files plus current branch reachability and never PR base SHA authority", () => {
+    const { config, text } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base").run ?? "";
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry").run ?? "";
+
+    expect(text).not.toContain(".base.sha");
+    expect(text).not.toMatch(/\bBASE_SHA\b/);
+    for (const script of [provenance, revalidate]) {
+      expect(script).toContain("--paginate");
+      expect(script).toContain("--slurp");
+      expect(script).toContain("/files?per_page=100");
+      expect(script).toContain("/git/ref/heads/");
+      expect(script).toContain("merge_base_commit.sha == $target");
+      expect(script).toContain("CURRENT");
+      expect(script).toContain("del(.version)");
+    }
+  });
+
+  it("guards repository npmrc, publishConfig, PATH, registry, and lifecycle scripts", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base").run ?? "";
+    const seal = namedStep(config, "Seal immutable inspected tarball and metadata").run ?? "";
+    const resolve = namedStep(config, "Resolve trusted npm before repository code").run ?? "";
+    const publish = namedStep(config, "Publish immutable inspected tarball").run ?? "";
+
+    expect(provenance).toContain("git ls-files -- '.npmrc' '*/.npmrc'");
+    expect(provenance).toContain('(.publishConfig // {}) == {"access":"public"}');
+    expect(seal).toContain("-name .npmrc");
+    expect(seal).toContain("--ignore-scripts");
+    expect(resolve).toContain('NPM_BIN="$(realpath "$(command -v npm)")"');
+    expect(resolve).toContain('case "$NPM_BIN"');
+    expect(publish).toContain('"$TRUSTED_NPM" publish');
+    expect(publish).toContain('--registry="https://registry.npmjs.org/"');
+  });
+
+  it("uses only version-qualified immutable dist-tags, preventing inverted-order downgrade", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base").run ?? "";
+    const publish = namedStep(config, "Publish immutable inspected tarball");
+    const versions = ["3.260723.7", "3.260723.6", "3.260723.5"];
+    const commandLogs: string[] = [];
+
+    expect(provenance).toContain(`IMMUTABLE_NPM_TAG="${dollarSign}{CHANNEL_PREFIX}-v${dollarSign}{VERSION//./-}"`);
+    expect(publish.run).not.toContain("--tag latest");
+    expect(publish.run).not.toContain("--tag next");
+
+    for (const version of versions) {
+      const fixture = createFixture();
+      try {
+        const immutableTag = `stable-v${version.replaceAll(".", "-")}`;
+        const result = runReleaseWorkflowFixture({
+          commands: { npm: npmCommand },
+          cwd: fixture.cwd,
+          env: {
+            FIXTURE_PUBLISH_EXIT: "0",
+            IMMUTABLE_NPM_TAG: immutableTag,
+            TARBALL: "/tmp/sealed-fixture.tgz",
+            TRUSTED_NPM: "__FIXTURE_BIN__/npm",
+          },
+          script: publish.run ?? "",
+        });
+        expect(result.status, result.stderr).toBe(0);
+        commandLogs.push(result.commandLog);
+      } finally {
+        rmSync(fixture.cwd, { force: true, recursive: true });
+      }
+    }
+
+    const combined = commandLogs.join("");
+    for (const version of versions) {
+      expect(combined).toContain(`--tag stable-v${version.replaceAll(".", "-")}`);
+    }
+    expect(combined).not.toMatch(/--tag (?:latest|next)(?:\s|$)/);
+  });
+
+  it("makes ambiguous npm publish retry idempotent only for exact SSRI, gitHead, and dist-tag", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const publish = namedStep(config, "Publish immutable inspected tarball");
+    const verify = namedStep(config, "Verify exact registry result after publish or retry");
+    const fixture = createFixture();
+    try {
+      expect(publish["continue-on-error"]).toBe(true);
+      expect(verify.if).toContain("always()");
+
+      const ambiguousPublish = runFixtureStep(publish, fixture, {
+        FIXTURE_PUBLISH_EXIT: "1",
+      });
+      expect(ambiguousPublish.status).not.toBe(0);
+      expect(ambiguousPublish.commandLog).toContain("npm publish");
+
+      // GitHub continues because the real step is continue-on-error. A registry
+      // read proving the exact version, sealed SSRI, gitHead, and immutable tag
+      // closes the ambiguous outcome as success.
+      const matching = runFixtureStep(verify, fixture);
+      expect(matching.status, matching.stderr).toBe(0);
+      expect(matching.commandLog).toContain("version gitHead dist.integrity --json");
+      expect(matching.commandLog).toContain(`/git/ref/tags/${fixture.tag}`);
+      expect(matching.commandLog).toContain("/git/ref/heads/main");
+      expect(matching.commandLog).toContain(`/pulls/${fixture.prNumber}/files?per_page=100`);
+
+      const mismatched = runFixtureStep(verify, fixture, {
+        FIXTURE_REGISTRY_METADATA_JSON: JSON.stringify({
+          gitHead: "e".repeat(40),
+          version: fixture.version,
+        }),
+      });
+      expect(mismatched.status).not.toBe(0);
+      expect(mismatched.stderr).toContain("mismatched integrity, gitHead, or dist-tag");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("recovers sealed publish provenance and keeps GitHub Release reruns exact", () => {
+    const { config, text } = readWorkflow(".github/workflows/release.yml");
+    const verify = namedStep(config, "Verify full published tag provenance");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const createScript = create.run ?? "";
+
+    expect(steps(config).some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+    expect(config.permissions?.actions).toBe("read");
+    expect(text).not.toContain(".base.sha");
+    expect(verify.run).toContain(`/actions/workflows/${dollarSign}{PUBLISH_WORKFLOW}/runs?`);
+    expect(verify.run).toContain("gh api --paginate --slurp");
+    expect(verify.run).toContain("artifact totals disagree");
+    expect(verify.run).toContain("gh run download");
+    expect(verify.run).toContain(".tarballIntegrity");
+    expect(verify.run).toContain('.["dist.integrity"] == $integrity');
+    expect(createScript).toContain(".tag_name == $tag");
+    expect(createScript).toContain(".name == $title");
+    expect(createScript).toContain(".draft == false");
+    expect(createScript).toContain(".prerelease == $prerelease");
+    expect(createScript).toContain(".target_commitish == $target");
+    expect(createScript).toContain(".gitHead == $sha");
+    expect(createScript).toContain('.["dist.integrity"] == $integrity');
+    expect(createScript).toContain('gh release create "$TAG"');
+    expect(createScript).toContain("--latest=false");
+    expect(createScript).toContain("CREATE_STATUS");
+    expect(createScript).toContain('revalidate_published_authorities "after GitHub Release create attempt"');
+    expect(createScript).toContain('revalidate_pr_authority "after GitHub Release create attempt"');
+    expect(createScript).toContain(`/commits/${dollarSign}{TARGET_SHA}/pulls?per_page=100`);
+  });
+
+  it("keeps all embedded workflow scripts bash-syntax valid without startup injection", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "ravi-bash-syntax-environment-"));
+    const marker = join(cwd, "bash-env-syntax-marker");
+    const poisonScript = join(cwd, "bash-env-syntax-poison.sh");
+    writeFileSync(poisonScript, `#!/bin/sh\n: > "${marker}"\nif then\n`);
+    chmodSync(poisonScript, 0o755);
+    const child = createHermeticFixtureProcess(cwd, {
+      env: { BASH_ENV: poisonScript },
+      parentEnvironment: { BASH_ENV: poisonScript },
+    });
+
+    expect(child.environment.BASH_ENV).toBeUndefined();
+    expect(() => execHermeticFixtureCommand(child, "/bin/bash", ["-n", poisonScript])).toThrow();
+    for (const path of workflowPaths) {
+      const { config } = readWorkflow(path);
+      for (const step of steps(config)) {
+        if (!step.run) continue;
+        expect(
+          () => execHermeticFixtureCommand(child, "/bin/bash", ["-n"], { input: step.run }),
+          `${path}: ${step.name ?? "unnamed"}`,
+        ).not.toThrow();
+      }
+    }
+    expect(existsSync(marker)).toBe(false);
+  });
+});
+
+describe("release workflow executable hostile fixtures", () => {
+  it("rejects a workflow_dispatch caller even when it supplies a valid tag ref", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(provenance, fixture, {
+        EVENT_NAME: "workflow_dispatch",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("tag push events only");
+      expect(result.commandLog).not.toContain("gh ");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a stale PR base SHA because current branch reachability is authoritative", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(provenance, fixture);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.commandLog).toContain("git/ref/heads/main");
+      expect(result.commandLog).toContain(`compare/${fixture.targetSha}...${fixture.currentBaseSha}`);
+      expect(result.commandLog).not.toContain(fixture.baseSha);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a second eligible associated PR before and after publication", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry");
+    const verify = namedStep(config, "Verify exact registry result after publish or retry");
+    const fixture = createFixture();
+    const associatedPrPages = JSON.stringify([
+      [associatedPullRequest(fixture)],
+      [associatedPullRequest(fixture, { number: Number(fixture.prNumber) + 1 })],
+    ]);
+    try {
+      const beforePublish = runPublishRevalidation(revalidate, fixture, fixture.tarball, {
+        FIXTURE_ASSOCIATED_PRS_JSON: associatedPrPages,
+      });
+      expect(beforePublish.status).not.toBe(0);
+      expect(beforePublish.stderr).toContain("Associated PR provenance changed after artifact sealing");
+      expect(beforePublish.commandLog).toContain("--paginate --slurp");
+      expect(beforePublish.commandLog).not.toContain(`/pulls/${fixture.prNumber}/files?per_page=100`);
+
+      const afterPublish = runFixtureStep(verify, fixture, {
+        FIXTURE_ASSOCIATED_PRS_JSON: associatedPrPages,
+      });
+      expect(afterPublish.status).not.toBe(0);
+      expect(afterPublish.stderr).toContain("Associated PR provenance diverged during publication");
+      expect(afterPublish.commandLog).toContain("--paginate --slurp");
+      expect(afterPublish.commandLog).not.toContain("npm view");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a cross-base second eligible PR before publication", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry");
+    const fixture = createFixture();
+    const associatedPrPages = JSON.stringify([
+      [associatedPullRequest(fixture, { base: "main" })],
+      [
+        associatedPullRequest(fixture, {
+          base: "dev",
+          number: Number(fixture.prNumber) + 1,
+        }),
+      ],
+    ]);
+    try {
+      const result = runPublishRevalidation(revalidate, fixture, fixture.tarball, {
+        FIXTURE_ASSOCIATED_PRS_JSON: associatedPrPages,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR provenance changed after artifact sealing");
+      expect(result.commandLog).toContain("--paginate --slurp");
+      expect(result.commandLog).not.toContain(`/pulls/${fixture.prNumber}/files?per_page=100`);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a cross-base second eligible PR after publication", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const verify = namedStep(config, "Verify exact registry result after publish or retry");
+    const fixture = createFixture();
+    const associatedPrPages = JSON.stringify([
+      [associatedPullRequest(fixture, { base: "main" })],
+      [
+        associatedPullRequest(fixture, {
+          base: "dev",
+          number: Number(fixture.prNumber) + 1,
+        }),
+      ],
+    ]);
+    try {
+      const result = runFixtureStep(verify, fixture, {
+        FIXTURE_ASSOCIATED_PRS_JSON: associatedPrPages,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR provenance diverged during publication");
+      expect(result.commandLog).toContain("--paginate --slurp");
+      expect(result.commandLog).not.toContain("npm view");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an extra file hidden on a later paginated PR-files page", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(provenance, fixture, {
+        FIXTURE_PR_FILES_JSON: JSON.stringify([
+          [{ filename: fixture.packagePath, previous_filename: null, status: "modified" }],
+          [{ filename: "src/hidden.ts", previous_filename: null, status: "added" }],
+        ]),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("full paginated delta");
+      expect(result.commandLog).toContain("--paginate --slurp");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects duplicate, symlinked, and multi-JSON package manifests in a sealed tarball", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry");
+    const fixture = createFixture();
+    try {
+      for (const kind of ["duplicate", "symlink", "multi-json"] as const) {
+        const tarball = createAdversarialTarball(fixture, kind);
+        const result = runPublishRevalidation(revalidate, fixture, tarball);
+        expect(result.status, `${kind}: ${result.stderr}`).not.toBe(0);
+        expect(result.commandLog, kind).not.toContain("gh ");
+        expect(result.commandLog, kind).not.toContain("npm ");
+      }
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an existing npm version whose dist.integrity differs from the sealed tarball", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry");
+    const fixture = createFixture();
+    try {
+      const result = runPublishRevalidation(revalidate, fixture, fixture.tarball, {
+        FIXTURE_REGISTRY_METADATA_JSON: JSON.stringify({
+          "dist.integrity": `sha512-${"A".repeat(86)}==`,
+          gitHead: fixture.targetSha,
+          version: fixture.version,
+        }),
+        FIXTURE_REGISTRY_VERSIONS_JSON: JSON.stringify(["3.260723.4", fixture.version]),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("mismatched gitHead or dist.integrity");
+      expect(result.commandLog).toContain("version gitHead dist.integrity --json");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps v7, v6, and v5 publishable when their immutable tags land in inverted order", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const revalidate = namedStep(config, "Revalidate artifact, tag, current base, PR files, and registry");
+    const publish = namedStep(config, "Publish immutable inspected tarball");
+    const publicationOrder = ["3.260723.7", "3.260723.6", "3.260723.5"];
+    const publishedVersions: string[] = ["3.260723.4"];
+    const publishedTags: Record<string, string> = {};
+    const publishLogs: string[] = [];
+
+    for (const version of publicationOrder) {
+      const fixture = createFixture({ version });
+      try {
+        const revalidation = runPublishRevalidation(revalidate, fixture, fixture.tarball, {
+          FIXTURE_DIST_TAGS_JSON: JSON.stringify(publishedTags),
+          FIXTURE_REGISTRY_VERSIONS_JSON: JSON.stringify(publishedVersions),
+        });
+        expect(revalidation.status, `${version}: ${revalidation.stderr}`).toBe(0);
+        expect(revalidation.githubOutput).toContain("already_published=false");
+
+        const publication = runFixtureStep(publish, fixture);
+        expect(publication.status, `${version}: ${publication.stderr}`).toBe(0);
+        publishLogs.push(publication.commandLog);
+
+        publishedVersions.push(version);
+        publishedTags[`stable-v${version.replaceAll(".", "-")}`] = version;
+      } finally {
+        rmSync(fixture.cwd, { force: true, recursive: true });
+      }
+    }
+
+    const combined = publishLogs.join("");
+    for (const version of publicationOrder) {
+      expect(combined).toContain(`--tag stable-v${version.replaceAll(".", "-")}`);
+    }
+    expect(combined).not.toMatch(/--tag (?:latest|next)(?:\s|$)/);
+  });
+
+  it("fails after publish when the remote tag diverges before final verification", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const verify = namedStep(config, "Verify exact registry result after publish or retry");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(verify, fixture, {
+        FIXTURE_TAG_REF_JSON: JSON.stringify({
+          object: { sha: "e".repeat(40), type: "commit" },
+          ref: `refs/tags/${fixture.tag}`,
+        }),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Remote tag diverged during publication");
+      expect(result.commandLog).not.toContain("npm view");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("finds a unique authoritative artifact after page 1 and rejects duplicates across pages", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const verify = namedStep(config, "Verify full published tag provenance");
+    const fixture = createFixture();
+    const artifact = { expired: false, name: "ravi-root-package-42-1" };
+    const unrelated = Array.from({ length: 100 }, (_, index) => ({
+      expired: false,
+      name: `unrelated-${index}`,
+    }));
+    try {
+      const pageTwoMatch = runFixtureStep(verify, fixture, {
+        FIXTURE_ARTIFACT_INDEX_JSON: JSON.stringify([
+          { artifacts: unrelated, total_count: 101 },
+          { artifacts: [artifact], total_count: 101 },
+        ]),
+      });
+      expect(pageTwoMatch.status, pageTwoMatch.stderr).toBe(0);
+      expect(pageTwoMatch.commandLog).toContain("gh api --paginate --slurp -H Accept: application/vnd.github+json");
+      expect(pageTwoMatch.commandLog).toContain("gh run download 42");
+
+      const inconsistentTotals = runFixtureStep(verify, fixture, {
+        FIXTURE_ARTIFACT_INDEX_JSON: JSON.stringify([
+          { artifacts: unrelated, total_count: 101 },
+          { artifacts: [artifact], total_count: 102 },
+        ]),
+      });
+      expect(inconsistentTotals.status).not.toBe(0);
+      expect(inconsistentTotals.stderr).toContain("Publishing artifact pages are incomplete or ambiguous");
+      expect(inconsistentTotals.commandLog).not.toContain("gh run download");
+
+      const duplicateAcrossPages = runFixtureStep(verify, fixture, {
+        FIXTURE_ARTIFACT_INDEX_JSON: JSON.stringify([
+          { artifacts: [...unrelated.slice(0, 99), artifact], total_count: 101 },
+          { artifacts: [artifact], total_count: 101 },
+        ]),
+      });
+      expect(duplicateAcrossPages.status).not.toBe(0);
+      expect(duplicateAcrossPages.stderr).toContain("Publishing artifact index is ambiguous");
+      expect(duplicateAcrossPages.commandLog).not.toContain("gh run download");
+      expect(duplicateAcrossPages.commandLog).not.toContain("npm view");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("recovers sealed SSRI from a successful push run without a manual integrity input", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const verify = namedStep(config, "Verify full published tag provenance");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(verify, fixture);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.githubOutput).toContain(`integrity=${fixture.tarballIntegrity}`);
+      expect(result.commandLog).toContain("/actions/workflows/version.yml/runs?event=push");
+      expect(result.commandLog).toContain("/actions/runs/42/artifacts?per_page=100");
+      expect(result.commandLog).toContain("gh run download 42");
+      expect(result.commandLog).toContain("version gitHead dist.integrity --json");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("fails GitHub Release verification when sealed publish provenance expired", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const verify = namedStep(config, "Verify full published tag provenance");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(verify, fixture, {
+        FIXTURE_ARTIFACT_INDEX_JSON: JSON.stringify([
+          {
+            artifacts: [{ expired: true, name: "ravi-root-package-42-1" }],
+            total_count: 1,
+          },
+        ]),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("No unexpired successful tag-push artifact");
+      expect(result.commandLog).not.toContain("npm view");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when the base branch moves after release verification", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_BRANCH_REF_JSON: JSON.stringify({
+          object: { sha: "e".repeat(40), type: "commit" },
+          ref: "refs/heads/main",
+        }),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Base branch moved");
+      expect(result.commandLog).not.toContain("gh release create");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a tracked hostile npmrc before any registry or package execution", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base");
+    const fixture = createFixture({ trackedNpmrc: true });
+    try {
+      const result = runFixtureStep(provenance, fixture);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Repository-controlled .npmrc");
+      expect(result.commandLog).not.toContain("npm ");
+      expect(result.commandLog).not.toContain("gh ");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when the controlled fixture PATH shadows npm before trust establishment", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const resolve = namedStep(config, "Resolve trusted npm before repository code");
+    const fixture = createFixture();
+    try {
+      const result = runReleaseWorkflowFixture({
+        commands: { npm: "exit 99" },
+        cwd: fixture.cwd,
+        script: resolve.run ?? "",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("outside the freshly configured Node toolchain");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects impossible calendar dates before GitHub provenance calls", () => {
+    const { config } = readWorkflow(".github/workflows/version.yml");
+    const provenance = namedStep(config, "Verify tag, reviewed PR delta, and current base");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(provenance, fixture, {
+        EVENT_REF: "refs/tags/v3.260231.1",
+        EVENT_REF_NAME: "v3.260231.1",
+        FIXTURE_DATE_FAIL: "1",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("not a real UTC calendar date");
+      expect(result.commandLog).not.toContain("gh ");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a later-page same-base associated PR before release lookup or create", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    const associatedPrPages = JSON.stringify([
+      [associatedPullRequest(fixture, { base: "main" })],
+      [
+        associatedPullRequest(fixture, {
+          base: "main",
+          number: Number(fixture.prNumber) + 1,
+        }),
+      ],
+    ]);
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_ASSOCIATED_PRS_JSON: associatedPrPages,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR authority is not unique after verification");
+      expect(result.commandLog).toContain("gh api --paginate --slurp");
+      expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(1);
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(0);
+      expect(commandCount(result.commandLog, "gh release create")).toBe(0);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects malformed associated PR pages before release lookup or create", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_ASSOCIATED_PRS_JSON: JSON.stringify([{ malformed: true }]),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR pages became ambiguous after verification");
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(0);
+      expect(commandCount(result.commandLog, "gh release create")).toBe(0);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a later-page same-base associated PR introduced after release create", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    const postCreatePages = JSON.stringify([
+      [associatedPullRequest(fixture, { base: "main" })],
+      [
+        associatedPullRequest(fixture, {
+          base: "main",
+          number: Number(fixture.prNumber) + 1,
+        }),
+      ],
+    ]);
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_POST_CREATE_ASSOCIATED_PRS_JSON: postCreatePages,
+        FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR authority is not unique after GitHub Release create attempt");
+      expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+      expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(2);
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(2);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a cross-base associated PR introduced after release create", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    const postCreatePages = JSON.stringify([
+      [associatedPullRequest(fixture, { base: "main" })],
+      [
+        associatedPullRequest(fixture, {
+          base: "dev",
+          number: Number(fixture.prNumber) + 1,
+        }),
+      ],
+    ]);
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_POST_CREATE_ASSOCIATED_PRS_JSON: postCreatePages,
+        FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Associated PR authority is not unique after GitHub Release create attempt");
+      expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+      expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(2);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts an existing exactly matching release without creating it again", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.commandLog).toContain(`/releases/tags/${fixture.tag}`);
+      expect(result.commandLog).not.toContain("gh release create");
+      expect(result.commandLog).toContain(
+        `npm view ${fixture.packageName}@${fixture.version} version gitHead dist.integrity --json`,
+      );
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(1);
+      expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(1);
+      expect(commandCount(result.commandLog, `/pulls/${fixture.prNumber}/files?per_page=100`)).toBe(1);
+      expect(commandCount(result.commandLog, "gh release create")).toBe(0);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  for (const createExit of ["0", "1"] as const) {
+    it(`accepts an exact canonical reread after a release create exit ${createExit}`, () => {
+      const { config } = readWorkflow(".github/workflows/release.yml");
+      const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+      const fixture = createFixture();
+      try {
+        const result = runFixtureStep(create, fixture, {
+          FIXTURE_RELEASE_CREATE_EXIT: createExit,
+          FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+        });
+        expect(result.status, result.stderr).toBe(0);
+        expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+        expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(2);
+        expect(commandCount(result.commandLog, `/git/ref/tags/${fixture.tag}`)).toBe(2);
+        expect(commandCount(result.commandLog, "/git/ref/heads/main")).toBe(2);
+        expect(commandCount(result.commandLog, "/compare/")).toBe(2);
+        expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(2);
+        expect(commandCount(result.commandLog, `/pulls/${fixture.prNumber}/files?per_page=100`)).toBe(1);
+        expect(
+          commandCount(
+            result.commandLog,
+            `npm view ${fixture.packageName}@${fixture.version} version gitHead dist.integrity --json`,
+          ),
+        ).toBe(2);
+        expect(commandCount(result.commandLog, `npm view ${fixture.packageName} dist-tags --json`)).toBe(2);
+      } finally {
+        rmSync(fixture.cwd, { force: true, recursive: true });
+      }
+    });
+  }
+
+  it("creates an exact dev prerelease with two authority reads", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    const immutableTag = `next-v${fixture.version.replaceAll(".", "-")}`;
+    const devPr = associatedPullRequest(fixture, { base: "dev" });
+    try {
+      const result = runFixtureStep(create, fixture, {
+        EXPECTED_BASE: "dev",
+        EXPECTED_IMMUTABLE_NPM_TAG: immutableTag,
+        FIXTURE_ASSOCIATED_PRS_JSON: JSON.stringify([[devPr]]),
+        FIXTURE_BRANCH_REF_JSON: JSON.stringify({
+          object: { sha: fixture.currentBaseSha, type: "commit" },
+          ref: "refs/heads/dev",
+        }),
+        FIXTURE_DIST_TAGS_JSON: JSON.stringify({ [immutableTag]: fixture.version }),
+        FIXTURE_PR_JSON: JSON.stringify(devPr),
+        FIXTURE_RELEASE_JSON: JSON.stringify({
+          draft: false,
+          name: fixture.tag,
+          prerelease: true,
+          tag_name: fixture.tag,
+          target_commitish: fixture.targetSha,
+        }),
+        FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+      expect(result.commandLog).toContain("--prerelease --latest=false");
+      expect(commandCount(result.commandLog, `/commits/${fixture.targetSha}/pulls?per_page=100`)).toBe(2);
+      expect(commandCount(result.commandLog, "/git/ref/heads/dev")).toBe(2);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a missing canonical reread after a release create attempt", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+        FIXTURE_RELEASE_REREAD_MODE: "missing",
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("GitHub Release is absent after create attempt");
+      expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(2);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a divergent canonical reread after a release create attempt", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+        FIXTURE_RELEASE_REREAD_JSON: JSON.stringify({
+          draft: false,
+          name: "divergent title",
+          prerelease: false,
+          tag_name: fixture.tag,
+          target_commitish: fixture.targetSha,
+        }),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Created GitHub Release metadata does not exactly match");
+      expect(commandCount(result.commandLog, "gh release create")).toBe(1);
+      expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`)).toBe(2);
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects every tag, base, reachability, or registry drift after release creation", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    const wrongSha = "e".repeat(40);
+    const wrongIntegrity = `sha512-${"A".repeat(86)}==`;
+    const cases: Array<{
+      expectedError: string;
+      name: string;
+      overrides: Record<string, string>;
+    }> = [
+      {
+        expectedError: "Tag changed after GitHub Release create attempt",
+        name: "tag",
+        overrides: {
+          FIXTURE_POST_CREATE_TAG_REF_JSON: JSON.stringify({
+            object: { sha: wrongSha, type: "commit" },
+            ref: `refs/tags/${fixture.tag}`,
+          }),
+        },
+      },
+      {
+        expectedError: "Base branch moved after GitHub Release create attempt",
+        name: "base",
+        overrides: {
+          FIXTURE_POST_CREATE_BRANCH_REF_JSON: JSON.stringify({
+            object: { sha: wrongSha, type: "commit" },
+            ref: "refs/heads/main",
+          }),
+        },
+      },
+      {
+        expectedError: "Target is no longer reachable",
+        name: "reachability",
+        overrides: {
+          FIXTURE_POST_CREATE_REACHABILITY_JSON: JSON.stringify({
+            base_commit: { sha: wrongSha },
+            head_commit: { sha: fixture.currentBaseSha },
+            merge_base_commit: { sha: wrongSha },
+            status: "diverged",
+          }),
+        },
+      },
+      {
+        expectedError: "required integrity, gitHead, or immutable dist-tag",
+        name: "registry version",
+        overrides: {
+          FIXTURE_POST_CREATE_REGISTRY_METADATA_JSON: JSON.stringify({
+            "dist.integrity": fixture.tarballIntegrity,
+            gitHead: fixture.targetSha,
+            version: "3.260723.4",
+          }),
+        },
+      },
+      {
+        expectedError: "required integrity, gitHead, or immutable dist-tag",
+        name: "registry gitHead",
+        overrides: {
+          FIXTURE_POST_CREATE_REGISTRY_METADATA_JSON: JSON.stringify({
+            "dist.integrity": fixture.tarballIntegrity,
+            gitHead: wrongSha,
+            version: fixture.version,
+          }),
+        },
+      },
+      {
+        expectedError: "required integrity, gitHead, or immutable dist-tag",
+        name: "registry integrity",
+        overrides: {
+          FIXTURE_POST_CREATE_REGISTRY_METADATA_JSON: JSON.stringify({
+            "dist.integrity": wrongIntegrity,
+            gitHead: fixture.targetSha,
+            version: fixture.version,
+          }),
+        },
+      },
+      {
+        expectedError: "required integrity, gitHead, or immutable dist-tag",
+        name: "registry dist-tag",
+        overrides: {
+          FIXTURE_POST_CREATE_DIST_TAGS_JSON: JSON.stringify({
+            [`stable-v${fixture.version.replaceAll(".", "-")}`]: "3.260723.4",
+          }),
+        },
+      },
+    ];
+
+    try {
+      for (const drift of cases) {
+        const result = runFixtureStep(create, fixture, {
+          FIXTURE_RELEASE_LOOKUP_MODE: "missing",
+          ...drift.overrides,
+        });
+        expect(result.status, drift.name).not.toBe(0);
+        expect(result.stderr, drift.name).toContain(drift.expectedError);
+        expect(commandCount(result.commandLog, "gh release create"), drift.name).toBe(1);
+        expect(commandCount(result.commandLog, `/releases/tags/${fixture.tag}`), drift.name).toBe(2);
+      }
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an existing release whose title or target metadata differs", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_RELEASE_JSON: JSON.stringify({
+          draft: false,
+          name: "wrong title",
+          prerelease: false,
+          tag_name: fixture.tag,
+          target_commitish: "e".repeat(40),
+        }),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("does not exactly match");
+      expect(result.commandLog).not.toContain("gh release create");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects release creation when the exact published version gitHead differs", () => {
+    const { config } = readWorkflow(".github/workflows/release.yml");
+    const create = namedStep(config, "Revalidate published artifact and create GitHub Release");
+    const fixture = createFixture();
+    try {
+      const result = runFixtureStep(create, fixture, {
+        FIXTURE_REGISTRY_METADATA_JSON: JSON.stringify({
+          gitHead: "e".repeat(40),
+          version: fixture.version,
+        }),
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("required integrity, gitHead");
+      expect(result.commandLog).not.toContain("gh release create");
+    } finally {
+      rmSync(fixture.cwd, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Objective

Make OSS package releases fail closed, reproducible, and publishable only from validated tag pushes with current repository and registry authority.

## Problem

Release verification and write-capable steps could observe different GitHub or npm state. Pagination gaps, concurrent metadata changes, ambiguous publish/create results, and expired provenance artifacts could otherwise create or accept a release without a single current source of truth.

## Solution

- Restrict root and SDK publishing to their tag namespaces and validate reusable workflow event context.
- Separate verification/package jobs from token-bearing publish steps.
- Seal package archives with canonical layout checks, SHA-512/SSRI integrity, exact version, `gitHead`, and immutable version dist-tags.
- Revalidate tag, branch reachability, associated PR cardinality across `dev|main`, registry metadata, and release authority before and after write operations.
- Make npm publication and GitHub Release creation idempotent across successful and ambiguous retries.
- Recover retained provenance artifacts through fully paginated, exact successful-run lookup and fail closed after expiry or ambiguity.
- Add executable stateful fixtures and hermetic subprocess isolation for release workflow coverage.

## Practical impact

Release operators can safely rerun interrupted jobs, publish absent versions out of order without moving shared tags, and receive deterministic failures when GitHub, npm, or provenance state is stale, incomplete, duplicated, or divergent.

## What does NOT change

- Public package names, runtime APIs, and tag namespaces remain unchanged.
- Application runtime behavior and normal development builds are unchanged.
- Releases do not update shared `latest` or `next` dist-tags.
- No tag, package, GitHub Release, or deployment is created by this pull request itself.

## Validation

- Release security tests: 49 passed.
- Quality-gate tests: 83 passed.
- Full `bun run test`: passed.
- Typecheck: passed.
- Biome lint: 923 files checked with no fixes.
- Workflow YAML parsing: 3/3 passed.
- Embedded Bash syntax checks: 17/17 passed.
- Repository pre-push checks: passed without bypass.
- Diff, conflict-marker, credential, and scope scans: clean.

## Risks

The stricter authority checks can intentionally block a release when GitHub API shapes, associated PR metadata, npm metadata, or retained artifacts are incomplete or change during publication. The workflow Bash is more extensive, so the executable fixtures are required to prevent drift between validation and write paths.

## Rollback

Revert commit `72ab88efc85bb4fc0e04161ddd4c34b4c1ae284b` (or the eventual merge commit) to restore the prior release workflows and CI coverage. No published package or Release migration is required because this change does not execute a release.