### PR TITLE
Recover turns after runtime model changes

### DIFF
--- a/src/omni/session-prompt-publication.ts
+++ b/src/omni/session-prompt-publication.ts
@@ -1,0 +1,45 @@
+import type { MessageTarget } from "../runtime/message-types.js";
+
+export interface SessionPromptPublicationInput {
+  sessionName: string;
+  payload: Record<string, unknown>;
+  publishDurably(): Promise<unknown>;
+  emitRuntimeEvent(topic: string, payload: Record<string, unknown>): Promise<unknown>;
+  recordPublishedTrace(input: { sessionName: string; payload: Record<string, unknown> }): unknown;
+  onRuntimeEventError(error: unknown): void;
+  onTraceError(error: unknown): void;
+}
+
+export async function publishSessionPromptPublication(input: SessionPromptPublicationInput): Promise<void> {
+  await input.publishDurably();
+
+  if (isMessageTarget(input.payload.source)) {
+    input
+      .emitRuntimeEvent(`ravi.session.${input.sessionName}.runtime`, {
+        type: "prompt.published",
+        sessionName: input.sessionName,
+        _source: input.payload.source,
+        deliveryBarrier: input.payload.deliveryBarrier,
+        deliveryBarrierSource: input.payload.deliveryBarrierSource,
+        timestamp: new Date().toISOString(),
+      })
+      .catch(input.onRuntimeEventError);
+  }
+
+  try {
+    input.recordPublishedTrace({
+      sessionName: input.sessionName,
+      payload: input.payload,
+    });
+  } catch (error) {
+    input.onTraceError(error);
+  }
+}
+
+function isMessageTarget(value: unknown): value is MessageTarget {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const target = value as Record<string, unknown>;
+  return (
+    typeof target.channel === "string" && typeof target.accountId === "string" && typeof target.chatId === "string"
+  );
+}

--- a/src/omni/session-stream.test.ts
+++ b/src/omni/session-stream.test.ts
@@ -1,30 +1,17 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   ensureSessionConsumer,
   ensureSessionPromptInfrastructure,
   ensureSessionPromptsStream,
-  publishSessionPrompt,
   resetSessionPromptInfrastructureCacheForTests,
-  setSessionPromptPublishHooksForTests,
 } from "./session-stream.js";
+import { publishSessionPromptPublication } from "./session-prompt-publication.js";
 
 let currentJsm: PromptJsm;
-const promptPublishMock = mock(async (_subject: string, _payload: Uint8Array) => ({}));
-const runtimeEmitMock = mock(async (_topic: string, _payload: Record<string, unknown>) => {});
-const recordPromptPublishedTraceMock = mock(() => null);
-
-afterAll(() => {
-  setSessionPromptPublishHooksForTests();
-  mock.restore();
-});
 
 beforeEach(() => {
   resetSessionPromptInfrastructureCacheForTests();
-  setSessionPromptPublishHooksForTests();
   currentJsm = makePromptJsm();
-  promptPublishMock.mockClear();
-  runtimeEmitMock.mockClear();
-  recordPromptPublishedTraceMock.mockClear();
 });
 
 describe("session prompt JetStream infrastructure", () => {
@@ -151,19 +138,11 @@ describe("session prompt JetStream infrastructure", () => {
   });
 
   it("announces a sourced prompt to the runtime after its durable publish", async () => {
+    const publishGate = deferred<void>();
     const callOrder: string[] = [];
-    promptPublishMock.mockImplementationOnce(async () => {
-      callOrder.push("prompt");
-      return {};
-    });
-    runtimeEmitMock.mockImplementationOnce(async () => {
-      callOrder.push("runtime");
-    });
-    setSessionPromptPublishHooksForTests({
-      publishPrompt: promptPublishMock,
-      emitRuntimeEvent: runtimeEmitMock,
-      recordPublishedTrace: recordPromptPublishedTraceMock,
-    });
+    const runtimeEvents: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+    const publishedTraces: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const errors: unknown[] = [];
     const source = {
       channel: "slack",
       accountId: "hana-slack",
@@ -171,25 +150,65 @@ describe("session prompt JetStream infrastructure", () => {
       chatId: "C123",
       sourceMessageId: "1784824412.623669",
     };
-
-    await publishSessionPrompt("ravi-slack-channel", {
-      prompt: "deixa eu testar",
-      source,
-      deliveryBarrier: "after_tool",
-      deliveryBarrierSource: "default",
-    });
-
-    expect(callOrder).toEqual(["prompt", "runtime"]);
-    expect(runtimeEmitMock).toHaveBeenCalledWith(
-      "ravi.session.ravi-slack-channel.runtime",
-      expect.objectContaining({
-        type: "prompt.published",
-        sessionName: "ravi-slack-channel",
-        _source: source,
+    const publish = publishSessionPromptPublication({
+      sessionName: "ravi-slack-channel",
+      payload: {
+        prompt: "deixa eu testar",
+        source,
         deliveryBarrier: "after_tool",
         deliveryBarrierSource: "default",
-      }),
-    );
+      },
+      publishDurably: async () => {
+        callOrder.push("prompt:start");
+        await publishGate.promise;
+        callOrder.push("prompt:durable");
+      },
+      emitRuntimeEvent: async (topic, payload) => {
+        callOrder.push("runtime");
+        runtimeEvents.push({ topic, payload });
+      },
+      recordPublishedTrace: (input) => {
+        publishedTraces.push(input);
+      },
+      onRuntimeEventError: (error) => {
+        errors.push(error);
+      },
+      onTraceError: (error) => {
+        errors.push(error);
+      },
+    });
+    await waitUntil(() => callOrder.includes("prompt:start"));
+
+    expect(callOrder).toEqual(["prompt:start"]);
+
+    publishGate.resolve();
+    await publish;
+
+    expect(callOrder).toEqual(["prompt:start", "prompt:durable", "runtime"]);
+    expect(runtimeEvents).toEqual([
+      {
+        topic: "ravi.session.ravi-slack-channel.runtime",
+        payload: expect.objectContaining({
+          type: "prompt.published",
+          sessionName: "ravi-slack-channel",
+          _source: source,
+          deliveryBarrier: "after_tool",
+          deliveryBarrierSource: "default",
+        }),
+      },
+    ]);
+    expect(publishedTraces).toEqual([
+      {
+        sessionName: "ravi-slack-channel",
+        payload: expect.objectContaining({
+          prompt: "deixa eu testar",
+          source,
+          deliveryBarrier: "after_tool",
+          deliveryBarrierSource: "default",
+        }),
+      },
+    ]);
+    expect(errors).toEqual([]);
   });
 });
 

--- a/src/omni/session-stream.ts
+++ b/src/omni/session-stream.ts
@@ -17,9 +17,9 @@
 import { AckPolicy, DeliverPolicy, RetentionPolicy, StringCodec, type JetStreamManager } from "nats";
 import { getNats, ensureConnected, nats } from "../nats.js";
 import { inferDeliveryBarrier, requireDeliveryBarrier, type DeliveryBarrierSource } from "../delivery-barriers.js";
-import type { MessageTarget } from "../runtime/message-types.js";
 import { recordPromptPublishedTrace } from "../session-trace/channel-trace.js";
 import { logger } from "../utils/logger.js";
+import { publishSessionPromptPublication } from "./session-prompt-publication.js";
 
 const log = logger.child("session-stream");
 const sc = StringCodec();
@@ -33,13 +33,6 @@ let legacyConsumerCleanupComplete = false;
 let legacyConsumerCleanupInFlight: Promise<void> | null = null;
 let sessionPromptInfrastructureInFlight: Promise<void> | null = null;
 let sessionPromptInfrastructureReady = false;
-let sessionPromptPublishHooksForTests: SessionPromptPublishHooks | undefined;
-
-interface SessionPromptPublishHooks {
-  publishPrompt(subject: string, payload: Uint8Array): Promise<unknown>;
-  emitRuntimeEvent(topic: string, payload: Record<string, unknown>): Promise<unknown>;
-  recordPublishedTrace(input: { sessionName: string; payload: Record<string, unknown> }): unknown;
-}
 
 export interface EnsureSessionPromptInfrastructureOptions {
   force?: boolean;
@@ -207,10 +200,6 @@ export function resetSessionPromptInfrastructureCacheForTests(): void {
   sessionPromptInfrastructureReady = false;
 }
 
-export function setSessionPromptPublishHooksForTests(hooks?: SessionPromptPublishHooks): void {
-  sessionPromptPublishHooksForTests = hooks;
-}
-
 async function ensureSessionPromptInfrastructureOnce(existingJsm?: JetStreamManager): Promise<void> {
   const jsm = existingJsm ?? (await getNats().jetstreamManager());
   await ensureSessionPromptsStream(jsm);
@@ -222,14 +211,10 @@ async function ensureSessionPromptInfrastructureOnce(existingJsm?: JetStreamMana
  * Replaces: nats.emit(`ravi.session.${sessionName}.prompt`, payload)
  */
 export async function publishSessionPrompt(sessionName: string, payload: Record<string, unknown>): Promise<void> {
-  const testHooks = sessionPromptPublishHooksForTests;
-  let publishPrompt = testHooks?.publishPrompt;
-  if (!publishPrompt) {
-    const nc = await ensureConnected();
-    await ensureSessionPromptInfrastructure();
-    const js = nc.jetstream();
-    publishPrompt = (subject, encodedPayload) => js.publish(subject, encodedPayload);
-  }
+  const nc = await ensureConnected();
+  await ensureSessionPromptInfrastructure();
+  const js = nc.jetstream();
+  const publishPrompt = (subject: string, encodedPayload: Uint8Array) => js.publish(subject, encodedPayload);
   const explicitDeliveryBarrier = typeof payload.deliveryBarrier === "string" ? payload.deliveryBarrier : undefined;
   const hasExplicitBarrier = Boolean(explicitDeliveryBarrier?.trim());
   const deliveryBarrier = hasExplicitBarrier
@@ -248,57 +233,37 @@ export async function publishSessionPrompt(sessionName: string, payload: Record<
   };
   const subject = `ravi.session.${sessionName}.prompt`;
   const encodedPayload = sc.encode(JSON.stringify(enrichedPayload));
-  try {
-    await publishPrompt(subject, encodedPayload);
-  } catch (error) {
-    if (testHooks || !isPromptPublishInfrastructureError(error)) {
-      throw error;
-    }
-    sessionPromptInfrastructureReady = false;
-    log.warn("SESSION_PROMPTS publish failed after cached infrastructure; revalidating once", {
-      sessionName,
-      error,
-    });
-    await ensureSessionPromptInfrastructure(undefined, { force: true });
-    await publishPrompt(subject, encodedPayload);
-  }
-  emitPromptPublishedRuntimeEvent(sessionName, enrichedPayload, testHooks?.emitRuntimeEvent);
-  try {
-    (testHooks?.recordPublishedTrace ?? recordPromptPublishedTrace)({ sessionName, payload: enrichedPayload });
-  } catch (error) {
-    log.warn("Failed to record prompt published trace", { sessionName, error });
-  }
-}
-
-function emitPromptPublishedRuntimeEvent(
-  sessionName: string,
-  payload: Record<string, unknown>,
-  emitRuntimeEvent: SessionPromptPublishHooks["emitRuntimeEvent"] = (topic, eventPayload) =>
-    nats.emit(topic, eventPayload),
-): void {
-  if (!isMessageTarget(payload.source)) return;
-
-  emitRuntimeEvent(`ravi.session.${sessionName}.runtime`, {
-    type: "prompt.published",
+  await publishSessionPromptPublication({
     sessionName,
-    _source: payload.source,
-    deliveryBarrier: payload.deliveryBarrier,
-    deliveryBarrierSource: payload.deliveryBarrierSource,
-    timestamp: new Date().toISOString(),
-  }).catch((error) => {
-    log.warn("Failed to emit prompt published runtime event", {
-      sessionName,
-      error,
-    });
+    payload: enrichedPayload,
+    publishDurably: async () => {
+      try {
+        await publishPrompt(subject, encodedPayload);
+      } catch (error) {
+        if (!isPromptPublishInfrastructureError(error)) {
+          throw error;
+        }
+        sessionPromptInfrastructureReady = false;
+        log.warn("SESSION_PROMPTS publish failed after cached infrastructure; revalidating once", {
+          sessionName,
+          error,
+        });
+        await ensureSessionPromptInfrastructure(undefined, { force: true });
+        await publishPrompt(subject, encodedPayload);
+      }
+    },
+    emitRuntimeEvent: (topic, eventPayload) => nats.emit(topic, eventPayload),
+    recordPublishedTrace: recordPromptPublishedTrace,
+    onRuntimeEventError: (error) => {
+      log.warn("Failed to emit prompt published runtime event", {
+        sessionName,
+        error,
+      });
+    },
+    onTraceError: (error) => {
+      log.warn("Failed to record prompt published trace", { sessionName, error });
+    },
   });
-}
-
-function isMessageTarget(value: unknown): value is MessageTarget {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const target = value as Record<string, unknown>;
-  return (
-    typeof target.channel === "string" && typeof target.accountId === "string" && typeof target.chatId === "string"
-  );
 }
 
 function isDeliveryBarrierSource(value: string): value is DeliveryBarrierSource {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -2342,11 +2342,15 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     }
     await closeRuntimeSession();
 
-    if (streamingSessions.delete(sessionName)) {
-      completeRuntimeCredentialAttempt(streaming.currentRuntimeCredential?.attemptId, {
-        status: "abandoned",
-        metadata: { phase: "runtime.event_loop.finally" },
-      });
+    const stillOwnsRuntimeSlot = streamingSessions.get(sessionName) === streaming;
+    if (stillOwnsRuntimeSlot) {
+      streamingSessions.delete(sessionName);
+    }
+    completeRuntimeCredentialAttempt(streaming.currentRuntimeCredential?.attemptId, {
+      status: "abandoned",
+      metadata: { phase: "runtime.event_loop.finally" },
+    });
+    if (stillOwnsRuntimeSlot) {
       if (restartStashedReason && restartStashedSession) {
         await restartStashedSession({
           sessionName,

--- a/src/runtime/host-subscriptions.ts
+++ b/src/runtime/host-subscriptions.ts
@@ -211,7 +211,9 @@ export class RuntimeHostSubscriptions {
             .map((value) => value.trim());
 
           for (const key of new Set(keys)) {
-            const status = await this.options.dispatcher.applySessionModelChange(key, effectiveModel);
+            const status = await this.options.dispatcher.applySessionModelChange(key, effectiveModel, {
+              restartStashedMessages: true,
+            });
             if (status !== "missing") {
               log.info("Session model change applied", { key, effectiveModel, status });
               break;

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -1038,6 +1038,96 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
     }
   });
 
+  it("restarts an in-flight thread prompt after an external model change", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-thread-model-change-");
+    try {
+      const sessionKey = "agent:dev:slack:test:group:C123:thread:1784907646.950319";
+      const sessionName = "dev-t-1784907646950319";
+      getOrCreateSession(sessionKey, "dev", stateDir, { name: sessionName });
+      const dispatcher = createDispatcher(1);
+      const restartedPrompts: RuntimeLaunchPrompt[] = [];
+      let interrupted = false;
+      dispatcher.startStreamingSession = mock(async (restartedName, prompt) => {
+        expect(restartedName).toBe(sessionName);
+        restartedPrompts.push(prompt);
+        dispatcher.streamingSessions.set(
+          sessionName,
+          createActiveSession({
+            currentModel: "next-model",
+          }),
+        );
+      });
+      dispatcher.streamingSessions.set(
+        sessionName,
+        createActiveSession({
+          turnActive: true,
+          traceRunId: "run-thread-model-change",
+          currentTraceTurnId: "turn-thread-model-change",
+          currentTraceTurnStartedAt: Date.now() - 1_000,
+          currentTraceTurnTerminalRecorded: false,
+          pendingMessages: [
+            createQueuedRuntimeUserMessage({
+              prompt: "continue this thread",
+              source: {
+                channel: "slack",
+                accountId: "test",
+                chatId: "C123",
+                threadId: "1784907646.950319",
+                sourceMessageId: "1784907662.660409",
+              },
+              _agentId: "dev",
+            }),
+          ],
+          queryHandle: {
+            provider: "codex",
+            events: (async function* () {})(),
+            interrupt: async () => {
+              interrupted = true;
+            },
+          },
+        }),
+      );
+
+      const result = await dispatcher.applySessionModelChange(sessionName, "next-model", {
+        restartStashedMessages: true,
+      });
+
+      expect(result).toBe("restart-next-turn");
+      expect(interrupted).toBe(true);
+      expect(restartedPrompts).toHaveLength(1);
+      expect(restartedPrompts[0]).toMatchObject({
+        prompt: "continue this thread",
+        _agentId: "dev",
+        _resumeStashedMessages: true,
+        source: {
+          channel: "slack",
+          accountId: "test",
+          chatId: "C123",
+          threadId: "1784907646.950319",
+          sourceMessageId: "1784907662.660409",
+        },
+      });
+
+      const trace = querySessionTrace({ sessionKey, sessionName });
+      const modelRestartEvents = trace.events.filter((event) =>
+        ["dispatch.restart_requested", "turn.interrupted"].includes(event.eventType),
+      );
+      expect(modelRestartEvents.map((event) => event.eventType)).toEqual([
+        "dispatch.restart_requested",
+        "turn.interrupted",
+        "dispatch.restart_requested",
+      ]);
+      expect(modelRestartEvents.every((event) => event.sessionKey === sessionKey)).toBe(true);
+      expect(modelRestartEvents.map((event) => (event.payloadJson as { reason?: string } | null)?.reason)).toEqual([
+        "model_change_restart",
+        "model_change_restart",
+        "model_change_restart",
+      ]);
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+
   it("releases task runtime sessions when task terminal events are emitted", async () => {
     const dispatcher = createDispatcher(1);
     let interrupted = false;

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -433,19 +433,27 @@ export class RuntimeSessionDispatcher {
     model: string,
     options: {
       drainReleasedSlot?: boolean;
+      restartStashedMessages?: boolean;
       modelSource?: string | null;
       modelPresetId?: string | null;
       modelPresetVersion?: number | null;
     } = {},
   ): Promise<"missing" | "unchanged" | "applied" | "restart-next-turn"> {
-    const streaming = this.streamingSessions.get(sessionName);
+    const resolved = resolveRuntimeStreamingSession(this.streamingSessions, {
+      sessionName,
+      sessionKey: sessionName,
+    });
+    const streaming = resolved?.session;
     if (!streaming || streaming.done) {
       return "missing";
     }
+    sessionName = resolved.name;
     if (streaming.currentModel === model) {
       return "unchanged";
     }
 
+    const sessionEntry = getSessionByName(sessionName) ?? getSession(sessionName);
+    const sessionKey = sessionEntry?.sessionKey ?? sessionName;
     const presetTrace = {
       ...(options.modelSource ? { modelSource: options.modelSource } : {}),
       ...(options.modelPresetId ? { modelPresetId: options.modelPresetId } : {}),
@@ -456,7 +464,7 @@ export class RuntimeSessionDispatcher {
 
     if (resolveRuntimeModelSwitchStrategy(streaming.queryHandle) === "direct-set") {
       recordRuntimeTraceEvent({
-        sessionKey: sessionName,
+        sessionKey,
         sessionName,
         agentId: streaming.agentId,
         runId: streaming.traceRunId,
@@ -479,12 +487,13 @@ export class RuntimeSessionDispatcher {
       return "applied";
     }
 
-    if (streaming.pendingMessages.length > 0) {
+    const hasStashedMessages = streaming.pendingMessages.length > 0;
+    if (hasStashedMessages) {
       stashPendingRuntimeMessages(sessionName, streaming, this.stashedMessages);
     }
     streaming.currentModel = model;
     recordRuntimeTraceEvent({
-      sessionKey: sessionName,
+      sessionKey,
       sessionName,
       agentId: streaming.agentId,
       runId: streaming.traceRunId,
@@ -502,9 +511,16 @@ export class RuntimeSessionDispatcher {
         ...presetTrace,
       },
     });
-    recordStreamingTurnInterruptedTrace(sessionName, streaming, "model_change_restart", sessionName);
+    recordStreamingTurnInterruptedTrace(sessionName, streaming, "model_change_restart", sessionKey);
     shutdownRuntimeStreamingSession(streaming, "model_change_restart");
-    this.releaseRuntimeSessionSlot(sessionName, { drainPendingStarts: options.drainReleasedSlot ?? true });
+    const shouldRestartStashedMessages = options.restartStashedMessages === true && hasStashedMessages;
+    this.releaseRuntimeSessionSlot(sessionName, {
+      drainPendingStarts: shouldRestartStashedMessages ? false : (options.drainReleasedSlot ?? true),
+    });
+    if (shouldRestartStashedMessages) {
+      await this.restartStashedSession(sessionName, "model_change_restart");
+      this.drainPendingStarts();
+    }
     return "restart-next-turn";
   }
 

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1696,4 +1696,24 @@ describe("runtime session trace instrumentation", () => {
     ]);
     expect(streaming.done).toBe(true);
   });
+
+  it("does not remove a replacement runtime when the previous event loop exits", async () => {
+    const streaming = makeStreamingSession({ turnActive: false });
+    const replacement = makeStreamingSession({ turnActive: false });
+    const streamingSessions = new Map([[SESSION_NAME, streaming]]);
+    const runtimeSession: RuntimeSessionHandle = {
+      provider: PROVIDER,
+      events: (async function* () {
+        streamingSessions.set(SESSION_NAME, replacement);
+        yield* [];
+      })(),
+      interrupt: async () => {},
+    };
+    streaming.queryHandle = runtimeSession;
+
+    await runTraceLoop(streaming, runtimeSession, { streamingSessions });
+
+    expect(streamingSessions.get(SESSION_NAME)).toBe(replacement);
+    expect(replacement.done).toBe(false);
+  });
 });


### PR DESCRIPTION
## Objective

Ensure an in-flight Slack thread prompt still receives a response when an external model change requires the runtime to restart, while keeping session-prompt publication ordering deterministic in CI.

## Problem

The `ravi-message` thread fork was created correctly, but its first Codex turn was interrupted by a model selector event. Ravi stashed the prompt and shut down the runtime, then waited for a future message instead of resuming the stashed turn. Immediate recovery also exposed a race where the old event loop could remove the replacement runtime from the session pool.

The Quality Gate additionally exposed a test-only race under CI Bun 1.3.11: mutable hooks in `session-stream.ts` could be reset before the asynchronous durable-publish assertion observed them.

## Solution

Resume stashed messages immediately for external model changes that use the `restart-next-turn` strategy. Resolve active runtimes through canonical session identity, record model-change traces under the canonical session key, and make event-loop cleanup conditional on the old runtime still owning the pool slot.

Extract session-prompt publication ordering into a pure helper. The production path still awaits the durable JetStream publish before announcing the prompt to the runtime, while the test now uses an explicit publish gate instead of module-global mutable hooks.

## Practical impact

New Slack thread forks no longer remain silent when their first turn overlaps a model change. The interrupted prompt resumes on the selected model, the replacement runtime stays registered until its own lifecycle completes, and the publication-ordering regression test is deterministic on the Bun version used by CI.

## What does NOT change

Providers that support direct live model switching keep their existing behavior. Slack routing, thread-fork creation, model selection semantics, durable JetStream ordering, and normal session dispatch are unchanged.

## Validation

- Build and typecheck passed.
- Full lint passed across 921 source files.
- Focused runtime and provider suite: 74 tests passed.
- Runtime guards and delivery barriers: 12 tests passed.
- Session prompt publication on Bun 1.3.11: 25 reruns, 150 tests passed.
- Full Omni suite on Bun 1.3.11: 70 tests passed.
- An unrelated Observation Plane hook timed out once at its 5-second boundary during the local full pre-push run; the exact test passed immediately in isolation in 284 ms.

## Risks

The interrupted prompt is replayed only when pending messages were actually stashed and the model-change event explicitly requests recovery. The runtime ownership guard is identity-based, so an exiting runtime cannot clean up a newer replacement that occupies the same session name. The extracted publication helper preserves the existing production order and error handling.

## Rollback

Revert commits `8c65c2ab16809c4483007b439249000944eddf78` and `eda5de264e21be83aab0d9fe9047fe8d0f7de557`. No data migration is required.