### PR TITLE
Stabilize session prompt publish ordering test

### DIFF
--- a/src/omni/session-stream.test.ts
+++ b/src/omni/session-stream.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   ensureSessionConsumer,
   ensureSessionPromptInfrastructure,
@@ -9,22 +9,11 @@ import {
 } from "./session-stream.js";
 
 let currentJsm: PromptJsm;
-const promptPublishMock = mock(async (_subject: string, _payload: Uint8Array) => ({}));
-const runtimeEmitMock = mock(async (_topic: string, _payload: Record<string, unknown>) => {});
-const recordPromptPublishedTraceMock = mock(() => null);
-
-afterAll(() => {
-  setSessionPromptPublishHooksForTests();
-  mock.restore();
-});
 
 beforeEach(() => {
   resetSessionPromptInfrastructureCacheForTests();
   setSessionPromptPublishHooksForTests();
   currentJsm = makePromptJsm();
-  promptPublishMock.mockClear();
-  runtimeEmitMock.mockClear();
-  recordPromptPublishedTraceMock.mockClear();
 });
 
 describe("session prompt JetStream infrastructure", () => {
@@ -151,18 +140,23 @@ describe("session prompt JetStream infrastructure", () => {
   });
 
   it("announces a sourced prompt to the runtime after its durable publish", async () => {
+    const publishGate = deferred<void>();
     const callOrder: string[] = [];
-    promptPublishMock.mockImplementationOnce(async () => {
-      callOrder.push("prompt");
-      return {};
-    });
-    runtimeEmitMock.mockImplementationOnce(async () => {
-      callOrder.push("runtime");
-    });
+    const runtimeEvents: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+    const publishedTraces: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
     setSessionPromptPublishHooksForTests({
-      publishPrompt: promptPublishMock,
-      emitRuntimeEvent: runtimeEmitMock,
-      recordPublishedTrace: recordPromptPublishedTraceMock,
+      publishPrompt: async () => {
+        callOrder.push("prompt:start");
+        await publishGate.promise;
+        callOrder.push("prompt:durable");
+      },
+      emitRuntimeEvent: async (topic, payload) => {
+        callOrder.push("runtime");
+        runtimeEvents.push({ topic, payload });
+      },
+      recordPublishedTrace: (input) => {
+        publishedTraces.push(input);
+      },
     });
     const source = {
       channel: "slack",
@@ -172,24 +166,43 @@ describe("session prompt JetStream infrastructure", () => {
       sourceMessageId: "1784824412.623669",
     };
 
-    await publishSessionPrompt("ravi-slack-channel", {
+    const publish = publishSessionPrompt("ravi-slack-channel", {
       prompt: "deixa eu testar",
       source,
       deliveryBarrier: "after_tool",
       deliveryBarrierSource: "default",
     });
+    await waitUntil(() => callOrder.includes("prompt:start"));
 
-    expect(callOrder).toEqual(["prompt", "runtime"]);
-    expect(runtimeEmitMock).toHaveBeenCalledWith(
-      "ravi.session.ravi-slack-channel.runtime",
-      expect.objectContaining({
-        type: "prompt.published",
+    expect(callOrder).toEqual(["prompt:start"]);
+
+    publishGate.resolve();
+    await publish;
+
+    expect(callOrder).toEqual(["prompt:start", "prompt:durable", "runtime"]);
+    expect(runtimeEvents).toEqual([
+      {
+        topic: "ravi.session.ravi-slack-channel.runtime",
+        payload: expect.objectContaining({
+          type: "prompt.published",
+          sessionName: "ravi-slack-channel",
+          _source: source,
+          deliveryBarrier: "after_tool",
+          deliveryBarrierSource: "default",
+        }),
+      },
+    ]);
+    expect(publishedTraces).toEqual([
+      {
         sessionName: "ravi-slack-channel",
-        _source: source,
-        deliveryBarrier: "after_tool",
-        deliveryBarrierSource: "default",
-      }),
-    );
+        payload: expect.objectContaining({
+          prompt: "deixa eu testar",
+          source,
+          deliveryBarrier: "after_tool",
+          deliveryBarrierSource: "default",
+        }),
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Objective

Make the session prompt publish-ordering test deterministic while preserving its ordering guarantee.

## Problem

The test installed module-global mock hooks and restored Bun mocks globally during teardown. Because test files can run concurrently, a global restore could remove the configured one-shot implementations before the assertion, producing an empty call-order trace.

## Solution

Replace the shared hook mocks with test-local closures and a deferred publish gate. The test now proves that no runtime event is emitted while the durable publish is pending, then verifies the prompt-published runtime event and trace after the publish resolves.

## Practical impact

The affected test is isolated from global mock lifecycle interference and provides a stronger, explicit check of durable-publish-before-runtime-event ordering.

## What does NOT change

- Production session-stream code or behavior
- Session prompt payloads or runtime event contracts
- Release, packaging, or deployment workflows

## Validation

- bun test src/omni/session-stream.test.ts
- bun test src/omni/
- 10 sequential focused repetitions
- bun run test
- bun run build
- make quality
- Repository pre-push checks, including the full test suite and SDK drift check

## Risks

Low. The change is limited to one test file. A future change to the publish hook contract may require updating the local test hooks.

## Rollback

Revert commit d9a2b9b1.