### PR TITLE
Add native inbound channel actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ When the configured local post-login provider supports identity linking,
 stdin. The challenge is intentionally unavailable as an argument or option so
 it cannot enter shell history, process titles, or CLI audit input.
 
+Native channel drivers may also declare a bounded set of inbound actions in
+their module, driver, and runtime descriptors. Declared slash actions are
+intercepted before model processing and dispatched to the channel runner over
+ephemeral request/reply transport. Only the action name, whether arguments
+were present, and the authenticated channel identity cross that boundary; raw
+arguments do not. A declared action fails closed with a safe unavailable
+response when its runtime is absent or unhealthy.
+
 The proprietary server policy for hosted artifacts, billing, quotas, private asset auth, custom domains, and Console product behavior intentionally lives outside this open-source repo.
 
 ### Build Against The SDK

--- a/packages/ravi-os-sdk/README.md
+++ b/packages/ravi-os-sdk/README.md
@@ -148,6 +148,15 @@ provider- and connection-bound credential through
 `context.host.readInstallationCredential()`. It cannot enumerate credentials
 or receive the human login session.
 
+Drivers can reserve provider-owned slash actions with the `inbound_actions`
+capability and an exact `inboundActions` list repeated in the module, driver,
+and runtime descriptors. The runtime implements
+`inboundActions.supports(action)` and `inboundActions.handle(request)`. The
+host sends only a bounded authenticated channel identity, the declared action
+name, and a `hasArguments` boolean; command arguments are never exposed to the
+driver. Declared actions are fail-closed and never fall through to model
+processing when the runtime cannot answer.
+
 ### Reconcile Locally Managed Agents
 
 Node-side integrations can reconcile an external desired identity into a

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
@@ -1,11 +1,15 @@
 {
   "capabilities": [
     "inbound",
+    "inbound_actions",
     "text_delivery",
     "chat_actions",
     "presence"
   ],
   "driverId": "example.native",
+  "inboundActions": [
+    "account.connect"
+  ],
   "protocol": "ravi.channel.native-driver",
   "provider": "example",
   "requiredHostCapabilities": [

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-request.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-request.json
@@ -1,0 +1,15 @@
+{
+  "action": "account.connect",
+  "hasArguments": false,
+  "identity": {
+    "accountId": "account-a",
+    "channelKind": "example",
+    "conversationId": "conversation-a",
+    "messageId": "message-a",
+    "senderId": "sender-a"
+  },
+  "protocol": "ravi.channel.native-driver",
+  "requestedAt": "2026-07-24T18:00:01.000Z",
+  "requestId": "channel-action-request-a",
+  "schemaVersion": 1
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-result.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-result.json
@@ -1,0 +1,8 @@
+{
+  "completedAt": "2026-07-24T18:00:01.000Z",
+  "disposition": "handled",
+  "protocol": "ravi.channel.native-driver",
+  "requestId": "channel-action-request-a",
+  "schemaVersion": 1,
+  "text": "Action completed."
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json
@@ -1,4 +1,7 @@
 {
+  "inboundActions": [
+    "account.connect"
+  ],
   "moduleSpecifier": "@example/native-channel-driver",
   "protocol": "ravi.channel.native-driver",
   "provider": "example",

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json
@@ -1,12 +1,16 @@
 {
   "capabilities": [
     "inbound",
+    "inbound_actions",
     "text_delivery",
     "chat_actions",
     "presence"
   ],
   "channelInstanceId": "example-channel-a",
   "driverId": "example.native",
+  "inboundActions": [
+    "account.connect"
+  ],
   "protocol": "ravi.channel.native-driver",
   "provider": "example",
   "runtimeId": "example-runtime-a",

--- a/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "bun:test";
 import {
   NATIVE_CHANNEL_DRIVER_PROTOCOL,
   NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+  MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES,
   NativeChannelDriverDescriptorSchema,
   NativeChannelDriverHostCapabilitiesSchema,
   NativeChannelDriverModuleConfigSchema,
   NativeChannelDriverModuleSpecifierSchema,
+  NativeInboundChannelActionRequestSchema,
+  NativeInboundChannelActionResultSchema,
   NativeChannelRuntimeDescriptorSchema,
   NativeChannelRuntimeHealthSchema,
   type NativeChannelDriver,
@@ -23,14 +27,72 @@ describe("native channel driver SDK contract", () => {
     const driverDescriptor = await fixture("driver-descriptor.json");
     const runtimeDescriptor = await fixture("runtime-descriptor.json");
     const installationCredential = await fixture("installation-credential.json");
+    const inboundActionRequest = await fixture("inbound-action-request.json");
+    const inboundActionResult = await fixture("inbound-action-result.json");
 
     expect(NativeChannelDriverModuleConfigSchema.parse(moduleConfig)).toEqual(moduleConfig);
     expect(NativeChannelDriverDescriptorSchema.parse(driverDescriptor)).toEqual(driverDescriptor);
     expect(NativeChannelRuntimeDescriptorSchema.parse(runtimeDescriptor)).toEqual(runtimeDescriptor);
+    expect(NativeInboundChannelActionRequestSchema.parse(inboundActionRequest)).toEqual(
+      inboundActionRequest,
+    );
+    expect(NativeInboundChannelActionResultSchema.parse(inboundActionResult)).toEqual(
+      inboundActionResult,
+    );
     expect(installationCredential).toMatchObject({ provider: "example" });
     expect(NativeChannelDriverHostCapabilitiesSchema.parse(["installation_credentials"])).toEqual([
       "installation_credentials",
     ]);
+  });
+
+  it("requires an explicit action declaration and exactly one handled response", async () => {
+    const descriptor = await fixture<Record<string, unknown>>("driver-descriptor.json");
+    const request = await fixture<Record<string, unknown>>("inbound-action-request.json");
+    const handled = await fixture<Record<string, unknown>>("inbound-action-result.json");
+
+    expect(
+      NativeChannelDriverDescriptorSchema.safeParse({
+        ...descriptor,
+        inboundActions: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeInboundChannelActionResultSchema.safeParse({
+        ...handled,
+        text: undefined,
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeInboundChannelActionResultSchema.safeParse({
+        ...handled,
+        error: {
+          code: "UNAVAILABLE",
+          category: "availability",
+          retryable: true,
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeChannelDriverDescriptorSchema.safeParse({
+        ...descriptor,
+        capabilities: ["inbound", "inbound"],
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeInboundChannelActionRequestSchema.safeParse({
+        ...request,
+        identity: {
+          ...(request.identity as Record<string, unknown>),
+          senderId: "é".repeat(MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES / 2 + 1),
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeInboundChannelActionResultSchema.safeParse({
+        ...handled,
+        text: "é".repeat(MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES / 2 + 1),
+      }).success,
+    ).toBe(false);
   });
 
   it("accepts only installed package names and absolute local file URLs", () => {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -1,9 +1,19 @@
 {
   "artifacts": [
     {
-      "sha256": "8630678beaba142d039194361e2cf8515dcebe6867ba616c43de6a5c84335add",
-      "sizeBytes": 290,
+      "sha256": "cc1202c653a571b66cf7b3e961673755ee26be90727d6eab27f4d1009ae304c0",
+      "sizeBytes": 362,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json"
+    },
+    {
+      "sha256": "66d6757bc5dbbdf095def00b1ad9c859f799a99f84b4d33dec0fae5f86828fbd",
+      "sizeBytes": 391,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-request.json"
+    },
+    {
+      "sha256": "78b8860ed68cd0a11bc7c94294cd301801570ba704818fca23d1b426e57879d5",
+      "sizeBytes": 216,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-result.json"
     },
     {
       "sha256": "f69ab6d8aceb58dfaa3775b71c14892f3d64252046506c7cd016a82d8813b8e5",
@@ -11,18 +21,18 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json"
     },
     {
-      "sha256": "d03296778c8bd5331120e3f317d7eec483b11a5e70ebc4bcffb51ea34ba2a63b",
-      "sizeBytes": 149,
+      "sha256": "d499e48cc64516a307e70a817b38e87a648be5cb4f95aa7e2bb066c261ef3f3a",
+      "sizeBytes": 198,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json"
     },
     {
-      "sha256": "3e9297ccedaaa551c00443cf099ee819f60c6eb5554570336ea01977b1967cb1",
-      "sizeBytes": 302,
+      "sha256": "7de2331a99f928e031b75a6207a9ac661e2469af3583414ef9b8e7736ce23d33",
+      "sizeBytes": 374,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "87781ea62713d9134f963878a552882624377214dfbbd358858c3a60c32102dc",
-      "sizeBytes": 6228,
+      "sha256": "05feff656c1d20bd6e56cb9dc465d7b07e8080ea77b5738b4fb7896cb6d6e449",
+      "sizeBytes": 12607,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
   ],
@@ -39,6 +49,8 @@
   ],
   "fileAllowlist": [
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-request.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-result.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json",
@@ -46,7 +58,7 @@
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "d8ca4a05ac15dd8598616f8d9d0915f6262ee5adbb2c18f92d3ce8c0feeb3eaf",
+  "outputDigest": "10eef000c762efe4545d1a89b61b49768fcebb6fef22781da5872e543095e03e",
   "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials without exposing human sessions, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
@@ -63,6 +75,10 @@
     },
     {
       "fields": [],
+      "schema": "NativeInboundChannelActionNames"
+    },
+    {
+      "fields": [],
       "schema": "NativeChannelDriverHostCapabilities"
     },
     {
@@ -70,7 +86,8 @@
         "protocol",
         "schemaVersion",
         "provider",
-        "moduleSpecifier"
+        "moduleSpecifier",
+        "inboundActions"
       ],
       "schema": "NativeChannelDriverModuleConfig"
     },
@@ -81,6 +98,7 @@
         "driverId",
         "provider",
         "capabilities",
+        "inboundActions",
         "requiredHostCapabilities"
       ],
       "schema": "NativeChannelDriverDescriptor"
@@ -93,9 +111,44 @@
         "provider",
         "runtimeId",
         "channelInstanceId",
-        "capabilities"
+        "capabilities",
+        "inboundActions"
       ],
       "schema": "NativeChannelRuntimeDescriptor"
+    },
+    {
+      "fields": [
+        "channelKind",
+        "accountId",
+        "conversationId",
+        "senderId",
+        "messageId"
+      ],
+      "schema": "NativeInboundChannelIdentity"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "action",
+        "hasArguments",
+        "identity",
+        "requestedAt"
+      ],
+      "schema": "NativeInboundChannelActionRequest"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "disposition",
+        "text",
+        "error",
+        "completedAt"
+      ],
+      "schema": "NativeInboundChannelActionResult"
     },
     {
       "fields": [
@@ -108,7 +161,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "4d43634a31d850c846d4add5964262f39781103f710099d38748f59778937fce",
+  "sourceDigest": "4b604dae68aaaeba81fd68ceb6c2864a0bdafc5bb61f0c70d2aeaff696794733",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -5,13 +5,14 @@
       "items": {
         "enum": [
           "inbound",
+          "inbound_actions",
           "text_delivery",
           "chat_actions",
           "presence"
         ],
         "type": "string"
       },
-      "maxItems": 4,
+      "maxItems": 5,
       "minItems": 1,
       "type": "array"
     },
@@ -19,6 +20,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [
         "inbound",
+        "inbound_actions",
         "text_delivery",
         "chat_actions",
         "presence"
@@ -32,19 +34,28 @@
           "items": {
             "enum": [
               "inbound",
+              "inbound_actions",
               "text_delivery",
               "chat_actions",
               "presence"
             ],
             "type": "string"
           },
-          "maxItems": 4,
+          "maxItems": 5,
           "minItems": 1,
           "type": "array"
         },
         "driverId": {
           "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
           "type": "string"
+        },
+        "inboundActions": {
+          "items": {
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "type": "array"
         },
         "protocol": {
           "const": "ravi.channel.native-driver",
@@ -101,6 +112,14 @@
     "NativeChannelDriverModuleConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "inboundActions": {
+          "items": {
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "type": "array"
+        },
         "moduleSpecifier": {
           "pattern": "^(?:@[a-z0-9][a-z0-9._-]*\\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\\/\\/\\/[^\\u0000-\\u001f\\u007f]+)$",
           "type": "string"
@@ -133,13 +152,14 @@
           "items": {
             "enum": [
               "inbound",
+              "inbound_actions",
               "text_delivery",
               "chat_actions",
               "presence"
             ],
             "type": "string"
           },
-          "maxItems": 4,
+          "maxItems": 5,
           "minItems": 1,
           "type": "array"
         },
@@ -150,6 +170,14 @@
         "driverId": {
           "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
           "type": "string"
+        },
+        "inboundActions": {
+          "items": {
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "type": "array"
         },
         "protocol": {
           "const": "ravi.channel.native-driver",
@@ -176,6 +204,203 @@
         "runtimeId",
         "channelInstanceId",
         "capabilities"
+      ],
+      "type": "object"
+    },
+    "NativeInboundChannelActionNames": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "items": {
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+        "type": "string"
+      },
+      "maxItems": 32,
+      "type": "array"
+    },
+    "NativeInboundChannelActionRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "hasArguments": {
+          "type": "boolean"
+        },
+        "identity": {
+          "additionalProperties": false,
+          "properties": {
+            "accountId": {
+              "type": "string"
+            },
+            "channelKind": {
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            "conversationId": {
+              "type": "string"
+            },
+            "messageId": {
+              "type": "string"
+            },
+            "senderId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channelKind",
+            "accountId",
+            "conversationId",
+            "senderId",
+            "messageId"
+          ],
+          "type": "object"
+        },
+        "protocol": {
+          "const": "ravi.channel.native-driver",
+          "type": "string"
+        },
+        "requestedAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "requestId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "action",
+        "hasArguments",
+        "identity",
+        "requestedAt"
+      ],
+      "type": "object"
+    },
+    "NativeInboundChannelActionResult": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "handled",
+            "pass"
+          ],
+          "type": "string"
+        },
+        "error": {
+          "properties": {
+            "category": {
+              "enum": [
+                "validation",
+                "authentication",
+                "authorization",
+                "capacity",
+                "availability",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "IDEMPOTENCY_CONFLICT",
+                "UNAUTHENTICATED",
+                "PERMISSION_DENIED",
+                "LOCAL_PERMISSION_DENIED",
+                "NOT_FOUND",
+                "RATE_LIMITED",
+                "OVERLOADED",
+                "UNAVAILABLE",
+                "INTERNAL"
+              ],
+              "type": "string"
+            },
+            "correlationId": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "retryAfterMs": {
+              "exclusiveMinimum": 0,
+              "maximum": 86400000,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "code",
+            "category",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "protocol": {
+          "const": "ravi.channel.native-driver",
+          "type": "string"
+        },
+        "requestId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "disposition",
+        "completedAt"
+      ],
+      "type": "object"
+    },
+    "NativeInboundChannelIdentity": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "channelKind": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "conversationId": {
+          "type": "string"
+        },
+        "messageId": {
+          "type": "string"
+        },
+        "senderId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "channelKind",
+        "accountId",
+        "conversationId",
+        "senderId",
+        "messageId"
       ],
       "type": "object"
     },
@@ -223,6 +448,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "4d43634a31d850c846d4add5964262f39781103f710099d38748f59778937fce",
+  "sourceDigest": "4b604dae68aaaeba81fd68ceb6c2864a0bdafc5bb61f0c70d2aeaff696794733",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/native-channel-driver.ts
+++ b/packages/ravi-os-sdk/src/native-channel-driver.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   ChannelBackendOpaqueIdSchema,
   ChannelBackendWireKindSchema,
+  ChannelSafeErrorSchema,
   type ChannelIngressRequest,
   type ChannelIngressResult,
   type ChannelOutputSink,
@@ -18,9 +19,27 @@ import type { RemoteInstallationCredential } from "./remote-login-provider.js";
 
 export const NATIVE_CHANNEL_DRIVER_PROTOCOL = "ravi.channel.native-driver" as const;
 export const NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION = 1 as const;
+export const MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES = 512;
+export const MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES = 4_096;
+
+const nativeChannelTextEncoder = new TextEncoder();
+
+function boundedNativeChannelString(maxBytes: number, label: string) {
+  return z
+    .string()
+    .refine(
+      (value) => nativeChannelTextEncoder.encode(value).byteLength >= 1,
+      `${label} must not be empty`,
+    )
+    .refine(
+      (value) => nativeChannelTextEncoder.encode(value).byteLength <= maxBytes,
+      `${label} exceeds ${maxBytes} UTF-8 bytes`,
+    );
+}
 
 export const NativeChannelDriverCapabilitySchema = z.enum([
   "inbound",
+  "inbound_actions",
   "text_delivery",
   "chat_actions",
   "presence",
@@ -29,14 +48,21 @@ export const NativeChannelDriverCapabilitySchema = z.enum([
 export const NativeChannelDriverCapabilitiesSchema = z
   .array(NativeChannelDriverCapabilitySchema)
   .min(1)
-  .max(4);
+  .max(NativeChannelDriverCapabilitySchema.options.length)
+  .refine((capabilities) => new Set(capabilities).size === capabilities.length);
+
+export const NativeInboundChannelActionNamesSchema = z
+  .array(ChannelBackendWireKindSchema)
+  .max(32)
+  .refine((actions) => new Set(actions).size === actions.length);
 
 export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
 
 export const NativeChannelDriverHostCapabilitiesSchema = z
   .array(NativeChannelDriverHostCapabilitySchema)
   .min(1)
-  .max(1);
+  .max(1)
+  .refine((capabilities) => new Set(capabilities).size === capabilities.length);
 
 export const NativeChannelDriverModuleSpecifierSchema = z
   .string()
@@ -45,31 +71,122 @@ export const NativeChannelDriverModuleSpecifierSchema = z
     "must be an installed package name or an absolute file URL",
   );
 
-export const NativeChannelDriverModuleConfigSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  provider: ChannelBackendWireKindSchema,
-  moduleSpecifier: NativeChannelDriverModuleSpecifierSchema,
-});
+export const NativeChannelDriverModuleConfigSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    provider: ChannelBackendWireKindSchema,
+    moduleSpecifier: NativeChannelDriverModuleSpecifierSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+  })
+  .strict();
 
-export const NativeChannelDriverDescriptorSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  driverId: ChannelBackendWireKindSchema,
-  provider: ChannelBackendWireKindSchema,
-  capabilities: NativeChannelDriverCapabilitiesSchema,
-  requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
-});
+export const NativeChannelDriverDescriptorSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    driverId: ChannelBackendWireKindSchema,
+    provider: ChannelBackendWireKindSchema,
+    capabilities: NativeChannelDriverCapabilitiesSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+    requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
+  })
+  .superRefine(validateInboundActionDeclaration);
 
-export const NativeChannelRuntimeDescriptorSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  driverId: ChannelBackendWireKindSchema,
-  provider: ChannelBackendWireKindSchema,
-  runtimeId: ChannelBackendOpaqueIdSchema,
-  channelInstanceId: ChannelBackendOpaqueIdSchema,
-  capabilities: NativeChannelDriverCapabilitiesSchema,
-});
+export const NativeChannelRuntimeDescriptorSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    driverId: ChannelBackendWireKindSchema,
+    provider: ChannelBackendWireKindSchema,
+    runtimeId: ChannelBackendOpaqueIdSchema,
+    channelInstanceId: ChannelBackendOpaqueIdSchema,
+    capabilities: NativeChannelDriverCapabilitiesSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+  })
+  .superRefine(validateInboundActionDeclaration);
+
+function validateInboundActionDeclaration(
+  value: {
+    capabilities: readonly string[];
+    inboundActions?: readonly string[];
+  },
+  context: z.RefinementCtx,
+): void {
+  const declared = value.capabilities.includes("inbound_actions");
+  if (
+    declared !==
+    (value.inboundActions !== undefined && value.inboundActions.length > 0)
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["inboundActions"],
+      message: "inbound_actions capability requires a non-empty action declaration",
+    });
+  }
+}
+
+export const NativeInboundChannelIdentitySchema = z
+  .object({
+    channelKind: ChannelBackendWireKindSchema,
+    accountId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action account identity",
+    ),
+    conversationId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action conversation identity",
+    ),
+    senderId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action sender identity",
+    ),
+    messageId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action message identity",
+    ),
+  })
+  .strict();
+
+export const NativeInboundChannelActionRequestSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    action: ChannelBackendWireKindSchema,
+    hasArguments: z.boolean(),
+    identity: NativeInboundChannelIdentitySchema,
+    requestedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const NativeInboundChannelActionResultSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    disposition: z.enum(["handled", "pass"]),
+    text: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES,
+      "native inbound action response",
+    ).optional(),
+    error: ChannelSafeErrorSchema.optional(),
+    completedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const responseFields = Number(value.text !== undefined) + Number(value.error !== undefined);
+    if (
+      (value.disposition === "handled" && responseFields !== 1) ||
+      (value.disposition === "pass" && responseFields !== 0)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["disposition"],
+        message: "handled actions require exactly one response; pass actions carry none",
+      });
+    }
+  });
 
 export const NativeChannelRuntimeHealthSchema = z.object({
   status: z.enum([
@@ -93,6 +210,10 @@ export type NativeChannelDriverModuleConfig = z.infer<typeof NativeChannelDriver
 export type NativeChannelDriverDescriptor = z.infer<typeof NativeChannelDriverDescriptorSchema>;
 export type NativeChannelRuntimeDescriptor = z.infer<typeof NativeChannelRuntimeDescriptorSchema>;
 export type NativeChannelRuntimeHealth = z.infer<typeof NativeChannelRuntimeHealthSchema>;
+export type NativeInboundChannelActionNames = z.infer<typeof NativeInboundChannelActionNamesSchema>;
+export type NativeInboundChannelIdentity = z.infer<typeof NativeInboundChannelIdentitySchema>;
+export type NativeInboundChannelActionRequest = z.infer<typeof NativeInboundChannelActionRequestSchema>;
+export type NativeInboundChannelActionResult = z.infer<typeof NativeInboundChannelActionResultSchema>;
 
 export interface NativeChannelDriverChannelConfig {
   readonly name: string;
@@ -234,12 +355,20 @@ export interface NativeChannelDriverContext {
 
 export interface NativeChannelDriverRuntime {
   readonly descriptor: NativeChannelRuntimeDescriptor;
+  readonly inboundActions?: NativeInboundChannelActionHandler;
   readonly delivery?: NativeChannelTextDelivery;
   readonly actions?: NativeChannelChatActionDelivery;
   readonly presence?: NativeChannelPresenceDelivery;
   start(): void | Promise<void>;
   stop(): void | Promise<void>;
   health(): NativeChannelRuntimeHealth;
+}
+
+export interface NativeInboundChannelActionHandler {
+  supports(action: string): boolean;
+  handle(
+    request: NativeInboundChannelActionRequest,
+  ): NativeInboundChannelActionResult | Promise<NativeInboundChannelActionResult>;
 }
 
 export interface NativeChannelDriver {

--- a/src/channels/inbound-actions.test.ts
+++ b/src/channels/inbound-actions.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, mock } from "bun:test";
+import { JSONCodec } from "nats";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeInboundChannelActionRequestSchema,
+  NativeInboundChannelActionResultSchema,
+  type NativeInboundChannelActionHandler,
+  type NativeInboundChannelActionRequest,
+  type NativeInboundChannelActionResult,
+} from "./native/driver.js";
+import {
+  configuredNativeInboundActionNames,
+  dispatchNativeInboundChannelAction,
+  NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT,
+  requestNativeInboundChannelAction,
+  startNativeInboundChannelActionResponder,
+  type NativeInboundChannelActionMessage,
+  type NativeInboundChannelActionSubscription,
+} from "./inbound-actions.js";
+
+const codec = JSONCodec<unknown>();
+
+function request(action = "account.connect"): NativeInboundChannelActionRequest {
+  return NativeInboundChannelActionRequestSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId: "channel-action-request-a",
+    action,
+    hasArguments: false,
+    identity: {
+      channelKind: "example",
+      accountId: "account-a",
+      conversationId: "conversation-a",
+      senderId: "sender-a",
+      messageId: "message-a",
+    },
+    requestedAt: "2026-07-24T18:00:01.000Z",
+  });
+}
+
+function result(requestId: string, disposition: "handled" | "pass"): NativeInboundChannelActionResult {
+  return NativeInboundChannelActionResultSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId,
+    disposition,
+    ...(disposition === "handled" ? { text: "Action completed." } : {}),
+    completedAt: "2026-07-24T18:00:02.000Z",
+  });
+}
+
+class TestSubscription implements NativeInboundChannelActionSubscription {
+  private readonly messages: NativeInboundChannelActionMessage[] = [];
+  private waiter: (() => void) | null = null;
+  private stopped = false;
+  unsubscribe = mock(() => {
+    this.stopped = true;
+    this.waiter?.();
+  });
+
+  push(message: NativeInboundChannelActionMessage): void {
+    this.messages.push(message);
+    this.waiter?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<NativeInboundChannelActionMessage> {
+    while (!this.stopped) {
+      const message = this.messages.shift();
+      if (message) {
+        yield message;
+        continue;
+      }
+      await new Promise<void>((resolve) => {
+        this.waiter = resolve;
+      });
+      this.waiter = null;
+    }
+  }
+}
+
+describe("native inbound channel actions", () => {
+  it("derives the sorted action union only from explicit module declarations", () => {
+    expect(
+      configuredNativeInboundActionNames(
+        JSON.stringify([
+          {
+            protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+            schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+            provider: "example-b",
+            moduleSpecifier: "@example/driver-b",
+            inboundActions: ["workspace.open", "account.connect"],
+          },
+          {
+            protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+            schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+            provider: "example-a",
+            moduleSpecifier: "@example/driver-a",
+            inboundActions: ["account.connect"],
+          },
+        ]),
+      ),
+    ).toEqual(["account.connect", "workspace.open"]);
+    expect(configuredNativeInboundActionNames(undefined)).toEqual([]);
+  });
+
+  it("dispatches only to the sole supporting handler", async () => {
+    const ignored = {
+      supports: mock(() => false),
+      handle: mock(async () => result("channel-action-request-a", "handled")),
+    } satisfies NativeInboundChannelActionHandler;
+    const handling = {
+      supports: mock(() => true),
+      handle: mock(async (input: NativeInboundChannelActionRequest) => result(input.requestId, "handled")),
+    } satisfies NativeInboundChannelActionHandler;
+
+    await expect(dispatchNativeInboundChannelAction([ignored, handling], request())).resolves.toEqual(
+      result("channel-action-request-a", "handled"),
+    );
+    expect(ignored.handle).not.toHaveBeenCalled();
+    expect(handling.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when no runtime owns the action and pass when owners decline it", async () => {
+    const unsupported = {
+      supports: () => false,
+      handle: async () => result("channel-action-request-a", "handled"),
+    } satisfies NativeInboundChannelActionHandler;
+    const passing = {
+      supports: () => true,
+      handle: async (input: NativeInboundChannelActionRequest) => result(input.requestId, "pass"),
+    } satisfies NativeInboundChannelActionHandler;
+
+    await expect(dispatchNativeInboundChannelAction([unsupported], request())).resolves.toBeNull();
+    await expect(dispatchNativeInboundChannelAction([passing], request())).resolves.toMatchObject({
+      requestId: "channel-action-request-a",
+      disposition: "pass",
+    });
+  });
+
+  it("replaces thrown details and mismatched responses with a safe internal error", async () => {
+    const sensitive = "private-handler-detail";
+    const throwing = {
+      supports: () => true,
+      handle: async () => {
+        throw new Error(sensitive);
+      },
+    } satisfies NativeInboundChannelActionHandler;
+    const mismatched = {
+      supports: () => true,
+      handle: async () => result("different-request", "handled"),
+    } satisfies NativeInboundChannelActionHandler;
+
+    const thrownResult = await dispatchNativeInboundChannelAction([throwing], request());
+    const mismatchedResult = await dispatchNativeInboundChannelAction([mismatched], request());
+
+    expect(thrownResult).toMatchObject({
+      requestId: "channel-action-request-a",
+      disposition: "handled",
+      error: { code: "INTERNAL", retryable: false },
+    });
+    expect(mismatchedResult).toMatchObject({
+      requestId: "channel-action-request-a",
+      disposition: "handled",
+      error: { code: "INTERNAL", retryable: false },
+    });
+    expect(JSON.stringify([thrownResult, mismatchedResult])).not.toContain(sensitive);
+  });
+
+  it("fails closed before side effects when multiple runtimes claim the same action", async () => {
+    const first = {
+      supports: mock(() => true),
+      handle: mock(async (input: NativeInboundChannelActionRequest) => result(input.requestId, "handled")),
+    } satisfies NativeInboundChannelActionHandler;
+    const second = {
+      supports: mock(() => true),
+      handle: mock(async (input: NativeInboundChannelActionRequest) => result(input.requestId, "handled")),
+    } satisfies NativeInboundChannelActionHandler;
+
+    await expect(dispatchNativeInboundChannelAction([first, second], request())).resolves.toMatchObject({
+      disposition: "handled",
+      error: { code: "INTERNAL", retryable: false },
+    });
+    expect(first.handle).not.toHaveBeenCalled();
+    expect(second.handle).not.toHaveBeenCalled();
+  });
+
+  it("serves supported actions over an ephemeral core NATS request/reply subject", async () => {
+    const subscription = new TestSubscription();
+    const subscribe = mock((_subject: string) => subscription);
+    const handler = {
+      supports: () => true,
+      handle: async (input: NativeInboundChannelActionRequest) => result(input.requestId, "handled"),
+    } satisfies NativeInboundChannelActionHandler;
+    const responder = startNativeInboundChannelActionResponder({
+      connection: { subscribe },
+      handlers: [handler],
+    });
+    let response: Uint8Array | undefined;
+
+    subscription.push({
+      data: codec.encode(request()),
+      reply: "_INBOX.reply",
+      respond(data) {
+        response = data;
+        return true;
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(subscribe).toHaveBeenCalledWith(NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT);
+    expect(codec.decode(response!)).toEqual(result("channel-action-request-a", "handled"));
+    await responder.stop();
+    expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates request/reply results and rejects mismatched correlation", async () => {
+    const requestCall = mock(async () => ({
+      data: codec.encode(result("channel-action-request-a", "handled")),
+    }));
+
+    await expect(
+      requestNativeInboundChannelAction(request(), {
+        connection: { request: requestCall },
+        timeoutMs: 250,
+      }),
+    ).resolves.toEqual(result("channel-action-request-a", "handled"));
+    expect(requestCall).toHaveBeenCalledWith(NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT, expect.any(Uint8Array), {
+      timeout: 250,
+    });
+
+    await expect(
+      requestNativeInboundChannelAction(request(), {
+        connection: {
+          request: async () => ({
+            data: codec.encode(result("different-request", "handled")),
+          }),
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/channels/inbound-actions.ts
+++ b/src/channels/inbound-actions.ts
@@ -1,0 +1,144 @@
+import { JSONCodec } from "nats";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeInboundChannelActionRequestSchema,
+  NativeInboundChannelActionResultSchema,
+  parseNativeChannelDriverModuleConfigs,
+  type NativeInboundChannelActionHandler,
+  type NativeInboundChannelActionRequest,
+  type NativeInboundChannelActionResult,
+} from "./native/driver.js";
+
+export const NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT = "_RAVI.channels.inbound-action" as const;
+export const NATIVE_INBOUND_CHANNEL_ACTION_TIMEOUT_MS = 1_000;
+
+const codec = JSONCodec<unknown>();
+
+export interface NativeInboundChannelActionMessage {
+  readonly data: Uint8Array;
+  readonly reply?: string;
+  respond(data: Uint8Array): boolean;
+}
+
+export interface NativeInboundChannelActionSubscription extends AsyncIterable<NativeInboundChannelActionMessage> {
+  unsubscribe(): void;
+}
+
+export interface NativeInboundChannelActionResponderConnection {
+  subscribe(subject: string): NativeInboundChannelActionSubscription;
+}
+
+export interface NativeInboundChannelActionRequestConnection {
+  request(subject: string, data: Uint8Array, options: { timeout: number }): Promise<{ data: Uint8Array }>;
+}
+
+export interface NativeInboundChannelActionResponder {
+  stop(): Promise<void>;
+}
+
+export function configuredNativeInboundActionNames(value: string | undefined): readonly string[] {
+  return [
+    ...new Set(
+      parseNativeChannelDriverModuleConfigs(value).flatMap((configuration) => configuration.inboundActions ?? []),
+    ),
+  ].sort();
+}
+
+export async function dispatchNativeInboundChannelAction(
+  handlers: readonly NativeInboundChannelActionHandler[],
+  input: NativeInboundChannelActionRequest,
+): Promise<NativeInboundChannelActionResult | null> {
+  const request = NativeInboundChannelActionRequestSchema.parse(input);
+  const supported: NativeInboundChannelActionHandler[] = [];
+  for (const handler of handlers) {
+    try {
+      if (handler.supports(request.action)) supported.push(handler);
+    } catch {}
+  }
+  if (supported.length === 0) return null;
+  if (supported.length > 1) return internalActionError(request.requestId);
+  try {
+    const result = NativeInboundChannelActionResultSchema.parse(await supported[0]!.handle(request));
+    return result.requestId === request.requestId ? result : internalActionError(request.requestId);
+  } catch {
+    return internalActionError(request.requestId);
+  }
+}
+
+export function startNativeInboundChannelActionResponder(options: {
+  connection: NativeInboundChannelActionResponderConnection;
+  handlers: readonly NativeInboundChannelActionHandler[];
+}): NativeInboundChannelActionResponder {
+  const subscription = options.connection.subscribe(NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT);
+  let stopped = false;
+  const task = respond(subscription, options.handlers, () => stopped);
+  return {
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      subscription.unsubscribe();
+      await task;
+    },
+  };
+}
+
+export async function requestNativeInboundChannelAction(
+  input: NativeInboundChannelActionRequest,
+  options: {
+    connection: NativeInboundChannelActionRequestConnection;
+    timeoutMs?: number;
+  },
+): Promise<NativeInboundChannelActionResult | null> {
+  const request = NativeInboundChannelActionRequestSchema.parse(input);
+  const timeout = options.timeoutMs ?? NATIVE_INBOUND_CHANNEL_ACTION_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeout) || timeout < 1 || timeout > 10_000) {
+    throw new RangeError("Native inbound action timeout is outside supported bounds.");
+  }
+  try {
+    const message = await options.connection.request(NATIVE_INBOUND_CHANNEL_ACTION_SUBJECT, codec.encode(request), {
+      timeout,
+    });
+    const result = NativeInboundChannelActionResultSchema.parse(codec.decode(message.data));
+    return result.requestId === request.requestId ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function respond(
+  subscription: NativeInboundChannelActionSubscription,
+  handlers: readonly NativeInboundChannelActionHandler[],
+  isStopped: () => boolean,
+): Promise<void> {
+  for await (const message of subscription) {
+    if (isStopped()) return;
+    let decoded: unknown;
+    try {
+      decoded = codec.decode(message.data);
+    } catch {
+      continue;
+    }
+    const parsed = NativeInboundChannelActionRequestSchema.safeParse(decoded);
+    if (!parsed.success) continue;
+    const result = await dispatchNativeInboundChannelAction(handlers, parsed.data);
+    if (result === null || !message.reply) continue;
+    message.respond(codec.encode(result));
+  }
+}
+
+function internalActionError(requestId: string): NativeInboundChannelActionResult {
+  return NativeInboundChannelActionResultSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId,
+    disposition: "handled",
+    error: {
+      code: "INTERNAL",
+      category: "internal",
+      retryable: false,
+      correlationId: requestId,
+    },
+    completedAt: new Date().toISOString(),
+  });
+}

--- a/src/channels/native/driver.test.ts
+++ b/src/channels/native/driver.test.ts
@@ -22,9 +22,11 @@ import {
   loadNativeChannelDriverModules,
   parseNativeChannelDriverModuleConfigs,
   type NativeChannelDriver,
+  type NativeChannelDriverCapability,
   type NativeChannelDriverDescriptor,
   type NativeChannelDriverHost,
   type NativeChannelDriverModuleConfig,
+  type NativeInboundChannelActionRequest,
   type NativeChannelRuntimeDescriptor,
 } from "./driver.js";
 import { createNativeChannelDriverHostLease, type NativeChannelDriverHostLease } from "./host.js";
@@ -118,7 +120,7 @@ function fullDriver(
   options: {
     health?: () => unknown;
     runtimeProvider?: string;
-    runtimeCapabilities?: Array<"inbound" | "text_delivery" | "chat_actions" | "presence">;
+    runtimeCapabilities?: NativeChannelDriverCapability[];
   } = {},
 ): NativeChannelDriver {
   const delivery = {
@@ -169,6 +171,47 @@ function fullDriver(
   };
 }
 
+function inboundActionDriver(
+  options: { includeHandler?: boolean; supports?: boolean; driverActions?: string[]; runtimeActions?: string[] } = {},
+): NativeChannelDriver {
+  const base = fullDriver();
+  const driverActions = options.driverActions ?? ["account.connect"];
+  const runtimeActions = options.runtimeActions ?? driverActions;
+  return {
+    descriptor: {
+      ...base.descriptor,
+      capabilities: [...base.descriptor.capabilities, "inbound_actions"],
+      inboundActions: driverActions,
+    },
+    async createRuntime(context) {
+      const runtime = await base.createRuntime(context);
+      return {
+        ...runtime,
+        descriptor: {
+          ...runtime.descriptor,
+          capabilities: [...runtime.descriptor.capabilities, "inbound_actions"],
+          inboundActions: runtimeActions,
+        },
+        ...(options.includeHandler === false
+          ? {}
+          : {
+              inboundActions: {
+                supports: mock(() => options.supports ?? true),
+                handle: mock(async (request: NativeInboundChannelActionRequest) => ({
+                  protocol: request.protocol,
+                  schemaVersion: request.schemaVersion,
+                  requestId: request.requestId,
+                  disposition: "handled" as const,
+                  text: "Action completed.",
+                  completedAt: "2026-07-24T18:00:02.000Z",
+                })),
+              },
+            }),
+      };
+    },
+  };
+}
+
 describe("native channel driver contract", () => {
   it("parses the generated module, driver, and runtime descriptors", async () => {
     const moduleConfig = await generatedFixture<NativeChannelDriverModuleConfig>("module-config.json");
@@ -199,6 +242,43 @@ describe("native channel driver contract", () => {
     expect(loaded).toEqual({ loadedProviders: ["example"], failures: [] });
     expect(registry.get("example")?.descriptor.driverId).toBe("example.native");
     expect(NATIVE_CHANNEL_DRIVER_MODULES_ENV).toBe("RAVI_NATIVE_CHANNEL_DRIVERS");
+  });
+
+  it("requires module, driver, and runtime action declarations to agree", async () => {
+    const driver = inboundActionDriver();
+    const matchingRegistry = new NativeChannelDriverRegistry();
+    const matching = await loadNativeChannelDriverModules(
+      [
+        {
+          protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+          schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+          provider: "example",
+          moduleSpecifier: "@example/driver",
+          inboundActions: ["account.connect"],
+        },
+      ],
+      matchingRegistry,
+      async () => ({ nativeChannelDriver: driver }),
+    );
+    expect(matching).toEqual({ loadedProviders: ["example"], failures: [] });
+
+    const mismatchedRegistry = new NativeChannelDriverRegistry();
+    const mismatched = await loadNativeChannelDriverModules(
+      [
+        {
+          protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+          schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+          provider: "example",
+          moduleSpecifier: "@example/driver",
+        },
+      ],
+      mismatchedRegistry,
+      async () => ({ nativeChannelDriver: driver }),
+    );
+    expect(mismatched).toEqual({
+      loadedProviders: [],
+      failures: [{ provider: "example", reason: "invalid_module_export" }],
+    });
   });
 
   it("rejects remote, inferred, duplicate, and incompatible module declarations", async () => {
@@ -331,6 +411,57 @@ describe("native channel driver contract", () => {
         status: "disconnected",
       },
     ]);
+  });
+
+  it("exposes only validated native inbound action handlers", async () => {
+    const registry = new NativeChannelDriverRegistry();
+    registry.register(inboundActionDriver());
+    const manager = new NativeChannelDriverManager({
+      channels: { "example-channel-a": channel() },
+      registry,
+      createHostLease: () => hostLease(),
+    });
+
+    await manager.start();
+
+    expect(manager.inboundActionHandlers()).toHaveLength(1);
+    expect(manager.health()[0]).toMatchObject({ status: "connected" });
+    await manager.stop();
+  });
+
+  it("fails closed on missing, unsupported, and mismatched inbound action surfaces", async () => {
+    const cases: Array<{ driver: NativeChannelDriver; reason: string }> = [
+      {
+        driver: inboundActionDriver({ includeHandler: false }),
+        reason: "runtime_surface_mismatch",
+      },
+      {
+        driver: inboundActionDriver({ supports: false }),
+        reason: "runtime_surface_mismatch",
+      },
+      {
+        driver: inboundActionDriver({ runtimeActions: ["workspace.open"] }),
+        reason: "runtime_capability_mismatch",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const registry = new NativeChannelDriverRegistry();
+      registry.register(testCase.driver);
+      const manager = new NativeChannelDriverManager({
+        channels: { "example-channel-a": channel() },
+        registry,
+        createHostLease: () => hostLease(),
+      });
+
+      await manager.start();
+
+      expect(manager.inboundActionHandlers()).toEqual([]);
+      expect(manager.health()[0]).toMatchObject({
+        status: "failed",
+        reason: testCase.reason,
+      });
+    }
   });
 
   it("fails closed on provider, capability, surface, and health mismatches", async () => {

--- a/src/channels/native/driver.ts
+++ b/src/channels/native/driver.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ChannelConfig } from "../../router/router-db.js";
 import {
   ChannelBackendOpaqueIdSchema,
+  ChannelSafeErrorSchema,
   ChannelBackendWireKindSchema,
   type ChannelIngressRequest,
   type ChannelIngressResult,
@@ -23,44 +24,165 @@ import { createNativeChannelDriverHostLease, type NativeChannelDriverHostLease }
 export const NATIVE_CHANNEL_DRIVER_PROTOCOL = "ravi.channel.native-driver" as const;
 export const NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION = 1 as const;
 export const NATIVE_CHANNEL_DRIVER_MODULES_ENV = "RAVI_NATIVE_CHANNEL_DRIVERS" as const;
+export const MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES = 512;
+export const MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES = 4_096;
 
-export const NativeChannelDriverCapabilitySchema = z.enum(["inbound", "text_delivery", "chat_actions", "presence"]);
+const nativeChannelTextEncoder = new TextEncoder();
 
-export const NativeChannelDriverCapabilitiesSchema = z.array(NativeChannelDriverCapabilitySchema).min(1).max(4);
+function boundedNativeChannelString(maxBytes: number, label: string) {
+  return z
+    .string()
+    .refine((value) => nativeChannelTextEncoder.encode(value).byteLength >= 1, `${label} must not be empty`)
+    .refine(
+      (value) => nativeChannelTextEncoder.encode(value).byteLength <= maxBytes,
+      `${label} exceeds ${maxBytes} UTF-8 bytes`,
+    );
+}
+
+export const NativeChannelDriverCapabilitySchema = z.enum([
+  "inbound",
+  "inbound_actions",
+  "text_delivery",
+  "chat_actions",
+  "presence",
+]);
+
+export const NativeChannelDriverCapabilitiesSchema = z
+  .array(NativeChannelDriverCapabilitySchema)
+  .min(1)
+  .max(NativeChannelDriverCapabilitySchema.options.length)
+  .refine((capabilities) => new Set(capabilities).size === capabilities.length);
+
+export const NativeInboundChannelActionNamesSchema = z
+  .array(ChannelBackendWireKindSchema)
+  .max(32)
+  .refine((actions) => new Set(actions).size === actions.length);
 
 export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
 
-export const NativeChannelDriverHostCapabilitiesSchema = z.array(NativeChannelDriverHostCapabilitySchema).min(1).max(1);
+export const NativeChannelDriverHostCapabilitiesSchema = z
+  .array(NativeChannelDriverHostCapabilitySchema)
+  .min(1)
+  .max(1)
+  .refine((capabilities) => new Set(capabilities).size === capabilities.length);
 
 export const NativeChannelDriverModuleSpecifierSchema = z
   .string()
   .regex(/^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/);
 
-export const NativeChannelDriverModuleConfigSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  provider: ChannelBackendWireKindSchema,
-  moduleSpecifier: NativeChannelDriverModuleSpecifierSchema,
-});
+export const NativeChannelDriverModuleConfigSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    provider: ChannelBackendWireKindSchema,
+    moduleSpecifier: NativeChannelDriverModuleSpecifierSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+  })
+  .strict();
 
-export const NativeChannelDriverDescriptorSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  driverId: ChannelBackendWireKindSchema,
-  provider: ChannelBackendWireKindSchema,
-  capabilities: NativeChannelDriverCapabilitiesSchema,
-  requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
-});
+export const NativeChannelDriverDescriptorSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    driverId: ChannelBackendWireKindSchema,
+    provider: ChannelBackendWireKindSchema,
+    capabilities: NativeChannelDriverCapabilitiesSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+    requiredHostCapabilities: NativeChannelDriverHostCapabilitiesSchema.optional(),
+  })
+  .superRefine(validateInboundActionDeclaration);
 
-export const NativeChannelRuntimeDescriptorSchema = z.object({
-  protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
-  schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
-  driverId: ChannelBackendWireKindSchema,
-  provider: ChannelBackendWireKindSchema,
-  runtimeId: ChannelBackendOpaqueIdSchema,
-  channelInstanceId: ChannelBackendOpaqueIdSchema,
-  capabilities: NativeChannelDriverCapabilitiesSchema,
-});
+export const NativeChannelRuntimeDescriptorSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    driverId: ChannelBackendWireKindSchema,
+    provider: ChannelBackendWireKindSchema,
+    runtimeId: ChannelBackendOpaqueIdSchema,
+    channelInstanceId: ChannelBackendOpaqueIdSchema,
+    capabilities: NativeChannelDriverCapabilitiesSchema,
+    inboundActions: NativeInboundChannelActionNamesSchema.optional(),
+  })
+  .superRefine(validateInboundActionDeclaration);
+
+function validateInboundActionDeclaration(
+  value: {
+    capabilities: readonly string[];
+    inboundActions?: readonly string[];
+  },
+  context: z.RefinementCtx,
+): void {
+  const declared = value.capabilities.includes("inbound_actions");
+  if (declared !== (value.inboundActions !== undefined && value.inboundActions.length > 0)) {
+    context.addIssue({
+      code: "custom",
+      path: ["inboundActions"],
+      message: "inbound_actions capability requires a non-empty action declaration",
+    });
+  }
+}
+
+export const NativeInboundChannelIdentitySchema = z
+  .object({
+    channelKind: ChannelBackendWireKindSchema,
+    accountId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action account identity",
+    ),
+    conversationId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action conversation identity",
+    ),
+    senderId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action sender identity",
+    ),
+    messageId: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
+      "native inbound action message identity",
+    ),
+  })
+  .strict();
+
+export const NativeInboundChannelActionRequestSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    action: ChannelBackendWireKindSchema,
+    hasArguments: z.boolean(),
+    identity: NativeInboundChannelIdentitySchema,
+    requestedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const NativeInboundChannelActionResultSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    disposition: z.enum(["handled", "pass"]),
+    text: boundedNativeChannelString(
+      MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES,
+      "native inbound action response",
+    ).optional(),
+    error: ChannelSafeErrorSchema.optional(),
+    completedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const responseFields = Number(value.text !== undefined) + Number(value.error !== undefined);
+    if (
+      (value.disposition === "handled" && responseFields !== 1) ||
+      (value.disposition === "pass" && responseFields !== 0)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["disposition"],
+        message: "handled actions require exactly one response; pass actions carry none",
+      });
+    }
+  });
 
 export const NativeChannelRuntimeHealthSchema = z.object({
   status: z.enum(["disabled", "starting", "connected", "degraded", "reconnecting", "disconnected", "failed"]),
@@ -76,6 +198,10 @@ export type NativeChannelDriverModuleConfig = z.infer<typeof NativeChannelDriver
 export type NativeChannelDriverDescriptor = z.infer<typeof NativeChannelDriverDescriptorSchema>;
 export type NativeChannelRuntimeDescriptor = z.infer<typeof NativeChannelRuntimeDescriptorSchema>;
 export type NativeChannelRuntimeHealth = z.infer<typeof NativeChannelRuntimeHealthSchema>;
+export type NativeInboundChannelActionNames = z.infer<typeof NativeInboundChannelActionNamesSchema>;
+export type NativeInboundChannelIdentity = z.infer<typeof NativeInboundChannelIdentitySchema>;
+export type NativeInboundChannelActionRequest = z.infer<typeof NativeInboundChannelActionRequestSchema>;
+export type NativeInboundChannelActionResult = z.infer<typeof NativeInboundChannelActionResultSchema>;
 
 export type NativeChannelDriverFailureReason =
   | "invalid_driver_configuration"
@@ -125,12 +251,20 @@ export interface NativeChannelDriverContext {
 
 export interface NativeChannelDriverRuntime {
   readonly descriptor: NativeChannelRuntimeDescriptor;
+  readonly inboundActions?: NativeInboundChannelActionHandler;
   readonly delivery?: NativeTextDelivery;
   readonly actions?: NativeChatActionDelivery;
   readonly presence?: NativePresenceDelivery;
   start(): void | Promise<void>;
   stop(): void | Promise<void>;
   health(): NativeChannelRuntimeHealth;
+}
+
+export interface NativeInboundChannelActionHandler {
+  supports(action: string): boolean;
+  handle(
+    request: NativeInboundChannelActionRequest,
+  ): NativeInboundChannelActionResult | Promise<NativeInboundChannelActionResult>;
 }
 
 export interface NativeChannelDriver {
@@ -243,6 +377,9 @@ export async function loadNativeChannelDriverModules(
       if (descriptor.provider !== config.provider) {
         throw new NativeChannelDriverContractError("provider_mismatch");
       }
+      if (!sameStrings(descriptor.inboundActions ?? [], config.inboundActions ?? [])) {
+        throw new NativeChannelDriverContractError("invalid_module_export");
+      }
       registry.register(driver);
       loadedProviders.push(config.provider);
     } catch (error) {
@@ -314,6 +451,10 @@ export class NativeChannelDriverManager {
 
   actionDeliveries(): NativeChatActionDelivery[] {
     return this.active.flatMap(({ runtime }) => (runtime.actions ? [runtime.actions] : []));
+  }
+
+  inboundActionHandlers(): NativeInboundChannelActionHandler[] {
+    return this.active.flatMap(({ runtime }) => (runtime.inboundActions ? [runtime.inboundActions] : []));
   }
 
   presenceDeliveries(): NativePresenceDelivery[] {
@@ -476,6 +617,9 @@ function validateRuntime(
   if (descriptor.capabilities.some((capability) => !driver.capabilities.includes(capability))) {
     throw new NativeChannelDriverContractError("runtime_capability_mismatch");
   }
+  if (!sameStrings(descriptor.inboundActions ?? [], driver.inboundActions ?? [])) {
+    throw new NativeChannelDriverContractError("runtime_capability_mismatch");
+  }
   if (
     typeof runtime.start !== "function" ||
     typeof runtime.stop !== "function" ||
@@ -486,12 +630,31 @@ function validateRuntime(
   validateOptionalSurface(descriptor, "text_delivery", runtime.delivery, "deliverText");
   validateOptionalSurface(descriptor, "chat_actions", runtime.actions, "executeChatAction");
   validateOptionalSurface(descriptor, "presence", runtime.presence, "sendPresence");
+  const declaresInboundActions = descriptor.capabilities.includes("inbound_actions");
+  const hasInboundActions =
+    isRecord(runtime.inboundActions) &&
+    typeof runtime.inboundActions.supports === "function" &&
+    typeof runtime.inboundActions.handle === "function";
+  if (declaresInboundActions !== hasInboundActions) {
+    throw new NativeChannelDriverContractError("runtime_surface_mismatch");
+  }
+  for (const action of descriptor.inboundActions ?? []) {
+    let supported = false;
+    try {
+      supported = runtime.inboundActions?.supports(action) === true;
+    } catch {
+      supported = false;
+    }
+    if (!supported) {
+      throw new NativeChannelDriverContractError("runtime_surface_mismatch");
+    }
+  }
   return descriptor;
 }
 
 function validateOptionalSurface(
   descriptor: NativeChannelRuntimeDescriptor,
-  capability: Exclude<NativeChannelDriverCapability, "inbound">,
+  capability: Exclude<NativeChannelDriverCapability, "inbound" | "inbound_actions">,
   surface: unknown,
   method: string,
 ): void {
@@ -526,4 +689,8 @@ function driverFailureReason(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -9,8 +9,14 @@ import {
   pruneChannelOutboundReceiptLedger,
   runChannelOutboundLedgerMaintenance,
   slackAdapterHealth,
+  startChannelRunnerInboundActionResponder,
   startChannelOutboundReceiptPruner,
 } from "./runner.js";
+import type {
+  NativeInboundChannelActionResponder,
+  NativeInboundChannelActionResponderConnection,
+} from "./inbound-actions.js";
+import type { NativeInboundChannelActionHandler } from "./native/driver.js";
 import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 
@@ -159,6 +165,42 @@ describe("channel runner native delivery registry", () => {
       },
     });
     expect(JSON.stringify(channels)).not.toContain("must-not-enter-channel-config");
+  });
+
+  it("starts one inbound action responder only when a native runtime exposes handlers", () => {
+    const connection = {} as NativeInboundChannelActionResponderConnection;
+    const handler = {
+      supports: (action: string) => action === "connect",
+      handle: mock(async () => {
+        throw new Error("not invoked by runner registration");
+      }),
+    } satisfies NativeInboundChannelActionHandler;
+    const responder = {
+      stop: mock(async () => {}),
+    } satisfies NativeInboundChannelActionResponder;
+    const startResponder = mock(() => responder);
+
+    expect(
+      startChannelRunnerInboundActionResponder({
+        connection,
+        handlers: [],
+        startResponder,
+      }),
+    ).toBeNull();
+    expect(startResponder).not.toHaveBeenCalled();
+
+    expect(
+      startChannelRunnerInboundActionResponder({
+        connection,
+        handlers: [handler],
+        startResponder,
+      }),
+    ).toBe(responder);
+    expect(startResponder).toHaveBeenCalledTimes(1);
+    expect(startResponder).toHaveBeenCalledWith({
+      connection,
+      handlers: [handler],
+    });
   });
 });
 

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -4,6 +4,10 @@ import { configStore } from "../config-store.js";
 import { listRemoteInstallationCredentials } from "../cloud-auth/installation-storage.js";
 import { logger } from "../utils/logger.js";
 import {
+  startNativeInboundChannelActionResponder,
+  type NativeInboundChannelActionResponder,
+} from "./inbound-actions.js";
+import {
   startChannelRunnerHealthResponder,
   type ChannelAdapterHealth,
   type ChannelRunnerHealthResponder,
@@ -92,6 +96,7 @@ export class ChannelRunner {
   private actionDeliveries: NativeChatActionDelivery[] = [];
   private presenceDeliveries: NativePresenceDelivery[] = [];
   private nativeChannelManager: NativeChannelDriverManager | null = null;
+  private inboundActionResponder: NativeInboundChannelActionResponder | null = null;
   private adapterStatuses = new Map<string, AdapterStatus>();
   private stopReceiptPruner: (() => void) | null = null;
   private healthResponder: ChannelRunnerHealthResponder | null = null;
@@ -172,6 +177,8 @@ export class ChannelRunner {
     this.outboundConsumer = null;
     await this.presenceConsumer?.stop();
     this.presenceConsumer = null;
+    await this.inboundActionResponder?.stop();
+    this.inboundActionResponder = null;
     await this.nativeChannelManager?.stop();
     this.nativeChannelManager = null;
     this.deliveries = [];
@@ -240,6 +247,13 @@ export class ChannelRunner {
       registry,
     });
     await this.nativeChannelManager.start();
+    const inboundActionHandlers = this.nativeChannelManager.inboundActionHandlers();
+    if (inboundActionHandlers.length > 0) {
+      this.inboundActionResponder = startNativeInboundChannelActionResponder({
+        connection: getNats(),
+        handlers: inboundActionHandlers,
+      });
+    }
     this.deliveries.push(...this.nativeChannelManager.deliveries());
     this.actionDeliveries.push(...this.nativeChannelManager.actionDeliveries());
     this.presenceDeliveries.push(...this.nativeChannelManager.presenceDeliveries());

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger.js";
 import {
   startNativeInboundChannelActionResponder,
   type NativeInboundChannelActionResponder,
+  type NativeInboundChannelActionResponderConnection,
 } from "./inbound-actions.js";
 import {
   startChannelRunnerHealthResponder,
@@ -19,6 +20,7 @@ import {
   NativeChannelDriverRegistry,
   loadNativeChannelDriverModules,
   parseNativeChannelDriverModuleConfigs,
+  type NativeInboundChannelActionHandler,
   type NativeChannelDriverRuntime,
 } from "./native/driver.js";
 import { mergeInstallationCredentialChannels } from "./native/installation-channels.js";
@@ -62,6 +64,18 @@ export function collectNativeRuntimeDeliveries(
     actionDeliveries: runtimes.flatMap((runtime) => (runtime.actions ? [runtime.actions] : [])),
     presenceDeliveries: runtimes.flatMap((runtime) => (runtime.presence ? [runtime.presence] : [])),
   };
+}
+
+export function startChannelRunnerInboundActionResponder(options: {
+  connection: NativeInboundChannelActionResponderConnection;
+  handlers: readonly NativeInboundChannelActionHandler[];
+  startResponder?: typeof startNativeInboundChannelActionResponder;
+}): NativeInboundChannelActionResponder | null {
+  if (options.handlers.length === 0) return null;
+  return (options.startResponder ?? startNativeInboundChannelActionResponder)({
+    connection: options.connection,
+    handlers: options.handlers,
+  });
 }
 
 type ReceiptPruneTimer = ReturnType<typeof setInterval>;
@@ -247,13 +261,10 @@ export class ChannelRunner {
       registry,
     });
     await this.nativeChannelManager.start();
-    const inboundActionHandlers = this.nativeChannelManager.inboundActionHandlers();
-    if (inboundActionHandlers.length > 0) {
-      this.inboundActionResponder = startNativeInboundChannelActionResponder({
-        connection: getNats(),
-        handlers: inboundActionHandlers,
-      });
-    }
+    this.inboundActionResponder = startChannelRunnerInboundActionResponder({
+      connection: getNats(),
+      handlers: this.nativeChannelManager.inboundActionHandlers(),
+    });
     this.deliveries.push(...this.nativeChannelManager.deliveries());
     this.actionDeliveries.push(...this.nativeChannelManager.actionDeliveries());
     this.presenceDeliveries.push(...this.nativeChannelManager.presenceDeliveries());

--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -42,6 +42,7 @@ const fetchCachedOmniMediaMock = mock(async () => null as Buffer | null);
 const fetchOmniMediaMock = mock(async () => null as Buffer | null);
 const saveToAgentAttachmentsMock = mock(async () => null as string | null);
 const transcribeAudioMock = mock(async () => ({ text: "" }));
+const handleSlashCommandMock = mock(async (_input: Record<string, unknown>) => false);
 let stateDir: string | null = null;
 let agentCwd = "/tmp/ravi-agent";
 let contactIntakeMode: "off" | "discovered" | "pending" = "off";
@@ -88,7 +89,7 @@ mock.module("./session-stream.js", () => ({
 }));
 
 mock.module("../slash/index.js", () => ({
-  handleSlashCommand: mock(async () => false),
+  handleSlashCommand: handleSlashCommandMock,
 }));
 
 // Note: we intentionally do NOT override `matchRoute` here. Overriding a
@@ -315,10 +316,12 @@ describe("OmniConsumer channel context", () => {
     fetchOmniMediaMock.mockClear();
     saveToAgentAttachmentsMock.mockClear();
     transcribeAudioMock.mockClear();
+    handleSlashCommandMock.mockClear();
     fetchCachedOmniMediaMock.mockImplementation(async () => null);
     fetchOmniMediaMock.mockImplementation(async () => null);
     saveToAgentAttachmentsMock.mockImplementation(async () => null);
     transcribeAudioMock.mockImplementation(async () => ({ text: "" }));
+    handleSlashCommandMock.mockImplementation(async () => false);
   });
 
   afterEach(async () => {
@@ -391,6 +394,55 @@ describe("OmniConsumer channel context", () => {
       groupId: "120363424772797713",
       groupMembers: ["Luis Filipe", "R M"],
     });
+  });
+
+  it("passes the provider message identifier to intercepted slash commands", async () => {
+    handleSlashCommandMock.mockImplementation(async () => true);
+    const sender = {
+      send: mock(async () => {}),
+      sendTyping: mock(async () => {}),
+      markRead: mock(async () => {}),
+    };
+    const consumer = new OmniConsumer(sender as never, "http://omni.local", "test-key", {
+      resolveGroupMetadata: async () => null,
+    });
+
+    await consumer["handleMessageEvent"]("message.received.whatsapp-baileys.instance-1", {
+      id: "evt-native-action",
+      type: "message.received",
+      payload: {
+        externalId: "msg-native-action",
+        chatId: "120363424772797713@g.us",
+        from: "178035101794451",
+        content: {
+          type: "text",
+          text: "/connect",
+        },
+        rawPayload: {
+          pushName: "Luis Filipe",
+          chatName: "ravi - dev",
+          resolvedSenderPhone: "5511947879044",
+          isGroup: true,
+        },
+      },
+      metadata: {
+        instanceId: "instance-1",
+        channelType: "whatsapp-baileys",
+        ingestMode: "realtime",
+      },
+      timestamp: Date.now(),
+    });
+
+    expect(handleSlashCommandMock).toHaveBeenCalledTimes(1);
+    expect(handleSlashCommandMock.mock.calls[0]?.[0]).toMatchObject({
+      text: "/connect",
+      messageId: "msg-native-action",
+      senderId: "178035101794451",
+      chatId: "120363424772797713@g.us",
+      channelType: "whatsapp-baileys",
+      accountId: "main",
+    });
+    expect(promptCalls).toHaveLength(0);
   });
 
   it("resolves new WhatsApp LID group senders through contact intake without canonicalizing the group as a DM", async () => {

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -1564,6 +1564,7 @@ export class OmniConsumer {
     if (rawText.startsWith("/")) {
       const handled = await handleSlashCommand({
         text: rawText,
+        messageId: payload.externalId,
         senderId: senderPhone,
         chatId: chatJid,
         isGroup,

--- a/src/slash/registry.test.ts
+++ b/src/slash/registry.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { NativeInboundChannelActionRequest, NativeInboundChannelActionResult } from "../channels/native/driver.js";
+import type { RouterConfig } from "../router/types.js";
+import { handleSlashCommand } from "./registry.js";
+
+function input(text: string) {
+  return {
+    text,
+    messageId: "message-a",
+    senderId: "sender-a",
+    senderName: "Sender",
+    chatId: "conversation-a",
+    isGroup: false,
+    channelType: "example",
+    accountId: "account-a",
+    routerConfig: {} as RouterConfig,
+    send: mock(async () => {}),
+  };
+}
+
+function handled(
+  request: NativeInboundChannelActionRequest,
+  text = "Continue in the browser.",
+): NativeInboundChannelActionResult {
+  return {
+    protocol: request.protocol,
+    schemaVersion: request.schemaVersion,
+    requestId: request.requestId,
+    disposition: "handled",
+    text,
+    completedAt: "2026-07-24T18:00:02.000Z",
+  };
+}
+
+describe("native inbound slash actions", () => {
+  it("intercepts a declared action before model processing without forwarding arguments", async () => {
+    const handleInput = input("/account.connect never-forward-this");
+    const requester = mock(async (request: NativeInboundChannelActionRequest) => handled(request));
+
+    await expect(
+      handleSlashCommand(handleInput, {
+        nativeInboundActions: new Set(["account.connect"]),
+        requestNativeInboundAction: requester,
+      }),
+    ).resolves.toBe(true);
+
+    expect(requester).toHaveBeenCalledTimes(1);
+    const request = requester.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      action: "account.connect",
+      hasArguments: true,
+      identity: {
+        channelKind: "example",
+        accountId: "account-a",
+        conversationId: "conversation-a",
+        senderId: "sender-a",
+        messageId: "message-a",
+      },
+    });
+    expect(JSON.stringify(request)).not.toContain("never-forward-this");
+    expect(handleInput.send).toHaveBeenCalledWith("account-a", "conversation-a", "Continue in the browser.");
+  });
+
+  it("fails closed when the declared action runtime is unavailable", async () => {
+    const handleInput = input("/account.connect");
+
+    await expect(
+      handleSlashCommand(handleInput, {
+        nativeInboundActions: new Set(["account.connect"]),
+        requestNativeInboundAction: async () => null,
+      }),
+    ).resolves.toBe(true);
+
+    expect(handleInput.send).toHaveBeenCalledWith(
+      "account-a",
+      "conversation-a",
+      "⚠️ /account.connect is temporarily unavailable.",
+    );
+  });
+
+  it("allows undeclared commands to continue through normal processing", async () => {
+    const handleInput = input("/unknown");
+    const requester = mock(async (request: NativeInboundChannelActionRequest) => handled(request));
+
+    await expect(
+      handleSlashCommand(handleInput, {
+        nativeInboundActions: new Set(["account.connect"]),
+        requestNativeInboundAction: requester,
+      }),
+    ).resolves.toBe(false);
+    expect(requester).not.toHaveBeenCalled();
+    expect(handleInput.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/slash/registry.ts
+++ b/src/slash/registry.ts
@@ -5,8 +5,18 @@
  * of slash commands intercepted at the gateway layer.
  */
 
+import { randomUUID } from "node:crypto";
 import type { RouterConfig } from "../router/types.js";
 import { getContact } from "../contacts.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeInboundChannelActionRequestSchema,
+  type NativeInboundChannelActionRequest,
+  type NativeInboundChannelActionResult,
+} from "../channels/native/driver.js";
+import { configuredNativeInboundActionNames, requestNativeInboundChannelAction } from "../channels/inbound-actions.js";
+import { getNats } from "../nats.js";
 import { logger } from "../utils/logger.js";
 
 const log = logger.child("slash");
@@ -41,6 +51,7 @@ export interface SlashContext {
 
 interface HandleInput {
   text: string;
+  messageId: string;
   senderId: string;
   senderName?: string;
   chatId: string;
@@ -52,11 +63,20 @@ interface HandleInput {
   send: (accountId: string, chatId: string, text: string) => Promise<void>;
 }
 
+export interface HandleSlashCommandOptions {
+  nativeInboundActions?: ReadonlySet<string>;
+  requestNativeInboundAction?: (
+    request: NativeInboundChannelActionRequest,
+  ) => Promise<NativeInboundChannelActionResult | null>;
+}
+
 // ============================================================================
 // Registry
 // ============================================================================
 
 const commands = new Map<string, SlashCommand>();
+let configuredActionSource: string | undefined;
+let configuredActions = new Set<string>();
 
 export function registerCommand(cmd: SlashCommand): void {
   commands.set(cmd.name.toLowerCase(), cmd);
@@ -97,12 +117,48 @@ export function parseSlashCommand(text: string): { name: string; args: string[] 
  * Returns true if the command was handled (intercepted), false if it should
  * fall through to normal message processing.
  */
-export async function handleSlashCommand(input: HandleInput): Promise<boolean> {
+export async function handleSlashCommand(
+  input: HandleInput,
+  options: HandleSlashCommandOptions = {},
+): Promise<boolean> {
   const parsed = parseSlashCommand(input.text);
   if (!parsed) return false;
 
   const cmd = getCommand(parsed.name);
-  if (!cmd) return false; // Unknown command → fall through
+  if (!cmd) {
+    if (!(options.nativeInboundActions ?? nativeInboundActions()).has(parsed.name)) return false;
+    const request = NativeInboundChannelActionRequestSchema.parse({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: `channel-action-${randomUUID()}`,
+      action: parsed.name,
+      hasArguments: parsed.args.length > 0,
+      identity: {
+        channelKind: input.channelType,
+        accountId: input.accountId,
+        conversationId: input.chatId,
+        senderId: input.senderId,
+        messageId: input.messageId,
+      },
+      requestedAt: new Date().toISOString(),
+    });
+    let result;
+    try {
+      result = options.requestNativeInboundAction
+        ? await options.requestNativeInboundAction(request)
+        : await requestNativeInboundChannelAction(request, {
+            connection: getNats(),
+          });
+    } catch {
+      result = null;
+    }
+    if (result?.disposition === "handled" && result.text !== undefined) {
+      await input.send(input.accountId, input.chatId, result.text);
+      return true;
+    }
+    await input.send(input.accountId, input.chatId, `⚠️ /${parsed.name} is temporarily unavailable.`);
+    return true;
+  }
 
   // Permission check
   if (cmd.permission === "admin") {
@@ -111,7 +167,6 @@ export async function handleSlashCommand(input: HandleInput): Promise<boolean> {
     if (!isAdmin) {
       log.info("Slash command denied (no admin tag)", {
         command: parsed.name,
-        senderId: input.senderId,
       });
       return false; // No permission → fall through as normal message
     }
@@ -119,8 +174,7 @@ export async function handleSlashCommand(input: HandleInput): Promise<boolean> {
 
   log.info("Executing slash command", {
     command: parsed.name,
-    senderId: input.senderId,
-    args: parsed.args,
+    hasArguments: parsed.args.length > 0,
   });
 
   try {
@@ -141,10 +195,22 @@ export async function handleSlashCommand(input: HandleInput): Promise<boolean> {
     if (response) {
       await input.send(input.accountId, input.chatId, response);
     }
-  } catch (err) {
-    log.error("Slash command error", { command: parsed.name, error: err });
+  } catch {
+    log.error("Slash command error", { command: parsed.name, code: "handler_failed" });
     await input.send(input.accountId, input.chatId, `⚠️ Error executing /${parsed.name}`);
   }
 
   return true;
+}
+
+function nativeInboundActions(): ReadonlySet<string> {
+  const source = process.env.RAVI_NATIVE_CHANNEL_DRIVERS;
+  if (source === configuredActionSource) return configuredActions;
+  configuredActionSource = source;
+  try {
+    configuredActions = new Set(configuredNativeInboundActionNames(source));
+  } catch {
+    configuredActions = new Set();
+  }
+  return configuredActions;
 }


### PR DESCRIPTION
## Objective

Allow native channel runtimes to declare and handle a bounded set of inbound actions before normal model processing.

## Problem

Declared channel commands had no provider-neutral runtime ABI, so they could not be handled safely across the daemon and channel-runner process boundary.

## Solution

Extend the native channel driver ABI and SDK with explicit action declarations, add ephemeral core NATS request and reply dispatch, and reserve configured slash actions before model ingress.

## Practical impact

A local native channel runtime can return a direct response for a declared command without exposing raw command arguments or routing the command through a model session.

## What does NOT change

Undeclared slash commands keep their existing behavior, channel message delivery remains unchanged, and no durable stream or new control-plane API is introduced.

## Validation

- `bun test src/channels/inbound-actions.test.ts`
- `bun test src/slash/registry.test.ts`
- `bun test src/channels/native/driver.test.ts`
- `bun test src/channels/runner.test.ts`
- `bun test packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts`
- `bun test src/omni/consumer-context.test.ts`
- `bun test src/omni/consumer-unregistered.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:cli`
- `bun run sdk:check`

The full pre-push checks progressed through build, typecheck, and preceding test groups, then stopped in an unrelated isolated-database test group because SQLite returned a disk I/O error.

## Risks

Multiple runtimes could claim the same action or a runtime could become unavailable, so ambiguous and unavailable handlers fail closed before any model ingress or side effect.

## Rollback

Revert this pull request to remove inbound action declarations and dispatch; existing native channel delivery and slash-command behavior remain available.