### PR TITLE
Fix in-process daemon runtime parity checks

### DIFF
--- a/src/cli/runtime-target.test.ts
+++ b/src/cli/runtime-target.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { matchesLiveDaemonRuntime } from "./runtime-target.js";
+
+describe("matchesLiveDaemonRuntime", () => {
+  it("accepts an in-process gateway invocation hosted by the live daemon", () => {
+    expect(
+      matchesLiveDaemonRuntime({
+        currentProcessPid: 4123,
+        daemonProcessPid: 4123,
+        cliBundlePath: "/opt/pm2/ProcessContainerForkBun.js",
+        daemonBundlePath: "/repo/dist/bundle/index.js",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps rejecting a separate CLI process from a different bundle", () => {
+    expect(
+      matchesLiveDaemonRuntime({
+        currentProcessPid: 5123,
+        daemonProcessPid: 4123,
+        cliBundlePath: "/global/dist/bundle/index.js",
+        daemonBundlePath: "/repo/dist/bundle/index.js",
+      }),
+    ).toBe(false);
+  });
+
+  it("continues accepting a separate CLI process from the daemon bundle", () => {
+    expect(
+      matchesLiveDaemonRuntime({
+        currentProcessPid: 5123,
+        daemonProcessPid: 4123,
+        cliBundlePath: "/repo/dist/bundle/index.js",
+        daemonBundlePath: "/repo/dist/bundle/index.js",
+      }),
+    ).toBe(true);
+  });
+
+  it("remains indeterminate when neither process nor bundle can prove parity", () => {
+    expect(
+      matchesLiveDaemonRuntime({
+        currentProcessPid: 5123,
+        daemonProcessPid: null,
+        cliBundlePath: null,
+        daemonBundlePath: "/repo/dist/bundle/index.js",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/cli/runtime-target.ts
+++ b/src/cli/runtime-target.ts
@@ -40,6 +40,25 @@ function normalizeComparablePath(value: string | null | undefined): string | nul
   return resolved ? resolved.toLowerCase() : null;
 }
 
+export function matchesLiveDaemonRuntime(input: {
+  currentProcessPid: number;
+  daemonProcessPid: number | null;
+  cliBundlePath: string | null;
+  daemonBundlePath: string | null;
+}): boolean | null {
+  if (
+    Number.isSafeInteger(input.daemonProcessPid) &&
+    input.daemonProcessPid !== null &&
+    input.daemonProcessPid > 0 &&
+    input.currentProcessPid === input.daemonProcessPid
+  ) {
+    return true;
+  }
+  const cliBundlePath = normalizeComparablePath(input.cliBundlePath);
+  const daemonBundlePath = normalizeComparablePath(input.daemonBundlePath);
+  return cliBundlePath && daemonBundlePath ? cliBundlePath === daemonBundlePath : null;
+}
+
 function readDaemonRuntimeInfo(): DaemonRuntimeInfo {
   try {
     const raw = execFileSync("pm2", ["jlist"], {
@@ -51,13 +70,17 @@ function readDaemonRuntimeInfo(): DaemonRuntimeInfo {
     const status = ravi?.pm2_env?.status;
     const execPath = safeRealpath(ravi?.pm2_env?.pm_exec_path ?? null);
     const cwd = safeRealpath(ravi?.pm2_env?.pm_cwd ?? null);
-    const cliBundlePath = normalizeComparablePath(process.argv[1] ?? null);
-    const daemonBundlePath = normalizeComparablePath(execPath);
+    const daemonProcessPid = typeof ravi?.pid === "number" ? ravi.pid : null;
     return {
       online: status === "online",
       execPath,
       cwd,
-      matchesCli: cliBundlePath && daemonBundlePath ? cliBundlePath === daemonBundlePath : null,
+      matchesCli: matchesLiveDaemonRuntime({
+        currentProcessPid: process.pid,
+        daemonProcessPid,
+        cliBundlePath: process.argv[1] ?? null,
+        daemonBundlePath: execPath,
+      }),
     };
   } catch {
     return {


### PR DESCRIPTION
## Objective

Recognize in-process command dispatch hosted by the live daemon without weakening runtime parity checks for separate CLI processes.

## Problem

A daemon launched through a process manager can expose the launcher as `process.argv[1]`, causing an in-process command to be rejected as a bundle mismatch even though it is already executing inside the live daemon PID.

## Solution

Treat a verified daemon PID match as authoritative for in-process dispatch, while preserving bundle-path comparison for separate processes and an indeterminate result when neither signal proves parity.

## Practical impact

Provider-backed mutations invoked inside the daemon can reach the live runtime without false mismatch errors. Separate CLIs built from another checkout remain blocked.

## What does NOT change

No command authorization, process discovery, daemon lifecycle, release behavior, or external API is changed.

## Validation

- `bun test src/cli/runtime-target.test.ts` (4 pass)
- `bun test src/cli/commands/agents.test.ts` (31 pass in the combined stack)
- `bun run typecheck`
- `bun run lint`
- `bun run build:cli`

## Risks

Incorrect PID attribution could accept a mismatched runtime, so the PID shortcut applies only when the invocation is hosted by the discovered live daemon process.

## Rollback

Revert this pull request to restore strict bundle-path parity for every invocation.