### PR TITLE
Return pending login challenge in JSON

### DIFF
--- a/src/cli/commands/cloud-auth.test.ts
+++ b/src/cli/commands/cloud-auth.test.ts
@@ -125,6 +125,69 @@ describe("cloud auth root command handlers", () => {
     expect(encoded).not.toContain("provider-secret");
   });
 
+  it("returns the public challenge when no-poll login remains pending", async () => {
+    const writeCredentials = mock(() => {});
+    const client = {
+      getAuthConfig: mock(async () => ({
+        configured: true,
+        clientId: "ravi-cli",
+        mode: "console_device",
+        endpoints: {
+          deviceAuthorization: "https://console.example/api/cli/auth/device",
+          token: null,
+        },
+      })),
+      startDeviceAuthorization: mock(async () => ({
+        verificationUriComplete: "https://console.example/device?user_code=ABC",
+        verificationUri: "https://console.example/device",
+        userCode: "ABC",
+        deviceCode: "device-secret",
+        expiresIn: 600,
+        interval: 1,
+      })),
+      exchange: mock(async () => {
+        throw new CloudAuthError("AUTH_PENDING", "Authorization is still pending.", {
+          status: 409,
+        });
+      }),
+    } as unknown as ConsoleApiClient;
+
+    const { output, result } = await captureConsole(() =>
+      runLogin(
+        {
+          console: "https://console.example",
+          json: true,
+          open: false,
+          poll: false,
+        },
+        {
+          client,
+          readCredentials: () => null,
+          writeCredentials,
+        },
+      ),
+    );
+    const payload = JSON.parse(output);
+    const encoded = JSON.stringify(payload);
+
+    expect(result).toEqual(payload);
+    expect(payload).toEqual({
+      success: true,
+      status: "pending",
+      endpointUrl: "https://console.example",
+      auth: {
+        provider: null,
+        authorizationUrl: "https://console.example/device?user_code=ABC",
+        verificationUri: "https://console.example/device",
+        userCode: "ABC",
+        expiresIn: 600,
+        interval: 1,
+      },
+    });
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(encoded).not.toContain("device-secret");
+  });
+
   it("discovers an explicit remote endpoint and stores its installation credential separately", async () => {
     let writtenHuman: CloudCredentials | null = null;
     let writtenInstallation: unknown;

--- a/src/cli/commands/cloud-auth.ts
+++ b/src/cli/commands/cloud-auth.ts
@@ -140,21 +140,38 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
     });
   }
 
-  const exchanged = await exchangeUntilComplete({
-    client,
-    installationId,
-    config,
-    deviceCode: deviceAuth.deviceCode,
-    existing,
-    poll: options.poll !== false,
-    timeoutSeconds: parsePositiveNumber(options.timeoutSeconds, 300),
-    intervalSeconds: parsePositiveNumber(
-      options.intervalSeconds,
-      deviceAuth.interval ?? numberFrom(config.interval) ?? 5,
-    ),
-    installation: localInstallationMetadata(env),
-    sleep: deps.sleep ?? sleep,
-  });
+  let exchanged: CloudCredentials;
+  try {
+    exchanged = await exchangeUntilComplete({
+      client,
+      installationId,
+      config,
+      deviceCode: deviceAuth.deviceCode,
+      existing,
+      poll: options.poll !== false,
+      timeoutSeconds: parsePositiveNumber(options.timeoutSeconds, 300),
+      intervalSeconds: parsePositiveNumber(
+        options.intervalSeconds,
+        deviceAuth.interval ?? numberFrom(config.interval) ?? 5,
+      ),
+      installation: localInstallationMetadata(env),
+      sleep: deps.sleep ?? sleep,
+    });
+  } catch (error) {
+    if (!isCloudAuthError(error) || error.code !== "AUTH_PENDING" || options.poll !== false) {
+      throw error;
+    }
+    const payload = {
+      success: true,
+      status: "pending" as const,
+      endpointUrl: selected.endpointUrl,
+      auth: safeAuthConfig(config, deviceAuth),
+    };
+    printPayload(payload, options.json, () => {
+      console.log("Authentication is pending. Complete the browser flow before the challenge expires.");
+    });
+    return payload;
+  }
   const credentials: CloudCredentials = {
     ...exchanged,
     consoleUrl: selected.endpointUrl,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -124,7 +124,7 @@ program
   .option("--console <url>", "Legacy Console base URL")
   .option("--json", "Print raw JSON result")
   .option("--no-open", "Do not open a browser")
-  .option("--no-poll", "Do not poll the exchange endpoint when auth is pending")
+  .option("--no-poll", "Return the public pending challenge without waiting for approval")
   .option("--timeout-seconds <seconds>", "Maximum login polling time", "300")
   .option("--interval-seconds <seconds>", "Login polling interval")
   .action(

--- a/src/cli/root-version.test.ts
+++ b/src/cli/root-version.test.ts
@@ -72,6 +72,7 @@ describe("CLI root version", () => {
     expect(result.stdout).toContain("--console <url>");
     expect(result.stdout).toContain("--json");
     expect(result.stdout).toContain("--no-open");
+    expect(result.stdout).toContain("Return the public pending challenge");
 
     const whoami = spawnSync("bun", ["src/cli/index.ts", "whoami", "--help"], {
       cwd: process.cwd(),


### PR DESCRIPTION
## Objective

Make non-polling JSON login usable by headless clients while preserving the existing credential and secret boundaries.

## Problem

JSON mode suppresses the interactive preamble, and an authorization-pending response previously terminated before returning structured verification data to the caller.

## Solution

Return a successful pending result containing only the public authorization URL, verification URL, user code, expiry, and polling interval when `login --no-poll --json` receives `AUTH_PENDING`. Device codes and credentials remain excluded and nothing is persisted while authorization is pending.

## Practical impact

Automation can initiate login and safely present the public challenge without scraping human output or receiving secret credential material.

## What does NOT change

Interactive login, polling login, credential storage after successful authorization, endpoint discovery, and provider behavior retain their existing contracts.

## Validation

Targeted cloud-auth command tests, the broader cloud-auth suite, root version and help tests, and the repository Quality Gate passed. A live endpoint smoke returned a pending public challenge without a device code.

## Risks

The short-lived user code and authorization URL are intentionally public challenge data, but consumers still need to avoid treating the pending result as completed authentication. Tests cover pending status, absent credential writes, and device-code redaction.

## Rollback

Revert commit `a9b2bd674205fff74b264e0143bab3879920975a`; the previous behavior of surfacing `AUTH_PENDING` without a final JSON payload is restored.