### PR TITLE
Bind installation credentials to native channel drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ An explicit endpoint publishes a versioned login contract at
 Endpoint-specific post-login integration is opt-in and loads only a local
 provider module explicitly configured by the operator.
 
+An explicitly installed native channel driver whose provider matches the
+stored installation credential may reconnect without a human session. Ravi
+passes that credential through a provider- and connection-scoped host
+capability; drivers do not read credential files directly.
+
 The proprietary server policy for hosted artifacts, billing, quotas, private asset auth, custom domains, and Console product behavior intentionally lives outside this open-source repo.
 
 ### Build Against The SDK

--- a/packages/ravi-os-sdk/README.md
+++ b/packages/ravi-os-sdk/README.md
@@ -140,6 +140,14 @@ returns a bounded opaque renewable credential. Ravi stores that credential
 separately from the human CLI session, redacts its material from command
 output, and preserves it when `ravi logout` removes the human session.
 
+When an explicitly installed native channel driver uses the same provider,
+the channel runner starts one hidden runtime for each non-expired installation
+credential. The driver declares
+`requiredHostCapabilities: ["installation_credentials"]` and reads only its
+provider- and connection-bound credential through
+`context.host.readInstallationCredential()`. It cannot enumerate credentials
+or receive the human login session.
+
 ### Reconcile Locally Managed Agents
 
 Node-side integrations can reconcile an external desired identity into a

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
@@ -8,5 +8,8 @@
   "driverId": "example.native",
   "protocol": "ravi.channel.native-driver",
   "provider": "example",
+  "requiredHostCapabilities": [
+    "installation_credentials"
+  ],
   "schemaVersion": 1
 }

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json
@@ -1,0 +1,11 @@
+{
+  "credentialId": "credential-a",
+  "expiresAt": "2026-08-24T18:00:00.000Z",
+  "material": {
+    "credentialHandle": "opaque-material-a"
+  },
+  "provider": "example",
+  "publicMetadata": {
+    "installationId": "installation-a"
+  }
+}

--- a/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
@@ -3,6 +3,7 @@ import {
   NATIVE_CHANNEL_DRIVER_PROTOCOL,
   NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
   NativeChannelDriverDescriptorSchema,
+  NativeChannelDriverHostCapabilitiesSchema,
   NativeChannelDriverModuleConfigSchema,
   NativeChannelDriverModuleSpecifierSchema,
   NativeChannelRuntimeDescriptorSchema,
@@ -21,10 +22,15 @@ describe("native channel driver SDK contract", () => {
     const moduleConfig = await fixture("module-config.json");
     const driverDescriptor = await fixture("driver-descriptor.json");
     const runtimeDescriptor = await fixture("runtime-descriptor.json");
+    const installationCredential = await fixture("installation-credential.json");
 
     expect(NativeChannelDriverModuleConfigSchema.parse(moduleConfig)).toEqual(moduleConfig);
     expect(NativeChannelDriverDescriptorSchema.parse(driverDescriptor)).toEqual(driverDescriptor);
     expect(NativeChannelRuntimeDescriptorSchema.parse(runtimeDescriptor)).toEqual(runtimeDescriptor);
+    expect(installationCredential).toMatchObject({ provider: "example" });
+    expect(NativeChannelDriverHostCapabilitiesSchema.parse(["installation_credentials"])).toEqual([
+      "installation_credentials",
+    ]);
   });
 
   it("accepts only installed package names and absolute local file URLs", () => {
@@ -65,6 +71,7 @@ describe("native channel driver SDK contract", () => {
         driverId: "example.native",
         provider: "example",
         capabilities: ["inbound"],
+        requiredHostCapabilities: ["installation_credentials"],
       },
       createRuntime(context) {
         return {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -1,9 +1,14 @@
 {
   "artifacts": [
     {
-      "sha256": "f69e2adac356ba436bc5107ef9f7ff672a1830faca7eaa07252cc7efd6e338d5",
-      "sizeBytes": 222,
+      "sha256": "8630678beaba142d039194361e2cf8515dcebe6867ba616c43de6a5c84335add",
+      "sizeBytes": 290,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json"
+    },
+    {
+      "sha256": "f69ab6d8aceb58dfaa3775b71c14892f3d64252046506c7cd016a82d8813b8e5",
+      "sizeBytes": 236,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json"
     },
     {
       "sha256": "d03296778c8bd5331120e3f317d7eec483b11a5e70ebc4bcffb51ea34ba2a63b",
@@ -16,8 +21,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "bf36b17fd75a88c3e973bb00e15627a0c027c2e24294c7a1885c64cf9be9946d",
-      "sizeBytes": 4163,
+      "sha256": "87781ea62713d9134f963878a552882624377214dfbbd358858c3a60c32102dc",
+      "sizeBytes": 6228,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
   ],
@@ -34,14 +39,15 @@
   ],
   "fileAllowlist": [
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json",
     "packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json",
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "bfcb36d84ec393d7f834112511ef80f43f8af6c68927369e4dbd0b6c5a9e96ac",
-  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers and include them in lifecycle and health.",
+  "outputDigest": "d8ca4a05ac15dd8598616f8d9d0915f6262ee5adbb2c18f92d3ce8c0feeb3eaf",
+  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials without exposing human sessions, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
       "fields": [],
@@ -50,6 +56,14 @@
     {
       "fields": [],
       "schema": "NativeChannelDriverCapabilities"
+    },
+    {
+      "fields": [],
+      "schema": "NativeChannelDriverHostCapability"
+    },
+    {
+      "fields": [],
+      "schema": "NativeChannelDriverHostCapabilities"
     },
     {
       "fields": [
@@ -66,7 +80,8 @@
         "schemaVersion",
         "driverId",
         "provider",
-        "capabilities"
+        "capabilities",
+        "requiredHostCapabilities"
       ],
       "schema": "NativeChannelDriverDescriptor"
     },
@@ -81,9 +96,19 @@
         "capabilities"
       ],
       "schema": "NativeChannelRuntimeDescriptor"
+    },
+    {
+      "fields": [
+        "provider",
+        "credentialId",
+        "material",
+        "publicMetadata",
+        "expiresAt"
+      ],
+      "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "816c67787b76c5b98f6ab356b0f178fdeda35cf0d81f92aa9b2a75655b370464",
+  "sourceDigest": "4d43634a31d850c846d4add5964262f39781103f710099d38748f59778937fce",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -54,6 +54,17 @@
           "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
           "type": "string"
         },
+        "requiredHostCapabilities": {
+          "items": {
+            "enum": [
+              "installation_credentials"
+            ],
+            "type": "string"
+          },
+          "maxItems": 1,
+          "minItems": 1,
+          "type": "array"
+        },
         "schemaVersion": {
           "const": 1,
           "type": "number"
@@ -67,6 +78,25 @@
         "capabilities"
       ],
       "type": "object"
+    },
+    "NativeChannelDriverHostCapabilities": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "items": {
+        "enum": [
+          "installation_credentials"
+        ],
+        "type": "string"
+      },
+      "maxItems": 1,
+      "minItems": 1,
+      "type": "array"
+    },
+    "NativeChannelDriverHostCapability": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "enum": [
+        "installation_credentials"
+      ],
+      "type": "string"
     },
     "NativeChannelDriverModuleConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -148,12 +178,51 @@
         "capabilities"
       ],
       "type": "object"
+    },
+    "RemoteInstallationCredential": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "credentialId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "expiresAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "material": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "provider": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "publicMetadata": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "provider",
+        "credentialId",
+        "material"
+      ],
+      "type": "object"
     }
   },
   "$id": "urn:ravi:channel-capsule:native-channel-driver:v1",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "816c67787b76c5b98f6ab356b0f178fdeda35cf0d81f92aa9b2a75655b370464",
+  "sourceDigest": "4d43634a31d850c846d4add5964262f39781103f710099d38748f59778937fce",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/native-channel-driver.ts
+++ b/packages/ravi-os-sdk/src/native-channel-driver.ts
@@ -14,6 +14,7 @@ import type {
   ChannelRuntimeReadbackRequest,
   ChannelRuntimeReadbackResult,
 } from "./channel-runtime-events.js";
+import type { RemoteInstallationCredential } from "./remote-login-provider.js";
 
 export const NATIVE_CHANNEL_DRIVER_PROTOCOL = "ravi.channel.native-driver" as const;
 export const NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION = 1 as const;
@@ -29,6 +30,13 @@ export const NativeChannelDriverCapabilitiesSchema = z
   .array(NativeChannelDriverCapabilitySchema)
   .min(1)
   .max(4);
+
+export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
+
+export const NativeChannelDriverHostCapabilitiesSchema = z
+  .array(NativeChannelDriverHostCapabilitySchema)
+  .min(1)
+  .max(1);
 
 export const NativeChannelDriverModuleSpecifierSchema = z
   .string()
@@ -50,6 +58,7 @@ export const NativeChannelDriverDescriptorSchema = z.object({
   driverId: ChannelBackendWireKindSchema,
   provider: ChannelBackendWireKindSchema,
   capabilities: NativeChannelDriverCapabilitiesSchema,
+  requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
 });
 
 export const NativeChannelRuntimeDescriptorSchema = z.object({
@@ -79,6 +88,7 @@ export const NativeChannelRuntimeHealthSchema = z.object({
 });
 
 export type NativeChannelDriverCapability = z.infer<typeof NativeChannelDriverCapabilitySchema>;
+export type NativeChannelDriverHostCapability = z.infer<typeof NativeChannelDriverHostCapabilitySchema>;
 export type NativeChannelDriverModuleConfig = z.infer<typeof NativeChannelDriverModuleConfigSchema>;
 export type NativeChannelDriverDescriptor = z.infer<typeof NativeChannelDriverDescriptorSchema>;
 export type NativeChannelRuntimeDescriptor = z.infer<typeof NativeChannelRuntimeDescriptorSchema>;
@@ -203,6 +213,7 @@ export interface NativeChannelPresenceDelivery {
 }
 
 export interface NativeChannelDriverHost {
+  readInstallationCredential(): Promise<RemoteInstallationCredential | null>;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;

--- a/src/channels/native/driver.test.ts
+++ b/src/channels/native/driver.test.ts
@@ -89,6 +89,7 @@ function ingressResult(request = ingressRequest()): ChannelIngressResult {
 
 function hostLease(overrides: Partial<NativeChannelDriverHost> = {}): NativeChannelDriverHostLease {
   const host: NativeChannelDriverHost = {
+    readInstallationCredential: mock(async () => null),
     ingress: mock(async (request) => ingressResult(request)),
     interrupt: mock(async (request) => ({
       protocol: "ravi.channel.runtime-events" as const,
@@ -142,6 +143,7 @@ function fullDriver(
       driverId: "example.native",
       provider: "example",
       capabilities: ["inbound", "text_delivery", "chat_actions", "presence"],
+      requiredHostCapabilities: ["installation_credentials"],
     },
     createRuntime(context) {
       return {
@@ -371,6 +373,39 @@ describe("native channel driver contract", () => {
     expect(JSON.stringify(manager.health())).not.toContain("sensitive-runtime-detail");
   });
 
+  it("fails closed before runtime creation when a required host capability is absent", async () => {
+    const registry = new NativeChannelDriverRegistry();
+    const driver = fullDriver();
+    const createRuntime = mock(driver.createRuntime.bind(driver));
+    registry.register({ ...driver, createRuntime });
+    const lease = hostLease();
+    const incompleteHost = {
+      ...lease.host,
+      readInstallationCredential: undefined,
+    } as unknown as NativeChannelDriverHost;
+    const manager = new NativeChannelDriverManager({
+      channels: { "example-channel-a": channel() },
+      registry,
+      createHostLease: () => ({
+        host: incompleteHost,
+        dispose: lease.dispose,
+      }),
+    });
+
+    await manager.start();
+
+    expect(createRuntime).not.toHaveBeenCalled();
+    expect(manager.health()).toEqual([
+      {
+        id: "example:example-channel-a",
+        channelId: "example",
+        status: "failed",
+        reason: "host_capability_missing",
+      },
+    ]);
+    expect(lease.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps module loader failures stable and free of thrown details", async () => {
     const registry = new NativeChannelDriverRegistry();
     const result = await loadNativeChannelDriverModules(
@@ -494,6 +529,47 @@ describe("native channel driver contract", () => {
 
     lease.dispose();
     await expect(channelOutputSinks.emit(envelope)).rejects.toThrow("unavailable");
+  });
+
+  it("binds installation credential access to the configured provider and connection", async () => {
+    const resolveInstallationCredential = mock(async () => ({
+      provider: "example",
+      credentialId: "credential-1",
+      material: { privateKey: "opaque-private-material" },
+    }));
+    const lease = createNativeChannelDriverHostLease({
+      channel: {
+        ...channel(),
+        credentialConnection: "https://remote.example",
+      },
+      provider: "example",
+      resolveInstallationCredential,
+    });
+
+    await expect(lease.host.readInstallationCredential()).resolves.toEqual({
+      provider: "example",
+      credentialId: "credential-1",
+      material: { privateKey: "opaque-private-material" },
+    });
+    expect(resolveInstallationCredential).toHaveBeenCalledWith({
+      provider: "example",
+      connection: "https://remote.example",
+    });
+
+    const wrongProvider = createNativeChannelDriverHostLease({
+      channel: channel(),
+      provider: "example",
+      resolveInstallationCredential: async () => ({
+        provider: "other",
+        credentialId: "credential-2",
+        material: {},
+      }),
+    });
+    await expect(wrongProvider.host.readInstallationCredential()).rejects.toThrow("scope_mismatch");
+
+    lease.dispose();
+    await expect(lease.host.readInstallationCredential()).rejects.toThrow("host_disposed");
+    wrongProvider.dispose();
   });
 
   it("rejects duplicate driver ownership without replacing the registered driver", () => {

--- a/src/channels/native/driver.ts
+++ b/src/channels/native/driver.ts
@@ -9,6 +9,7 @@ import {
   type ExternalChannelIdentity,
 } from "../backend.js";
 import type { ChannelAdapterHealth } from "../health.js";
+import type { RemoteInstallationCredential } from "../../cloud-auth/remote-login.js";
 import type {
   ChannelInterruptRequest,
   ChannelInterruptResult,
@@ -27,6 +28,10 @@ export const NativeChannelDriverCapabilitySchema = z.enum(["inbound", "text_deli
 
 export const NativeChannelDriverCapabilitiesSchema = z.array(NativeChannelDriverCapabilitySchema).min(1).max(4);
 
+export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
+
+export const NativeChannelDriverHostCapabilitiesSchema = z.array(NativeChannelDriverHostCapabilitySchema).min(1).max(1);
+
 export const NativeChannelDriverModuleSpecifierSchema = z
   .string()
   .regex(/^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/);
@@ -44,6 +49,7 @@ export const NativeChannelDriverDescriptorSchema = z.object({
   driverId: ChannelBackendWireKindSchema,
   provider: ChannelBackendWireKindSchema,
   capabilities: NativeChannelDriverCapabilitiesSchema,
+  requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
 });
 
 export const NativeChannelRuntimeDescriptorSchema = z.object({
@@ -65,6 +71,7 @@ export const NativeChannelRuntimeHealthSchema = z.object({
 });
 
 export type NativeChannelDriverCapability = z.infer<typeof NativeChannelDriverCapabilitySchema>;
+export type NativeChannelDriverHostCapability = z.infer<typeof NativeChannelDriverHostCapabilitySchema>;
 export type NativeChannelDriverModuleConfig = z.infer<typeof NativeChannelDriverModuleConfigSchema>;
 export type NativeChannelDriverDescriptor = z.infer<typeof NativeChannelDriverDescriptorSchema>;
 export type NativeChannelRuntimeDescriptor = z.infer<typeof NativeChannelRuntimeDescriptorSchema>;
@@ -83,6 +90,7 @@ export type NativeChannelDriverFailureReason =
   | "runtime_descriptor_invalid"
   | "runtime_capability_mismatch"
   | "runtime_surface_mismatch"
+  | "host_capability_missing"
   | "missing_credentials"
   | "startup_failed"
   | "health_invalid"
@@ -96,6 +104,7 @@ export interface NativeChannelDriverChannelConfig {
 }
 
 export interface NativeChannelDriverHost {
+  readInstallationCredential(): Promise<RemoteInstallationCredential | null>;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;
@@ -373,6 +382,7 @@ export class NativeChannelDriverManager {
     try {
       lease = createHostLease(channel, provider);
       const driverDescriptor = parseDriverDescriptor(driver.descriptor);
+      assertHostCapabilities(driverDescriptor, lease.host);
       runtime = await driver.createRuntime({
         channel: {
           name: channel.name,
@@ -405,6 +415,14 @@ export class NativeChannelDriverManager {
         status: "failed",
         reason: driverFailureReason(error, "startup_failed"),
       });
+    }
+  }
+}
+
+function assertHostCapabilities(descriptor: NativeChannelDriverDescriptor, host: NativeChannelDriverHost): void {
+  for (const capability of descriptor.requiredHostCapabilities ?? []) {
+    if (capability === "installation_credentials" && typeof host.readInstallationCredential !== "function") {
+      throw new NativeChannelDriverContractError("host_capability_missing");
     }
   }
 }

--- a/src/channels/native/host.ts
+++ b/src/channels/native/host.ts
@@ -1,4 +1,9 @@
 import type { ChannelConfig } from "../../router/router-db.js";
+import { readRemoteInstallationCredential } from "../../cloud-auth/installation-storage.js";
+import {
+  RemoteInstallationCredentialSchema,
+  type RemoteInstallationCredential,
+} from "../../cloud-auth/remote-login.js";
 import {
   ChannelBackendOpaqueIdSchema,
   ChannelBackendWireKindSchema,
@@ -20,9 +25,15 @@ export interface NativeChannelDriverHostLease {
   dispose(): void;
 }
 
+export type NativeChannelInstallationCredentialResolver = (input: {
+  readonly provider: string;
+  readonly connection?: string;
+}) => RemoteInstallationCredential | null | Promise<RemoteInstallationCredential | null>;
+
 export function createNativeChannelDriverHostLease(options: {
   channel: ChannelConfig;
   provider: string;
+  resolveInstallationCredential?: NativeChannelInstallationCredentialResolver;
 }): NativeChannelDriverHostLease {
   const channelInstanceId = ChannelBackendOpaqueIdSchema.parse(options.channel.name);
   const provider = ChannelBackendWireKindSchema.parse(options.provider);
@@ -47,6 +58,25 @@ export function createNativeChannelDriverHostLease(options: {
   };
 
   const host: NativeChannelDriverHost = {
+    async readInstallationCredential() {
+      ensureActive();
+      const resolve =
+        options.resolveInstallationCredential ??
+        ((input: { readonly provider: string; readonly connection?: string }) => {
+          const stored = readRemoteInstallationCredential(input.connection);
+          return stored?.credential ?? null;
+        });
+      const resolved = await resolve({
+        provider,
+        ...(options.channel.credentialConnection ? { connection: options.channel.credentialConnection } : {}),
+      });
+      if (resolved === null) return null;
+      const credential = RemoteInstallationCredentialSchema.parse(resolved);
+      if (credential.provider !== provider) {
+        throw new Error("native_channel_driver_scope_mismatch");
+      }
+      return structuredClone(credential);
+    },
     async ingress(input) {
       ensureActive();
       const request = ChannelIngressRequestSchema.parse(input);

--- a/src/channels/native/installation-channels.test.ts
+++ b/src/channels/native/installation-channels.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import type { StoredRemoteInstallationCredential } from "../../cloud-auth/installation-storage.js";
+import type { ChannelConfig } from "../../router/router-db.js";
+import { installationChannelName, mergeInstallationCredentialChannels } from "./installation-channels.js";
+
+function stored(endpointUrl: string, provider = "example", expiresAt?: string): StoredRemoteInstallationCredential {
+  return {
+    endpointUrl,
+    credential: {
+      provider,
+      credentialId: `credential-${provider}`,
+      material: { opaque: "secret-material" },
+      ...(expiresAt === undefined ? {} : { expiresAt }),
+    },
+    createdAt: "2026-07-25T12:00:00.000Z",
+    updatedAt: "2026-07-25T12:00:00.000Z",
+  };
+}
+
+describe("installation credential native channels", () => {
+  it("adds one stable hidden runtime per matching installed provider", () => {
+    const registry = {
+      get(provider: string) {
+        return provider === "example"
+          ? {
+              descriptor: {
+                requiredHostCapabilities: ["installation_credentials"],
+              },
+            }
+          : undefined;
+      },
+    };
+    const channels = mergeInstallationCredentialChannels({
+      configured: {},
+      credentials: [
+        stored("https://two.example"),
+        stored("https://one.example"),
+        stored("https://ignored.example", "not-installed"),
+      ],
+      registry,
+      now: Date.parse("2026-07-25T13:00:00.000Z"),
+    });
+
+    expect(Object.keys(channels)).toEqual([
+      installationChannelName("example", "https://one.example"),
+      installationChannelName("example", "https://two.example"),
+    ]);
+    expect(Object.values(channels)[0]).toMatchObject({
+      provider: "example",
+      enabled: true,
+      credentialConnection: "https://one.example",
+    });
+    expect(JSON.stringify(channels)).not.toContain("secret-material");
+  });
+
+  it("preserves explicit configuration and skips duplicates, expiry, and name collisions", () => {
+    const endpointUrl = "https://one.example";
+    const explicit: ChannelConfig = {
+      name: "explicit",
+      provider: "example",
+      enabled: true,
+      credentialConnection: endpointUrl,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const collisionName = installationChannelName("example", "https://collision.example");
+    const collision: ChannelConfig = {
+      name: collisionName,
+      provider: "other",
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const configured = { explicit, [collisionName]: collision };
+    const channels = mergeInstallationCredentialChannels({
+      configured,
+      credentials: [
+        stored(endpointUrl),
+        stored("https://expired.example", "example", "2026-07-25T12:00:00.000Z"),
+        stored("https://collision.example"),
+      ],
+      registry: {
+        get: () => ({
+          descriptor: {
+            requiredHostCapabilities: ["installation_credentials"],
+          },
+        }),
+      },
+      now: Date.parse("2026-07-25T13:00:00.000Z"),
+    });
+
+    expect(channels).toEqual(configured);
+  });
+});

--- a/src/channels/native/installation-channels.ts
+++ b/src/channels/native/installation-channels.ts
@@ -1,0 +1,59 @@
+import { createHash } from "node:crypto";
+import type { StoredRemoteInstallationCredential } from "../../cloud-auth/installation-storage.js";
+import type { ChannelConfig } from "../../router/router-db.js";
+
+export interface InstallationChannelRegistry {
+  get(provider: string):
+    | {
+        readonly descriptor?: {
+          readonly requiredHostCapabilities?: readonly string[];
+        };
+      }
+    | undefined;
+}
+
+export function mergeInstallationCredentialChannels(input: {
+  readonly configured: Readonly<Record<string, ChannelConfig>>;
+  readonly credentials: readonly StoredRemoteInstallationCredential[];
+  readonly registry: InstallationChannelRegistry;
+  readonly now?: number;
+}): Record<string, ChannelConfig> {
+  const merged: Record<string, ChannelConfig> = {
+    ...input.configured,
+  };
+  const now = input.now ?? Date.now();
+
+  for (const stored of [...input.credentials].sort((left, right) =>
+    left.endpointUrl.localeCompare(right.endpointUrl),
+  )) {
+    const provider = stored.credential.provider;
+    const driver = input.registry.get(provider);
+    if (driver?.descriptor?.requiredHostCapabilities?.includes("installation_credentials") !== true) {
+      continue;
+    }
+    if (stored.credential.expiresAt !== undefined && Date.parse(stored.credential.expiresAt) <= now) {
+      continue;
+    }
+    const alreadyConfigured = Object.values(merged).some(
+      (channel) => channel.provider === provider && channel.credentialConnection === stored.endpointUrl,
+    );
+    if (alreadyConfigured) continue;
+
+    const name = installationChannelName(provider, stored.endpointUrl);
+    if (merged[name] !== undefined) continue;
+    merged[name] = {
+      name,
+      provider,
+      enabled: true,
+      credentialConnection: stored.endpointUrl,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+  return merged;
+}
+
+export function installationChannelName(provider: string, endpointUrl: string): string {
+  const digest = createHash("sha256").update(provider).update("\0").update(endpointUrl).digest("hex").slice(0, 24);
+  return `remote-${digest}`;
+}

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import type { StoredRemoteInstallationCredential } from "../cloud-auth/installation-storage.js";
 import { CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS } from "./outbound-publish-outbox.js";
 import { CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS } from "./outbound-receipts.js";
 import {
@@ -10,6 +11,7 @@ import {
   slackAdapterHealth,
   startChannelOutboundReceiptPruner,
 } from "./runner.js";
+import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 
 describe("channel runner native delivery registry", () => {
@@ -114,6 +116,49 @@ describe("channel runner native delivery registry", () => {
     });
     await runtime.stop();
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("materializes one credential-backed native runtime without copying credential material", () => {
+    const endpointUrl = "https://remote.example";
+    const stored: StoredRemoteInstallationCredential = {
+      endpointUrl,
+      credential: {
+        provider: "example",
+        credentialId: "credential-example",
+        material: { privateValue: "must-not-enter-channel-config" },
+      },
+      createdAt: "2026-07-25T12:00:00.000Z",
+      updatedAt: "2026-07-25T12:00:00.000Z",
+    };
+
+    const channels = mergeInstallationCredentialChannels({
+      configured: {},
+      credentials: [stored],
+      registry: {
+        get(provider) {
+          return provider === "example"
+            ? {
+                descriptor: {
+                  requiredHostCapabilities: ["installation_credentials"],
+                },
+              }
+            : undefined;
+        },
+      },
+      now: Date.parse("2026-07-25T13:00:00.000Z"),
+    });
+
+    expect(channels).toEqual({
+      [installationChannelName("example", endpointUrl)]: {
+        name: installationChannelName("example", endpointUrl),
+        provider: "example",
+        enabled: true,
+        credentialConnection: endpointUrl,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    });
+    expect(JSON.stringify(channels)).not.toContain("must-not-enter-channel-config");
   });
 });
 

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -1,6 +1,7 @@
 import { closeAllRaviDbs } from "../db/close-all.js";
 import { closeNats, connectNats, getNats } from "../nats.js";
 import { configStore } from "../config-store.js";
+import { listRemoteInstallationCredentials } from "../cloud-auth/installation-storage.js";
 import { logger } from "../utils/logger.js";
 import {
   startChannelRunnerHealthResponder,
@@ -16,6 +17,7 @@ import {
   parseNativeChannelDriverModuleConfigs,
   type NativeChannelDriverRuntime,
 } from "./native/driver.js";
+import { mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import type { NativeChatActionDelivery, NativePresenceDelivery, NativeTextDelivery } from "./native/types.js";
 import { ChannelOutboundConsumer } from "./outbound-consumer.js";
 import {
@@ -221,8 +223,20 @@ export class ChannelRunner {
       log.warn("Native channel driver configuration was rejected", { reason });
     }
 
+    let channels = configStore.getConfig().channels ?? {};
+    try {
+      channels = mergeInstallationCredentialChannels({
+        configured: channels,
+        credentials: listRemoteInstallationCredentials(env),
+        registry,
+      });
+    } catch {
+      this.markAdapter("native-driver:installation-credentials", "native", "failed", "missing_credentials");
+      log.warn("Remote installation credentials were unavailable to native channels");
+    }
+
     this.nativeChannelManager = new NativeChannelDriverManager({
-      channels: configStore.getConfig().channels ?? {},
+      channels,
       registry,
     });
     await this.nativeChannelManager.start();

--- a/src/cloud-auth/installation-storage.test.ts
+++ b/src/cloud-auth/installation-storage.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   ensureRemoteClientInstallationId,
   getRemoteInstallationCredentialsPath,
+  listRemoteInstallationCredentials,
   readRemoteInstallationCredential,
   readRemoteInstallationCredentialState,
   toSafeRemoteInstallationCredential,
@@ -76,6 +77,10 @@ describe("remote installation credential storage", () => {
       endpointUrl: "https://two.example",
       credential: { credentialId: "credential_2" },
     });
+    expect(listRemoteInstallationCredentials().map((stored) => stored.endpointUrl)).toEqual([
+      "https://one.example",
+      "https://two.example",
+    ]);
   });
 
   it("stores secret material with user-only permissions but excludes it from safe metadata", () => {

--- a/src/cloud-auth/installation-storage.ts
+++ b/src/cloud-auth/installation-storage.ts
@@ -83,6 +83,16 @@ export function readRemoteInstallationCredential(
   return state.connections[endpoint] ?? null;
 }
 
+export function listRemoteInstallationCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): StoredRemoteInstallationCredential[] {
+  const state = readRemoteInstallationCredentialState(env);
+  if (!state) return [];
+  return Object.values(state.connections)
+    .sort((left, right) => left.endpointUrl.localeCompare(right.endpointUrl))
+    .map((stored) => structuredClone(stored));
+}
+
 export function writeRemoteInstallationCredential(
   endpointUrl: string,
   clientInstallationId: string,


### PR DESCRIPTION
## Objective

Allow an explicitly installed native channel driver to reuse the machine installation credential established by endpoint login, without depending on a human session credential.

## Problem

Endpoint login and native channel execution happen in separate processes. The runtime had no capability-scoped way to pass the existing provider-bound installation credential to the matching driver, which otherwise required a second machine secret or direct storage access.

## Solution

Add an opt-in `installation_credentials` host capability to the native driver ABI. The host binds reads to the current provider and connection, rejects unsupported required capabilities, and materializes a hidden runtime only when an explicitly installed driver declares the capability and a non-expired matching installation credential exists. The generated native-driver ABI capsule and provenance are refreshed with the new contract.

## Practical impact

A native channel process can reconnect using the installation identity already created by login, including after the human session is removed. Operators no longer need to copy a second machine credential into channel configuration.

## What does NOT change

Drivers still require explicit local installation. Human session tokens are not exposed, channel configuration contains no credential material, credentials cannot be enumerated across providers or connections, and existing configured channel runtimes continue to work unchanged.

## Validation

Passed focused SDK, native-driver, installation-channel, credential-storage, runner, and CLI authentication tests. Also passed `bun run typecheck`, `bun run lint`, `bun run build:cli`, and `git diff --check`.

## Risks

A trusted native driver gains access to the installation credential bound to its own provider and runtime connection. The boundary is constrained by explicit installation, declared capability negotiation, provider matching, expiry validation, and the absence of enumeration APIs.

## Rollback

Revert this pull request to remove the additive host capability and implicit credential-backed runtime; existing explicitly configured runtimes remain available.