### PR TITLE
test: clean isolated state fixtures immediately

### DIFF
--- a/src/test/ravi-state.test.ts
+++ b/src/test/ravi-state.test.ts
@@ -1,0 +1,21 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "./ravi-state.js";
+
+describe("isolated Ravi state", () => {
+  it("removes its temporary directory during cleanup", async () => {
+    let stateDir: string | null = null;
+
+    try {
+      stateDir = await createIsolatedRaviState("ravi-state-cleanup-test-");
+      writeFileSync(join(stateDir, "fixture.txt"), "test fixture");
+
+      await cleanupIsolatedRaviState(stateDir);
+      expect(existsSync(stateDir)).toBe(false);
+      stateDir = null;
+    } finally {
+      if (stateDir) await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+});

--- a/src/test/ravi-state.ts
+++ b/src/test/ravi-state.ts
@@ -131,6 +131,12 @@ export async function cleanupIsolatedRaviState(stateDir?: string | null): Promis
     process.env.RAVI_SUPPRESS_AUDIT_EVENTS = previousAuditSuppression;
   }
   previousAuditSuppression = undefined;
-  if (stateDir) pendingStateDirs.add(stateDir);
-  releaseRaviStateLock();
+  try {
+    if (stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+      pendingStateDirs.delete(stateDir);
+    }
+  } finally {
+    releaseRaviStateLock();
+  }
 }


### PR DESCRIPTION
## Objective

Prevent isolated Ravi test fixtures from accumulating in the macOS temporary directory during a test run.

## Problem

The shared test-state helper retained every fixture directory until the Bun process exited. Interrupted test runs therefore left large temporary SQLite fixture trees behind and exhausted local disk space.

## Solution

Remove the exact isolated state directory during cleanup after its database handles are closed, then remove it from the process-exit fallback set. The process-exit cleanup remains available for tests that terminate before cleanup executes.

## Practical impact

Long and interrupted test runs no longer retain completed fixtures until process shutdown, substantially reducing temporary-disk growth. The new regression test asserts that cleanup removes the fixture directory immediately.

## What does NOT change

This does not change daemon state, production databases, runtime behavior, or the fixture layout used while an individual test is executing. It also does not remove unrelated temporary worktrees or manual reproduction folders.

## Risks

A test that continues asynchronous work after its cleanup hook now sees its fixture removed sooner. That is an invalid lifecycle dependency and the failure would expose it. Deletion errors still release the state lock and leave the exit fallback entry intact.

## Rollback

Revert commit dd40fef8 to restore deferred, process-exit-only fixture cleanup.

## Validation

- `bun test src/test/ravi-state.test.ts`
- `git diff --check`