### PR TITLE
Add remote endpoint login discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,15 @@ Cloud-linked artifact publishing is exposed through a generic Console-compatible
 
 ```bash
 ravi login
+ravi login --endpoint https://auth.example.com
 ravi whoami
 ravi artifacts publish <artifact-id-or-path> --project <project> --site <site>
 ```
+
+An explicit endpoint publishes a versioned login contract at
+`/.well-known/ravi-auth`. HTTPS is required outside loopback development.
+Endpoint-specific post-login integration is opt-in and loads only a local
+provider module explicitly configured by the operator.
 
 The proprietary server policy for hosted artifacts, billing, quotas, private asset auth, custom domains, and Console product behavior intentionally lives outside this open-source repo.
 

--- a/packages/ravi-os-sdk/README.md
+++ b/packages/ravi-os-sdk/README.md
@@ -120,8 +120,25 @@ Deep imports are available when you want smaller bundles:
 import { RaviClient } from "@ravi-os/sdk/client";
 import type { NativeChannelDriver } from "@ravi-os/sdk/native-channel-driver";
 import { LocalAgentReconciler } from "@ravi-os/sdk/local-agent-reconciliation";
+import type { RemoteLoginProvider } from "@ravi-os/sdk/remote-login-provider";
 import { createHttpTransport } from "@ravi-os/sdk/transport/http";
 ```
+
+### Extend Remote Login Locally
+
+`ravi login --endpoint https://auth.example.com` discovers the endpoint's
+versioned authentication contract. An endpoint may name a post-login provider,
+but Ravi loads it only when the operator explicitly maps that provider to a
+local package or `file:///` module:
+
+```bash
+export RAVI_REMOTE_LOGIN_PROVIDERS='[{"protocol":"ravi.auth.post-login","schemaVersion":1,"provider":"example","moduleSpecifier":"@example/ravi-login-provider"}]'
+```
+
+The module exports `remoteLoginProvider`, implements `RemoteLoginProvider`, and
+returns a bounded opaque renewable credential. Ravi stores that credential
+separately from the human CLI session, redacts its material from command
+output, and preserves it when `ravi logout` removes the human session.
 
 ### Reconcile Locally Managed Agents
 

--- a/packages/ravi-os-sdk/package.json
+++ b/packages/ravi-os-sdk/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/native-channel-driver.d.ts",
       "default": "./dist/native-channel-driver.js"
     },
+    "./remote-login-provider": {
+      "types": "./dist/remote-login-provider.d.ts",
+      "default": "./dist/remote-login-provider.js"
+    },
     "./local-agent-reconciliation": {
       "types": "./dist/local-agent-reconciliation.d.ts",
       "default": "./dist/local-agent-reconciliation.js"

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-request.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-request.json
@@ -1,0 +1,8 @@
+{
+  "body": {
+    "clientInstallationId": "client-installation-a",
+    "publicProof": "opaque-public-proof-a"
+  },
+  "method": "POST",
+  "path": "/v1/installations/reconcile"
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-response.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-response.json
@@ -1,0 +1,7 @@
+{
+  "body": {
+    "credentialId": "credential-a",
+    "disposition": "reconciled"
+  },
+  "status": 200
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json
@@ -1,0 +1,13 @@
+{
+  "authConfigEndpoint": "https://auth.example/v1/auth/config",
+  "installationProvider": "example",
+  "issuer": "https://auth.example",
+  "protocol": "ravi.auth.discovery",
+  "schemaVersion": 1,
+  "sessionEndpoints": {
+    "exchange": "https://auth.example/v1/auth/exchange",
+    "logout": "https://auth.example/v1/auth/logout",
+    "me": "https://auth.example/v1/auth/me",
+    "refresh": "https://auth.example/v1/auth/refresh"
+  }
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-credential.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-credential.json
@@ -1,0 +1,11 @@
+{
+  "credentialId": "credential-a",
+  "expiresAt": "2026-08-24T18:00:00.000Z",
+  "material": {
+    "credentialHandle": "opaque-material-a"
+  },
+  "provider": "example",
+  "publicMetadata": {
+    "installationId": "installation-a"
+  }
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-metadata.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-metadata.json
@@ -1,0 +1,7 @@
+{
+  "clientInstallationId": "client-installation-a",
+  "hostname": "example-host",
+  "name": "Example runtime",
+  "platform": "example-platform",
+  "raviVersion": "1.0.0"
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/module-config.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/module-config.json
@@ -1,0 +1,6 @@
+{
+  "moduleSpecifier": "@example/remote-login-provider",
+  "protocol": "ravi.auth.post-login",
+  "provider": "example",
+  "schemaVersion": 1
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json
@@ -1,0 +1,5 @@
+{
+  "protocol": "ravi.auth.post-login",
+  "provider": "example",
+  "schemaVersion": 1
+}

--- a/packages/ravi-os-sdk/src/__tests__/remote-login-provider.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/remote-login-provider.test.ts
@@ -5,12 +5,34 @@ import {
   REMOTE_LOGIN_PROVIDER_PROTOCOL,
   REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
   RemoteInstallationCredentialSchema,
+  RemoteLoginAuthorizedRequestSchema,
+  RemoteLoginAuthorizedResponseSchema,
   RemoteLoginDiscoverySchema,
+  RemoteLoginInstallationMetadataSchema,
   RemoteLoginProviderDescriptorSchema,
+  RemoteLoginProviderModuleConfigSchema,
   type RemoteLoginProvider,
 } from "../remote-login-provider.js";
 
+const fixtureDirectory = new URL("./fixtures/remote-login-provider/", import.meta.url);
+
+async function fixture(name: string): Promise<unknown> {
+  return Bun.file(new URL(name, fixtureDirectory)).json();
+}
+
 describe("remote login provider SDK contract", () => {
+  it("accepts every projected ABI fixture", async () => {
+    expect(RemoteLoginDiscoverySchema.parse(await fixture("discovery.json"))).toBeDefined();
+    expect(RemoteLoginInstallationMetadataSchema.parse(await fixture("installation-metadata.json"))).toBeDefined();
+    expect(RemoteLoginAuthorizedRequestSchema.parse(await fixture("authorized-request.json"))).toBeDefined();
+    expect(RemoteLoginAuthorizedResponseSchema.parse(await fixture("authorized-response.json"))).toBeDefined();
+    expect(RemoteLoginProviderDescriptorSchema.parse(await fixture("provider-descriptor.json"))).toBeDefined();
+    expect(RemoteInstallationCredentialSchema.parse(await fixture("installation-credential.json"))).toBeDefined();
+    expect(
+      RemoteLoginProviderModuleConfigSchema.parse(await fixture("module-config.json")),
+    ).toMatchObject({ provider: "example" });
+  });
+
   it("validates discovery, provider, and opaque installation credentials", async () => {
     const discovery = RemoteLoginDiscoverySchema.parse({
       protocol: REMOTE_LOGIN_DISCOVERY_PROTOCOL,
@@ -31,13 +53,25 @@ describe("remote login provider SDK contract", () => {
         schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
         provider: "example",
       }),
-      reconcileInstallation: async () =>
-        RemoteInstallationCredentialSchema.parse({
+      reconcileInstallation: async (context) => {
+        const response = await context.authorization.request({
+          method: "POST",
+          path: "/v1/installations/reconcile",
+          body: {
+            clientInstallationId: context.installation.clientInstallationId,
+          },
+        });
+        expect(response).toEqual({
+          status: 200,
+          body: { disposition: "reconciled" },
+        });
+        return RemoteInstallationCredentialSchema.parse({
           provider: "example",
           credentialId: "credential_1",
-          material: { renewableCredential: "secret" },
+          material: { credentialHandle: "opaque-material" },
           publicMetadata: { installationId: "installation_1" },
-        }),
+        });
+      },
     };
 
     expect(discovery.installationProvider).toBe("example");
@@ -45,11 +79,11 @@ describe("remote login provider SDK contract", () => {
       provider.reconcileInstallation({
         endpointUrl: discovery.issuer,
         discovery,
-        humanCredentials: {
-          accessToken: "access-secret",
-          refreshToken: "refresh-secret",
-          accessTokenExpiresAt: null,
-          scopes: [],
+        authorization: {
+          request: async () => ({
+            status: 200,
+            body: { disposition: "reconciled" },
+          }),
         },
         installation: {
           clientInstallationId: "client_installation_1",

--- a/packages/ravi-os-sdk/src/__tests__/remote-login-provider.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/remote-login-provider.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import {
+  REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+  REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+  REMOTE_LOGIN_PROVIDER_PROTOCOL,
+  REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+  RemoteInstallationCredentialSchema,
+  RemoteLoginDiscoverySchema,
+  RemoteLoginProviderDescriptorSchema,
+  type RemoteLoginProvider,
+} from "../remote-login-provider.js";
+
+describe("remote login provider SDK contract", () => {
+  it("validates discovery, provider, and opaque installation credentials", async () => {
+    const discovery = RemoteLoginDiscoverySchema.parse({
+      protocol: REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+      schemaVersion: REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+      issuer: "https://auth.example",
+      authConfigEndpoint: "https://auth.example/v1/auth/config",
+      sessionEndpoints: {
+        exchange: "https://auth.example/v1/auth/exchange",
+        refresh: "https://auth.example/v1/auth/refresh",
+        logout: "https://auth.example/v1/auth/logout",
+        me: "https://auth.example/v1/me",
+      },
+      installationProvider: "example",
+    });
+    const provider: RemoteLoginProvider = {
+      descriptor: RemoteLoginProviderDescriptorSchema.parse({
+        protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+        schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+        provider: "example",
+      }),
+      reconcileInstallation: async () =>
+        RemoteInstallationCredentialSchema.parse({
+          provider: "example",
+          credentialId: "credential_1",
+          material: { renewableCredential: "secret" },
+          publicMetadata: { installationId: "installation_1" },
+        }),
+    };
+
+    expect(discovery.installationProvider).toBe("example");
+    await expect(
+      provider.reconcileInstallation({
+        endpointUrl: discovery.issuer,
+        discovery,
+        humanCredentials: {
+          accessToken: "access-secret",
+          refreshToken: "refresh-secret",
+          accessTokenExpiresAt: null,
+          scopes: [],
+        },
+        installation: {
+          clientInstallationId: "client_installation_1",
+          name: "Example runtime",
+          hostname: "example-host",
+          platform: "example-platform",
+        },
+      }),
+    ).resolves.toMatchObject({
+      provider: "example",
+      credentialId: "credential_1",
+    });
+  });
+
+  it("rejects values that would be silently changed by JSON persistence", () => {
+    expect(() =>
+      RemoteInstallationCredentialSchema.parse({
+        provider: "example",
+        credentialId: "credential_1",
+        material: { silentlyDropped: undefined },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
@@ -36,8 +36,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json"
     },
     {
-      "sha256": "6fc68f80da12c6e55d080aff8de21567dd6463ccfb157eb1a73595a35a098841",
-      "sizeBytes": 6492,
+      "sha256": "e941d8337ae59c44ecf411e7d76c6e081a2f028f01f5741f837a749aa2a6d5ad",
+      "sizeBytes": 6502,
       "targetPath": "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
     }
   ],
@@ -64,7 +64,7 @@
     "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "7cf7a63d04cad430a724b28ecbe5004a16166b836dea244a5f735f094102a8e5",
+  "outputDigest": "940b72acd4cffb9320f513b09c2a6361eed48079e51515cab860ade2ac049920",
   "rationale": "Remote endpoint login needs a versioned provider-neutral boundary for explicit local post-login reconciliation without loading code from the endpoint.",
   "schemaAllowlist": [
     {
@@ -131,7 +131,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "c724404620daa292da750d11d1f90b8cc246756fe95b3f0663492b8ce9e01229",
+  "sourceDigest": "ffa2384caf33507d6b65e49ed43e087d522ea81cf062082c834d82748649b6bd",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
@@ -1,0 +1,127 @@
+{
+  "artifacts": [
+    {
+      "sha256": "0666f1ea6acae947b8185f2d54fab2fdc23e5072fa9ada22fdc3f02e7c69fbe2",
+      "sizeBytes": 436,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json"
+    },
+    {
+      "sha256": "f69ab6d8aceb58dfaa3775b71c14892f3d64252046506c7cd016a82d8813b8e5",
+      "sizeBytes": 236,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-credential.json"
+    },
+    {
+      "sha256": "fed1716f244fb6822b1bd2bf24562ae6401da0c25a1e19e54d20711b40a6950f",
+      "sizeBytes": 173,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-metadata.json"
+    },
+    {
+      "sha256": "4e18d16c75c1c299471ffb08c12c756174b7332b0ef55a0aae0383e4f1484c85",
+      "sizeBytes": 143,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/module-config.json"
+    },
+    {
+      "sha256": "ad40c24bc0c94946eb64642a348265c6d0968a7a81409b11d7912e8ae109af2c",
+      "sizeBytes": 88,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json"
+    },
+    {
+      "sha256": "46f50c2ab6518de0cd526fa2092924c1bcc6eac357e06e74a6f1b797e9f360d7",
+      "sizeBytes": 5293,
+      "targetPath": "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
+    }
+  ],
+  "capsule": "remote-login-provider",
+  "capsuleVersion": 1,
+  "compatibilityProfile": "additive-v1",
+  "exclusions": [
+    "taxonomy-boundary-v1",
+    "authorization-boundary-v1",
+    "commercial-boundary-v1",
+    "network-boundary-v1",
+    "payload-boundary-v1",
+    "secret-boundary-v1"
+  ],
+  "fileAllowlist": [
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-credential.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-metadata.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/module-config.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json",
+    "packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json",
+    "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
+  ],
+  "formatVersion": 1,
+  "outputDigest": "354e5ab65c8fc3ea2de0a12a4a4b70169ef8e88ebd887bb607fbc7029e4c6192",
+  "rationale": "Remote endpoint login needs a versioned provider-neutral boundary for explicit local post-login reconciliation without loading code from the endpoint.",
+  "schemaAllowlist": [
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "issuer",
+        "authConfigEndpoint",
+        "sessionEndpoints",
+        "installationProvider"
+      ],
+      "schema": "RemoteLoginDiscovery"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "provider",
+        "moduleSpecifier"
+      ],
+      "schema": "RemoteLoginProviderModuleConfig"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "provider"
+      ],
+      "schema": "RemoteLoginProviderDescriptor"
+    },
+    {
+      "fields": [
+        "clientInstallationId",
+        "name",
+        "hostname",
+        "platform",
+        "raviVersion"
+      ],
+      "schema": "RemoteLoginInstallationMetadata"
+    },
+    {
+      "fields": [
+        "provider",
+        "credentialId",
+        "material",
+        "publicMetadata",
+        "expiresAt"
+      ],
+      "schema": "RemoteInstallationCredential"
+    }
+  ],
+  "sourceDigest": "555770c31a1e959b678fdeebf424bc76808dd5e2d802bfdc15a1dd9e71a320cb",
+  "targetRepository": "filipexyz/ravi",
+  "validations": [
+    {
+      "command": [
+        "bun",
+        "test",
+        "packages/ravi-os-sdk/src/__tests__/remote-login-provider.test.ts"
+      ],
+      "id": "sdk-contract"
+    },
+    {
+      "command": [
+        "bun",
+        "run",
+        "typecheck"
+      ],
+      "id": "typecheck"
+    }
+  ]
+}

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.capsule.json
@@ -1,6 +1,16 @@
 {
   "artifacts": [
     {
+      "sha256": "7cd0358ac4ca4b42ff191419803a39018a4443f10306b60ce14205fcdbfcab5a",
+      "sizeBytes": 177,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-request.json"
+    },
+    {
+      "sha256": "12f882826462fc7afe8e5fbfad501134a4dd576f914be9db2573142f27f80bcf",
+      "sizeBytes": 105,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-response.json"
+    },
+    {
       "sha256": "0666f1ea6acae947b8185f2d54fab2fdc23e5072fa9ada22fdc3f02e7c69fbe2",
       "sizeBytes": 436,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json"
@@ -26,8 +36,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/provider-descriptor.json"
     },
     {
-      "sha256": "46f50c2ab6518de0cd526fa2092924c1bcc6eac357e06e74a6f1b797e9f360d7",
-      "sizeBytes": 5293,
+      "sha256": "6fc68f80da12c6e55d080aff8de21567dd6463ccfb157eb1a73595a35a098841",
+      "sizeBytes": 6492,
       "targetPath": "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
     }
   ],
@@ -43,6 +53,8 @@
     "secret-boundary-v1"
   ],
   "fileAllowlist": [
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-request.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/authorized-response.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/discovery.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-credential.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/remote-login-provider/installation-metadata.json",
@@ -52,7 +64,7 @@
     "packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "354e5ab65c8fc3ea2de0a12a4a4b70169ef8e88ebd887bb607fbc7029e4c6192",
+  "outputDigest": "7cf7a63d04cad430a724b28ecbe5004a16166b836dea244a5f735f094102a8e5",
   "rationale": "Remote endpoint login needs a versioned provider-neutral boundary for explicit local post-login reconciliation without loading code from the endpoint.",
   "schemaAllowlist": [
     {
@@ -95,6 +107,21 @@
     },
     {
       "fields": [
+        "method",
+        "path",
+        "body"
+      ],
+      "schema": "RemoteLoginAuthorizedRequest"
+    },
+    {
+      "fields": [
+        "status",
+        "body"
+      ],
+      "schema": "RemoteLoginAuthorizedResponse"
+    },
+    {
+      "fields": [
         "provider",
         "credentialId",
         "material",
@@ -104,7 +131,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "555770c31a1e959b678fdeebf424bc76808dd5e2d802bfdc15a1dd9e71a320cb",
+  "sourceDigest": "c724404620daa292da750d11d1f90b8cc246756fe95b3f0663492b8ce9e01229",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
@@ -1,0 +1,193 @@
+{
+  "$defs": {
+    "RemoteInstallationCredential": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "credentialId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "expiresAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "material": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "provider": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "publicMetadata": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "provider",
+        "credentialId",
+        "material"
+      ],
+      "type": "object"
+    },
+    "RemoteLoginDiscovery": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "authConfigEndpoint": {
+          "format": "uri",
+          "type": "string"
+        },
+        "installationProvider": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "issuer": {
+          "format": "uri",
+          "type": "string"
+        },
+        "protocol": {
+          "const": "ravi.auth.discovery",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        },
+        "sessionEndpoints": {
+          "additionalProperties": false,
+          "properties": {
+            "exchange": {
+              "format": "uri",
+              "type": "string"
+            },
+            "logout": {
+              "format": "uri",
+              "type": "string"
+            },
+            "me": {
+              "format": "uri",
+              "type": "string"
+            },
+            "refresh": {
+              "format": "uri",
+              "type": "string"
+            }
+          },
+          "required": [
+            "exchange",
+            "refresh",
+            "logout",
+            "me"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "issuer",
+        "authConfigEndpoint",
+        "sessionEndpoints"
+      ],
+      "type": "object"
+    },
+    "RemoteLoginInstallationMetadata": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "clientInstallationId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "raviVersion": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientInstallationId",
+        "name",
+        "hostname",
+        "platform"
+      ],
+      "type": "object"
+    },
+    "RemoteLoginProviderDescriptor": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "protocol": {
+          "const": "ravi.auth.post-login",
+          "type": "string"
+        },
+        "provider": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "provider"
+      ],
+      "type": "object"
+    },
+    "RemoteLoginProviderModuleConfig": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "moduleSpecifier": {
+          "pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\\/\\/\\/[^\\u0000-\\u001f\\u007f]+)$",
+          "type": "string"
+        },
+        "protocol": {
+          "const": "ravi.auth.post-login",
+          "type": "string"
+        },
+        "provider": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "provider",
+        "moduleSpecifier"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "urn:ravi:channel-capsule:remote-login-provider:v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "capsuleVersion": 1,
+  "compatibilityProfile": "additive-v1",
+  "sourceDigest": "555770c31a1e959b678fdeebf424bc76808dd5e2d802bfdc15a1dd9e71a320cb",
+  "title": "remote-login-provider channel capability"
+}

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
@@ -39,6 +39,57 @@
       ],
       "type": "object"
     },
+    "RemoteLoginAuthorizedRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "method": {
+          "enum": [
+            "GET",
+            "POST"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "pattern": "^\\/(?!\\/)[^\\u0000-\\u001f\\u007f#]*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method",
+        "path"
+      ],
+      "type": "object"
+    },
+    "RemoteLoginAuthorizedResponse": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "status": {
+          "maximum": 599,
+          "minimum": 100,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
     "RemoteLoginDiscovery": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -188,6 +239,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "555770c31a1e959b678fdeebf424bc76808dd5e2d802bfdc15a1dd9e71a320cb",
+  "sourceDigest": "c724404620daa292da750d11d1f90b8cc246756fe95b3f0663492b8ce9e01229",
   "title": "remote-login-provider channel capability"
 }

--- a/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
+++ b/packages/ravi-os-sdk/src/generated/remote-login-provider.schema.json
@@ -58,7 +58,7 @@
           "type": "string"
         },
         "path": {
-          "pattern": "^\\/(?!\\/)[^\\u0000-\\u001f\\u007f#]*$",
+          "pattern": "^\\/(?!\\/)(?!.*\\\\)[^\\u0000-\\u001f\\u007f#]*$",
           "type": "string"
         }
       },
@@ -239,6 +239,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "c724404620daa292da750d11d1f90b8cc246756fe95b3f0663492b8ce9e01229",
+  "sourceDigest": "ffa2384caf33507d6b65e49ed43e087d522ea81cf062082c834d82748649b6bd",
   "title": "remote-login-provider channel capability"
 }

--- a/packages/ravi-os-sdk/src/index.ts
+++ b/packages/ravi-os-sdk/src/index.ts
@@ -60,5 +60,6 @@ export { SDK_VERSION, REGISTRY_HASH, GIT_SHA } from "./version.js";
 export * from "./channel-backend.js";
 export * from "./channel-runtime-events.js";
 export * from "./native-channel-driver.js";
+export * from "./remote-login-provider.js";
 export * from "./types.js";
 export * from "./schemas.js";

--- a/packages/ravi-os-sdk/src/remote-login-provider.ts
+++ b/packages/ravi-os-sdk/src/remote-login-provider.ts
@@ -7,6 +7,11 @@ export const REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION = 1 as const;
 
 const WireKindSchema = z.string().regex(/^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/).max(96);
 const OpaqueIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._~-]*$/).max(128);
+const ModuleSpecifierSchema = z
+  .string()
+  .regex(
+    /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/,
+  );
 const BoundedOpaqueRecordSchema = z.record(z.string(), z.unknown()).superRefine((value, context) => {
   if (!isJsonRecord(value)) {
     context.addIssue({
@@ -78,6 +83,56 @@ export const RemoteLoginProviderDescriptorSchema = z
   })
   .strict();
 
+export const RemoteLoginProviderModuleConfigSchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_PROVIDER_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION),
+    provider: WireKindSchema,
+    moduleSpecifier: ModuleSpecifierSchema,
+  })
+  .strict();
+
+export const RemoteLoginInstallationMetadataSchema = z
+  .object({
+    clientInstallationId: OpaqueIdSchema,
+    name: z.string().min(1).max(256),
+    hostname: z.string().min(1).max(256),
+    platform: z.string().min(1).max(128),
+    raviVersion: z.string().min(1).max(128).optional(),
+  })
+  .strict();
+
+export const RemoteLoginAuthorizedRequestSchema = z
+  .object({
+    method: z.enum(["GET", "POST"]),
+    path: z
+      .string()
+      .min(1)
+      .max(4096)
+      .regex(
+        /^\/(?!\/)(?!.*\\)[^\u0000-\u001f\u007f#]*$/,
+        "must be an origin-relative path without a fragment",
+      ),
+    body: BoundedOpaqueRecordSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.method === "GET" && value.body !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["body"],
+        message: "GET requests must not carry a body",
+      });
+    }
+  });
+
+export const RemoteLoginAuthorizedResponseSchema = z
+  .object({
+    status: z.number().int().min(100).max(599),
+    body: BoundedOpaqueRecordSchema.optional(),
+  })
+  .strict();
+
 export const RemoteInstallationCredentialSchema = z
   .object({
     provider: WireKindSchema,
@@ -89,28 +144,20 @@ export const RemoteInstallationCredentialSchema = z
   .strict();
 
 export type RemoteLoginDiscovery = z.infer<typeof RemoteLoginDiscoverySchema>;
+export type RemoteLoginProviderModuleConfig = z.infer<typeof RemoteLoginProviderModuleConfigSchema>;
+export type RemoteLoginInstallationMetadata = z.infer<typeof RemoteLoginInstallationMetadataSchema>;
+export type RemoteLoginAuthorizedRequest = z.infer<typeof RemoteLoginAuthorizedRequestSchema>;
+export type RemoteLoginAuthorizedResponse = z.infer<typeof RemoteLoginAuthorizedResponseSchema>;
 export type RemoteInstallationCredential = z.infer<typeof RemoteInstallationCredentialSchema>;
 
-export interface RemoteLoginHumanCredentials {
-  readonly accessToken: string;
-  readonly refreshToken: string;
-  readonly accessTokenExpiresAt: string | null;
-  readonly refreshTokenExpiresAt?: string | null;
-  readonly scopes: readonly string[];
-}
-
-export interface RemoteLoginInstallationMetadata {
-  readonly clientInstallationId: string;
-  readonly name: string;
-  readonly hostname: string;
-  readonly platform: string;
-  readonly raviVersion?: string;
+export interface RemoteLoginAuthorization {
+  request(input: RemoteLoginAuthorizedRequest): Promise<RemoteLoginAuthorizedResponse>;
 }
 
 export interface RemoteLoginProviderContext {
   readonly endpointUrl: string;
   readonly discovery: RemoteLoginDiscovery;
-  readonly humanCredentials: RemoteLoginHumanCredentials;
+  readonly authorization: RemoteLoginAuthorization;
   readonly installation: RemoteLoginInstallationMetadata;
   readonly previousCredential?: RemoteInstallationCredential;
 }

--- a/packages/ravi-os-sdk/src/remote-login-provider.ts
+++ b/packages/ravi-os-sdk/src/remote-login-provider.ts
@@ -1,0 +1,154 @@
+import { z } from "zod";
+
+export const REMOTE_LOGIN_DISCOVERY_PROTOCOL = "ravi.auth.discovery" as const;
+export const REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION = 1 as const;
+export const REMOTE_LOGIN_PROVIDER_PROTOCOL = "ravi.auth.post-login" as const;
+export const REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION = 1 as const;
+
+const WireKindSchema = z.string().regex(/^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/).max(96);
+const OpaqueIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._~-]*$/).max(128);
+const BoundedOpaqueRecordSchema = z.record(z.string(), z.unknown()).superRefine((value, context) => {
+  if (!isJsonRecord(value)) {
+    context.addIssue({
+      code: "custom",
+      message: "value must contain only JSON values",
+    });
+    return;
+  }
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    context.addIssue({
+      code: "custom",
+      message: "value must be JSON serializable",
+    });
+    return;
+  }
+  if (new TextEncoder().encode(encoded).byteLength > 65_536) {
+    context.addIssue({
+      code: "custom",
+      message: "value exceeds the supported size",
+    });
+  }
+});
+
+export const RemoteLoginDiscoverySchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_DISCOVERY_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION),
+    issuer: z.url(),
+    authConfigEndpoint: z.url(),
+    sessionEndpoints: z
+      .object({
+        exchange: z.url(),
+        refresh: z.url(),
+        logout: z.url(),
+        me: z.url(),
+      })
+      .strict(),
+    installationProvider: WireKindSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const issuerOrigin = new URL(value.issuer).origin;
+    if (new URL(value.authConfigEndpoint).origin !== issuerOrigin) {
+      context.addIssue({
+        code: "custom",
+        path: ["authConfigEndpoint"],
+        message: "authConfigEndpoint must share the issuer origin",
+      });
+    }
+    for (const [field, endpoint] of Object.entries(value.sessionEndpoints)) {
+      if (new URL(endpoint).origin !== issuerOrigin) {
+        context.addIssue({
+          code: "custom",
+          path: ["sessionEndpoints", field],
+          message: `${field} must share the issuer origin`,
+        });
+      }
+    }
+  });
+
+export const RemoteLoginProviderDescriptorSchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_PROVIDER_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION),
+    provider: WireKindSchema,
+  })
+  .strict();
+
+export const RemoteInstallationCredentialSchema = z
+  .object({
+    provider: WireKindSchema,
+    credentialId: OpaqueIdSchema,
+    material: BoundedOpaqueRecordSchema,
+    publicMetadata: BoundedOpaqueRecordSchema.optional(),
+    expiresAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  .strict();
+
+export type RemoteLoginDiscovery = z.infer<typeof RemoteLoginDiscoverySchema>;
+export type RemoteInstallationCredential = z.infer<typeof RemoteInstallationCredentialSchema>;
+
+export interface RemoteLoginHumanCredentials {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly accessTokenExpiresAt: string | null;
+  readonly refreshTokenExpiresAt?: string | null;
+  readonly scopes: readonly string[];
+}
+
+export interface RemoteLoginInstallationMetadata {
+  readonly clientInstallationId: string;
+  readonly name: string;
+  readonly hostname: string;
+  readonly platform: string;
+  readonly raviVersion?: string;
+}
+
+export interface RemoteLoginProviderContext {
+  readonly endpointUrl: string;
+  readonly discovery: RemoteLoginDiscovery;
+  readonly humanCredentials: RemoteLoginHumanCredentials;
+  readonly installation: RemoteLoginInstallationMetadata;
+  readonly previousCredential?: RemoteInstallationCredential;
+}
+
+export interface RemoteLoginProvider {
+  readonly descriptor: z.infer<typeof RemoteLoginProviderDescriptorSchema>;
+  reconcileInstallation(
+    context: RemoteLoginProviderContext,
+  ): Promise<RemoteInstallationCredential> | RemoteInstallationCredential;
+}
+
+export interface RemoteLoginProviderModule {
+  readonly remoteLoginProvider: RemoteLoginProvider;
+}
+
+function isJsonRecord(value: Record<string, unknown>): boolean {
+  const stack: unknown[] = [value];
+  const seen = new WeakSet<object>();
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (
+      current === null ||
+      typeof current === "string" ||
+      typeof current === "boolean" ||
+      (typeof current === "number" && Number.isFinite(current))
+    ) {
+      continue;
+    }
+    if (typeof current !== "object") return false;
+    if (seen.has(current)) return false;
+    seen.add(current);
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    stack.push(...Object.values(current));
+  }
+  return true;
+}

--- a/src/cli/commands/cloud-auth.test.ts
+++ b/src/cli/commands/cloud-auth.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { ConsoleApiClient } from "../../cloud-auth/client.js";
 import { CloudAuthError } from "../../cloud-auth/errors.js";
-import type { CloudCredentials, CredentialExchangeInput } from "../../cloud-auth/types.js";
+import {
+  REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+  REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+  REMOTE_LOGIN_PROVIDER_PROTOCOL,
+  REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+} from "../../cloud-auth/remote-login.js";
+import { DEFAULT_CONSOLE_URL, type CloudCredentials, type CredentialExchangeInput } from "../../cloud-auth/types.js";
 import { runLogin, runLogout, runWhoami } from "./cloud-auth.js";
 
 describe("cloud auth root command handlers", () => {
@@ -119,6 +125,148 @@ describe("cloud auth root command handlers", () => {
     expect(encoded).not.toContain("provider-secret");
   });
 
+  it("discovers an explicit remote endpoint and stores its installation credential separately", async () => {
+    let writtenHuman: CloudCredentials | null = null;
+    let writtenInstallation: unknown;
+    const client = loginClient();
+    const provider = {
+      descriptor: {
+        protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+        schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+        provider: "example",
+      },
+      reconcileInstallation: mock(async () => ({
+        provider: "example",
+        credentialId: "credential_1",
+        material: {
+          privateKeyPem: "private-key-secret",
+          renewableCredential: "renewable-secret",
+        },
+        publicMetadata: { installationId: "installation_1" },
+      })),
+    };
+
+    const { output } = await captureConsole(() =>
+      runLogin(
+        {
+          endpoint: "https://auth.example",
+          json: true,
+          open: false,
+          poll: false,
+        },
+        {
+          client,
+          readCredentials: () => null,
+          writeCredentials: (credentials) => {
+            writtenHuman = credentials;
+          },
+          ensureClientInstallationId: () => "client_installation_1",
+          discoverEndpoint: mock(async () => remoteDiscovery()),
+          readInstallationCredential: () => null,
+          writeInstallationCredential: (endpointUrl, clientInstallationId, credential) => {
+            writtenInstallation = { endpointUrl, clientInstallationId, credential };
+            return {
+              endpointUrl,
+              credential,
+              createdAt: "2026-07-25T00:00:00.000Z",
+              updatedAt: "2026-07-25T00:00:00.000Z",
+            };
+          },
+          loadProvider: mock(async () => provider),
+          env: { RAVI_CLI_INSTALLATION_NAME: "Test runtime" } as NodeJS.ProcessEnv,
+        },
+      ),
+    );
+    const payload = JSON.parse(output);
+    const encoded = JSON.stringify(payload);
+
+    expect(writtenHuman).toMatchObject({
+      consoleUrl: "https://auth.example",
+      authMode: "remote",
+      installationId: "client_installation_1",
+      accessToken: "login-access-secret",
+      refreshToken: "login-refresh-secret",
+    });
+    expect(writtenInstallation).toMatchObject({
+      endpointUrl: "https://auth.example",
+      clientInstallationId: "client_installation_1",
+      credential: {
+        provider: "example",
+        credentialId: "credential_1",
+        material: { privateKeyPem: "private-key-secret" },
+      },
+    });
+    expect(payload.installationCredential).toEqual({
+      endpointUrl: "https://auth.example",
+      provider: "example",
+      credentialId: "credential_1",
+      publicMetadata: { installationId: "installation_1" },
+    });
+    expect(encoded).not.toContain("login-access-secret");
+    expect(encoded).not.toContain("login-refresh-secret");
+    expect(encoded).not.toContain("private-key-secret");
+    expect(encoded).not.toContain("renewable-secret");
+  });
+
+  it("prompts for a remote endpoint only in an interactive login without stored credentials", async () => {
+    const promptEndpoint = mock(async () => "https://auth.example");
+    const discoverEndpoint = mock(async () => ({
+      ...remoteDiscovery(),
+      installationProvider: undefined,
+    }));
+    await captureConsole(() =>
+      runLogin(
+        { json: true, open: false, poll: false },
+        {
+          client: loginClient(),
+          readCredentials: () => null,
+          writeCredentials: () => {},
+          ensureClientInstallationId: () => "client_installation_1",
+          isInteractive: true,
+          promptEndpoint,
+          discoverEndpoint,
+        },
+      ),
+    );
+
+    expect(promptEndpoint).toHaveBeenCalledWith(DEFAULT_CONSOLE_URL);
+    expect(discoverEndpoint).toHaveBeenCalledWith("https://auth.example");
+  });
+
+  it("rejects ambiguous or unsafe explicit login endpoint selection before reading credentials", async () => {
+    const readCredentials = mock(() => makeCredentials());
+
+    await expect(
+      runLogin(
+        {
+          endpoint: "https://auth.example",
+          console: "https://console.example",
+          json: true,
+          open: false,
+          poll: false,
+        },
+        { readCredentials },
+      ),
+    ).rejects.toEqual(expect.objectContaining({ code: "PAYLOAD_INVALID" }));
+    await expect(
+      runLogin(
+        {
+          endpoint: "https://user:secret@auth.example",
+          json: true,
+          open: false,
+          poll: false,
+        },
+        { readCredentials },
+      ),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        code: "PAYLOAD_INVALID",
+        message: "Remote login endpoint must not contain credentials, query, or fragment.",
+      }),
+    );
+    expect(readCredentials).not.toHaveBeenCalled();
+  });
+
   it("revokes on logout, deletes local credentials, and redacts JSON output", async () => {
     const credentials = makeCredentials();
     let deleted = false;
@@ -156,6 +304,43 @@ describe("cloud auth root command handlers", () => {
     });
     expect(encoded).not.toContain("access-secret");
     expect(encoded).not.toContain("refresh-secret");
+  });
+
+  it("deletes the active human session when remote discovery is unavailable", async () => {
+    const credentials = {
+      ...makeCredentials(),
+      consoleUrl: "https://auth.example",
+      authMode: "remote" as const,
+    };
+    let deleted = false;
+
+    const { output } = await captureConsole(() =>
+      runLogout(
+        { json: true },
+        {
+          readCredentials: () => credentials,
+          deleteCredentials: () => {
+            deleted = true;
+          },
+          writeCredentials: () => {},
+          discoverEndpoint: async () => {
+            throw new CloudAuthError("SERVER_UNAVAILABLE", "Remote login discovery failed.");
+          },
+        },
+      ),
+    );
+    const payload = JSON.parse(output);
+
+    expect(deleted).toBe(true);
+    expect(payload).toMatchObject({
+      success: true,
+      loggedOut: true,
+      consoleUrl: "https://auth.example",
+      revoked: false,
+      revokeError: {
+        code: "SERVER_UNAVAILABLE",
+      },
+    });
   });
 
   it("deletes invalid local credentials even when Console revoke cannot run", async () => {
@@ -221,4 +406,48 @@ function makeCredentials(): CloudCredentials {
     createdAt: "2026-05-09T00:00:00.000Z",
     updatedAt: "2026-05-09T00:00:00.000Z",
   };
+}
+
+function loginClient(): ConsoleApiClient {
+  return {
+    getAuthConfig: mock(async () => ({
+      configured: true,
+      clientId: "ravi-cli",
+      mode: "console_device",
+      endpoints: {
+        deviceAuthorization: "https://auth.example/v1/device",
+        token: null,
+      },
+    })),
+    startDeviceAuthorization: mock(async () => ({
+      verificationUriComplete: "https://auth.example/device?user_code=ABC",
+      verificationUri: "https://auth.example/device",
+      userCode: "ABC",
+      deviceCode: "device-secret",
+      interval: 1,
+    })),
+    exchange: mock(async (input: CredentialExchangeInput) => ({
+      ...makeCredentials(),
+      consoleUrl: "https://auth.example",
+      installationId: input.installationId,
+      accessToken: "login-access-secret",
+      refreshToken: "login-refresh-secret",
+    })),
+  } as unknown as ConsoleApiClient;
+}
+
+function remoteDiscovery() {
+  return {
+    protocol: REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+    schemaVersion: REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+    issuer: "https://auth.example",
+    authConfigEndpoint: "https://auth.example/v1/auth/config",
+    sessionEndpoints: {
+      exchange: "https://auth.example/v1/auth/exchange",
+      refresh: "https://auth.example/v1/auth/refresh",
+      logout: "https://auth.example/v1/auth/logout",
+      me: "https://auth.example/v1/me",
+    },
+    installationProvider: "example",
+  } as const;
 }

--- a/src/cli/commands/cloud-auth.ts
+++ b/src/cli/commands/cloud-auth.ts
@@ -24,6 +24,7 @@ import {
 } from "../../cloud-auth/installation-storage.js";
 import {
   discoverRemoteLoginEndpoint,
+  createRemoteLoginAuthorization,
   loadRemoteLoginProvider,
   normalizeRemoteLoginEndpoint,
   parseRemoteLoginProviderModuleConfigs,
@@ -168,7 +169,10 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
     const credential = await reconcileRemoteInstallation(provider, {
       endpointUrl: selected.endpointUrl,
       discovery,
-      humanCredentials: credentials,
+      authorization: createRemoteLoginAuthorization({
+        endpointUrl: selected.endpointUrl,
+        accessToken: credentials.accessToken,
+      }),
       installation: {
         clientInstallationId: installationId,
         ...localInstallationMetadata(env),

--- a/src/cli/commands/cloud-auth.ts
+++ b/src/cli/commands/cloud-auth.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { hostname } from "node:os";
+import { createInterface } from "node:readline/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import {
   ConsoleApiClient,
@@ -15,6 +16,23 @@ import {
 } from "../../cloud-auth/errors.js";
 import { redactCloudAuthPayload } from "../../cloud-auth/redaction.js";
 import {
+  ensureRemoteClientInstallationId,
+  readRemoteInstallationCredential,
+  toSafeRemoteInstallationCredential,
+  writeRemoteInstallationCredential,
+  type StoredRemoteInstallationCredential,
+} from "../../cloud-auth/installation-storage.js";
+import {
+  discoverRemoteLoginEndpoint,
+  loadRemoteLoginProvider,
+  normalizeRemoteLoginEndpoint,
+  parseRemoteLoginProviderModuleConfigs,
+  reconcileRemoteInstallation,
+  type RemoteInstallationCredential,
+  type RemoteLoginDiscovery,
+  type RemoteLoginProvider,
+} from "../../cloud-auth/remote-login.js";
+import {
   deleteCloudCredentials,
   readCloudCredentials,
   toSafeCloudAuthSession,
@@ -25,6 +43,7 @@ import { DEFAULT_CONSOLE_URL } from "../../cloud-auth/types.js";
 
 export interface CloudLoginOptions {
   console?: string;
+  endpoint?: string;
   json?: boolean;
   open?: boolean;
   poll?: boolean;
@@ -51,16 +70,43 @@ export interface CloudAuthCommandDeps {
   sleep?: (ms: number) => Promise<void>;
   env?: NodeJS.ProcessEnv;
   now?: () => string;
+  isInteractive?: boolean;
+  promptEndpoint?: (defaultEndpoint: string) => Promise<string>;
+  discoverEndpoint?: (endpointUrl: string) => Promise<RemoteLoginDiscovery>;
+  ensureClientInstallationId?: (seed?: string) => string;
+  readInstallationCredential?: (endpointUrl?: string) => StoredRemoteInstallationCredential | null;
+  writeInstallationCredential?: (
+    endpointUrl: string,
+    clientInstallationId: string,
+    credential: RemoteInstallationCredential,
+  ) => StoredRemoteInstallationCredential;
+  loadProvider?: (provider: string) => Promise<RemoteLoginProvider>;
 }
 
 export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthCommandDeps = {}) {
-  const consoleUrl = normalizeConsoleUrl(options.console ?? DEFAULT_CONSOLE_URL);
-  const client = deps.client ?? new ConsoleApiClient({ consoleUrl });
   const read = deps.readCredentials ?? readCloudCredentials;
   const write = deps.writeCredentials ?? writeCloudCredentials;
   const env = deps.env ?? process.env;
+  const explicitEndpoint = selectExplicitLoginEndpoint(options);
   const existing = read();
-  const installationId = existing?.consoleUrl === consoleUrl ? existing.installationId : crypto.randomUUID();
+  const selected = explicitEndpoint ?? (await selectDefaultLoginEndpoint(existing, deps));
+  const discovery = selected.remote
+    ? await (deps.discoverEndpoint ?? discoverRemoteLoginEndpoint)(selected.endpointUrl)
+    : undefined;
+  const client =
+    deps.client ??
+    new ConsoleApiClient({
+      consoleUrl: selected.endpointUrl,
+      ...(discovery === undefined
+        ? {}
+        : {
+            authConfigEndpoint: discovery.authConfigEndpoint,
+            sessionEndpoints: discovery.sessionEndpoints,
+          }),
+    });
+  const installationId = (
+    deps.ensureClientInstallationId ?? ((seed?: string) => ensureRemoteClientInstallationId(seed, env))
+  )(existing?.installationId);
   const config = await client.getAuthConfig();
   const deviceAuth = await client.startDeviceAuthorization(config);
   const authUrl = deviceAuth.verificationUriComplete;
@@ -77,10 +123,17 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
   }
 
   if (!options.json) {
-    printLoginStart({ consoleUrl, authUrl, verificationUrl, userCode, openBrowser });
+    printLoginStart({
+      endpointUrl: selected.endpointUrl,
+      remote: selected.remote,
+      authUrl,
+      verificationUrl,
+      userCode,
+      openBrowser,
+    });
   }
 
-  const credentials = await exchangeUntilComplete({
+  const exchanged = await exchangeUntilComplete({
     client,
     installationId,
     config,
@@ -95,15 +148,51 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
     installation: localInstallationMetadata(env),
     sleep: deps.sleep ?? sleep,
   });
+  const credentials: CloudCredentials = {
+    ...exchanged,
+    consoleUrl: selected.endpointUrl,
+    authMode: selected.remote ? "remote" : "console",
+  };
+  let installationCredential: ReturnType<typeof toSafeRemoteInstallationCredential> | undefined;
+  if (discovery?.installationProvider) {
+    const provider = await (
+      deps.loadProvider ??
+      ((providerId: string) =>
+        loadRemoteLoginProvider(providerId, parseRemoteLoginProviderModuleConfigs(env.RAVI_REMOTE_LOGIN_PROVIDERS)))
+    )(discovery.installationProvider);
+    const previous =
+      (
+        deps.readInstallationCredential ??
+        ((endpointUrl?: string) => readRemoteInstallationCredential(endpointUrl, env))
+      )(selected.endpointUrl) ?? undefined;
+    const credential = await reconcileRemoteInstallation(provider, {
+      endpointUrl: selected.endpointUrl,
+      discovery,
+      humanCredentials: credentials,
+      installation: {
+        clientInstallationId: installationId,
+        ...localInstallationMetadata(env),
+      },
+      ...(previous === undefined ? {} : { previousCredential: previous.credential }),
+    });
+    const stored = (
+      deps.writeInstallationCredential ??
+      ((endpointUrl, clientInstallationId, value) =>
+        writeRemoteInstallationCredential(endpointUrl, clientInstallationId, value, env))
+    )(selected.endpointUrl, installationId, credential);
+    installationCredential = toSafeRemoteInstallationCredential(stored);
+  }
   write(credentials);
 
   const payload = {
     success: true,
     session: toSafeCloudAuthSession(credentials),
     auth: safeAuthConfig(config, deviceAuth),
+    ...(installationCredential === undefined ? {} : { installationCredential }),
   };
   printPayload(payload, options.json, () => {
-    const label = credentials.user?.email ?? credentials.user?.name ?? credentials.user?.displayName ?? "Ravi Cloud";
+    const label =
+      credentials.user?.email ?? credentials.user?.name ?? credentials.user?.displayName ?? "remote account";
     console.log(`✓ Logged in to ${credentials.consoleUrl} as ${label}`);
     console.log("Run `ravi whoami` to inspect the linked CLI session.");
   });
@@ -114,8 +203,11 @@ export async function runWhoami(options: CloudWhoamiOptions = {}, deps: CloudAut
   const read = deps.readCredentials ?? readCloudCredentials;
   const write = deps.writeCredentials ?? writeCloudCredentials;
   const del = deps.deleteCredentials ?? deleteCloudCredentials;
-  const credentials = requireStoredCredentials(read(), options.console);
-  const client = deps.client ?? new ConsoleApiClient({ consoleUrl: credentials.consoleUrl });
+  const credentials = requireStoredCredentials(
+    read(),
+    options.console ? normalizeConsoleUrl(options.console) : undefined,
+  );
+  const client = deps.client ?? (await clientForCredentials(credentials, deps));
   const result = await getMeWithAutoRefresh({
     client,
     credentials,
@@ -123,7 +215,18 @@ export async function runWhoami(options: CloudWhoamiOptions = {}, deps: CloudAut
     delete: del,
   });
   const session = mergeMeIntoSession(result.credentials, result.me);
-  const payload = { success: true, authenticated: true, session };
+  const storedInstallation = (
+    deps.readInstallationCredential ??
+    ((endpointUrl?: string) => readRemoteInstallationCredential(endpointUrl, deps.env ?? process.env))
+  )(credentials.consoleUrl);
+  const payload = {
+    success: true,
+    authenticated: true,
+    session,
+    ...(storedInstallation === null
+      ? {}
+      : { installationCredential: toSafeRemoteInstallationCredential(storedInstallation) }),
+  };
   printPayload(payload, options.json, () => printWhoami(session));
   return payload;
 }
@@ -167,18 +270,19 @@ export async function runLogout(options: CloudLogoutOptions = {}, deps: CloudAut
     return payload;
   }
 
-  const client = deps.client ?? new ConsoleApiClient({ consoleUrl: credentials.consoleUrl });
   let revoked = false;
   let revokeError: ReturnType<CloudAuthError["toJSON"]> | null = null;
   let logoutCredentials = credentials;
+  let client: ConsoleApiClient | null = null;
   try {
+    client = deps.client ?? (await clientForCredentials(credentials, deps));
     await client.logout(
       { refreshToken: logoutCredentials.refreshToken, installationId: logoutCredentials.installationId },
       logoutCredentials.accessToken,
     );
     revoked = true;
   } catch (error) {
-    if (isCloudAuthError(error) && error.code === "AUTH_EXPIRED") {
+    if (isCloudAuthError(error) && error.code === "AUTH_EXPIRED" && client) {
       try {
         logoutCredentials = await refreshCredentialsForStore({
           client,
@@ -232,17 +336,93 @@ export async function runCloudAuthRootCommand<T>(asJson: boolean | undefined, fn
   }
 }
 
-function requireStoredCredentials(credentials: CloudCredentials | null, consoleUrl?: string): CloudCredentials {
+function requireStoredCredentials(credentials: CloudCredentials | null, endpointUrl?: string): CloudCredentials {
   if (!credentials) {
     throw new CloudAuthError("AUTH_REQUIRED", "No Ravi Cloud CLI credentials found. Run `ravi login`.");
   }
-  if (consoleUrl && normalizeConsoleUrl(consoleUrl) !== credentials.consoleUrl) {
-    throw new CloudAuthError(
-      "AUTH_REQUIRED",
-      `No Ravi Cloud CLI credentials found for ${normalizeConsoleUrl(consoleUrl)}.`,
-    );
+  if (endpointUrl && endpointUrl !== credentials.consoleUrl) {
+    throw new CloudAuthError("AUTH_REQUIRED", `No Ravi CLI credentials found for ${endpointUrl}.`);
   }
   return credentials;
+}
+
+function selectExplicitLoginEndpoint(options: CloudLoginOptions): { endpointUrl: string; remote: boolean } | undefined {
+  if (options.endpoint && options.console) {
+    throw new CloudAuthError("PAYLOAD_INVALID", "Use either --endpoint or --console, not both.");
+  }
+  if (options.endpoint) {
+    return {
+      endpointUrl: normalizeRemoteLoginEndpoint(options.endpoint),
+      remote: true,
+    };
+  }
+  if (options.console) {
+    return {
+      endpointUrl: normalizeConsoleUrl(options.console),
+      remote: false,
+    };
+  }
+  return undefined;
+}
+
+async function selectDefaultLoginEndpoint(
+  existing: CloudCredentials | null,
+  deps: CloudAuthCommandDeps,
+): Promise<{ endpointUrl: string; remote: boolean }> {
+  if (existing) {
+    return {
+      endpointUrl:
+        existing.authMode === "remote"
+          ? normalizeRemoteLoginEndpoint(existing.consoleUrl)
+          : normalizeConsoleUrl(existing.consoleUrl),
+      remote: existing.authMode === "remote",
+    };
+  }
+  const interactive = deps.isInteractive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    return {
+      endpointUrl: normalizeConsoleUrl(DEFAULT_CONSOLE_URL),
+      remote: false,
+    };
+  }
+  const entered = await (deps.promptEndpoint ?? promptForEndpoint)(DEFAULT_CONSOLE_URL);
+  if (!entered.trim() || normalizeConsoleUrl(entered) === normalizeConsoleUrl(DEFAULT_CONSOLE_URL)) {
+    return {
+      endpointUrl: normalizeConsoleUrl(DEFAULT_CONSOLE_URL),
+      remote: false,
+    };
+  }
+  return {
+    endpointUrl: normalizeRemoteLoginEndpoint(entered),
+    remote: true,
+  };
+}
+
+async function clientForCredentials(
+  credentials: CloudCredentials,
+  deps: CloudAuthCommandDeps,
+): Promise<ConsoleApiClient> {
+  if (credentials.authMode !== "remote") {
+    return new ConsoleApiClient({ consoleUrl: credentials.consoleUrl });
+  }
+  const discovery = await (deps.discoverEndpoint ?? discoverRemoteLoginEndpoint)(credentials.consoleUrl);
+  return new ConsoleApiClient({
+    consoleUrl: credentials.consoleUrl,
+    authConfigEndpoint: discovery.authConfigEndpoint,
+    sessionEndpoints: discovery.sessionEndpoints,
+  });
+}
+
+async function promptForEndpoint(defaultEndpoint: string): Promise<string> {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    return await readline.question(`Remote login endpoint [${defaultEndpoint}]: `);
+  } finally {
+    readline.close();
+  }
 }
 
 async function exchangeUntilComplete(input: {
@@ -301,6 +481,7 @@ async function exchangeDeviceCredentials(input: {
 function mergeMeIntoSession(credentials: CloudCredentials, me: ConsoleMeResponse) {
   return {
     consoleUrl: credentials.consoleUrl,
+    authMode: credentials.authMode ?? "console",
     user: me.user ?? credentials.user ?? null,
     organization: me.organization ?? me.org ?? credentials.organization ?? null,
     installation: {
@@ -339,13 +520,14 @@ function safeAuthConfig(
 }
 
 function printLoginStart(input: {
-  consoleUrl: string;
+  endpointUrl: string;
+  remote: boolean;
   authUrl?: string;
   verificationUrl?: string;
   userCode?: string;
   openBrowser: boolean;
 }): void {
-  console.log(`Ravi Cloud login: ${input.consoleUrl}`);
+  console.log(`${input.remote ? "Remote endpoint" : "Ravi Cloud"} login: ${input.endpointUrl}`);
   if (input.openBrowser && input.authUrl) console.log("Opening browser for authentication...");
   if (input.verificationUrl) console.log(`Verification URL: ${input.verificationUrl}`);
   if (input.userCode) console.log(`Code: ${input.userCode}`);
@@ -354,7 +536,7 @@ function printLoginStart(input: {
 function printWhoami(session: ReturnType<typeof mergeMeIntoSession>): void {
   const user = session.user?.email ?? session.user?.name ?? session.user?.displayName ?? "unknown user";
   const org = session.organization?.name ?? session.organization?.slug ?? session.organization?.id ?? "no organization";
-  console.log(`Console: ${session.consoleUrl}`);
+  console.log(`Endpoint: ${session.consoleUrl}`);
   console.log(`User: ${user}`);
   console.log(`Organization: ${org}`);
   console.log(`Installation: ${session.installation.id}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@
 import "./env.js";
 
 import "reflect-metadata";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -119,8 +119,9 @@ program
 
 program
   .command("login")
-  .description("Link this local Ravi CLI to a Console-compatible endpoint")
-  .option("--console <url>", "Console base URL", "https://console.ravi.bot")
+  .description("Link this local Ravi CLI to a remote authentication endpoint")
+  .option("--endpoint <url>", "Remote authentication endpoint")
+  .option("--console <url>", "Legacy Console base URL")
   .option("--json", "Print raw JSON result")
   .option("--no-open", "Do not open a browser")
   .option("--no-poll", "Do not poll the exchange endpoint when auth is pending")
@@ -129,6 +130,7 @@ program
   .action(
     async (options: {
       console?: string;
+      endpoint?: string;
       json?: boolean;
       open?: boolean;
       poll?: boolean;
@@ -150,8 +152,8 @@ program
 
 program
   .command("whoami")
-  .description("Show the linked Ravi Cloud CLI identity")
-  .option("--console <url>", "Console base URL")
+  .description("Show the linked Ravi CLI identity")
+  .addOption(new Option("--console <url>", "Legacy Console base URL").hideHelp())
   .option("--json", "Print raw JSON result")
   .action(async (options: { console?: string; json?: boolean }) => {
     await runWithCliAudit(
@@ -168,8 +170,8 @@ program
 
 program
   .command("logout")
-  .description("Remove local Ravi Cloud CLI credentials and revoke them in Console when possible")
-  .option("--console <url>", "Console base URL")
+  .description("Remove the local human CLI session and revoke it remotely when possible")
+  .addOption(new Option("--console <url>", "Legacy Console base URL").hideHelp())
   .option("--json", "Print raw JSON result")
   .action(async (options: { console?: string; json?: boolean }) => {
     await runWithCliAudit(

--- a/src/cli/root-version.test.ts
+++ b/src/cli/root-version.test.ts
@@ -59,6 +59,40 @@ describe("CLI root version", () => {
     expect(result.stdout).toContain("ravi --help");
   });
 
+  it("documents explicit remote and legacy endpoint selection for login", () => {
+    const stateDir = join(tmpdir(), `ravi-login-help-${process.pid}`);
+    const result = spawnSync("bun", ["src/cli/index.ts", "login", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: testEnv(stateDir),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--endpoint <url>");
+    expect(result.stdout).toContain("--console <url>");
+    expect(result.stdout).toContain("--json");
+    expect(result.stdout).toContain("--no-open");
+
+    const whoami = spawnSync("bun", ["src/cli/index.ts", "whoami", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: testEnv(stateDir),
+    });
+    const logout = spawnSync("bun", ["src/cli/index.ts", "logout", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: testEnv(stateDir),
+    });
+    rmSync(stateDir, { recursive: true, force: true });
+
+    expect(whoami.status).toBe(0);
+    expect(logout.status).toBe(0);
+    expect(whoami.stdout).not.toContain("--endpoint");
+    expect(whoami.stdout).not.toContain("--console");
+    expect(logout.stdout).not.toContain("--endpoint");
+    expect(logout.stdout).not.toContain("--console");
+  });
+
   it("suggests the plural tasks command for singular task help", () => {
     const stateDir = join(tmpdir(), `ravi-root-task-suggestion-${process.pid}`);
     const result = spawnSync("bun", ["src/cli/index.ts", "task", "--help"], {

--- a/src/cloud-auth/client.test.ts
+++ b/src/cloud-auth/client.test.ts
@@ -134,6 +134,74 @@ describe("ConsoleApiClient", () => {
     ]);
   });
 
+  it("uses every endpoint supplied by a discovered remote contract", async () => {
+    const calls: FetchCall[] = [];
+    const client = new ConsoleApiClient({
+      consoleUrl: "https://auth.example",
+      authConfigEndpoint: "https://auth.example/v1/auth/config",
+      sessionEndpoints: {
+        exchange: "https://auth.example/v1/auth/exchange",
+        refresh: "https://auth.example/v1/auth/refresh",
+        logout: "https://auth.example/v1/auth/logout",
+        me: "https://auth.example/v1/me",
+      },
+      fetch: async (url, init) => {
+        calls.push(recordFetchCall(url, init));
+        const path = new URL(url).pathname;
+        if (path === "/v1/auth/config") {
+          return jsonResponse({
+            configured: true,
+            clientId: "ravi-cli",
+            mode: "console_device",
+            endpoints: {
+              deviceAuthorization: "https://auth.example/v1/auth/device",
+              token: null,
+            },
+          });
+        }
+        if (path === "/v1/me") {
+          return jsonResponse({ user: { email: "alice@example.com" } });
+        }
+        if (path === "/v1/auth/logout") {
+          return jsonResponse({ success: true });
+        }
+        return jsonResponse({
+          accessToken: "access-secret",
+          refreshToken: "refresh-secret",
+        });
+      },
+    });
+
+    await client.getAuthConfig();
+    const credentials = await client.exchange({
+      installationId: "client_installation_1",
+      deviceCode: "device-secret",
+    });
+    await client.refresh(
+      {
+        installationId: "client_installation_1",
+        refreshToken: credentials.refreshToken,
+      },
+      credentials,
+    );
+    await client.me(credentials.accessToken);
+    await client.logout(
+      {
+        installationId: "client_installation_1",
+        refreshToken: credentials.refreshToken,
+      },
+      credentials.accessToken,
+    );
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://auth.example/v1/auth/config",
+      "https://auth.example/v1/auth/exchange",
+      "https://auth.example/v1/auth/refresh",
+      "https://auth.example/v1/me",
+      "https://auth.example/v1/auth/logout",
+    ]);
+  });
+
   it("creates artifact upload sessions through the CLI bearer endpoint", async () => {
     const calls: FetchCall[] = [];
     const client = new ConsoleApiClient({

--- a/src/cloud-auth/client.ts
+++ b/src/cloud-auth/client.ts
@@ -18,6 +18,13 @@ type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
 export interface ConsoleApiClientOptions {
   consoleUrl?: string;
+  authConfigEndpoint?: string;
+  sessionEndpoints?: {
+    exchange: string;
+    refresh: string;
+    logout: string;
+    me: string;
+  };
   fetch?: FetchLike;
   timeoutMs?: number;
 }
@@ -25,9 +32,18 @@ export interface ConsoleApiClientOptions {
 export class ConsoleApiClient {
   readonly consoleUrl: string;
   private readonly fetchImpl: FetchLike;
+  private readonly authConfigEndpoint: string;
+  private readonly sessionEndpoints: NonNullable<ConsoleApiClientOptions["sessionEndpoints"]>;
 
   constructor(options: ConsoleApiClientOptions = {}) {
     this.consoleUrl = normalizeConsoleUrl(options.consoleUrl ?? DEFAULT_CONSOLE_URL);
+    this.authConfigEndpoint = options.authConfigEndpoint ?? "/api/cli/auth/config";
+    this.sessionEndpoints = options.sessionEndpoints ?? {
+      exchange: "/api/cli/auth/exchange",
+      refresh: "/api/cli/auth/refresh",
+      logout: "/api/cli/auth/logout",
+      me: "/api/cli/me",
+    };
     this.fetchImpl =
       options.fetch ??
       ((url, init) => {
@@ -36,7 +52,7 @@ export class ConsoleApiClient {
   }
 
   async getAuthConfig(): Promise<ConsoleAuthConfig> {
-    return this.requestJson<ConsoleAuthConfig>("GET", "/api/cli/auth/config", undefined, undefined, {
+    return this.requestJson<ConsoleAuthConfig>("GET", this.authConfigEndpoint, undefined, undefined, {
       "x-ravi-cli-auth-flow": "console_device",
     });
   }
@@ -66,22 +82,22 @@ export class ConsoleApiClient {
   }
 
   async exchange(input: CredentialExchangeInput): Promise<CloudCredentials> {
-    const response = await this.requestJson<unknown>("POST", "/api/cli/auth/exchange", input);
+    const response = await this.requestJson<unknown>("POST", this.sessionEndpoints.exchange, input);
     return credentialsFromConsoleResponse(response, this.consoleUrl, input.installationId);
   }
 
   async refresh(input: CredentialRefreshInput, previous?: CloudCredentials | null): Promise<CloudCredentials> {
-    const response = await this.requestJson<unknown>("POST", "/api/cli/auth/refresh", input);
+    const response = await this.requestJson<unknown>("POST", this.sessionEndpoints.refresh, input);
     return credentialsFromConsoleResponse(response, this.consoleUrl, input.installationId, previous);
   }
 
   async logout(input: LogoutInput, accessToken?: string): Promise<{ success: true }> {
-    await this.requestJson<unknown>("POST", "/api/cli/auth/logout", input, accessToken);
+    await this.requestJson<unknown>("POST", this.sessionEndpoints.logout, input, accessToken);
     return { success: true };
   }
 
   async me(accessToken: string): Promise<ConsoleMeResponse> {
-    return this.requestJson<ConsoleMeResponse>("GET", "/api/cli/me", undefined, accessToken);
+    return this.requestJson<ConsoleMeResponse>("GET", this.sessionEndpoints.me, undefined, accessToken);
   }
 
   async createPageUploadSession(
@@ -126,7 +142,7 @@ export class ConsoleApiClient {
 
     let response: Response;
     try {
-      response = await this.fetchImpl(`${this.consoleUrl}${path}`, {
+      response = await this.fetchImpl(this.requestUrl(path), {
         method,
         headers,
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
@@ -142,6 +158,11 @@ export class ConsoleApiClient {
       throw mapConsoleError(response.status, payload);
     }
     return (payload ?? {}) as T;
+  }
+
+  private requestUrl(path: string): string {
+    if (/^https?:\/\//i.test(path)) return path;
+    return `${this.consoleUrl}${path}`;
   }
 
   private async requestFormJson<T>(method: string, url: string, body: URLSearchParams): Promise<T> {

--- a/src/cloud-auth/installation-storage.test.ts
+++ b/src/cloud-auth/installation-storage.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ensureRemoteClientInstallationId,
+  getRemoteInstallationCredentialsPath,
+  readRemoteInstallationCredential,
+  readRemoteInstallationCredentialState,
+  toSafeRemoteInstallationCredential,
+  writeRemoteInstallationCredential,
+} from "./installation-storage.js";
+
+let stateDir: string | null = null;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "ravi-remote-installation-storage-"));
+  process.env.RAVI_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  delete process.env.RAVI_STATE_DIR;
+  if (stateDir) rmSync(stateDir, { recursive: true, force: true });
+  stateDir = null;
+});
+
+describe("remote installation credential storage", () => {
+  it("keeps one client identity and independent credentials for multiple endpoints", () => {
+    const clientInstallationId = ensureRemoteClientInstallationId(
+      undefined,
+      process.env,
+      () => "client_installation_1",
+    );
+    expect(ensureRemoteClientInstallationId("ignored")).toBe(clientInstallationId);
+
+    const first = writeRemoteInstallationCredential(
+      "https://one.example",
+      clientInstallationId,
+      {
+        provider: "example",
+        credentialId: "credential_1",
+        material: { privateKeyPem: "first-private-secret" },
+        publicMetadata: { installationId: "installation_1" },
+      },
+      process.env,
+      () => "2026-07-25T12:00:00.000Z",
+    );
+    writeRemoteInstallationCredential(
+      "https://two.example",
+      clientInstallationId,
+      {
+        provider: "example",
+        credentialId: "credential_2",
+        material: { privateKeyPem: "second-private-secret" },
+        publicMetadata: { installationId: "installation_2" },
+      },
+      process.env,
+      () => "2026-07-25T12:01:00.000Z",
+    );
+
+    expect(readRemoteInstallationCredentialState()).toMatchObject({
+      version: 1,
+      clientInstallationId,
+      activeEndpointUrl: "https://two.example",
+      connections: {
+        "https://one.example": {
+          credential: { credentialId: "credential_1" },
+        },
+        "https://two.example": {
+          credential: { credentialId: "credential_2" },
+        },
+      },
+    });
+    expect(readRemoteInstallationCredential("https://one.example")).toEqual(first);
+    expect(readRemoteInstallationCredential()).toMatchObject({
+      endpointUrl: "https://two.example",
+      credential: { credentialId: "credential_2" },
+    });
+  });
+
+  it("stores secret material with user-only permissions but excludes it from safe metadata", () => {
+    const clientInstallationId = ensureRemoteClientInstallationId("client_installation_1");
+    const stored = writeRemoteInstallationCredential("https://auth.example", clientInstallationId, {
+      provider: "example",
+      credentialId: "credential_1",
+      material: {
+        privateKeyPem: "private-secret",
+        renewableCredential: "renewable-secret",
+      },
+      publicMetadata: { installationId: "installation_1" },
+    });
+    const path = getRemoteInstallationCredentialsPath();
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toContain("private-secret");
+
+    const safe = toSafeRemoteInstallationCredential(stored);
+    expect(safe).toEqual({
+      endpointUrl: "https://auth.example",
+      provider: "example",
+      credentialId: "credential_1",
+      publicMetadata: { installationId: "installation_1" },
+    });
+    expect(JSON.stringify(safe)).not.toContain("private-secret");
+    expect(JSON.stringify(safe)).not.toContain("renewable-secret");
+  });
+
+  it("refuses credential state readable by another user", () => {
+    ensureRemoteClientInstallationId("client_installation_1");
+    chmodSync(getRemoteInstallationCredentialsPath(), 0o644);
+    expect(() => readRemoteInstallationCredentialState()).toThrow(
+      expect.objectContaining({ code: "CREDENTIALS_INVALID" }),
+    );
+  });
+});

--- a/src/cloud-auth/installation-storage.ts
+++ b/src/cloud-auth/installation-storage.ts
@@ -1,0 +1,224 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getCloudAuthDir } from "./storage.js";
+import {
+  RemoteInstallationCredentialSchema,
+  normalizeRemoteLoginEndpoint,
+  type RemoteInstallationCredential,
+} from "./remote-login.js";
+import { CloudAuthError } from "./errors.js";
+
+const STORE_DIR_MODE = 0o700;
+const CREDENTIALS_FILE_MODE = 0o600;
+const INSTALLATION_CREDENTIALS_FILE = "installation-credentials.json";
+
+export interface StoredRemoteInstallationCredential {
+  readonly endpointUrl: string;
+  readonly credential: RemoteInstallationCredential;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface RemoteInstallationCredentialState {
+  readonly version: 1;
+  readonly clientInstallationId: string;
+  readonly activeEndpointUrl?: string;
+  readonly connections: Record<string, StoredRemoteInstallationCredential>;
+}
+
+export interface SafeRemoteInstallationCredential {
+  readonly endpointUrl: string;
+  readonly provider: string;
+  readonly credentialId: string;
+  readonly publicMetadata?: Record<string, unknown>;
+  readonly expiresAt?: string;
+}
+
+export function getRemoteInstallationCredentialsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(getCloudAuthDir(env), INSTALLATION_CREDENTIALS_FILE);
+}
+
+export function readRemoteInstallationCredentialState(
+  env: NodeJS.ProcessEnv = process.env,
+): RemoteInstallationCredentialState | null {
+  const path = getRemoteInstallationCredentialsPath(env);
+  if (!existsSync(path)) return null;
+  assertUserOnlyFileMode(path);
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch (error) {
+    throw invalidCredentials(error);
+  }
+  return normalizeState(decoded);
+}
+
+export function ensureRemoteClientInstallationId(
+  seed: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  idFactory: () => string = () => crypto.randomUUID(),
+): string {
+  const current = readRemoteInstallationCredentialState(env);
+  if (current) return current.clientInstallationId;
+  const clientInstallationId = normalizeOpaqueId(seed ?? idFactory());
+  writeState(
+    {
+      version: 1,
+      clientInstallationId,
+      connections: {},
+    },
+    env,
+  );
+  return clientInstallationId;
+}
+
+export function readRemoteInstallationCredential(
+  endpointUrl?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): StoredRemoteInstallationCredential | null {
+  const state = readRemoteInstallationCredentialState(env);
+  if (!state) return null;
+  const endpoint = endpointUrl ? normalizeRemoteLoginEndpoint(endpointUrl) : state.activeEndpointUrl;
+  if (!endpoint) return null;
+  return state.connections[endpoint] ?? null;
+}
+
+export function writeRemoteInstallationCredential(
+  endpointUrl: string,
+  clientInstallationId: string,
+  credentialInput: RemoteInstallationCredential,
+  env: NodeJS.ProcessEnv = process.env,
+  now: () => string = () => new Date().toISOString(),
+): StoredRemoteInstallationCredential {
+  const endpoint = normalizeRemoteLoginEndpoint(endpointUrl);
+  const credential = RemoteInstallationCredentialSchema.parse(credentialInput);
+  const current = readRemoteInstallationCredentialState(env);
+  const normalizedInstallationId = normalizeOpaqueId(clientInstallationId);
+  if (current && current.clientInstallationId !== normalizedInstallationId) {
+    throw new CloudAuthError(
+      "CREDENTIALS_INVALID",
+      "Stored remote installation identity does not match the active Ravi installation.",
+    );
+  }
+  const timestamp = now();
+  const previous = current?.connections[endpoint];
+  const stored: StoredRemoteInstallationCredential = {
+    endpointUrl: endpoint,
+    credential,
+    createdAt: previous?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+  };
+  writeState(
+    {
+      version: 1,
+      clientInstallationId: normalizedInstallationId,
+      activeEndpointUrl: endpoint,
+      connections: {
+        ...(current?.connections ?? {}),
+        [endpoint]: stored,
+      },
+    },
+    env,
+  );
+  return stored;
+}
+
+export function toSafeRemoteInstallationCredential(
+  stored: StoredRemoteInstallationCredential,
+): SafeRemoteInstallationCredential {
+  return {
+    endpointUrl: stored.endpointUrl,
+    provider: stored.credential.provider,
+    credentialId: stored.credential.credentialId,
+    ...(stored.credential.publicMetadata === undefined
+      ? {}
+      : { publicMetadata: structuredClone(stored.credential.publicMetadata) }),
+    ...(stored.credential.expiresAt === undefined ? {} : { expiresAt: stored.credential.expiresAt }),
+  };
+}
+
+function normalizeState(value: unknown): RemoteInstallationCredentialState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidCredentials();
+  }
+  const input = value as Record<string, unknown>;
+  if (input.version !== 1 || typeof input.clientInstallationId !== "string") {
+    throw invalidCredentials();
+  }
+  const rawConnections = input.connections;
+  if (!rawConnections || typeof rawConnections !== "object" || Array.isArray(rawConnections)) {
+    throw invalidCredentials();
+  }
+  const connections: Record<string, StoredRemoteInstallationCredential> = {};
+  for (const [rawEndpoint, rawStored] of Object.entries(rawConnections)) {
+    const endpointUrl = normalizeRemoteLoginEndpoint(rawEndpoint);
+    if (!rawStored || typeof rawStored !== "object" || Array.isArray(rawStored)) {
+      throw invalidCredentials();
+    }
+    const stored = rawStored as Record<string, unknown>;
+    if (
+      stored.endpointUrl !== endpointUrl ||
+      typeof stored.createdAt !== "string" ||
+      typeof stored.updatedAt !== "string"
+    ) {
+      throw invalidCredentials();
+    }
+    const credential = RemoteInstallationCredentialSchema.safeParse(stored.credential);
+    if (!credential.success) throw invalidCredentials();
+    connections[endpointUrl] = {
+      endpointUrl,
+      credential: credential.data,
+      createdAt: stored.createdAt,
+      updatedAt: stored.updatedAt,
+    };
+  }
+  const activeEndpointUrl =
+    typeof input.activeEndpointUrl === "string" ? normalizeRemoteLoginEndpoint(input.activeEndpointUrl) : undefined;
+  if (activeEndpointUrl && !connections[activeEndpointUrl]) {
+    throw invalidCredentials();
+  }
+  return {
+    version: 1,
+    clientInstallationId: normalizeOpaqueId(input.clientInstallationId),
+    ...(activeEndpointUrl ? { activeEndpointUrl } : {}),
+    connections,
+  };
+}
+
+function writeState(state: RemoteInstallationCredentialState, env: NodeJS.ProcessEnv): void {
+  const dir = getCloudAuthDir(env);
+  const path = getRemoteInstallationCredentialsPath(env);
+  mkdirSync(dir, { recursive: true, mode: STORE_DIR_MODE });
+  chmodSync(dir, STORE_DIR_MODE);
+  const temporaryPath = join(dir, `.installation-credentials.${process.pid}.${Date.now()}.tmp`);
+  writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, { mode: CREDENTIALS_FILE_MODE });
+  chmodSync(temporaryPath, CREDENTIALS_FILE_MODE);
+  renameSync(temporaryPath, path);
+  chmodSync(path, CREDENTIALS_FILE_MODE);
+}
+
+function normalizeOpaqueId(value: string): string {
+  const normalized = value.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/.test(normalized)) {
+    throw invalidCredentials();
+  }
+  return normalized;
+}
+
+function assertUserOnlyFileMode(path: string): void {
+  const mode = statSync(path).mode & 0o777;
+  if (mode & 0o077) {
+    throw new CloudAuthError(
+      "CREDENTIALS_INVALID",
+      `Stored remote installation credentials file has mode 0${mode.toString(8).padStart(3, "0")}; expected 0600.`,
+    );
+  }
+}
+
+function invalidCredentials(cause?: unknown): CloudAuthError {
+  return new CloudAuthError(
+    "CREDENTIALS_INVALID",
+    "Stored remote installation credentials are invalid.",
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/src/cloud-auth/redaction.test.ts
+++ b/src/cloud-auth/redaction.test.ts
@@ -17,6 +17,11 @@ describe("cloud auth redaction", () => {
         verificationUri: "https://console.example/device",
         clientSecret: "client-secret",
       },
+      installationCredential: {
+        material: {
+          privateKeyPem: "private-key-secret",
+        },
+      },
     };
 
     const redacted = redactCloudAuthPayload(payload);
@@ -25,11 +30,13 @@ describe("cloud auth redaction", () => {
     expect(encoded).not.toContain("access-secret");
     expect(encoded).not.toContain("refresh-secret");
     expect(encoded).not.toContain("client-secret");
+    expect(encoded).not.toContain("private-key-secret");
     expect(redacted.session.accessToken).toBe("[REDACTED]");
     expect(redacted.session.refreshToken).toBe("[REDACTED]");
     expect(redacted.session.accessTokenExpiresAt).toBe("2026-05-10T00:00:00.000Z");
     expect(redacted.session.refreshTokenExpiresAt).toBe("2026-06-10T00:00:00.000Z");
     expect(redacted.session.installation.id).toBe("ins_123");
     expect(redacted.auth.authorizationUrl).toBe("https://console.example/login?code=ABC");
+    expect(redacted.installationCredential.material as unknown).toBe("[REDACTED]");
   });
 });

--- a/src/cloud-auth/redaction.ts
+++ b/src/cloud-auth/redaction.ts
@@ -26,7 +26,11 @@ function isSecretKey(key: string): boolean {
     normalized === "idtoken" ||
     normalized === "provideraccesstoken" ||
     normalized === "authorization" ||
-    normalized === "cookie"
+    normalized === "cookie" ||
+    normalized === "material" ||
+    normalized.includes("privatekey") ||
+    normalized === "credentialmaterial" ||
+    normalized === "machinecredential"
   ) {
     return true;
   }

--- a/src/cloud-auth/remote-login.test.ts
+++ b/src/cloud-auth/remote-login.test.ts
@@ -5,6 +5,7 @@ import {
   REMOTE_LOGIN_PROVIDER_PROTOCOL,
   REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
   RemoteLoginContractError,
+  createRemoteLoginAuthorization,
   discoverRemoteLoginEndpoint,
   loadRemoteLoginProvider,
   normalizeRemoteLoginEndpoint,
@@ -95,17 +96,8 @@ describe("remote post-login provider contract", () => {
     const result = await reconcileRemoteInstallation(loaded, {
       endpointUrl: "https://auth.example",
       discovery,
-      humanCredentials: {
-        version: 1,
-        consoleUrl: "https://auth.example",
-        authMode: "remote",
-        installationId: "client_installation_1",
-        accessToken: "access-secret",
-        refreshToken: "refresh-secret",
-        accessTokenExpiresAt: null,
-        scopes: [],
-        createdAt: "2026-07-25T00:00:00.000Z",
-        updatedAt: "2026-07-25T00:00:00.000Z",
+      authorization: {
+        request: async () => ({ status: 200 }),
       },
       installation: {
         clientInstallationId: "client_installation_1",
@@ -122,6 +114,48 @@ describe("remote post-login provider contract", () => {
       publicMetadata: { installationId: "installation_1" },
     });
     expect(provider.reconcileInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the human credential inside a same-origin request capability", async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const authorization = createRemoteLoginAuthorization({
+      endpointUrl: "https://auth.example",
+      accessToken: "access-secret",
+      fetch: async (input, init) => {
+        requests.push({
+          url: input.toString(),
+          init: init ?? {},
+        });
+        return Response.json({ disposition: "reconciled" });
+      },
+    });
+
+    await expect(
+      authorization.request({
+        method: "POST",
+        path: "/v1/installations/reconcile",
+        body: { clientInstallationId: "client_installation_1" },
+      }),
+    ).resolves.toEqual({
+      status: 200,
+      body: { disposition: "reconciled" },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://auth.example/v1/installations/reconcile");
+    expect(requests[0]?.init).toEqual(
+      expect.objectContaining({
+        redirect: "error",
+        headers: expect.objectContaining({
+          Authorization: "Bearer access-secret",
+        }),
+      }),
+    );
+    await expect(
+      authorization.request({
+        method: "POST",
+        path: "//other.example/reconcile",
+      }),
+    ).rejects.toThrow();
   });
 
   it("rejects remote module specifiers, duplicate providers, and provider mismatches", async () => {
@@ -198,17 +232,8 @@ describe("remote post-login provider contract", () => {
       reconcileRemoteInstallation(provider, {
         endpointUrl: "https://auth.example",
         discovery,
-        humanCredentials: {
-          version: 1,
-          consoleUrl: "https://auth.example",
-          authMode: "remote",
-          installationId: "client_installation_1",
-          accessToken: "access-secret",
-          refreshToken: "refresh-secret",
-          accessTokenExpiresAt: null,
-          scopes: [],
-          createdAt: "2026-07-25T00:00:00.000Z",
-          updatedAt: "2026-07-25T00:00:00.000Z",
+        authorization: {
+          request: async () => ({ status: 200 }),
         },
         installation: {
           clientInstallationId: "client_installation_1",

--- a/src/cloud-auth/remote-login.test.ts
+++ b/src/cloud-auth/remote-login.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+  REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+  REMOTE_LOGIN_PROVIDER_PROTOCOL,
+  REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+  RemoteLoginContractError,
+  discoverRemoteLoginEndpoint,
+  loadRemoteLoginProvider,
+  normalizeRemoteLoginEndpoint,
+  parseRemoteLoginProviderModuleConfigs,
+  reconcileRemoteInstallation,
+  type RemoteLoginDiscovery,
+} from "./remote-login.js";
+
+const discovery: RemoteLoginDiscovery = {
+  protocol: REMOTE_LOGIN_DISCOVERY_PROTOCOL,
+  schemaVersion: REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION,
+  issuer: "https://auth.example",
+  authConfigEndpoint: "https://auth.example/v1/auth/config",
+  sessionEndpoints: {
+    exchange: "https://auth.example/v1/auth/exchange",
+    refresh: "https://auth.example/v1/auth/refresh",
+    logout: "https://auth.example/v1/auth/logout",
+    me: "https://auth.example/v1/me",
+  },
+  installationProvider: "example",
+};
+
+describe("remote login discovery", () => {
+  it("loads a versioned, origin-bound contract", async () => {
+    const fetcher = mock(async () => Response.json(discovery));
+
+    await expect(discoverRemoteLoginEndpoint("https://auth.example/", fetcher)).resolves.toEqual(discovery);
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.example/.well-known/ravi-auth",
+      expect.objectContaining({
+        method: "GET",
+        redirect: "error",
+      }),
+    );
+  });
+
+  it("rejects issuer substitution, insecure remote HTTP, and embedded credentials", async () => {
+    await expect(
+      discoverRemoteLoginEndpoint("https://auth.example", async () =>
+        Response.json({
+          ...discovery,
+          issuer: "https://other.example",
+          authConfigEndpoint: "https://other.example/v1/auth/config",
+          sessionEndpoints: {
+            exchange: "https://other.example/v1/auth/exchange",
+            refresh: "https://other.example/v1/auth/refresh",
+            logout: "https://other.example/v1/auth/logout",
+            me: "https://other.example/v1/me",
+          },
+        }),
+      ),
+    ).rejects.toEqual(expect.objectContaining({ reason: "issuer_mismatch" }));
+    expect(() => normalizeRemoteLoginEndpoint("http://auth.example")).toThrow();
+    expect(() => normalizeRemoteLoginEndpoint("https://user:secret@auth.example")).toThrow();
+    expect(normalizeRemoteLoginEndpoint("http://127.0.0.1:8787/")).toBe("http://127.0.0.1:8787");
+  });
+});
+
+describe("remote post-login provider contract", () => {
+  it("loads only an explicitly configured local provider and validates its result", async () => {
+    const moduleSpecifier = new URL("./remote-login.test.ts", import.meta.url).href;
+    const configs = parseRemoteLoginProviderModuleConfigs(
+      JSON.stringify([
+        {
+          protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+          schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+          provider: "example",
+          moduleSpecifier,
+        },
+      ]),
+    );
+    const provider = {
+      descriptor: {
+        protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+        schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+        provider: "example",
+      },
+      reconcileInstallation: mock(async () => ({
+        provider: "example",
+        credentialId: "credential_1",
+        material: { privateKeyPem: "secret-key-material" },
+        publicMetadata: { installationId: "installation_1" },
+      })),
+    };
+    const loaded = await loadRemoteLoginProvider("example", configs, async () => ({
+      remoteLoginProvider: provider,
+    }));
+    const result = await reconcileRemoteInstallation(loaded, {
+      endpointUrl: "https://auth.example",
+      discovery,
+      humanCredentials: {
+        version: 1,
+        consoleUrl: "https://auth.example",
+        authMode: "remote",
+        installationId: "client_installation_1",
+        accessToken: "access-secret",
+        refreshToken: "refresh-secret",
+        accessTokenExpiresAt: null,
+        scopes: [],
+        createdAt: "2026-07-25T00:00:00.000Z",
+        updatedAt: "2026-07-25T00:00:00.000Z",
+      },
+      installation: {
+        clientInstallationId: "client_installation_1",
+        name: "Test runtime",
+        hostname: "test-host",
+        platform: "test-platform",
+      },
+    });
+
+    expect(result).toEqual({
+      provider: "example",
+      credentialId: "credential_1",
+      material: { privateKeyPem: "secret-key-material" },
+      publicMetadata: { installationId: "installation_1" },
+    });
+    expect(provider.reconcileInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects remote module specifiers, duplicate providers, and provider mismatches", async () => {
+    expect(() =>
+      parseRemoteLoginProviderModuleConfigs(
+        JSON.stringify([
+          {
+            protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+            schemaVersion: 1,
+            provider: "example",
+            moduleSpecifier: "https://untrusted.example/provider.js",
+          },
+        ]),
+      ),
+    ).toThrow(RemoteLoginContractError);
+    expect(() =>
+      parseRemoteLoginProviderModuleConfigs(
+        JSON.stringify([
+          {
+            protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+            schemaVersion: 1,
+            provider: "example",
+            moduleSpecifier: "@example/one",
+          },
+          {
+            protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+            schemaVersion: 1,
+            provider: "example",
+            moduleSpecifier: "@example/two",
+          },
+        ]),
+      ),
+    ).toThrow(expect.objectContaining({ reason: "duplicate_provider" }));
+    await expect(
+      loadRemoteLoginProvider(
+        "example",
+        [
+          {
+            protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+            schemaVersion: 1,
+            provider: "example",
+            moduleSpecifier: "@example/provider",
+          },
+        ],
+        async () => ({
+          remoteLoginProvider: {
+            descriptor: {
+              protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+              schemaVersion: 1,
+              provider: "other",
+            },
+            reconcileInstallation() {},
+          },
+        }),
+      ),
+    ).rejects.toEqual(expect.objectContaining({ reason: "provider_mismatch" }));
+  });
+
+  it("rejects provider material that cannot round-trip through JSON", async () => {
+    const provider = {
+      descriptor: {
+        protocol: REMOTE_LOGIN_PROVIDER_PROTOCOL,
+        schemaVersion: REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION,
+        provider: "example",
+      },
+      reconcileInstallation: async () => ({
+        provider: "example",
+        credentialId: "credential_1",
+        material: { silentlyDropped: undefined },
+      }),
+    };
+
+    await expect(
+      reconcileRemoteInstallation(provider, {
+        endpointUrl: "https://auth.example",
+        discovery,
+        humanCredentials: {
+          version: 1,
+          consoleUrl: "https://auth.example",
+          authMode: "remote",
+          installationId: "client_installation_1",
+          accessToken: "access-secret",
+          refreshToken: "refresh-secret",
+          accessTokenExpiresAt: null,
+          scopes: [],
+          createdAt: "2026-07-25T00:00:00.000Z",
+          updatedAt: "2026-07-25T00:00:00.000Z",
+        },
+        installation: {
+          clientInstallationId: "client_installation_1",
+          name: "Test runtime",
+          hostname: "test-host",
+          platform: "test-platform",
+        },
+      }),
+    ).rejects.toEqual(expect.objectContaining({ reason: "invalid_provider_result" }));
+  });
+});

--- a/src/cloud-auth/remote-login.ts
+++ b/src/cloud-auth/remote-login.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { CloudAuthError } from "./errors.js";
-import type { CloudCredentials } from "./types.js";
 
 export const REMOTE_LOGIN_DISCOVERY_PROTOCOL = "ravi.auth.discovery" as const;
 export const REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION = 1 as const;
@@ -100,6 +99,44 @@ const BoundedOpaqueRecordSchema = z.record(z.string(), z.unknown()).superRefine(
   }
 });
 
+export const RemoteLoginInstallationMetadataSchema = z
+  .object({
+    clientInstallationId: OpaqueIdSchema,
+    name: z.string().min(1).max(256),
+    hostname: z.string().min(1).max(256),
+    platform: z.string().min(1).max(128),
+    raviVersion: z.string().min(1).max(128).optional(),
+  })
+  .strict();
+
+export const RemoteLoginAuthorizedRequestSchema = z
+  .object({
+    method: z.enum(["GET", "POST"]),
+    path: z
+      .string()
+      .min(1)
+      .max(4096)
+      .regex(/^\/(?!\/)(?!.*\\)[^\u0000-\u001f\u007f#]*$/, "must be an origin-relative path without a fragment"),
+    body: BoundedOpaqueRecordSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.method === "GET" && value.body !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["body"],
+        message: "GET requests must not carry a body",
+      });
+    }
+  });
+
+export const RemoteLoginAuthorizedResponseSchema = z
+  .object({
+    status: z.number().int().min(100).max(599),
+    body: BoundedOpaqueRecordSchema.optional(),
+  })
+  .strict();
+
 export const RemoteInstallationCredentialSchema = z
   .object({
     provider: WireKindSchema,
@@ -112,20 +149,19 @@ export const RemoteInstallationCredentialSchema = z
 
 export type RemoteLoginDiscovery = z.infer<typeof RemoteLoginDiscoverySchema>;
 export type RemoteLoginProviderModuleConfig = z.infer<typeof RemoteLoginProviderModuleConfigSchema>;
+export type RemoteLoginInstallationMetadata = z.infer<typeof RemoteLoginInstallationMetadataSchema>;
+export type RemoteLoginAuthorizedRequest = z.infer<typeof RemoteLoginAuthorizedRequestSchema>;
+export type RemoteLoginAuthorizedResponse = z.infer<typeof RemoteLoginAuthorizedResponseSchema>;
 export type RemoteInstallationCredential = z.infer<typeof RemoteInstallationCredentialSchema>;
 
-export interface RemoteLoginInstallationMetadata {
-  readonly clientInstallationId: string;
-  readonly name: string;
-  readonly hostname: string;
-  readonly platform: string;
-  readonly raviVersion?: string;
+export interface RemoteLoginAuthorization {
+  request(input: RemoteLoginAuthorizedRequest): Promise<RemoteLoginAuthorizedResponse>;
 }
 
 export interface RemoteLoginProviderContext {
   readonly endpointUrl: string;
   readonly discovery: RemoteLoginDiscovery;
-  readonly humanCredentials: CloudCredentials;
+  readonly authorization: RemoteLoginAuthorization;
   readonly installation: RemoteLoginInstallationMetadata;
   readonly previousCredential?: RemoteInstallationCredential;
 }
@@ -155,7 +191,10 @@ export class RemoteLoginContractError extends Error {
       | "provider_mismatch"
       | "duplicate_provider"
       | "provider_not_configured"
-      | "invalid_provider_result",
+      | "invalid_provider_result"
+      | "invalid_authorized_request"
+      | "authorized_request_failed"
+      | "invalid_authorized_response",
   ) {
     super(reason);
     this.name = "RemoteLoginContractError";
@@ -219,6 +258,72 @@ export function normalizeRemoteLoginEndpoint(value: string): string {
   }
   parsed.pathname = parsed.pathname.replace(/\/+$/, "");
   return parsed.toString().replace(/\/+$/, "");
+}
+
+export function createRemoteLoginAuthorization(options: {
+  endpointUrl: string;
+  accessToken: string;
+  fetch?: RemoteLoginFetch;
+}): RemoteLoginAuthorization {
+  const endpointUrl = normalizeRemoteLoginEndpoint(options.endpointUrl);
+  const endpointOrigin = new URL(endpointUrl).origin;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+
+  return {
+    async request(input) {
+      const parsed = RemoteLoginAuthorizedRequestSchema.safeParse(input);
+      if (!parsed.success) {
+        throw new RemoteLoginContractError("invalid_authorized_request");
+      }
+      const requestUrl = new URL(parsed.data.path, `${endpointUrl}/`);
+      if (requestUrl.origin !== endpointOrigin) {
+        throw new RemoteLoginContractError("invalid_authorized_request");
+      }
+      let response: Response;
+      try {
+        response = await fetchImpl(requestUrl, {
+          method: parsed.data.method,
+          redirect: "error",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${options.accessToken}`,
+            ...(parsed.data.body === undefined ? {} : { "Content-Type": "application/json" }),
+          },
+          ...(parsed.data.body === undefined ? {} : { body: JSON.stringify(parsed.data.body) }),
+        });
+      } catch {
+        throw new RemoteLoginContractError("authorized_request_failed");
+      }
+
+      let body: Record<string, unknown> | undefined;
+      let text: string;
+      try {
+        text = await response.text();
+      } catch {
+        throw new RemoteLoginContractError("invalid_authorized_response");
+      }
+      if (new TextEncoder().encode(text).byteLength > 65_536) {
+        throw new RemoteLoginContractError("invalid_authorized_response");
+      }
+      if (text.length > 0) {
+        let decoded: unknown;
+        try {
+          decoded = JSON.parse(text);
+        } catch {
+          throw new RemoteLoginContractError("invalid_authorized_response");
+        }
+        const parsedBody = BoundedOpaqueRecordSchema.safeParse(decoded);
+        if (!parsedBody.success) {
+          throw new RemoteLoginContractError("invalid_authorized_response");
+        }
+        body = parsedBody.data;
+      }
+      return RemoteLoginAuthorizedResponseSchema.parse({
+        status: response.status,
+        ...(body === undefined ? {} : { body }),
+      });
+    },
+  };
 }
 
 export function parseRemoteLoginProviderModuleConfigs(value: string | undefined): RemoteLoginProviderModuleConfig[] {

--- a/src/cloud-auth/remote-login.ts
+++ b/src/cloud-auth/remote-login.ts
@@ -1,0 +1,326 @@
+import { z } from "zod";
+import { CloudAuthError } from "./errors.js";
+import type { CloudCredentials } from "./types.js";
+
+export const REMOTE_LOGIN_DISCOVERY_PROTOCOL = "ravi.auth.discovery" as const;
+export const REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION = 1 as const;
+export const REMOTE_LOGIN_DISCOVERY_PATH = "/.well-known/ravi-auth" as const;
+export const REMOTE_LOGIN_PROVIDER_PROTOCOL = "ravi.auth.post-login" as const;
+export const REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION = 1 as const;
+export const REMOTE_LOGIN_PROVIDER_MODULES_ENV = "RAVI_REMOTE_LOGIN_PROVIDERS" as const;
+
+const WireKindSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/)
+  .max(96);
+const OpaqueIdSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._~-]*$/)
+  .max(128);
+const ModuleSpecifierSchema = z
+  .string()
+  .regex(/^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/);
+
+export const RemoteLoginDiscoverySchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_DISCOVERY_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_DISCOVERY_SCHEMA_VERSION),
+    issuer: z.url(),
+    authConfigEndpoint: z.url(),
+    sessionEndpoints: z
+      .object({
+        exchange: z.url(),
+        refresh: z.url(),
+        logout: z.url(),
+        me: z.url(),
+      })
+      .strict(),
+    installationProvider: WireKindSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (new URL(value.authConfigEndpoint).origin !== new URL(value.issuer).origin) {
+      context.addIssue({
+        code: "custom",
+        path: ["authConfigEndpoint"],
+        message: "authConfigEndpoint must share the issuer origin",
+      });
+    }
+    for (const [field, endpoint] of Object.entries(value.sessionEndpoints)) {
+      if (new URL(endpoint).origin !== new URL(value.issuer).origin) {
+        context.addIssue({
+          code: "custom",
+          path: ["sessionEndpoints", field],
+          message: `${field} must share the issuer origin`,
+        });
+      }
+    }
+  });
+
+export const RemoteLoginProviderModuleConfigSchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_PROVIDER_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION),
+    provider: WireKindSchema,
+    moduleSpecifier: ModuleSpecifierSchema,
+  })
+  .strict();
+
+export const RemoteLoginProviderDescriptorSchema = z
+  .object({
+    protocol: z.literal(REMOTE_LOGIN_PROVIDER_PROTOCOL),
+    schemaVersion: z.literal(REMOTE_LOGIN_PROVIDER_SCHEMA_VERSION),
+    provider: WireKindSchema,
+  })
+  .strict();
+
+const BoundedOpaqueRecordSchema = z.record(z.string(), z.unknown()).superRefine((value, context) => {
+  if (!isJsonRecord(value)) {
+    context.addIssue({
+      code: "custom",
+      message: "value must contain only JSON values",
+    });
+    return;
+  }
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    context.addIssue({
+      code: "custom",
+      message: "value must be JSON serializable",
+    });
+    return;
+  }
+  if (new TextEncoder().encode(encoded).byteLength > 65_536) {
+    context.addIssue({
+      code: "custom",
+      message: "value exceeds the supported size",
+    });
+  }
+});
+
+export const RemoteInstallationCredentialSchema = z
+  .object({
+    provider: WireKindSchema,
+    credentialId: OpaqueIdSchema,
+    material: BoundedOpaqueRecordSchema,
+    publicMetadata: BoundedOpaqueRecordSchema.optional(),
+    expiresAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  .strict();
+
+export type RemoteLoginDiscovery = z.infer<typeof RemoteLoginDiscoverySchema>;
+export type RemoteLoginProviderModuleConfig = z.infer<typeof RemoteLoginProviderModuleConfigSchema>;
+export type RemoteInstallationCredential = z.infer<typeof RemoteInstallationCredentialSchema>;
+
+export interface RemoteLoginInstallationMetadata {
+  readonly clientInstallationId: string;
+  readonly name: string;
+  readonly hostname: string;
+  readonly platform: string;
+  readonly raviVersion?: string;
+}
+
+export interface RemoteLoginProviderContext {
+  readonly endpointUrl: string;
+  readonly discovery: RemoteLoginDiscovery;
+  readonly humanCredentials: CloudCredentials;
+  readonly installation: RemoteLoginInstallationMetadata;
+  readonly previousCredential?: RemoteInstallationCredential;
+}
+
+export interface RemoteLoginProvider {
+  readonly descriptor: z.infer<typeof RemoteLoginProviderDescriptorSchema>;
+  reconcileInstallation(
+    context: RemoteLoginProviderContext,
+  ): Promise<RemoteInstallationCredential> | RemoteInstallationCredential;
+}
+
+export interface RemoteLoginProviderModule {
+  readonly remoteLoginProvider: RemoteLoginProvider;
+}
+
+export type RemoteLoginProviderImporter = (moduleSpecifier: string) => Promise<unknown>;
+export type RemoteLoginFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export class RemoteLoginContractError extends Error {
+  constructor(
+    readonly reason:
+      | "invalid_discovery"
+      | "issuer_mismatch"
+      | "invalid_provider_configuration"
+      | "module_load_failed"
+      | "invalid_module_export"
+      | "provider_mismatch"
+      | "duplicate_provider"
+      | "provider_not_configured"
+      | "invalid_provider_result",
+  ) {
+    super(reason);
+    this.name = "RemoteLoginContractError";
+  }
+}
+
+export async function discoverRemoteLoginEndpoint(
+  endpointUrl: string,
+  fetchImpl: RemoteLoginFetch = globalThis.fetch,
+): Promise<RemoteLoginDiscovery> {
+  const endpoint = normalizeRemoteLoginEndpoint(endpointUrl);
+  let response: Response;
+  try {
+    response = await fetchImpl(`${endpoint}${REMOTE_LOGIN_DISCOVERY_PATH}`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      redirect: "error",
+    });
+  } catch (error) {
+    throw new CloudAuthError("SERVER_UNAVAILABLE", "Remote login discovery failed.", { cause: error });
+  }
+  if (!response.ok) {
+    throw new CloudAuthError("SERVER_UNAVAILABLE", "Remote login discovery is unavailable.", {
+      status: response.status,
+    });
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new CloudAuthError("PAYLOAD_INVALID", "Remote login discovery returned invalid JSON.", { cause: error });
+  }
+  const parsed = RemoteLoginDiscoverySchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new RemoteLoginContractError("invalid_discovery");
+  }
+  if (normalizeRemoteLoginEndpoint(parsed.data.issuer) !== endpoint) {
+    throw new RemoteLoginContractError("issuer_mismatch");
+  }
+  return parsed.data;
+}
+
+export function normalizeRemoteLoginEndpoint(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    throw new CloudAuthError("PAYLOAD_INVALID", "Remote login endpoint is invalid.");
+  }
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback(parsed.hostname))) {
+    throw new CloudAuthError(
+      "PAYLOAD_INVALID",
+      "Remote login endpoints require HTTPS; loopback HTTP is allowed for local development.",
+    );
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new CloudAuthError(
+      "PAYLOAD_INVALID",
+      "Remote login endpoint must not contain credentials, query, or fragment.",
+    );
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseRemoteLoginProviderModuleConfigs(value: string | undefined): RemoteLoginProviderModuleConfig[] {
+  if (!value?.trim()) return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value);
+  } catch {
+    throw new RemoteLoginContractError("invalid_provider_configuration");
+  }
+  const parsed = z.array(RemoteLoginProviderModuleConfigSchema).safeParse(decoded);
+  if (!parsed.success) {
+    throw new RemoteLoginContractError("invalid_provider_configuration");
+  }
+  const providers = new Set<string>();
+  for (const config of parsed.data) {
+    if (providers.has(config.provider)) {
+      throw new RemoteLoginContractError("duplicate_provider");
+    }
+    providers.add(config.provider);
+  }
+  return parsed.data;
+}
+
+export async function loadRemoteLoginProvider(
+  provider: string,
+  configs: readonly RemoteLoginProviderModuleConfig[],
+  importer: RemoteLoginProviderImporter = (moduleSpecifier) => import(moduleSpecifier),
+): Promise<RemoteLoginProvider> {
+  const config = configs.find((candidate) => candidate.provider === provider);
+  if (!config) throw new RemoteLoginContractError("provider_not_configured");
+  let moduleValue: unknown;
+  try {
+    moduleValue = await importer(config.moduleSpecifier);
+  } catch {
+    throw new RemoteLoginContractError("module_load_failed");
+  }
+  const record = objectValue(moduleValue);
+  const candidate = objectValue(record?.remoteLoginProvider) as unknown as RemoteLoginProvider | null;
+  if (!candidate || typeof candidate.reconcileInstallation !== "function") {
+    throw new RemoteLoginContractError("invalid_module_export");
+  }
+  const descriptor = RemoteLoginProviderDescriptorSchema.safeParse(candidate.descriptor);
+  if (!descriptor.success) {
+    throw new RemoteLoginContractError("invalid_module_export");
+  }
+  if (descriptor.data.provider !== provider) {
+    throw new RemoteLoginContractError("provider_mismatch");
+  }
+  return candidate;
+}
+
+export async function reconcileRemoteInstallation(
+  provider: RemoteLoginProvider,
+  context: RemoteLoginProviderContext,
+): Promise<RemoteInstallationCredential> {
+  let result: unknown;
+  try {
+    result = await provider.reconcileInstallation(context);
+  } catch (error) {
+    if (error instanceof CloudAuthError || error instanceof RemoteLoginContractError) throw error;
+    throw new CloudAuthError("SERVER_UNAVAILABLE", "Remote installation reconciliation failed.", { cause: error });
+  }
+  const parsed = RemoteInstallationCredentialSchema.safeParse(result);
+  if (!parsed.success || parsed.data.provider !== provider.descriptor.provider) {
+    throw new RemoteLoginContractError("invalid_provider_result");
+  }
+  return parsed.data;
+}
+
+function isLoopback(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function isJsonRecord(value: Record<string, unknown>): boolean {
+  const stack: unknown[] = [value];
+  const seen = new WeakSet<object>();
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (
+      current === null ||
+      typeof current === "string" ||
+      typeof current === "boolean" ||
+      (typeof current === "number" && Number.isFinite(current))
+    ) {
+      continue;
+    }
+    if (typeof current !== "object") return false;
+    if (seen.has(current)) return false;
+    seen.add(current);
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    stack.push(...Object.values(current));
+  }
+  return true;
+}

--- a/src/cloud-auth/storage.ts
+++ b/src/cloud-auth/storage.ts
@@ -92,6 +92,7 @@ function normalizeStoredCredentials(value: unknown): CloudCredentials {
   return {
     version: 1,
     consoleUrl,
+    ...(input.authMode === "remote" || input.authMode === "console" ? { authMode: input.authMode } : {}),
     installationId,
     accessToken,
     refreshToken,

--- a/src/cloud-auth/types.ts
+++ b/src/cloud-auth/types.ts
@@ -16,6 +16,7 @@ export interface CloudAuthOrganization {
 export interface CloudCredentials {
   version: 1;
   consoleUrl: string;
+  authMode?: "console" | "remote";
   installationId: string;
   accessToken: string;
   refreshToken: string;


### PR DESCRIPTION
## Objective

Support explicit authentication against a remotely discovered endpoint while preserving the existing default authentication flow.

## Problem

The CLI previously assumed one fixed authentication service and had no versioned boundary for post-login installation reconciliation.

## Solution

Add origin-bound discovery, an opt-in endpoint flag for login, a provider-neutral local reconciliation ABI, generated SDK artifacts, and separate storage for renewable installation credentials.

## Practical impact

Operators can register an installation with an explicitly selected compatible endpoint, while normal identity inspection and logout remain simple and endpoint-independent.

## What does NOT change

The default login flow remains available, identity inspection does not require an endpoint argument, and logout still removes the active human session locally.

## Validation

- `bun run typecheck`
- targeted discovery, provider, authentication command, storage, redaction, and SDK fixture tests
- generated SDK build and drift checks
- Biome checks on changed CLI and runtime files
- deterministic capsule compilation and exclusion scans

The full pre-push suite reached an unrelated isolated-database test group that reproducibly returned a SQLite disk I/O error; this change does not modify the database subsystem exercised there.

## Risks

A misconfigured endpoint or provider module could otherwise widen credential exposure, so discovery is origin-bound, redirects are rejected, outputs are bounded, and provider modules require explicit local configuration.

## Rollback

Revert this pull request to remove remote endpoint discovery and provider reconciliation; the pre-existing default authentication flow remains the fallback.