### PR TITLE
feat(channels): reconcile local agents through native host

### DIFF
--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -280,6 +280,16 @@ details are excluded. The ABI introduces no new Ravi capability. Local driver
 code runs inside the channel runner, so installation remains an explicit
 operator trust decision.
 
+When a driver needs a locally managed agent, it declares
+`requiredHostCapabilities: ["local_agent_reconciliation"]` (alongside any
+other required host capabilities) and calls
+`context.host.reconcileLocalAgent()`. Requests must use the current channel
+instance as `sourceId` and the `native-channel-default` template. Ravi scopes
+the request to that channel, reconciles the agent through its in-process
+authorization pipeline, and returns a bounded result without exposing a
+context key. The default template accepts managed instructions and no
+capability aliases or runtime overrides.
+
 The generated driver schema and neutral fixtures live under
 `packages/ravi-os-sdk/src/generated` and
 `packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver`.

--- a/packages/ravi-os-sdk/README.md
+++ b/packages/ravi-os-sdk/README.md
@@ -148,6 +148,15 @@ provider- and connection-bound credential through
 `context.host.readInstallationCredential()`. It cannot enumerate credentials
 or receive the human login session.
 
+Drivers that need a local agent declare the
+`local_agent_reconciliation` host capability and call
+`context.host.reconcileLocalAgent()`. The host validates the request against
+the channel instance, applies the local `native-channel-default` template, and
+returns only the bounded reconciliation result. Reconciliation runs through
+Ravi's in-process authorization path; no context key or local admin credential
+is exposed to the driver. The default template accepts managed instructions
+but grants no requested capability aliases or runtime overrides.
+
 Drivers can reserve provider-owned slash actions with the `inbound_actions`
 capability and an exact `inboundActions` list repeated in the module, driver,
 and runtime descriptors. The runtime implements

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
@@ -13,7 +13,8 @@
   "protocol": "ravi.channel.native-driver",
   "provider": "example",
   "requiredHostCapabilities": [
-    "installation_credentials"
+    "installation_credentials",
+    "local_agent_reconciliation"
   ],
   "schemaVersion": 1
 }

--- a/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
@@ -4,6 +4,7 @@ import {
   NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
   MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
   MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES,
+  NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID,
   NativeChannelDriverDescriptorSchema,
   NativeChannelDriverHostCapabilitiesSchema,
   NativeChannelDriverModuleConfigSchema,
@@ -40,9 +41,18 @@ describe("native channel driver SDK contract", () => {
       inboundActionResult,
     );
     expect(installationCredential).toMatchObject({ provider: "example" });
-    expect(NativeChannelDriverHostCapabilitiesSchema.parse(["installation_credentials"])).toEqual([
+    expect(
+      NativeChannelDriverHostCapabilitiesSchema.parse([
+        "installation_credentials",
+        "local_agent_reconciliation",
+      ]),
+    ).toEqual([
       "installation_credentials",
+      "local_agent_reconciliation",
     ]);
+    expect(NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID).toBe(
+      "native-channel-default",
+    );
   });
 
   it("requires an explicit action declaration and exactly one handled response", async () => {
@@ -133,7 +143,10 @@ describe("native channel driver SDK contract", () => {
         driverId: "example.native",
         provider: "example",
         capabilities: ["inbound"],
-        requiredHostCapabilities: ["installation_credentials"],
+        requiredHostCapabilities: [
+          "installation_credentials",
+          "local_agent_reconciliation",
+        ],
       },
       createRuntime(context) {
         return {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -1,8 +1,8 @@
 {
   "artifacts": [
     {
-      "sha256": "cc1202c653a571b66cf7b3e961673755ee26be90727d6eab27f4d1009ae304c0",
-      "sizeBytes": 362,
+      "sha256": "e20f0bb904c3742e85e31cc10ea8211229b6838f495272a14bd6fc056174385e",
+      "sizeBytes": 396,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json"
     },
     {
@@ -31,8 +31,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "05feff656c1d20bd6e56cb9dc465d7b07e8080ea77b5738b4fb7896cb6d6e449",
-      "sizeBytes": 12607,
+      "sha256": "62860dba85f9fd292f8f0ebaa1be9e791bbc999e41be71c92d69c110bd2f0af4",
+      "sizeBytes": 12729,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
   ],
@@ -58,8 +58,8 @@
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "10eef000c762efe4545d1a89b61b49768fcebb6fef22781da5872e543095e03e",
-  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials without exposing human sessions, and include runtimes in lifecycle and health.",
+  "outputDigest": "e0cdaaee77da043ffd34a5c017d6cbc288d9a69acfeebc728333a1d5a19177b2",
+  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials, reconcile locally managed agents without exporting runtime authorization, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
       "fields": [],
@@ -161,7 +161,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "4b604dae68aaaeba81fd68ceb6c2864a0bdafc5bb61f0c70d2aeaff696794733",
+  "sourceDigest": "ab2475d54a833066b96e0d9aa127f3961fb589b33829012006c176d74a2e94ce",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -68,11 +68,12 @@
         "requiredHostCapabilities": {
           "items": {
             "enum": [
-              "installation_credentials"
+              "installation_credentials",
+              "local_agent_reconciliation"
             ],
             "type": "string"
           },
-          "maxItems": 1,
+          "maxItems": 2,
           "minItems": 1,
           "type": "array"
         },
@@ -94,18 +95,20 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "items": {
         "enum": [
-          "installation_credentials"
+          "installation_credentials",
+          "local_agent_reconciliation"
         ],
         "type": "string"
       },
-      "maxItems": 1,
+      "maxItems": 2,
       "minItems": 1,
       "type": "array"
     },
     "NativeChannelDriverHostCapability": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [
-        "installation_credentials"
+        "installation_credentials",
+        "local_agent_reconciliation"
       ],
       "type": "string"
     },
@@ -448,6 +451,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "4b604dae68aaaeba81fd68ceb6c2864a0bdafc5bb61f0c70d2aeaff696794733",
+  "sourceDigest": "ab2475d54a833066b96e0d9aa127f3961fb589b33829012006c176d74a2e94ce",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/native-channel-driver.ts
+++ b/packages/ravi-os-sdk/src/native-channel-driver.ts
@@ -16,9 +16,15 @@ import type {
   ChannelRuntimeReadbackResult,
 } from "./channel-runtime-events.js";
 import type { RemoteInstallationCredential } from "./remote-login-provider.js";
+import type {
+  LocalAgentReconciliationRequest,
+  LocalAgentReconciliationResult,
+} from "./local-agent-reconciliation.js";
 
 export const NATIVE_CHANNEL_DRIVER_PROTOCOL = "ravi.channel.native-driver" as const;
 export const NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION = 1 as const;
+export const NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID =
+  "native-channel-default" as const;
 export const MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES = 512;
 export const MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES = 4_096;
 
@@ -56,12 +62,15 @@ export const NativeInboundChannelActionNamesSchema = z
   .max(32)
   .refine((actions) => new Set(actions).size === actions.length);
 
-export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
+export const NativeChannelDriverHostCapabilitySchema = z.enum([
+  "installation_credentials",
+  "local_agent_reconciliation",
+]);
 
 export const NativeChannelDriverHostCapabilitiesSchema = z
   .array(NativeChannelDriverHostCapabilitySchema)
   .min(1)
-  .max(1)
+  .max(NativeChannelDriverHostCapabilitySchema.options.length)
   .refine((capabilities) => new Set(capabilities).size === capabilities.length);
 
 export const NativeChannelDriverModuleSpecifierSchema = z
@@ -335,6 +344,9 @@ export interface NativeChannelPresenceDelivery {
 
 export interface NativeChannelDriverHost {
   readInstallationCredential(): Promise<RemoteInstallationCredential | null>;
+  reconcileLocalAgent?(
+    request: LocalAgentReconciliationRequest,
+  ): Promise<LocalAgentReconciliationResult>;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;

--- a/src/channels/native/driver.test.ts
+++ b/src/channels/native/driver.test.ts
@@ -537,6 +537,46 @@ describe("native channel driver contract", () => {
     expect(lease.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("fails closed when local agent reconciliation is required but absent", async () => {
+    const registry = new NativeChannelDriverRegistry();
+    const driver = fullDriver();
+    const createRuntime = mock(driver.createRuntime.bind(driver));
+    registry.register({
+      ...driver,
+      descriptor: {
+        ...driver.descriptor,
+        requiredHostCapabilities: ["installation_credentials", "local_agent_reconciliation"],
+      },
+      createRuntime,
+    });
+    const lease = hostLease();
+    const incompleteHost = {
+      ...lease.host,
+      reconcileLocalAgent: undefined,
+    } as unknown as NativeChannelDriverHost;
+    const manager = new NativeChannelDriverManager({
+      channels: { "example-channel-a": channel() },
+      registry,
+      createHostLease: () => ({
+        host: incompleteHost,
+        dispose: lease.dispose,
+      }),
+    });
+
+    await manager.start();
+
+    expect(createRuntime).not.toHaveBeenCalled();
+    expect(manager.health()).toEqual([
+      {
+        id: "example:example-channel-a",
+        channelId: "example",
+        status: "failed",
+        reason: "host_capability_missing",
+      },
+    ]);
+    expect(lease.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps module loader failures stable and free of thrown details", async () => {
     const registry = new NativeChannelDriverRegistry();
     const result = await loadNativeChannelDriverModules(
@@ -701,6 +741,53 @@ describe("native channel driver contract", () => {
     lease.dispose();
     await expect(lease.host.readInstallationCredential()).rejects.toThrow("host_disposed");
     wrongProvider.dispose();
+  });
+
+  it("binds local agent reconciliation to the configured channel instance", async () => {
+    const reconcileLocalAgent = mock(async (request) => ({
+      protocol: "ravi.agent.local-reconciliation" as const,
+      schemaVersion: 1 as const,
+      requestId: request.requestId,
+      disposition: "unchanged" as const,
+      state: "ready" as const,
+      agentId: "native-channel-example",
+      appliedRevision: request.revision,
+      grantedCapabilities: [],
+      observedAt: "2026-07-26T00:00:00.000Z",
+    }));
+    const lease = createNativeChannelDriverHostLease({
+      channel: channel(),
+      provider: "example",
+      reconcileLocalAgent,
+    });
+    const request = {
+      protocol: "ravi.agent.local-reconciliation" as const,
+      schemaVersion: 1 as const,
+      requestId: "request-local-agent-1",
+      idempotencyKey: "idempotency-local-agent-1",
+      sourceId: "example-channel-a",
+      agentKey: "agent-key-1",
+      templateId: "native-channel-default",
+      revision: "a".repeat(64),
+      requestedCapabilities: [],
+    };
+
+    await expect(lease.host.reconcileLocalAgent?.(request)).resolves.toMatchObject({
+      state: "ready",
+      agentId: "native-channel-example",
+    });
+    expect(reconcileLocalAgent).toHaveBeenCalledWith(request);
+    await expect(
+      lease.host.reconcileLocalAgent?.({
+        ...request,
+        requestId: "request-local-agent-2",
+        sourceId: "other-channel",
+      }),
+    ).rejects.toThrow("scope_mismatch");
+    expect(reconcileLocalAgent).toHaveBeenCalledTimes(1);
+
+    lease.dispose();
+    await expect(lease.host.reconcileLocalAgent?.(request)).rejects.toThrow("host_disposed");
   });
 
   it("rejects duplicate driver ownership without replacing the registered driver", () => {

--- a/src/channels/native/driver.ts
+++ b/src/channels/native/driver.ts
@@ -12,6 +12,10 @@ import {
 import type { ChannelAdapterHealth } from "../health.js";
 import type { RemoteInstallationCredential } from "../../cloud-auth/remote-login.js";
 import type {
+  LocalAgentReconciliationRequest,
+  LocalAgentReconciliationResult,
+} from "../../../packages/ravi-os-sdk/src/local-agent-reconciliation.js";
+import type {
   ChannelInterruptRequest,
   ChannelInterruptResult,
   ChannelRuntimeEventSink,
@@ -58,12 +62,15 @@ export const NativeInboundChannelActionNamesSchema = z
   .max(32)
   .refine((actions) => new Set(actions).size === actions.length);
 
-export const NativeChannelDriverHostCapabilitySchema = z.enum(["installation_credentials"]);
+export const NativeChannelDriverHostCapabilitySchema = z.enum([
+  "installation_credentials",
+  "local_agent_reconciliation",
+]);
 
 export const NativeChannelDriverHostCapabilitiesSchema = z
   .array(NativeChannelDriverHostCapabilitySchema)
   .min(1)
-  .max(1)
+  .max(NativeChannelDriverHostCapabilitySchema.options.length)
   .refine((capabilities) => new Set(capabilities).size === capabilities.length);
 
 export const NativeChannelDriverModuleSpecifierSchema = z
@@ -231,6 +238,7 @@ export interface NativeChannelDriverChannelConfig {
 
 export interface NativeChannelDriverHost {
   readInstallationCredential(): Promise<RemoteInstallationCredential | null>;
+  reconcileLocalAgent?(request: LocalAgentReconciliationRequest): Promise<LocalAgentReconciliationResult>;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;
@@ -563,6 +571,9 @@ export class NativeChannelDriverManager {
 function assertHostCapabilities(descriptor: NativeChannelDriverDescriptor, host: NativeChannelDriverHost): void {
   for (const capability of descriptor.requiredHostCapabilities ?? []) {
     if (capability === "installation_credentials" && typeof host.readInstallationCredential !== "function") {
+      throw new NativeChannelDriverContractError("host_capability_missing");
+    }
+    if (capability === "local_agent_reconciliation" && typeof host.reconcileLocalAgent !== "function") {
       throw new NativeChannelDriverContractError("host_capability_missing");
     }
   }

--- a/src/channels/native/host.ts
+++ b/src/channels/native/host.ts
@@ -19,6 +19,13 @@ import {
   requestChannelRuntimeInterrupt,
 } from "../runtime-events.js";
 import type { NativeChannelDriverHost } from "./driver.js";
+import {
+  LocalAgentReconciliationRequestSchema,
+  LocalAgentReconciliationResultSchema,
+  type LocalAgentReconciliationRequest,
+  type LocalAgentReconciliationResult,
+} from "../../../packages/ravi-os-sdk/src/local-agent-reconciliation.js";
+import { createNativeChannelLocalAgentReconciler, type NativeChannelLocalAgentReconciler } from "./local-agent-host.js";
 
 export interface NativeChannelDriverHostLease {
   readonly host: NativeChannelDriverHost;
@@ -30,15 +37,21 @@ export type NativeChannelInstallationCredentialResolver = (input: {
   readonly connection?: string;
 }) => RemoteInstallationCredential | null | Promise<RemoteInstallationCredential | null>;
 
+export type NativeChannelLocalAgentResolver = (
+  input: LocalAgentReconciliationRequest,
+) => LocalAgentReconciliationResult | Promise<LocalAgentReconciliationResult>;
+
 export function createNativeChannelDriverHostLease(options: {
   channel: ChannelConfig;
   provider: string;
   resolveInstallationCredential?: NativeChannelInstallationCredentialResolver;
+  reconcileLocalAgent?: NativeChannelLocalAgentResolver;
 }): NativeChannelDriverHostLease {
   const channelInstanceId = ChannelBackendOpaqueIdSchema.parse(options.channel.name);
   const provider = ChannelBackendWireKindSchema.parse(options.provider);
   const unregister: Array<() => void> = [];
   let disposed = false;
+  let localAgentReconciler: NativeChannelLocalAgentReconciler | undefined;
 
   const ensureActive = () => {
     if (disposed) throw new Error("native_channel_driver_host_disposed");
@@ -76,6 +89,20 @@ export function createNativeChannelDriverHostLease(options: {
         throw new Error("native_channel_driver_scope_mismatch");
       }
       return structuredClone(credential);
+    },
+    async reconcileLocalAgent(input) {
+      ensureActive();
+      const request = LocalAgentReconciliationRequestSchema.parse(input);
+      if (request.sourceId !== channelInstanceId) {
+        throw new Error("native_channel_driver_scope_mismatch");
+      }
+      const resolve =
+        options.reconcileLocalAgent ??
+        ((scopedRequest: LocalAgentReconciliationRequest) => {
+          localAgentReconciler ??= createNativeChannelLocalAgentReconciler();
+          return localAgentReconciler.reconcile(scopedRequest);
+        });
+      return LocalAgentReconciliationResultSchema.parse(await resolve(request));
     },
     async ingress(input) {
       ensureActive();

--- a/src/channels/native/local-agent-host.test.ts
+++ b/src/channels/native/local-agent-host.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import {
+  NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID,
+  createNativeChannelLocalAgentReconciler,
+} from "./local-agent-host.js";
+
+describe("native channel local agent host", () => {
+  it("keeps the default template least-privilege", async () => {
+    const unexpected = mock(async () => {
+      throw new Error("runtime_must_not_be_called");
+    });
+    const reconciler = createNativeChannelLocalAgentReconciler({
+      stateDirectory: process.cwd(),
+      runtime: {
+        inspect: unexpected,
+        create: unexpected,
+        configureRuntime: unexpected,
+        configurePermissions: unexpected,
+      },
+      now: () => "2026-07-26T00:00:00.000Z",
+    });
+
+    const result = await reconciler.reconcile({
+      protocol: "ravi.agent.local-reconciliation",
+      schemaVersion: 1,
+      requestId: "request-native-channel-agent-1",
+      idempotencyKey: "idempotency-native-channel-agent-1",
+      sourceId: "example-channel-a",
+      agentKey: "example-agent-a",
+      templateId: NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID,
+      revision: "a".repeat(64),
+      requestedCapabilities: ["unmapped.capability"],
+    });
+
+    expect(result).toEqual({
+      protocol: "ravi.agent.local-reconciliation",
+      schemaVersion: 1,
+      requestId: "request-native-channel-agent-1",
+      disposition: "blocked",
+      state: "blocked",
+      grantedCapabilities: [],
+      error: {
+        code: "LOCAL_PERMISSION_DENIED",
+        category: "authorization",
+        retryable: false,
+        correlationId: "request-native-channel-agent-1",
+      },
+      observedAt: "2026-07-26T00:00:00.000Z",
+    });
+    expect(unexpected).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/native/local-agent-host.ts
+++ b/src/channels/native/local-agent-host.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+
+import {
+  LocalAgentReconciler,
+  LocalAgentReconciliationRequestSchema,
+  LocalAgentReconciliationResultSchema,
+  createRaviClientLocalAgentRuntimeAdapter,
+  type LocalAgentReconciliationRequest,
+  type LocalAgentReconciliationResult,
+  type LocalAgentRuntimeAdapter,
+  type LocalAgentRaviClient,
+} from "../../../packages/ravi-os-sdk/src/local-agent-reconciliation.js";
+import { createInProcessTransport } from "../../../packages/ravi-os-sdk/src/transport/in-process.js";
+import { getRegistry } from "../../cli/registry-snapshot.js";
+import type { ContextRecord } from "../../router/router-db.js";
+import { getRaviStateDir } from "../../utils/paths.js";
+
+export const NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID = "native-channel-default" as const;
+
+const NATIVE_CHANNEL_HOST_AGENT_ID = "native-channel-host";
+const NATIVE_CHANNEL_AGENT_ID_PREFIX = "native-channel";
+
+export interface NativeChannelLocalAgentReconciler {
+  reconcile(request: LocalAgentReconciliationRequest): Promise<LocalAgentReconciliationResult>;
+}
+
+export interface NativeChannelLocalAgentReconcilerOptions {
+  readonly stateDirectory?: string;
+  readonly runtime?: LocalAgentRuntimeAdapter;
+  readonly now?: () => string;
+}
+
+export function createNativeChannelLocalAgentReconciler(
+  options: NativeChannelLocalAgentReconcilerOptions = {},
+): NativeChannelLocalAgentReconciler {
+  const runtime = options.runtime ?? createHostRuntimeAdapter();
+  const reconciler = new LocalAgentReconciler({
+    runtime,
+    templates: [
+      {
+        templateId: NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID,
+        workspaceRoot: path.join(options.stateDirectory ?? getRaviStateDir(), "channels", "native", "managed-agents"),
+        agentIdPrefix: NATIVE_CHANNEL_AGENT_ID_PREFIX,
+        manageInstructions: true,
+        permissionProfile: "bootstrap",
+        capabilityMap: {},
+      },
+    ],
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+
+  return {
+    async reconcile(input) {
+      const request = LocalAgentReconciliationRequestSchema.parse(input);
+      return LocalAgentReconciliationResultSchema.parse(await reconciler.reconcile(request));
+    },
+  };
+}
+
+function createHostRuntimeAdapter(): LocalAgentRuntimeAdapter {
+  const context = nativeChannelHostContext();
+  const transport = createInProcessTransport({
+    registry: getRegistry(),
+    scopeContext: {
+      contextId: context.contextId,
+      context,
+      agentId: context.agentId,
+    },
+    contextRecord: context,
+  });
+  const client: LocalAgentRaviClient = {
+    agents: {
+      list: (options) =>
+        transport.call({
+          groupSegments: ["agents"],
+          command: "list",
+          body: { ...(options ?? {}) },
+        }),
+      create: (agentId, cwd, options) =>
+        transport.call({
+          groupSegments: ["agents"],
+          command: "create",
+          body: { id: agentId, cwd, ...(options ?? {}) },
+        }),
+      set: (agentId, key, value) =>
+        transport.call({
+          groupSegments: ["agents"],
+          command: "set",
+          body: { id: agentId, key, value },
+        }),
+      permissions: (agentId, profile, options) =>
+        transport.call({
+          groupSegments: ["agents"],
+          command: "permissions",
+          body: { id: agentId, profile, ...(options ?? {}) },
+        }),
+    },
+  };
+  return createRaviClientLocalAgentRuntimeAdapter(client);
+}
+
+function nativeChannelHostContext(): ContextRecord {
+  return {
+    contextId: "ctx_native_channel_host",
+    contextKey: "host-internal",
+    kind: "native-channel-host",
+    agentId: NATIVE_CHANNEL_HOST_AGENT_ID,
+    capabilities: [
+      {
+        permission: "execute",
+        objectType: "group",
+        objectId: "agents_list",
+      },
+      {
+        permission: "execute",
+        objectType: "group",
+        objectId: "agents_create",
+      },
+      {
+        permission: "execute",
+        objectType: "group",
+        objectId: "agents_set",
+      },
+      {
+        permission: "execute",
+        objectType: "group",
+        objectId: "agents_permissions",
+      },
+      {
+        permission: "view",
+        objectType: "agent",
+        objectId: `${NATIVE_CHANNEL_AGENT_ID_PREFIX}-*`,
+      },
+    ],
+    metadata: {
+      authorityMode: "host-internal",
+    },
+    createdAt: 0,
+  };
+}

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -18,7 +18,13 @@ import type {
   NativeInboundChannelActionResponder,
   NativeInboundChannelActionResponderConnection,
 } from "./inbound-actions.js";
-import type { NativeInboundChannelActionHandler } from "./native/driver.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeChannelDriverManager,
+  NativeChannelDriverRegistry,
+  type NativeInboundChannelActionHandler,
+} from "./native/driver.js";
 import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 
@@ -167,6 +173,73 @@ describe("channel runner native delivery registry", () => {
       },
     });
     expect(JSON.stringify(channels)).not.toContain("must-not-enter-channel-config");
+  });
+
+  it("provides host-owned local agent reconciliation through the runner lifecycle", async () => {
+    let reconciliationCapability: unknown;
+    const stop = mock(async () => {});
+    const registry = new NativeChannelDriverRegistry();
+    registry.register({
+      descriptor: {
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        driverId: "example.native",
+        provider: "example",
+        capabilities: ["inbound"],
+        requiredHostCapabilities: ["local_agent_reconciliation"],
+      },
+      createRuntime(context) {
+        reconciliationCapability = context.host.reconcileLocalAgent;
+        return {
+          descriptor: {
+            protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+            schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+            driverId: "example.native",
+            provider: "example",
+            runtimeId: "example-runtime-a",
+            channelInstanceId: context.channel.name,
+            capabilities: ["inbound"],
+          },
+          start: mock(async () => {}),
+          stop,
+          health: () => ({ status: "connected" as const }),
+        };
+      },
+    });
+    const manager = new NativeChannelDriverManager({
+      channels: {
+        "example-channel-a": {
+          name: "example-channel-a",
+          provider: "example",
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      },
+      registry,
+    });
+
+    await manager.start();
+
+    expect(typeof reconciliationCapability).toBe("function");
+    expect(manager.health()).toEqual([
+      {
+        id: "example:example-channel-a:example-runtime-a",
+        channelId: "example",
+        status: "connected",
+      },
+    ]);
+
+    await manager.stop();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(manager.health()).toEqual([
+      {
+        id: "example:example-channel-a:example-runtime-a",
+        channelId: "example",
+        status: "disconnected",
+      },
+    ]);
   });
 
   it("starts one inbound action responder only when a native runtime exposes handlers", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "types": ["bun-types"],
     "jsx": "react-jsx",
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Objective

Allow a native channel driver to request bounded local-agent reconciliation without receiving reusable administrative credentials.

## Problem

Native drivers that need a managed local agent currently must depend on externally provisioned authorization material, coupling driver lifecycle to credential expiry and exposing more authority than the operation requires.

## Solution

Add a versioned `local_agent_reconciliation` host capability, SDK schemas and adapter types, plus an in-process host implementation scoped to the active channel instance and a trusted local template. The host executes through least-privilege in-process authorization and fails closed on source, template, runtime, ownership, capability, or idempotency conflicts.

## Practical impact

Compatible native drivers can declaratively converge their managed local agent while the host retains workspace configuration and authorization authority. Retries are idempotent and no context key is exposed through the driver boundary.

## What does NOT change

Existing native driver actions, explicit HTTP SDK authentication, external channel contracts, release behavior, and drivers that do not request the new capability remain unchanged.

## Validation

Validated with focused native-driver and local-agent host tests, the complete channel suite, SDK contract suite and drift check, TypeScript typecheck, CLI and SDK builds, formatting checks, and the full pre-push quality gate.

## Risks

A host-template policy mistake could provision an agent with unintended local settings. The implementation limits templates to host-owned definitions, rejects driver-supplied workspace or runtime configuration, scopes requests to the configured source, and uses an explicit capability allowlist.

## Rollback

Revert the feature commit to remove the host capability, implementation, SDK surface, generated schema artifacts, and documentation together.

## Review

Automated review metadata may be attached below this non-required section.