### PR TITLE
fix(auth): preserve remote mode across token refresh

### DIFF
--- a/src/cloud-auth/client.test.ts
+++ b/src/cloud-auth/client.test.ts
@@ -321,7 +321,10 @@ describe("ConsoleApiClient", () => {
   });
 
   it("refreshes once on AUTH_EXPIRED and preserves cached metadata omitted by refresh", async () => {
-    const previous = makeCredentials();
+    const previous = {
+      ...makeCredentials(),
+      authMode: "remote" as const,
+    };
     const calls: FetchCall[] = [];
     let meCalls = 0;
     let written: CloudCredentials | null = null;
@@ -369,6 +372,7 @@ describe("ConsoleApiClient", () => {
     expect(result.credentials.accessToken).toBe("new-access-secret");
     expect(result.me.accessTokenExpiresAt).toBe("2026-05-10T01:00:00.000Z");
     expect(written).toMatchObject({
+      authMode: "remote",
       accessToken: "new-access-secret",
       refreshToken: "new-refresh-secret",
       scopes: ["artifacts:publish"],

--- a/src/cloud-auth/client.ts
+++ b/src/cloud-auth/client.ts
@@ -324,6 +324,7 @@ export function credentialsFromConsoleResponse(
   return {
     version: 1,
     consoleUrl,
+    ...(previous?.authMode === undefined ? {} : { authMode: previous.authMode }),
     installationId:
       stringValue(source.installationId) ??
       stringValue(root.installationId) ??


### PR DESCRIPTION
## Objective

Keep an authenticated remote session bound to its discovered endpoint family across every successful token refresh.

## Problem

The refresh normalizer preserved cached identity, organization, scopes, and refresh expiry, but omitted `authMode`. After writing rotated credentials, a later command treated the session as the default legacy mode and selected a different endpoint family.

## Solution

Carry the previously validated `authMode` into normalized refresh credentials when the server omits cached metadata, and assert remote-mode preservation in the existing refresh regression test.

## Practical impact

Remote login sessions continue to use their discovered refresh and identity endpoints after repeated token rotations, without requiring another login. Existing default-mode sessions behave exactly as before.

## What does NOT change

This does not alter token validation, endpoint discovery, credential storage format, installation identity, revocation behavior, or any server contract.

## Validation

- focused cloud-auth client tests
- Biome check on changed files
- TypeScript typecheck
- complete pre-push gate: SDK drift, build, typecheck, and full test suite

## Risks

Risk is low and limited to retaining an already validated enum value from the prior credential set. The regression test covers the remote branch while existing tests cover the default branch.

## Rollback

Revert the single production-line change and its regression assertion. Stored credentials remain readable because the persistence schema is unchanged.
