### PR TITLE
Harden local agent reconciliation after ambiguous mutations

### DIFF
--- a/packages/ravi-os-sdk/src/__tests__/local-agent-reconciliation.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/local-agent-reconciliation.test.ts
@@ -35,6 +35,8 @@ class FakeRuntime implements LocalAgentRuntimeAdapter {
     { profile: string; capabilities: readonly string[] }
   >();
   createCount = 0;
+  failCreateBeforePersist = false;
+  failCreateAfterPersist = false;
 
   async inspect(agentId: string) {
     return this.agents.get(agentId) ?? null;
@@ -46,11 +48,17 @@ class FakeRuntime implements LocalAgentRuntimeAdapter {
     runtime: LocalAgentRuntimePreference;
   }) {
     this.createCount += 1;
+    if (this.failCreateBeforePersist) {
+      throw new Error("definitive_create_failure");
+    }
     this.agents.set(input.agentId, {
       agentId: input.agentId,
       cwd: input.cwd,
       ...input.runtime,
     });
+    if (this.failCreateAfterPersist) {
+      throw new Error("ambiguous_create_result");
+    }
   }
 
   async configureRuntime(
@@ -185,6 +193,57 @@ describe("local agent reconciliation", () => {
         "utf8",
       ),
     ).toContain("Answer only within the configured scope.");
+  });
+
+  it("recovers when create persisted before returning an error", async () => {
+    const harness = await createHarness();
+    harness.runtime.failCreateAfterPersist = true;
+    const request = LocalAgentReconciliationRequestSchema.parse({
+      protocol: LOCAL_AGENT_RECONCILIATION_PROTOCOL,
+      schemaVersion: LOCAL_AGENT_RECONCILIATION_SCHEMA_VERSION,
+      requestId: "request-ambiguous-create",
+      idempotencyKey: "idempotency-ambiguous-create",
+      sourceId: "channel-example",
+      agentKey: "external-agent-ambiguous-create",
+      templateId: "standard",
+      revision: digest("revision-ambiguous-create"),
+      runtime: {
+        provider: "codex",
+        modelPreset: "balanced",
+      },
+      requestedCapabilities: ["read.messages"],
+    });
+
+    await expect(harness.reconciler.reconcile(request)).resolves.toMatchObject({
+      disposition: "created",
+      state: "ready",
+      appliedRevision: request.revision,
+      grantedCapabilities: ["read.messages"],
+    });
+    expect(harness.runtime.createCount).toBe(1);
+  });
+
+  it("stays blocked when a failed create did not persist the agent", async () => {
+    const harness = await createHarness();
+    harness.runtime.failCreateBeforePersist = true;
+    const request = LocalAgentReconciliationRequestSchema.parse({
+      protocol: LOCAL_AGENT_RECONCILIATION_PROTOCOL,
+      schemaVersion: LOCAL_AGENT_RECONCILIATION_SCHEMA_VERSION,
+      requestId: "request-definitive-create-failure",
+      idempotencyKey: "idempotency-definitive-create-failure",
+      sourceId: "channel-example",
+      agentKey: "external-agent-definitive-create-failure",
+      templateId: "standard",
+      revision: digest("revision-definitive-create-failure"),
+      requestedCapabilities: [],
+    });
+
+    await expect(harness.reconciler.reconcile(request)).resolves.toMatchObject({
+      disposition: "blocked",
+      state: "blocked",
+      error: { code: "INTERNAL" },
+    });
+    expect(harness.runtime.createCount).toBe(1);
   });
 
   it("fails closed for capability, runtime, ownership, and idempotency conflicts", async () => {

--- a/packages/ravi-os-sdk/src/local-agent-reconciliation.ts
+++ b/packages/ravi-os-sdk/src/local-agent-reconciliation.ts
@@ -576,7 +576,7 @@ export class LocalAgentReconciler {
         );
       }
 
-      const existing = await this.runtime.inspect(agentId);
+      let existing = await this.runtime.inspect(agentId);
       if (
         existing !== null &&
         normalizePath(existing.cwd) !== normalizePath(workspace)
@@ -626,12 +626,27 @@ export class LocalAgentReconciler {
           )) || changed;
       }
 
+      const createdLocally = existing === null;
       if (existing === null) {
-        await this.runtime.create({
-          agentId,
-          cwd: workspace,
-          runtime,
-        });
+        try {
+          await this.runtime.create({
+            agentId,
+            cwd: workspace,
+            runtime,
+          });
+        } catch (error) {
+          const recovered = await this.runtime.inspect(agentId);
+          if (
+            recovered === null ||
+            normalizePath(recovered.cwd) !== normalizePath(workspace)
+          ) {
+            throw error;
+          }
+          existing = recovered;
+          changed =
+            (await this.runtime.configureRuntime(recovered, runtime)) ||
+            changed;
+        }
         changed = true;
       } else {
         changed =
@@ -666,7 +681,7 @@ export class LocalAgentReconciler {
         schemaVersion: LOCAL_AGENT_RECONCILIATION_SCHEMA_VERSION,
         requestId: request.requestId,
         disposition:
-          existing === null
+          createdLocally
             ? "created"
             : changed
               ? "updated"

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -1724,12 +1724,300 @@ export const AgentsPermissionsReturnSchema = {
       ]
     },
     "agent": {
-      "additionalProperties": {
-        "$ref": "#/$defs/__schema0"
+      "additionalProperties": false,
+      "properties": {
+        "allowedSessions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "contactScope": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "debounceMs": {
+          "type": "number"
+        },
+        "defaults": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/__schema0"
+              },
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dmScope": {
+          "enum": [
+            "main",
+            "per-peer",
+            "per-channel-peer",
+            "per-account-channel-peer"
+          ],
+          "type": "string"
+        },
+        "effectiveModel": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effectiveProvider": {
+          "type": "string"
+        },
+        "effort": {
+          "enum": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+            "ultra"
+          ],
+          "type": "string"
+        },
+        "groupDebounceMs": {
+          "type": "number"
+        },
+        "heartbeat": {
+          "additionalProperties": false,
+          "properties": {
+            "accountId": {
+              "type": "string"
+            },
+            "activeEnd": {
+              "type": "string"
+            },
+            "activeStart": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "intervalMs": {
+              "type": "number"
+            },
+            "lastRunAt": {
+              "type": "number"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled",
+            "intervalMs"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "matrixAccount": {
+          "type": "string"
+        },
+        "memoryModel": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "active",
+            "sentinel"
+          ],
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelPresetId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modelPresetVersion": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modelSource": {
+          "anyOf": [
+            {
+              "enum": [
+                "agent_preset",
+                "agent_default",
+                "global_default"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "remote": {
+          "type": "string"
+        },
+        "remoteUser": {
+          "type": "string"
+        },
+        "settingSources": {
+          "items": {
+            "enum": [
+              "user",
+              "project"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "specMode": {
+          "type": "boolean"
+        },
+        "systemPromptAppend": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "assetId": {
+                "type": "string"
+              },
+              "assetType": {
+                "enum": [
+                  "agent",
+                  "automation",
+                  "app",
+                  "session",
+                  "task",
+                  "project",
+                  "profile",
+                  "contact",
+                  "chat",
+                  "route",
+                  "instance",
+                  "artifact",
+                  "insight",
+                  "workflow_spec",
+                  "workflow_run",
+                  "workflow_node",
+                  "cron_job",
+                  "trigger",
+                  "hook",
+                  "task_automation",
+                  "observer_rule",
+                  "observer_binding",
+                  "observer_profile",
+                  "command",
+                  "skill",
+                  "skill_gate_rule",
+                  "context",
+                  "call_profile",
+                  "call_request",
+                  "call_voice_agent",
+                  "call_tool",
+                  "outbound_queue",
+                  "outbound_entry",
+                  "spec",
+                  "devin_session"
+                ],
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "number"
+              },
+              "createdBy": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": {
+                  "$ref": "#/$defs/__schema0"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "source": {
+                "type": "string"
+              },
+              "tagId": {
+                "type": "string"
+              },
+              "tagSlug": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "number"
+              },
+              "updatedBy": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "tagId",
+              "tagSlug",
+              "assetType",
+              "assetId",
+              "source",
+              "createdAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
       },
-      "propertyNames": {
-        "type": "string"
-      },
+      "required": [
+        "id",
+        "cwd",
+        "modelPresetId",
+        "isDefault",
+        "effectiveProvider",
+        "effectiveModel",
+        "modelSource",
+        "modelPresetVersion",
+        "tags"
+      ],
       "type": "object"
     },
     "agentId": {

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -323,7 +323,56 @@ export type AgentsPermissionsReturn = {
     })>;
     profile?: "bootstrap" | "full-access";
   }) | null;
-  agent?: Record<string, unknown>;
+  agent?: {
+    allowedSessions?: string[];
+    contactScope?: string;
+    cwd: string;
+    debounceMs?: number;
+    defaults?: (Record<string, unknown>) | null;
+    dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+    effectiveModel: string | null;
+    effectiveProvider: string;
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
+    groupDebounceMs?: number;
+    heartbeat?: {
+      accountId?: string;
+      activeEnd?: string;
+      activeStart?: string;
+      enabled: boolean;
+      intervalMs: number;
+      lastRunAt?: number;
+      model?: string;
+    };
+    id: string;
+    isDefault: boolean;
+    matrixAccount?: string;
+    memoryModel?: string;
+    mode?: "active" | "sentinel";
+    model?: string;
+    modelPresetId: string | null;
+    modelPresetVersion: number | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    name?: string;
+    provider?: string;
+    remote?: string;
+    remoteUser?: string;
+    settingSources?: Array<"user" | "project">;
+    specMode?: boolean;
+    systemPromptAppend?: string;
+    tags: Array<{
+      assetId: string;
+      assetType: "agent" | "automation" | "app" | "session" | "task" | "project" | "profile" | "contact" | "chat" | "route" | "instance" | "artifact" | "insight" | "workflow_spec" | "workflow_run" | "workflow_node" | "cron_job" | "trigger" | "hook" | "task_automation" | "observer_rule" | "observer_binding" | "observer_profile" | "command" | "skill" | "skill_gate_rule" | "context" | "call_profile" | "call_request" | "call_voice_agent" | "call_tool" | "outbound_queue" | "outbound_entry" | "spec" | "devin_session";
+      createdAt: number;
+      createdBy?: string;
+      id: string;
+      metadata?: Record<string, unknown>;
+      source: string;
+      tagId: string;
+      tagSlug: string;
+      updatedAt: number;
+      updatedBy?: string;
+    }>;
+  };
   agentId: string;
   before?: ({
     capabilities?: Array<string | ({

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:8454b109dade2d0c46f430067c2bb571598bacf6aace7f21972854564f476051";
+export const REGISTRY_HASH = "sha256:0b086659e9e513b19a759e940b13b19c392d03894813f0e343425eb1b0cb39f2";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "da9be7fcb14d";
+export const GIT_SHA = "ba85577521cf";

--- a/src/cli/commands/agents.test.ts
+++ b/src/cli/commands/agents.test.ts
@@ -15,6 +15,15 @@ type AgentLike = {
   provider?: string;
   remote?: string;
   defaults?: Record<string, unknown> | null;
+  heartbeat?: {
+    enabled: boolean;
+    intervalMs: number;
+    model?: string;
+    accountId?: string;
+    activeStart?: string;
+    activeEnd?: string;
+    lastRunAt?: number;
+  };
 };
 
 type SessionLike = {
@@ -220,9 +229,8 @@ mock.module("../../runtime/model-preset-store.js", () => ({
 }));
 
 const { AgentsCommands } = await import("./agents.js");
-const { agentSetReturnSchema, agentShowReturnSchema, agentsListReturnSchema } = await import(
-  "./operational-return-schemas.js"
-);
+const { agentPermissionsReturnSchema, agentSetReturnSchema, agentShowReturnSchema, agentsListReturnSchema } =
+  await import("./operational-return-schemas.js");
 
 describe("AgentsCommands public return contracts", () => {
   beforeEach(() => {
@@ -702,6 +710,30 @@ describe("AgentsCommands permissions", () => {
     }
 
     expect(updateAgentCalls).toEqual([]);
+  });
+
+  it("validates a permission payload before JSON strips optional heartbeat fields", () => {
+    currentAgent = {
+      id: "dev",
+      cwd: "/tmp/dev",
+      heartbeat: {
+        enabled: false,
+        intervalMs: 1_800_000,
+        model: undefined,
+        accountId: undefined,
+      },
+    };
+    const commands = new AgentsCommands();
+    const originalLog = console.log;
+    console.log = () => {};
+
+    try {
+      const payload = commands.permissions("dev", undefined, undefined, true);
+
+      expect(agentPermissionsReturnSchema.safeParse(payload).success).toBe(true);
+    } finally {
+      console.log = originalLog;
+    }
   });
 
   it("clears provider-runtime permissions from agent defaults", () => {

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -1963,7 +1963,7 @@ export const agentPermissionsReturnSchema = z.object({
   after: agentRuntimePermissionsConfigReturnSchema.optional(),
   defaults: jsonObjectSchema.nullable().optional(),
   command: z.string().optional(),
-  agent: jsonObjectSchema.optional(),
+  agent: agentJsonSummaryReturnSchema.optional(),
 });
 
 export const agentDebounceReturnSchema = z


### PR DESCRIPTION
## Objective

Make local agent reconciliation converge safely when a create mutation persists but its response is lost or ambiguous.

## Problem

A transport failure after persistence can make a retry observe an existing agent and incorrectly treat the operation as a conflict, while a permissive retry could take ownership of an unrelated workspace.

## Solution

Re-inspect the persisted agent after ambiguous create failures, accept only an exact trusted local ownership match, converge runtime permissions idempotently, validate command return payloads, and refresh the generated SDK projection.

## Practical impact

Provider-backed local reconciliation can recover from post-commit response failures without duplicate agents or repeated equal permission writes.

## What does NOT change

Remote requests still cannot carry local workspace configuration, mismatched ownership remains blocked, and no new authority is granted.

## Validation

- `bun test packages/ravi-os-sdk/src/__tests__/local-agent-reconciliation.test.ts` (7 pass)
- `bun test src/cli/commands/agents.test.ts` (31 pass)
- `bun run sdk:check`
- `bun run typecheck`
- `bun run lint`
- `bun run build:cli`

## Risks

An overly broad recovery match could claim an unrelated agent, so recovery requires the exact expected identifier, workspace ownership, capability, runtime, and idempotency context.

## Rollback

Revert this pull request to restore fail-closed behavior after every ambiguous create response.