### PR TITLE
feat(channels): expose source-scoped local agent actions

### DIFF
--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json
@@ -14,7 +14,8 @@
   "provider": "example",
   "requiredHostCapabilities": [
     "installation_credentials",
-    "local_agent_reconciliation"
+    "local_agent_reconciliation",
+    "local_agent_actions"
   ],
   "schemaVersion": 1
 }

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json
@@ -1,0 +1,16 @@
+{
+  "description": "Create a provider-owned collaboration space.",
+  "inputSchema": {
+    "properties": {
+      "name": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  },
+  "sourceAccountId": "account-a",
+  "toolName": "example_create_space"
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-request.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-request.json
@@ -1,0 +1,17 @@
+{
+  "agentId": "agent-a",
+  "arguments": {
+    "name": "roadmap"
+  },
+  "protocol": "ravi.channel.native-driver",
+  "requestedAt": "2026-07-24T18:00:01.000Z",
+  "requestId": "local-agent-action-a",
+  "schemaVersion": 1,
+  "sessionName": "session-a",
+  "source": {
+    "accountId": "account-a",
+    "channelKind": "example",
+    "conversationId": "conversation-a"
+  },
+  "toolName": "example_create_space"
+}

--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-result.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-result.json
@@ -1,0 +1,8 @@
+{
+  "completedAt": "2026-07-24T18:00:01.000Z",
+  "disposition": "completed",
+  "protocol": "ravi.channel.native-driver",
+  "requestId": "local-agent-action-a",
+  "schemaVersion": 1,
+  "text": "Space created."
+}

--- a/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/native-channel-driver.test.ts
@@ -4,6 +4,7 @@ import {
   NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
   MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES,
   MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES,
+  MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES,
   NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID,
   NativeChannelDriverDescriptorSchema,
   NativeChannelDriverHostCapabilitiesSchema,
@@ -11,6 +12,9 @@ import {
   NativeChannelDriverModuleSpecifierSchema,
   NativeInboundChannelActionRequestSchema,
   NativeInboundChannelActionResultSchema,
+  NativeLocalAgentActionDescriptorSchema,
+  NativeLocalAgentActionRequestSchema,
+  NativeLocalAgentActionResultSchema,
   NativeChannelRuntimeDescriptorSchema,
   NativeChannelRuntimeHealthSchema,
   type NativeChannelDriver,
@@ -30,6 +34,15 @@ describe("native channel driver SDK contract", () => {
     const installationCredential = await fixture("installation-credential.json");
     const inboundActionRequest = await fixture("inbound-action-request.json");
     const inboundActionResult = await fixture("inbound-action-result.json");
+    const localAgentActionDescriptor = await fixture(
+      "local-agent-action-descriptor.json",
+    );
+    const localAgentActionRequest = await fixture(
+      "local-agent-action-request.json",
+    );
+    const localAgentActionResult = await fixture(
+      "local-agent-action-result.json",
+    );
 
     expect(NativeChannelDriverModuleConfigSchema.parse(moduleConfig)).toEqual(moduleConfig);
     expect(NativeChannelDriverDescriptorSchema.parse(driverDescriptor)).toEqual(driverDescriptor);
@@ -40,19 +53,96 @@ describe("native channel driver SDK contract", () => {
     expect(NativeInboundChannelActionResultSchema.parse(inboundActionResult)).toEqual(
       inboundActionResult,
     );
+    expect(
+      NativeLocalAgentActionDescriptorSchema.parse(localAgentActionDescriptor),
+    ).toEqual(localAgentActionDescriptor);
+    expect(
+      NativeLocalAgentActionRequestSchema.parse(localAgentActionRequest),
+    ).toEqual(localAgentActionRequest);
+    expect(
+      NativeLocalAgentActionResultSchema.parse(localAgentActionResult),
+    ).toEqual(localAgentActionResult);
     expect(installationCredential).toMatchObject({ provider: "example" });
     expect(
       NativeChannelDriverHostCapabilitiesSchema.parse([
         "installation_credentials",
         "local_agent_reconciliation",
+        "local_agent_actions",
       ]),
     ).toEqual([
       "installation_credentials",
       "local_agent_reconciliation",
+      "local_agent_actions",
     ]);
     expect(NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID).toBe(
       "native-channel-default",
     );
+  });
+
+  it("bounds provider-neutral local agent actions and their safe results", () => {
+    const descriptor = NativeLocalAgentActionDescriptorSchema.parse({
+      toolName: "example_create_space",
+      description: "Create a provider-owned collaboration space.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+        required: ["name"],
+      },
+      sourceAccountId: "account-1",
+    });
+    const request = NativeLocalAgentActionRequestSchema.parse({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: "request-1",
+      toolName: descriptor.toolName,
+      arguments: { name: "roadmap" },
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channelKind: "example",
+        accountId: "account-1",
+        conversationId: "conversation-1",
+      },
+      requestedAt: "2026-07-26T12:00:00.000Z",
+    });
+    expect(request.arguments).toEqual({ name: "roadmap" });
+    expect(
+      NativeLocalAgentActionResultSchema.parse({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }).disposition,
+    ).toBe("completed");
+    expect(
+      NativeLocalAgentActionResultSchema.safeParse({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        error: {
+          code: "DENIED",
+          category: "authorization",
+          retryable: false,
+        },
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }).success,
+    ).toBe(false);
+    expect(
+      NativeLocalAgentActionRequestSchema.safeParse({
+        ...request,
+        arguments: {
+          value: "x".repeat(
+            MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES,
+          ),
+        },
+      }).success,
+    ).toBe(false);
   });
 
   it("requires an explicit action declaration and exactly one handled response", async () => {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -1,8 +1,8 @@
 {
   "artifacts": [
     {
-      "sha256": "e20f0bb904c3742e85e31cc10ea8211229b6838f495272a14bd6fc056174385e",
-      "sizeBytes": 396,
+      "sha256": "056d9a7937fa057ea90f72ab30855a595e88531fd87c887829387203b9c4c936",
+      "sizeBytes": 423,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/driver-descriptor.json"
     },
     {
@@ -21,6 +21,21 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json"
     },
     {
+      "sha256": "062b8df900ed52f13b9fe68329a11a76c711ceae33e71dcaffdf75981b4eefb0",
+      "sizeBytes": 299,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json"
+    },
+    {
+      "sha256": "de723184195655ab62bb1ed859c2df6a2d47b6351f3ce92ed2ef626e718b55a9",
+      "sizeBytes": 407,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-request.json"
+    },
+    {
+      "sha256": "3a8abf7fe2ebadcfa3664df18df40942d270edbcb0b0d8aac4fd0f217f986ee9",
+      "sizeBytes": 211,
+      "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-result.json"
+    },
+    {
       "sha256": "d499e48cc64516a307e70a817b38e87a648be5cb4f95aa7e2bb066c261ef3f3a",
       "sizeBytes": 198,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json"
@@ -31,8 +46,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "62860dba85f9fd292f8f0ebaa1be9e791bbc999e41be71c92d69c110bd2f0af4",
-      "sizeBytes": 12729,
+      "sha256": "b389d9e149661d1f484e51f284fb4e54af15081d7eddba0531df9f08eb46b2d6",
+      "sizeBytes": 19586,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
   ],
@@ -52,14 +67,17 @@
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-request.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/inbound-action-result.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-request.json",
+    "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-result.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/module-config.json",
     "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json",
     "packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json",
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "e0cdaaee77da043ffd34a5c017d6cbc288d9a69acfeebc728333a1d5a19177b2",
-  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials, reconcile locally managed agents without exporting runtime authorization, and include runtimes in lifecycle and health.",
+  "outputDigest": "fe4a89d8c7ea04721ef0b72e3679180603e953c7f68a1131d20241197ad9ee30",
+  "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials, reconcile locally managed agents, register source-scoped local actions without exporting runtime authorization, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
       "fields": [],
@@ -151,6 +169,54 @@
       "schema": "NativeInboundChannelActionResult"
     },
     {
+      "fields": [],
+      "schema": "NativeLocalAgentActionToolName"
+    },
+    {
+      "fields": [
+        "toolName",
+        "description",
+        "inputSchema",
+        "sourceAccountId"
+      ],
+      "schema": "NativeLocalAgentActionDescriptor"
+    },
+    {
+      "fields": [
+        "channelKind",
+        "accountId",
+        "conversationId",
+        "threadId"
+      ],
+      "schema": "NativeLocalAgentActionSource"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "toolName",
+        "arguments",
+        "agentId",
+        "sessionName",
+        "source",
+        "requestedAt"
+      ],
+      "schema": "NativeLocalAgentActionRequest"
+    },
+    {
+      "fields": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "disposition",
+        "text",
+        "error",
+        "completedAt"
+      ],
+      "schema": "NativeLocalAgentActionResult"
+    },
+    {
       "fields": [
         "provider",
         "credentialId",
@@ -161,7 +227,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "ab2475d54a833066b96e0d9aa127f3961fb589b33829012006c176d74a2e94ce",
+  "sourceDigest": "68f08f202a5edaba75c6158112ee3823f62d8e14eb948884bcea7e67b7b15d75",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -46,7 +46,7 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "b389d9e149661d1f484e51f284fb4e54af15081d7eddba0531df9f08eb46b2d6",
+      "sha256": "104e326cdb967bd518d9dcc2592594fb18918b077fbcc6140a9fae3a57f5241b",
       "sizeBytes": 19586,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
@@ -76,7 +76,7 @@
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "fe4a89d8c7ea04721ef0b72e3679180603e953c7f68a1131d20241197ad9ee30",
+  "outputDigest": "15151358749e25b525f5bb4bfae815c5204379c1fc31c6d1de4db4528cbb4dac",
   "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials, reconcile locally managed agents, register source-scoped local actions without exporting runtime authorization, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
@@ -227,7 +227,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "68f08f202a5edaba75c6158112ee3823f62d8e14eb948884bcea7e67b7b15d75",
+  "sourceDigest": "838e646ed2c4ab9d5d631231355cf7275f779ce99612154a4cd37aa9a827f212",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -69,11 +69,12 @@
           "items": {
             "enum": [
               "installation_credentials",
-              "local_agent_reconciliation"
+              "local_agent_reconciliation",
+              "local_agent_actions"
             ],
             "type": "string"
           },
-          "maxItems": 2,
+          "maxItems": 3,
           "minItems": 1,
           "type": "array"
         },
@@ -96,11 +97,12 @@
       "items": {
         "enum": [
           "installation_credentials",
-          "local_agent_reconciliation"
+          "local_agent_reconciliation",
+          "local_agent_actions"
         ],
         "type": "string"
       },
-      "maxItems": 2,
+      "maxItems": 3,
       "minItems": 1,
       "type": "array"
     },
@@ -108,7 +110,8 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [
         "installation_credentials",
-        "local_agent_reconciliation"
+        "local_agent_reconciliation",
+        "local_agent_actions"
       ],
       "type": "string"
     },
@@ -407,6 +410,239 @@
       ],
       "type": "object"
     },
+    "NativeLocalAgentActionDescriptor": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "sourceAccountId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "toolName": {
+          "pattern": "^[a-z][a-z0-9_]{0,127}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "toolName",
+        "description",
+        "inputSchema"
+      ],
+      "type": "object"
+    },
+    "NativeLocalAgentActionRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "agentId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "protocol": {
+          "const": "ravi.channel.native-driver",
+          "type": "string"
+        },
+        "requestedAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "requestId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        },
+        "sessionName": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "source": {
+          "additionalProperties": false,
+          "properties": {
+            "accountId": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+              "type": "string"
+            },
+            "channelKind": {
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            "conversationId": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+              "type": "string"
+            },
+            "threadId": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "channelKind",
+            "accountId",
+            "conversationId"
+          ],
+          "type": "object"
+        },
+        "toolName": {
+          "pattern": "^[a-z][a-z0-9_]{0,127}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "toolName",
+        "arguments",
+        "agentId",
+        "sessionName",
+        "source",
+        "requestedAt"
+      ],
+      "type": "object"
+    },
+    "NativeLocalAgentActionResult": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "completed",
+            "rejected"
+          ],
+          "type": "string"
+        },
+        "error": {
+          "properties": {
+            "category": {
+              "enum": [
+                "validation",
+                "authentication",
+                "authorization",
+                "capacity",
+                "availability",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "IDEMPOTENCY_CONFLICT",
+                "UNAUTHENTICATED",
+                "PERMISSION_DENIED",
+                "LOCAL_PERMISSION_DENIED",
+                "NOT_FOUND",
+                "RATE_LIMITED",
+                "OVERLOADED",
+                "UNAVAILABLE",
+                "INTERNAL"
+              ],
+              "type": "string"
+            },
+            "correlationId": {
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            },
+            "retryAfterMs": {
+              "exclusiveMinimum": 0,
+              "maximum": 86400000,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "code",
+            "category",
+            "retryable"
+          ],
+          "type": "object"
+        },
+        "protocol": {
+          "const": "ravi.channel.native-driver",
+          "type": "string"
+        },
+        "requestId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "const": 1,
+          "type": "number"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "protocol",
+        "schemaVersion",
+        "requestId",
+        "disposition",
+        "completedAt"
+      ],
+      "type": "object"
+    },
+    "NativeLocalAgentActionSource": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "accountId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "channelKind": {
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "conversationId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        },
+        "threadId": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channelKind",
+        "accountId",
+        "conversationId"
+      ],
+      "type": "object"
+    },
+    "NativeLocalAgentActionToolName": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "pattern": "^[a-z][a-z0-9_]{0,127}$",
+      "type": "string"
+    },
     "RemoteInstallationCredential": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
@@ -451,6 +687,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "ab2475d54a833066b96e0d9aa127f3961fb589b33829012006c176d74a2e94ce",
+  "sourceDigest": "68f08f202a5edaba75c6158112ee3823f62d8e14eb948884bcea7e67b7b15d75",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -687,6 +687,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "68f08f202a5edaba75c6158112ee3823f62d8e14eb948884bcea7e67b7b15d75",
+  "sourceDigest": "838e646ed2c4ab9d5d631231355cf7275f779ce99612154a4cd37aa9a827f212",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/native-channel-driver.ts
+++ b/packages/ravi-os-sdk/src/native-channel-driver.ts
@@ -27,6 +27,9 @@ export const NATIVE_CHANNEL_DEFAULT_LOCAL_AGENT_TEMPLATE_ID =
   "native-channel-default" as const;
 export const MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES = 512;
 export const MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES = 4_096;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_DESCRIPTION_BYTES = 2_048;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES = 65_536;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_RESULT_BYTES = 16_384;
 
 const nativeChannelTextEncoder = new TextEncoder();
 
@@ -41,6 +44,22 @@ function boundedNativeChannelString(maxBytes: number, label: string) {
       (value) => nativeChannelTextEncoder.encode(value).byteLength <= maxBytes,
       `${label} exceeds ${maxBytes} UTF-8 bytes`,
     );
+}
+
+function hasBoundedNativeChannelJson(
+  value: unknown,
+  maximumBytes: number,
+): boolean {
+  try {
+    const serialized = JSON.stringify(value);
+    return (
+      serialized !== undefined &&
+      nativeChannelTextEncoder.encode(serialized).byteLength <=
+        maximumBytes
+    );
+  } catch {
+    return false;
+  }
 }
 
 export const NativeChannelDriverCapabilitySchema = z.enum([
@@ -65,6 +84,7 @@ export const NativeInboundChannelActionNamesSchema = z
 export const NativeChannelDriverHostCapabilitySchema = z.enum([
   "installation_credentials",
   "local_agent_reconciliation",
+  "local_agent_actions",
 ]);
 
 export const NativeChannelDriverHostCapabilitiesSchema = z
@@ -79,6 +99,98 @@ export const NativeChannelDriverModuleSpecifierSchema = z
     /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/,
     "must be an installed package name or an absolute file URL",
   );
+
+export const NativeLocalAgentActionToolNameSchema = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9_]{0,127}$/,
+    "local agent action tool name must be lowercase snake case",
+  );
+
+const NativeLocalAgentActionArgumentsSchema = z
+  .record(z.string(), z.unknown())
+  .refine(
+    (value) =>
+      hasBoundedNativeChannelJson(
+        value,
+        MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES,
+      ),
+    `local agent action arguments exceed ${MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES} UTF-8 bytes`,
+  );
+
+export const NativeLocalAgentActionDescriptorSchema = z
+  .object({
+    toolName: NativeLocalAgentActionToolNameSchema,
+    description: boundedNativeChannelString(
+      MAX_NATIVE_LOCAL_AGENT_ACTION_DESCRIPTION_BYTES,
+      "local agent action description",
+    ),
+    inputSchema: z
+      .record(z.string(), z.unknown())
+      .refine(
+        (value) =>
+          hasBoundedNativeChannelJson(
+            value,
+            MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES,
+          ),
+        "local agent action input schema is too large",
+      ),
+    sourceAccountId: ChannelBackendOpaqueIdSchema.optional(),
+  })
+  .strict();
+
+export const NativeLocalAgentActionSourceSchema = z
+  .object({
+    channelKind: ChannelBackendWireKindSchema,
+    accountId: ChannelBackendOpaqueIdSchema,
+    conversationId: ChannelBackendOpaqueIdSchema,
+    threadId: ChannelBackendOpaqueIdSchema.optional(),
+  })
+  .strict();
+
+export const NativeLocalAgentActionRequestSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    toolName: NativeLocalAgentActionToolNameSchema,
+    arguments: NativeLocalAgentActionArgumentsSchema,
+    agentId: ChannelBackendOpaqueIdSchema,
+    sessionName: ChannelBackendOpaqueIdSchema,
+    source: NativeLocalAgentActionSourceSchema,
+    requestedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const NativeLocalAgentActionResultSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    disposition: z.enum(["completed", "rejected"]),
+    text: boundedNativeChannelString(
+      MAX_NATIVE_LOCAL_AGENT_ACTION_RESULT_BYTES,
+      "local agent action result",
+    ).optional(),
+    error: ChannelSafeErrorSchema.optional(),
+    completedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      (value.disposition === "completed" &&
+        (value.text === undefined || value.error !== undefined)) ||
+      (value.disposition === "rejected" &&
+        (value.error === undefined || value.text !== undefined))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["disposition"],
+        message:
+          "completed actions require text; rejected actions require one safe error",
+      });
+    }
+  });
 
 export const NativeChannelDriverModuleConfigSchema = z
   .object({
@@ -223,6 +335,18 @@ export type NativeInboundChannelActionNames = z.infer<typeof NativeInboundChanne
 export type NativeInboundChannelIdentity = z.infer<typeof NativeInboundChannelIdentitySchema>;
 export type NativeInboundChannelActionRequest = z.infer<typeof NativeInboundChannelActionRequestSchema>;
 export type NativeInboundChannelActionResult = z.infer<typeof NativeInboundChannelActionResultSchema>;
+export type NativeLocalAgentActionDescriptor = z.infer<
+  typeof NativeLocalAgentActionDescriptorSchema
+>;
+export type NativeLocalAgentActionRequest = z.infer<
+  typeof NativeLocalAgentActionRequestSchema
+>;
+export type NativeLocalAgentActionResult = z.infer<
+  typeof NativeLocalAgentActionResultSchema
+>;
+export type NativeLocalAgentActionHandler = (
+  request: NativeLocalAgentActionRequest,
+) => NativeLocalAgentActionResult | Promise<NativeLocalAgentActionResult>;
 
 export interface NativeChannelDriverChannelConfig {
   readonly name: string;
@@ -347,6 +471,10 @@ export interface NativeChannelDriverHost {
   reconcileLocalAgent?(
     request: LocalAgentReconciliationRequest,
   ): Promise<LocalAgentReconciliationResult>;
+  registerLocalAgentAction?(
+    descriptor: NativeLocalAgentActionDescriptor,
+    handler: NativeLocalAgentActionHandler,
+  ): () => void;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;

--- a/src/channels/native/agent-actions.test.ts
+++ b/src/channels/native/agent-actions.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { ContextRecord } from "../../router/router-db.js";
+import { NATIVE_CHANNEL_DRIVER_PROTOCOL, NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION } from "./driver.js";
+import { nativeLocalAgentActions } from "./agent-actions.js";
+
+function context(overrides: Partial<ContextRecord> = {}): ContextRecord {
+  return {
+    contextId: "context-1",
+    contextKey: "context-key-1",
+    kind: "turn-runtime",
+    agentId: "agent-1",
+    sessionName: "session-1",
+    source: {
+      channel: "example",
+      accountId: "account-1",
+      chatId: "conversation-1",
+    },
+    capabilities: [],
+    createdAt: Date.parse("2026-07-26T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function register(sourceAccountId = "account-1") {
+  const requests: unknown[] = [];
+  const dispose = nativeLocalAgentActions.register({
+    provider: "example",
+    channelInstanceId: "example-local",
+    descriptor: {
+      toolName: "example_create_space",
+      description: "Create a provider-owned collaboration space.",
+      inputSchema: {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+      sourceAccountId,
+    },
+    async handler(request) {
+      requests.push(structuredClone(request));
+      return {
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      };
+    },
+  });
+  return { dispose, requests };
+}
+
+afterEach(() => {
+  nativeLocalAgentActions.clearForTests();
+});
+
+describe("native local agent action registry", () => {
+  it("advertises and invokes only the action scoped to the current source", async () => {
+    const registered = register();
+    expect(nativeLocalAgentActions.list(context()).map(({ toolName }) => toolName)).toEqual(["example_create_space"]);
+    expect(
+      nativeLocalAgentActions.list(
+        context({
+          source: {
+            channel: "example",
+            accountId: "another-account",
+            chatId: "conversation-1",
+          },
+        }),
+      ),
+    ).toEqual([]);
+
+    const result = await nativeLocalAgentActions.invoke({
+      context: context(),
+      toolName: "example_create_space",
+      arguments: { name: "roadmap" },
+      requestId: "request-1",
+      now: () => "2026-07-26T12:00:00.000Z",
+    });
+    expect(result?.disposition).toBe("completed");
+    expect(registered.requests).toEqual([
+      {
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: "request-1",
+        toolName: "example_create_space",
+        arguments: { name: "roadmap" },
+        agentId: "agent-1",
+        sessionName: "session-1",
+        source: {
+          channelKind: "example",
+          accountId: "account-1",
+          conversationId: "conversation-1",
+        },
+        requestedAt: "2026-07-26T12:00:00.000Z",
+      },
+    ]);
+
+    registered.dispose();
+    expect(nativeLocalAgentActions.list(context())).toEqual([]);
+  });
+
+  it("fails closed when two registrations match the same tool and source", async () => {
+    register();
+    register();
+    expect(nativeLocalAgentActions.list(context())).toEqual([]);
+    expect(
+      await nativeLocalAgentActions.invoke({
+        context: context(),
+        toolName: "example_create_space",
+        arguments: { name: "roadmap" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/channels/native/agent-actions.ts
+++ b/src/channels/native/agent-actions.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import type { ContextRecord } from "../../router/router-db.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeLocalAgentActionDescriptorSchema,
+  NativeLocalAgentActionRequestSchema,
+  NativeLocalAgentActionResultSchema,
+  type NativeLocalAgentActionDescriptor,
+  type NativeLocalAgentActionHandler,
+  type NativeLocalAgentActionResult,
+} from "./driver.js";
+
+interface RegisteredNativeLocalAgentAction {
+  readonly registrationId: string;
+  readonly provider: string;
+  readonly channelInstanceId: string;
+  readonly descriptor: NativeLocalAgentActionDescriptor;
+  readonly handler: NativeLocalAgentActionHandler;
+}
+
+export interface RegisterNativeLocalAgentActionInput {
+  readonly provider: string;
+  readonly channelInstanceId: string;
+  readonly descriptor: NativeLocalAgentActionDescriptor;
+  readonly handler: NativeLocalAgentActionHandler;
+}
+
+export class NativeLocalAgentActionRegistry {
+  private readonly registrations = new Map<string, RegisteredNativeLocalAgentAction>();
+
+  register(input: RegisterNativeLocalAgentActionInput): () => void {
+    const descriptor = NativeLocalAgentActionDescriptorSchema.parse(input.descriptor);
+    if (typeof input.handler !== "function") {
+      throw new TypeError("local agent action handler must be callable");
+    }
+    const registrationId = randomUUID();
+    this.registrations.set(registrationId, {
+      registrationId,
+      provider: input.provider,
+      channelInstanceId: input.channelInstanceId,
+      descriptor,
+      handler: input.handler,
+    });
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      this.registrations.delete(registrationId);
+    };
+  }
+
+  list(context: ContextRecord): NativeLocalAgentActionDescriptor[] {
+    const grouped = new Map<string, RegisteredNativeLocalAgentAction[]>();
+    for (const registration of this.matching(context)) {
+      const entries = grouped.get(registration.descriptor.toolName) ?? [];
+      entries.push(registration);
+      grouped.set(registration.descriptor.toolName, entries);
+    }
+    return [...grouped.values()]
+      .filter((entries) => entries.length === 1)
+      .map(([entry]) => structuredClone(entry!.descriptor))
+      .sort((left, right) => left.toolName.localeCompare(right.toolName));
+  }
+
+  async invoke(input: {
+    readonly context: ContextRecord;
+    readonly toolName: string;
+    readonly arguments: Record<string, unknown>;
+    readonly requestId?: string;
+    readonly now?: () => string;
+  }): Promise<NativeLocalAgentActionResult | undefined> {
+    const candidates = this.matching(input.context).filter(({ descriptor }) => descriptor.toolName === input.toolName);
+    if (candidates.length !== 1) return undefined;
+    const agentId = input.context.agentId;
+    const sessionName = input.context.sessionName;
+    const source = input.context.source;
+    if (agentId === undefined || sessionName === undefined || source === undefined) {
+      return undefined;
+    }
+    const request = NativeLocalAgentActionRequestSchema.parse({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: input.requestId ?? `action-${randomUUID()}`,
+      toolName: input.toolName,
+      arguments: input.arguments,
+      agentId,
+      sessionName,
+      source: {
+        channelKind: source.channel,
+        accountId: source.accountId,
+        conversationId: source.chatId,
+        ...(source.threadId === undefined ? {} : { threadId: source.threadId }),
+      },
+      requestedAt: (input.now ?? (() => new Date().toISOString()))(),
+    });
+    const result = NativeLocalAgentActionResultSchema.parse(await candidates[0]!.handler(request));
+    if (result.requestId !== request.requestId) {
+      throw new Error("native_local_agent_action_request_mismatch");
+    }
+    return result;
+  }
+
+  clearForTests(): void {
+    this.registrations.clear();
+  }
+
+  private matching(context: ContextRecord): RegisteredNativeLocalAgentAction[] {
+    const source = context.source;
+    if (source === undefined || context.agentId === undefined || context.sessionName === undefined) {
+      return [];
+    }
+    return [...this.registrations.values()].filter(
+      ({ provider, descriptor }) =>
+        provider === source.channel &&
+        (descriptor.sourceAccountId === undefined || descriptor.sourceAccountId === source.accountId),
+    );
+  }
+}
+
+export const nativeLocalAgentActions = new NativeLocalAgentActionRegistry();

--- a/src/channels/native/driver.test.ts
+++ b/src/channels/native/driver.test.ts
@@ -30,6 +30,7 @@ import {
   type NativeChannelRuntimeDescriptor,
 } from "./driver.js";
 import { createNativeChannelDriverHostLease, type NativeChannelDriverHostLease } from "./host.js";
+import { nativeLocalAgentActions } from "./agent-actions.js";
 
 const generatedFixtureDirectory = new URL(
   "../../../packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/",
@@ -577,6 +578,46 @@ describe("native channel driver contract", () => {
     expect(lease.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("fails closed when local agent actions are required but absent", async () => {
+    const registry = new NativeChannelDriverRegistry();
+    const driver = fullDriver();
+    const createRuntime = mock(driver.createRuntime.bind(driver));
+    registry.register({
+      ...driver,
+      descriptor: {
+        ...driver.descriptor,
+        requiredHostCapabilities: ["installation_credentials", "local_agent_actions"],
+      },
+      createRuntime,
+    });
+    const lease = hostLease();
+    const incompleteHost = {
+      ...lease.host,
+      registerLocalAgentAction: undefined,
+    } as unknown as NativeChannelDriverHost;
+    const manager = new NativeChannelDriverManager({
+      channels: { "example-channel-a": channel() },
+      registry,
+      createHostLease: () => ({
+        host: incompleteHost,
+        dispose: lease.dispose,
+      }),
+    });
+
+    await manager.start();
+
+    expect(createRuntime).not.toHaveBeenCalled();
+    expect(manager.health()).toEqual([
+      {
+        id: "example:example-channel-a",
+        channelId: "example",
+        status: "failed",
+        reason: "host_capability_missing",
+      },
+    ]);
+    expect(lease.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps module loader failures stable and free of thrown details", async () => {
     const registry = new NativeChannelDriverRegistry();
     const result = await loadNativeChannelDriverModules(
@@ -788,6 +829,69 @@ describe("native channel driver contract", () => {
 
     lease.dispose();
     await expect(lease.host.reconcileLocalAgent?.(request)).rejects.toThrow("host_disposed");
+  });
+
+  it("scopes local agent actions to the provider account and disposes them with the host", async () => {
+    nativeLocalAgentActions.clearForTests();
+    const lease = createNativeChannelDriverHostLease({
+      channel: channel(),
+      provider: "example",
+    });
+    lease.host.registerLocalAgentAction?.(
+      {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+        sourceAccountId: "account-1",
+      },
+      async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    );
+    const context = {
+      contextId: "context-1",
+      contextKey: "context-key-1",
+      kind: "turn-runtime",
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channel: "example",
+        accountId: "account-1",
+        chatId: "conversation-1",
+      },
+      capabilities: [],
+      createdAt: Date.parse("2026-07-26T12:00:00.000Z"),
+    };
+
+    expect(nativeLocalAgentActions.list(context)).toHaveLength(1);
+    lease.dispose();
+    expect(nativeLocalAgentActions.list(context)).toEqual([]);
+    expect(() =>
+      lease.host.registerLocalAgentAction?.(
+        {
+          toolName: "example_create_space",
+          description: "Create a provider-owned collaboration space.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        async (request) => ({
+          protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+          schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+          requestId: request.requestId,
+          disposition: "completed",
+          text: "Created.",
+          completedAt: "2026-07-26T12:00:01.000Z",
+        }),
+      ),
+    ).toThrow("host_disposed");
+    nativeLocalAgentActions.clearForTests();
   });
 
   it("rejects duplicate driver ownership without replacing the registered driver", () => {

--- a/src/channels/native/driver.ts
+++ b/src/channels/native/driver.ts
@@ -30,6 +30,9 @@ export const NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION = 1 as const;
 export const NATIVE_CHANNEL_DRIVER_MODULES_ENV = "RAVI_NATIVE_CHANNEL_DRIVERS" as const;
 export const MAX_NATIVE_INBOUND_ACTION_IDENTITY_BYTES = 512;
 export const MAX_NATIVE_INBOUND_ACTION_RESPONSE_BYTES = 4_096;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_DESCRIPTION_BYTES = 2_048;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES = 65_536;
+export const MAX_NATIVE_LOCAL_AGENT_ACTION_RESULT_BYTES = 16_384;
 
 const nativeChannelTextEncoder = new TextEncoder();
 
@@ -41,6 +44,15 @@ function boundedNativeChannelString(maxBytes: number, label: string) {
       (value) => nativeChannelTextEncoder.encode(value).byteLength <= maxBytes,
       `${label} exceeds ${maxBytes} UTF-8 bytes`,
     );
+}
+
+function hasBoundedNativeChannelJson(value: unknown, maximumBytes: number): boolean {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized !== undefined && nativeChannelTextEncoder.encode(serialized).byteLength <= maximumBytes;
+  } catch {
+    return false;
+  }
 }
 
 export const NativeChannelDriverCapabilitySchema = z.enum([
@@ -65,6 +77,7 @@ export const NativeInboundChannelActionNamesSchema = z
 export const NativeChannelDriverHostCapabilitySchema = z.enum([
   "installation_credentials",
   "local_agent_reconciliation",
+  "local_agent_actions",
 ]);
 
 export const NativeChannelDriverHostCapabilitiesSchema = z
@@ -76,6 +89,84 @@ export const NativeChannelDriverHostCapabilitiesSchema = z
 export const NativeChannelDriverModuleSpecifierSchema = z
   .string()
   .regex(/^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*|file:\/\/\/[^\u0000-\u001f\u007f]+)$/);
+
+export const NativeLocalAgentActionToolNameSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9_]{0,127}$/, "local agent action tool name must be lowercase snake case");
+
+const NativeLocalAgentActionArgumentsSchema = z
+  .record(z.string(), z.unknown())
+  .refine(
+    (value) => hasBoundedNativeChannelJson(value, MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES),
+    `local agent action arguments exceed ${MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES} UTF-8 bytes`,
+  );
+
+export const NativeLocalAgentActionDescriptorSchema = z
+  .object({
+    toolName: NativeLocalAgentActionToolNameSchema,
+    description: boundedNativeChannelString(
+      MAX_NATIVE_LOCAL_AGENT_ACTION_DESCRIPTION_BYTES,
+      "local agent action description",
+    ),
+    inputSchema: z
+      .record(z.string(), z.unknown())
+      .refine(
+        (value) => hasBoundedNativeChannelJson(value, MAX_NATIVE_LOCAL_AGENT_ACTION_ARGUMENT_BYTES),
+        "local agent action input schema is too large",
+      ),
+    sourceAccountId: ChannelBackendOpaqueIdSchema.optional(),
+  })
+  .strict();
+
+export const NativeLocalAgentActionSourceSchema = z
+  .object({
+    channelKind: ChannelBackendWireKindSchema,
+    accountId: ChannelBackendOpaqueIdSchema,
+    conversationId: ChannelBackendOpaqueIdSchema,
+    threadId: ChannelBackendOpaqueIdSchema.optional(),
+  })
+  .strict();
+
+export const NativeLocalAgentActionRequestSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    toolName: NativeLocalAgentActionToolNameSchema,
+    arguments: NativeLocalAgentActionArgumentsSchema,
+    agentId: ChannelBackendOpaqueIdSchema,
+    sessionName: ChannelBackendOpaqueIdSchema,
+    source: NativeLocalAgentActionSourceSchema,
+    requestedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export const NativeLocalAgentActionResultSchema = z
+  .object({
+    protocol: z.literal(NATIVE_CHANNEL_DRIVER_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    disposition: z.enum(["completed", "rejected"]),
+    text: boundedNativeChannelString(
+      MAX_NATIVE_LOCAL_AGENT_ACTION_RESULT_BYTES,
+      "local agent action result",
+    ).optional(),
+    error: ChannelSafeErrorSchema.optional(),
+    completedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      (value.disposition === "completed" && (value.text === undefined || value.error !== undefined)) ||
+      (value.disposition === "rejected" && (value.error === undefined || value.text !== undefined))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["disposition"],
+        message: "completed actions require text; rejected actions require one safe error",
+      });
+    }
+  });
 
 export const NativeChannelDriverModuleConfigSchema = z
   .object({
@@ -209,6 +300,12 @@ export type NativeInboundChannelActionNames = z.infer<typeof NativeInboundChanne
 export type NativeInboundChannelIdentity = z.infer<typeof NativeInboundChannelIdentitySchema>;
 export type NativeInboundChannelActionRequest = z.infer<typeof NativeInboundChannelActionRequestSchema>;
 export type NativeInboundChannelActionResult = z.infer<typeof NativeInboundChannelActionResultSchema>;
+export type NativeLocalAgentActionDescriptor = z.infer<typeof NativeLocalAgentActionDescriptorSchema>;
+export type NativeLocalAgentActionRequest = z.infer<typeof NativeLocalAgentActionRequestSchema>;
+export type NativeLocalAgentActionResult = z.infer<typeof NativeLocalAgentActionResultSchema>;
+export type NativeLocalAgentActionHandler = (
+  request: NativeLocalAgentActionRequest,
+) => NativeLocalAgentActionResult | Promise<NativeLocalAgentActionResult>;
 
 export type NativeChannelDriverFailureReason =
   | "invalid_driver_configuration"
@@ -239,6 +336,10 @@ export interface NativeChannelDriverChannelConfig {
 export interface NativeChannelDriverHost {
   readInstallationCredential(): Promise<RemoteInstallationCredential | null>;
   reconcileLocalAgent?(request: LocalAgentReconciliationRequest): Promise<LocalAgentReconciliationResult>;
+  registerLocalAgentAction?(
+    descriptor: NativeLocalAgentActionDescriptor,
+    handler: NativeLocalAgentActionHandler,
+  ): () => void;
   ingress(request: ChannelIngressRequest): Promise<ChannelIngressResult>;
   interrupt(request: ChannelInterruptRequest): Promise<ChannelInterruptResult>;
   readback(request: ChannelRuntimeReadbackRequest): Promise<ChannelRuntimeReadbackResult>;
@@ -574,6 +675,9 @@ function assertHostCapabilities(descriptor: NativeChannelDriverDescriptor, host:
       throw new NativeChannelDriverContractError("host_capability_missing");
     }
     if (capability === "local_agent_reconciliation" && typeof host.reconcileLocalAgent !== "function") {
+      throw new NativeChannelDriverContractError("host_capability_missing");
+    }
+    if (capability === "local_agent_actions" && typeof host.registerLocalAgentAction !== "function") {
       throw new NativeChannelDriverContractError("host_capability_missing");
     }
   }

--- a/src/channels/native/host.ts
+++ b/src/channels/native/host.ts
@@ -26,6 +26,8 @@ import {
   type LocalAgentReconciliationResult,
 } from "../../../packages/ravi-os-sdk/src/local-agent-reconciliation.js";
 import { createNativeChannelLocalAgentReconciler, type NativeChannelLocalAgentReconciler } from "./local-agent-host.js";
+import { nativeLocalAgentActions } from "./agent-actions.js";
+import { NativeLocalAgentActionDescriptorSchema, type NativeLocalAgentActionHandler } from "./driver.js";
 
 export interface NativeChannelDriverHostLease {
   readonly host: NativeChannelDriverHost;
@@ -103,6 +105,21 @@ export function createNativeChannelDriverHostLease(options: {
           return localAgentReconciler.reconcile(scopedRequest);
         });
       return LocalAgentReconciliationResultSchema.parse(await resolve(request));
+    },
+    registerLocalAgentAction(descriptorInput, handler) {
+      ensureActive();
+      const descriptor = NativeLocalAgentActionDescriptorSchema.parse(descriptorInput);
+      if (typeof handler !== "function") {
+        throw new TypeError("native_local_agent_action_handler_invalid");
+      }
+      return register(
+        nativeLocalAgentActions.register({
+          provider,
+          channelInstanceId,
+          descriptor,
+          handler: handler as NativeLocalAgentActionHandler,
+        }),
+      );
     },
     async ingress(input) {
       ensureActive();

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { StoredRemoteInstallationCredential } from "../cloud-auth/installation-storage.js";
+import type { ContextRecord } from "../router/router-db.js";
 import { CHANNEL_OUTBOUND_PUBLISH_RETENTION_MS } from "./outbound-publish-outbox.js";
 import { CHANNEL_OUTBOUND_RECEIPT_RETENTION_MS } from "./outbound-receipts.js";
 import {
@@ -25,6 +26,7 @@ import {
   NativeChannelDriverRegistry,
   type NativeInboundChannelActionHandler,
 } from "./native/driver.js";
+import { nativeLocalAgentActions } from "./native/agent-actions.js";
 import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 
@@ -240,6 +242,94 @@ describe("channel runner native delivery registry", () => {
         status: "disconnected",
       },
     ]);
+  });
+
+  it("disposes source-scoped local agent actions with the native runner lifecycle", async () => {
+    nativeLocalAgentActions.clearForTests();
+    const registry = new NativeChannelDriverRegistry();
+    registry.register({
+      descriptor: {
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        driverId: "example.native",
+        provider: "example",
+        capabilities: ["inbound"],
+        requiredHostCapabilities: ["local_agent_actions"],
+      },
+      createRuntime(context) {
+        context.host.registerLocalAgentAction?.(
+          {
+            toolName: "example_create_space",
+            description: "Create a provider-owned collaboration space.",
+            inputSchema: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+            sourceAccountId: "account-1",
+          },
+          async (request) => ({
+            protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+            schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+            requestId: request.requestId,
+            disposition: "completed",
+            text: "Created.",
+            completedAt: "2026-07-26T12:00:01.000Z",
+          }),
+        );
+        return {
+          descriptor: {
+            protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+            schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+            driverId: "example.native",
+            provider: "example",
+            runtimeId: "example-runtime-a",
+            channelInstanceId: context.channel.name,
+            capabilities: ["inbound"],
+          },
+          start: mock(async () => {}),
+          stop: mock(async () => {}),
+          health: () => ({ status: "connected" as const }),
+        };
+      },
+    });
+    const manager = new NativeChannelDriverManager({
+      channels: {
+        "example-channel-a": {
+          name: "example-channel-a",
+          provider: "example",
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      },
+      registry,
+    });
+    const runtimeContext: ContextRecord = {
+      contextId: "context-1",
+      contextKey: "context-key-1",
+      kind: "turn-runtime",
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channel: "example",
+        accountId: "account-1",
+        chatId: "conversation-1",
+      },
+      capabilities: [],
+      createdAt: Date.parse("2026-07-26T12:00:00.000Z"),
+    };
+
+    try {
+      await manager.start();
+      expect(nativeLocalAgentActions.list(runtimeContext).map(({ toolName }) => toolName)).toEqual([
+        "example_create_space",
+      ]);
+    } finally {
+      await manager.stop();
+    }
+
+    expect(nativeLocalAgentActions.list(runtimeContext)).toEqual([]);
+    nativeLocalAgentActions.clearForTests();
   });
 
   it("starts one inbound action responder only when a native runtime exposes handlers", () => {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -233,7 +233,7 @@ describe("createCodexRuntimeProvider", () => {
     });
   });
 
-  it("does not pass dynamic tools when bootstrapping a resumed app-server thread", async () => {
+  it("passes host-approved dynamic tools when bootstrapping a resumed app-server thread", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "ravi-codex-resume-tools-"));
     const command = join(cwd, "fake-codex-app-server.mjs");
     const requestsPath = join(cwd, "thread-requests.jsonl");
@@ -309,7 +309,7 @@ rl.on("line", (line) => {
     expect(threadRequests).toHaveLength(1);
     expect(threadRequests[0]?.method).toBe("thread/resume");
     expect(threadRequests[0]?.params.threadId).toBe("thread_prev");
-    expect(threadRequests[0]?.params.dynamicTools).toBeNull();
+    expect(threadRequests[0]?.params.dynamicTools).toEqual([toolSpec]);
   });
 
   it("recovers a resumed multi-agent sub-agent thread into a fresh top-level thread", async () => {
@@ -2217,8 +2217,9 @@ const finishIfReady = () => {
 rl.on("line", (line) => {
   const message = JSON.parse(line);
   if (message.id && !message.method) {
-    if (message.id === "tool_req") {
+    if (message.id === 77) {
       if (message.jsonrpc !== "2.0") throw new Error("tool response must include jsonrpc 2.0");
+      if (typeof message.id !== "number") throw new Error("numeric tool request ids must remain numeric");
       if (!Array.isArray(message.result?.contentItems)) throw new Error("tool response must use contentItems");
       if (message.result?.content_items) throw new Error("tool response must not use content_items");
     }
@@ -2250,7 +2251,7 @@ rl.on("line", (line) => {
     });
     send({
       jsonrpc: "2.0",
-      id: "tool_req",
+      id: 77,
       method: "item/tool/call",
       params: {
         callId: "dyn_tool_1",

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -215,7 +215,7 @@ export function createCodexRuntimeProvider(options: CreateCodexRuntimeProviderOp
           operations: CODEX_RUNTIME_CONTROL_OPERATIONS,
         },
         dynamicTools: {
-          mode: "none",
+          mode: "host",
         },
         execution: {
           mode: "subprocess-rpc",
@@ -579,8 +579,9 @@ async function* normalizeCodexEvents(
         forkFrom: forkFromSessionId,
         systemPromptAppend,
         approveRuntimeRequest: input.approveRuntimeRequest,
-        dynamicTools: undefined,
-        handleRuntimeToolCall: undefined,
+        dynamicTools: input.dynamicTools,
+        handleRuntimeToolCall:
+          input.dynamicTools !== undefined && input.dynamicTools.length > 0 ? input.handleRuntimeToolCall : undefined,
       });
       forkFromSessionId = undefined;
 
@@ -1100,7 +1101,11 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     });
   }
 
-  async function handleServerRequest(id: string, method: string, params: Record<string, unknown>): Promise<void> {
+  async function handleServerRequest(
+    id: string | number,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<void> {
     if (isCodexApprovalRequestMethod(method)) {
       const request = buildRuntimeApprovalRequest(method, params, activeTurn, currentThreadId);
       activeTurn?.queue.push(buildApprovalTraceEvent("approval.requested", request));
@@ -1143,7 +1148,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     }
   }
 
-  async function handleDynamicToolCall(id: string, params: Record<string, unknown>): Promise<void> {
+  async function handleDynamicToolCall(id: string | number, params: Record<string, unknown>): Promise<void> {
     const request = buildRuntimeDynamicToolCallRequest(params, activeTurn, currentThreadId);
     activeTurn?.queue.push(buildDynamicToolTraceEvent("item.started", request));
 
@@ -1393,9 +1398,11 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
 
   function routeAppServerMessage(message: CodexJsonRpcMessage): void {
     if (typeof message.id === "string" || typeof message.id === "number") {
-      const requestId = String(message.id);
       if (typeof message.method === "string") {
-        void handleServerRequest(requestId, message.method, asRecord(message.params) ?? {}).catch((error) => {
+        // JSON-RPC request ids are type-sensitive in the Codex app-server
+        // callback registry. Preserve the original string/number representation
+        // when replying to a server-initiated request.
+        void handleServerRequest(message.id, message.method, asRecord(message.params) ?? {}).catch((error) => {
           if (activeTurn) {
             settleTurn(activeTurn, { exitCode: 1, stderr: getStderr() }, { failQueue: error });
           }
@@ -1403,6 +1410,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         return;
       }
 
+      const requestId = String(message.id);
       const pending = pendingRequests.get(requestId);
       if (pending) {
         pendingRequests.delete(requestId);
@@ -1648,7 +1656,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
             config: { model_reasoning_effort: effort },
             baseInstructions: null,
             developerInstructions: input.systemPromptAppend || null,
-            dynamicTools: null,
+            dynamicTools: input.dynamicTools ?? null,
             personality: null,
             persistExtendedHistory: false,
           })
@@ -1662,7 +1670,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
             serviceName: null,
             baseInstructions: null,
             developerInstructions: input.systemPromptAppend || null,
-            dynamicTools: null,
+            dynamicTools: input.dynamicTools ?? null,
             personality: null,
             ephemeral: false,
             experimentalRawEvents: false,

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -37,6 +37,7 @@ import { evaluateRuntimeCommandSkillGate, evaluateRuntimeToolSkillGate } from ".
 import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
 
 const RUNTIME_BUILTIN_EXECUTABLES = new Set(["ravi"]);
+const DYNAMIC_TOOL_TIMEOUT_MS = 60_000;
 let cachedRuntimeDynamicTools: ExportedTool[] | null = null;
 let cachedRuntimeDynamicToolSpecs: RuntimeDynamicToolSpec[] | null = null;
 
@@ -106,7 +107,7 @@ function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDy
   );
 
   const commandTools = getRuntimeDynamicToolSpecs().filter((tool) => allowedToolNames.has(tool.name));
-  const commandToolNames = new Set(commandTools.map(({ name }) => name));
+  const commandToolNames = new Set(getRuntimeDynamicToolDefinitions().map(({ name }) => name));
   const nativeActions = nativeLocalAgentActions
     .list(context)
     .filter(
@@ -144,6 +145,21 @@ function canAdvertiseRuntimeDynamicTool(context: ContextRecord, tool: ExportedTo
       );
     default:
       return false;
+  }
+}
+
+async function runDynamicToolWithTimeout<T>(toolName: string, operation: () => Promise<T> | T): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error(`Dynamic tool ${toolName} timed out after ${DYNAMIC_TOOL_TIMEOUT_MS}ms`)),
+      DYNAMIC_TOOL_TIMEOUT_MS,
+    );
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(operation), timeoutError]);
+  } finally {
+    clearTimeout(timeoutHandle);
   }
 }
 
@@ -284,20 +300,10 @@ async function executeRuntimeDynamicTool(
   }
 
   const args = normalizeDynamicToolArguments(request.arguments);
-  const DYNAMIC_TOOL_TIMEOUT_MS = 60_000;
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  const timeoutError = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(
-      () => reject(new Error(`Dynamic tool ${tool.name} timed out after ${DYNAMIC_TOOL_TIMEOUT_MS}ms`)),
-      DYNAMIC_TOOL_TIMEOUT_MS,
-    );
-  });
-  try {
-    const result = await Promise.race([runWithContext(options.toolContext, () => tool.handler(args)), timeoutError]);
-    return buildRuntimeDynamicToolResult(result);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
+  const result = await runDynamicToolWithTimeout(tool.name, () =>
+    runWithContext(options.toolContext, () => tool.handler(args)),
+  );
+  return buildRuntimeDynamicToolResult(result);
 }
 
 async function executeNativeLocalAgentAction(
@@ -337,12 +343,14 @@ async function executeNativeLocalAgentAction(
     };
   }
   try {
-    const result = await nativeLocalAgentActions.invoke({
-      context: options.context,
-      toolName: request.toolName,
-      arguments: normalizeDynamicToolArguments(request.arguments),
-      ...(request.callId === undefined ? {} : { requestId: request.callId }),
-    });
+    const result = await runDynamicToolWithTimeout(request.toolName, () =>
+      nativeLocalAgentActions.invoke({
+        context: options.context,
+        toolName: request.toolName,
+        arguments: normalizeDynamicToolArguments(request.arguments),
+        ...(request.callId === undefined ? {} : { requestId: request.callId }),
+      }),
+    );
     if (result === undefined) {
       return {
         success: false,

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -34,6 +34,7 @@ import type {
   RuntimeCapabilities,
 } from "./types.js";
 import { evaluateRuntimeCommandSkillGate, evaluateRuntimeToolSkillGate } from "./skill-gate.js";
+import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
 
 const RUNTIME_BUILTIN_EXECUTABLES = new Set(["ravi"]);
 let cachedRuntimeDynamicTools: ExportedTool[] | null = null;
@@ -104,7 +105,22 @@ function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDy
       .map((tool) => tool.name),
   );
 
-  return getRuntimeDynamicToolSpecs().filter((tool) => allowedToolNames.has(tool.name));
+  const commandTools = getRuntimeDynamicToolSpecs().filter((tool) => allowedToolNames.has(tool.name));
+  const commandToolNames = new Set(commandTools.map(({ name }) => name));
+  const nativeActions = nativeLocalAgentActions
+    .list(context)
+    .filter(
+      ({ toolName }) => !commandToolNames.has(toolName) && canWithCapabilityContext(context, "use", "tool", toolName),
+    )
+    .map(
+      ({ toolName, description, inputSchema }) =>
+        ({
+          name: toolName,
+          description,
+          inputSchema,
+        }) satisfies RuntimeDynamicToolSpec,
+    );
+  return [...commandTools, ...nativeActions].sort((left, right) => left.name.localeCompare(right.name));
 }
 
 function canAdvertiseRuntimeDynamicTool(context: ContextRecord, tool: ExportedTool): boolean {
@@ -232,10 +248,7 @@ async function executeRuntimeDynamicTool(
 ): Promise<RuntimeDynamicToolCallResult> {
   const tool = getRuntimeDynamicToolDefinitions().find((candidate) => candidate.name === request.toolName);
   if (!tool) {
-    return {
-      success: false,
-      contentItems: [{ type: "inputText", text: `Unknown Ravi dynamic tool: ${request.toolName}` }],
-    };
+    return executeNativeLocalAgentAction(options, request, executionOptions);
   }
 
   const authorization = await authorizeRuntimeDynamicToolCall(options, tool, executionOptions?.eventData);
@@ -284,6 +297,90 @@ async function executeRuntimeDynamicTool(
     return buildRuntimeDynamicToolResult(result);
   } finally {
     clearTimeout(timeoutHandle);
+  }
+}
+
+async function executeNativeLocalAgentAction(
+  options: Pick<RuntimeHostServicesOptions, "context" | "agentId" | "sessionName">,
+  request: RuntimeDynamicToolCallRequest,
+  executionOptions?: RuntimeDynamicToolExecutionOptions,
+): Promise<RuntimeDynamicToolCallResult> {
+  const available = nativeLocalAgentActions.list(options.context).some(({ toolName }) => toolName === request.toolName);
+  if (!available) {
+    return {
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: `Unknown Ravi dynamic tool: ${request.toolName}`,
+        },
+      ],
+    };
+  }
+  const authorization = await authorizeRuntimeContext({
+    context: options.context,
+    permission: "use",
+    objectType: "tool",
+    objectId: request.toolName,
+    eventData: executionOptions?.eventData,
+  });
+  if (!authorization.allowed) {
+    return {
+      success: false,
+      reason: authorization.reason,
+      contentItems: [
+        {
+          type: "inputText",
+          text: authorization.reason ?? `${request.toolName} tool permission denied.`,
+        },
+      ],
+    };
+  }
+  try {
+    const result = await nativeLocalAgentActions.invoke({
+      context: options.context,
+      toolName: request.toolName,
+      arguments: normalizeDynamicToolArguments(request.arguments),
+      ...(request.callId === undefined ? {} : { requestId: request.callId }),
+    });
+    if (result === undefined) {
+      return {
+        success: false,
+        contentItems: [
+          {
+            type: "inputText",
+            text: `${request.toolName} is unavailable for this turn.`,
+          },
+        ],
+      };
+    }
+    if (result.disposition === "rejected") {
+      return {
+        success: false,
+        reason: result.error?.code,
+        contentItems: [
+          {
+            type: "inputText",
+            text: `Action rejected: ${result.error?.code ?? "UNAVAILABLE"}`,
+          },
+        ],
+      };
+    }
+    return {
+      success: true,
+      contentItems: [{ type: "inputText", text: result.text! }],
+    };
+  } catch {
+    return {
+      success: false,
+      reason: "native_local_agent_action_failed",
+      contentItems: [
+        {
+          type: "inputText",
+          text: `${request.toolName} could not be completed.`,
+        },
+      ],
+    };
   }
 }
 

--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
+import { NATIVE_CHANNEL_DRIVER_PROTOCOL, NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION } from "../channels/native/driver.js";
+import type { ContextRecord } from "../router/router-db.js";
+import { createRuntimeHostServices } from "./host-services.js";
 import {
   assertRuntimeCompatibility,
   createRuntimeProvider,
@@ -11,6 +15,73 @@ import {
 import type { RuntimeProvider } from "./types.js";
 
 describe("runtime compatibility preflight", () => {
+  it("exposes a source-scoped driver action only with matching local tool permission", async () => {
+    const runtimeContext: ContextRecord = {
+      contextId: "context-1",
+      contextKey: "context-key-1",
+      kind: "turn-runtime",
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channel: "example",
+        accountId: "account-1",
+        chatId: "conversation-1",
+      },
+      capabilities: [
+        {
+          permission: "use",
+          objectType: "tool",
+          objectId: "example_create_space",
+          source: "test",
+        },
+      ],
+      createdAt: Date.parse("2026-07-26T12:00:00.000Z"),
+    };
+    const dispose = nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+        sourceAccountId: "account-1",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    });
+
+    try {
+      const services = createRuntimeHostServices({
+        context: runtimeContext,
+        agentId: "agent-1",
+        sessionName: "session-1",
+        toolContext: { context: runtimeContext },
+      });
+      expect(services.listDynamicTools().map(({ name }) => name)).toContain("example_create_space");
+      expect(
+        await services.executeDynamicTool({
+          toolName: "example_create_space",
+          callId: "request-1",
+          arguments: { name: "roadmap" },
+        }),
+      ).toEqual({
+        success: true,
+        contentItems: [{ type: "inputText", text: "Created." }],
+      });
+    } finally {
+      dispose();
+    }
+  });
+
   it("uses Codex as the default runtime provider", () => {
     expect(DEFAULT_RUNTIME_PROVIDER_ID).toBe("codex");
     expect(createRuntimeProvider().id).toBe("codex");

--- a/src/runtime/native-local-agent-actions.test.ts
+++ b/src/runtime/native-local-agent-actions.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { NATIVE_CHANNEL_DRIVER_PROTOCOL, NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION } from "../channels/native/driver.js";
+import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
+import type { ContextRecord } from "../router/router-db.js";
+import { createRuntimeHostServices } from "./host-services.js";
+
+function context(allowed: boolean): ContextRecord {
+  return {
+    contextId: "context-1",
+    contextKey: "context-key-1",
+    kind: "turn-runtime",
+    agentId: "agent-1",
+    sessionKey: "agent:agent-1:example",
+    sessionName: "session-1",
+    source: {
+      channel: "example",
+      accountId: "account-1",
+      chatId: "conversation-1",
+    },
+    capabilities: allowed
+      ? [
+          {
+            permission: "use",
+            objectType: "tool",
+            objectId: "example_create_space",
+            source: "test",
+          },
+        ]
+      : [],
+    createdAt: Date.parse("2026-07-26T12:00:00.000Z"),
+  };
+}
+
+afterEach(() => {
+  nativeLocalAgentActions.clearForTests();
+});
+
+describe("runtime native local agent actions", () => {
+  it("advertises and executes a source-scoped driver action through host services", async () => {
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+        sourceAccountId: "account-1",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: `Created ${String(request.arguments.name)}.`,
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    });
+    const runtimeContext = context(true);
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: {
+        context: runtimeContext,
+        agentId: "agent-1",
+        sessionName: "session-1",
+      },
+    });
+
+    expect(services.listDynamicTools()).toContainEqual({
+      name: "example_create_space",
+      description: "Create a provider-owned collaboration space.",
+      inputSchema: {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+    });
+    expect(
+      await services.executeDynamicTool({
+        toolName: "example_create_space",
+        callId: "request-1",
+        arguments: { name: "roadmap" },
+      }),
+    ).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "Created roadmap." }],
+    });
+  });
+
+  it("does not advertise a driver action without local tool permission", () => {
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: { type: "object", properties: {} },
+        sourceAccountId: "account-1",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    });
+    const runtimeContext = context(false);
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+    expect(services.listDynamicTools().some(({ name }) => name === "example_create_space")).toBe(false);
+  });
+});

--- a/src/runtime/native-local-agent-actions.test.ts
+++ b/src/runtime/native-local-agent-actions.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { NATIVE_CHANNEL_DRIVER_PROTOCOL, NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION } from "../channels/native/driver.js";
 import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
 import type { ContextRecord } from "../router/router-db.js";
 import { createRuntimeHostServices } from "./host-services.js";
 
-function context(allowed: boolean): ContextRecord {
+function context(allowed: boolean, toolName = "example_create_space"): ContextRecord {
   return {
     contextId: "context-1",
     contextKey: "context-key-1",
@@ -22,7 +22,7 @@ function context(allowed: boolean): ContextRecord {
           {
             permission: "use",
             objectType: "tool",
-            objectId: "example_create_space",
+            objectId: toolName,
             source: "test",
           },
         ]
@@ -63,5 +63,86 @@ describe("runtime native local agent actions", () => {
       toolContext: { context: runtimeContext },
     });
     expect(services.listDynamicTools().some(({ name }) => name === "example_create_space")).toBe(false);
+  });
+
+  it("does not advertise a driver action that collides with any built-in command", () => {
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "channels_create",
+        description: "Create a provider-owned channel.",
+        inputSchema: { type: "object", properties: {} },
+        sourceAccountId: "account-1",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Must not run.",
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    });
+    const runtimeContext = context(true, "channels_create");
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+
+    expect(services.listDynamicTools().some(({ name }) => name === "channels_create")).toBe(false);
+  });
+
+  it("bounds a stalled driver action with the runtime tool timeout", async () => {
+    let handlerStarted = false;
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: { type: "object", properties: {} },
+        sourceAccountId: "account-1",
+      },
+      handler: async () => {
+        handlerStarted = true;
+        return await new Promise<never>(() => {});
+      },
+    });
+    const runtimeContext = context(true);
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+    const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: (...args: unknown[]) => void,
+      _delay?: number,
+      ...args: unknown[]
+    ) => {
+      setImmediate(() => callback(...args));
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    try {
+      expect(
+        await services.executeDynamicTool({
+          toolName: "example_create_space",
+          callId: "request-timeout",
+          arguments: {},
+        }),
+      ).toEqual({
+        success: false,
+        reason: "native_local_agent_action_failed",
+        contentItems: [{ type: "inputText", text: "example_create_space could not be completed." }],
+      });
+      expect(handlerStarted).toBe(true);
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 });

--- a/src/runtime/native-local-agent-actions.test.ts
+++ b/src/runtime/native-local-agent-actions.test.ts
@@ -36,62 +36,6 @@ afterEach(() => {
 });
 
 describe("runtime native local agent actions", () => {
-  it("advertises and executes a source-scoped driver action through host services", async () => {
-    nativeLocalAgentActions.register({
-      provider: "example",
-      channelInstanceId: "example-local",
-      descriptor: {
-        toolName: "example_create_space",
-        description: "Create a provider-owned collaboration space.",
-        inputSchema: {
-          type: "object",
-          properties: { name: { type: "string" } },
-          required: ["name"],
-        },
-        sourceAccountId: "account-1",
-      },
-      handler: async (request) => ({
-        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
-        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
-        requestId: request.requestId,
-        disposition: "completed",
-        text: `Created ${String(request.arguments.name)}.`,
-        completedAt: "2026-07-26T12:00:01.000Z",
-      }),
-    });
-    const runtimeContext = context(true);
-    const services = createRuntimeHostServices({
-      context: runtimeContext,
-      agentId: "agent-1",
-      sessionName: "session-1",
-      toolContext: {
-        context: runtimeContext,
-        agentId: "agent-1",
-        sessionName: "session-1",
-      },
-    });
-
-    expect(services.listDynamicTools()).toContainEqual({
-      name: "example_create_space",
-      description: "Create a provider-owned collaboration space.",
-      inputSchema: {
-        type: "object",
-        properties: { name: { type: "string" } },
-        required: ["name"],
-      },
-    });
-    expect(
-      await services.executeDynamicTool({
-        toolName: "example_create_space",
-        callId: "request-1",
-        arguments: { name: "roadmap" },
-      }),
-    ).toEqual({
-      success: true,
-      contentItems: [{ type: "inputText", text: "Created roadmap." }],
-    });
-  });
-
   it("does not advertise a driver action without local tool permission", () => {
     nativeLocalAgentActions.register({
       provider: "example",

--- a/src/runtime/provider-contract.test.ts
+++ b/src/runtime/provider-contract.test.ts
@@ -165,7 +165,7 @@ describe("runtime provider contract", () => {
         operations: ["thread.list", "thread.read", "thread.rollback", "thread.fork", "turn.steer", "turn.interrupt"],
       },
       dynamicTools: {
-        mode: "none",
+        mode: "host",
       },
       execution: {
         mode: "subprocess-rpc",

--- a/src/runtime/runtime-provider-bootstrap.test.ts
+++ b/src/runtime/runtime-provider-bootstrap.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
+import { NATIVE_CHANNEL_DRIVER_PROTOCOL, NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION } from "../channels/native/driver.js";
+import type { AgentConfig } from "../router/index.js";
+import type { ContextRecord } from "../router/router-db.js";
+import { prepareRuntimeProviderBootstrap } from "./runtime-provider-bootstrap.js";
+import type { RuntimeCapabilities, SessionRuntimeProvider } from "./types.js";
+
+const capabilities: RuntimeCapabilities = {
+  runtimeControl: { supported: false, operations: [] },
+  dynamicTools: { mode: "host" },
+  execution: { mode: "sdk" },
+  sessionState: { mode: "provider-session-id" },
+  usage: { semantics: "terminal-event" },
+  tools: {
+    permissionMode: "ravi-host",
+    accessRequirement: "tool_surface",
+    supportsParallelCalls: false,
+  },
+  systemPrompt: { mode: "append" },
+  terminalEvents: { guarantee: "adapter" },
+  skillVisibility: {
+    availability: "none",
+    loadedState: "none",
+  },
+  supportsSessionResume: false,
+  supportsSessionFork: false,
+  supportsPartialText: true,
+  supportsToolHooks: true,
+  supportsPlugins: false,
+  supportsMcpServers: false,
+  supportsRemoteSpawn: false,
+};
+
+afterEach(() => {
+  nativeLocalAgentActions.clearForTests();
+});
+
+describe("runtime provider bootstrap", () => {
+  it("bridges source-scoped native Channel actions through the shared host capability", async () => {
+    const context: ContextRecord = {
+      contextId: "context-1",
+      contextKey: "context-key-1",
+      kind: "turn-runtime",
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channel: "example",
+        accountId: "account-1",
+        chatId: "conversation-1",
+      },
+      capabilities: [
+        {
+          permission: "use",
+          objectType: "tool",
+          objectId: "example_create_space",
+          source: "test",
+        },
+      ],
+      createdAt: Date.parse("2026-07-27T12:00:00.000Z"),
+    };
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+        sourceAccountId: "account-1",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Created.",
+        completedAt: "2026-07-27T12:00:01.000Z",
+      }),
+    });
+    const provider: SessionRuntimeProvider = {
+      id: "test-provider",
+      getCapabilities: () => capabilities,
+      prepareSession: () => ({
+        startRequest: {
+          approveRuntimeRequest: async () => ({ approved: true }),
+        },
+      }),
+      startSession: () => ({
+        provider: "test-provider",
+        events: (async function* () {})(),
+        interrupt: async () => {},
+      }),
+    };
+
+    const result = await prepareRuntimeProviderBootstrap({
+      runtimeProvider: provider,
+      runtimeCapabilities: capabilities,
+      agent: { id: "agent-1", cwd: "/tmp/agent-1" } satisfies AgentConfig,
+      sessionName: "session-1",
+      sessionCwd: "/tmp/agent-1",
+      resolvedSource: context.source,
+      toolContext: { context },
+      context,
+    });
+    const startRequest = result.providerBootstrap?.startRequest;
+
+    expect(typeof startRequest?.approveRuntimeRequest).toBe("function");
+    expect(startRequest?.dynamicTools?.map(({ name }) => name)).toContain("example_create_space");
+    await expect(
+      startRequest?.handleRuntimeToolCall?.({
+        toolName: "example_create_space",
+        callId: "call-1",
+        arguments: { name: "roadmap" },
+      }),
+    ).resolves.toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "Created." }],
+    });
+  });
+});

--- a/src/runtime/runtime-provider-bootstrap.ts
+++ b/src/runtime/runtime-provider-bootstrap.ts
@@ -53,11 +53,29 @@ export async function prepareRuntimeProviderBootstrap(
     ...(discoveredPlugins.length > 0 ? { plugins: discoveredPlugins } : {}),
     hostServices,
   });
+  const dynamicToolBridge =
+    options.runtimeCapabilities.dynamicTools.mode === "host"
+      ? {
+          dynamicTools: hostServices.listDynamicTools(),
+          handleRuntimeToolCall: (request: Parameters<RuntimeHostServices["executeDynamicTool"]>[0]) =>
+            hostServices.executeDynamicTool(request),
+        }
+      : undefined;
+  const resolvedProviderBootstrap =
+    dynamicToolBridge === undefined
+      ? providerBootstrap
+      : {
+          ...(providerBootstrap ?? {}),
+          startRequest: {
+            ...(providerBootstrap?.startRequest ?? {}),
+            ...dynamicToolBridge,
+          },
+        };
   const runtimePlugins = options.runtimeCapabilities.supportsPlugins ? discoveredPlugins : [];
 
   return {
     hostServices,
-    ...(providerBootstrap ? { providerBootstrap } : {}),
+    ...(resolvedProviderBootstrap ? { providerBootstrap: resolvedProviderBootstrap } : {}),
     runtimePlugins,
   };
 }


### PR DESCRIPTION
## Objective

Add a provider-neutral boundary that lets a native channel driver register local actions for the agent handling the current source conversation. The runtime should expose and execute those actions without granting the driver remote authorization authority.

## Problem

Native drivers can currently deliver messages and reconcile local agents, but they cannot safely contribute channel-specific actions to the active agent tool surface. Ad hoc integrations would either bypass local permissions or lose the provider, account, session, and conversation binding.

## Solution

- Add bounded descriptor, request, result, and host-capability contracts to the native-driver ABI and SDK capsule.
- Register actions in a host-owned lifecycle registry scoped by provider and optional source account.
- Advertise actions only for the exact active source context and a matching local tool capability.
- Fail closed on ambiguous registrations, invalid responses, request mismatches, and disposed hosts.

## Practical impact

Native channel drivers can offer small provider-owned operations directly to the local agent handling a conversation. Operators retain the existing local capability controls, and actions disappear automatically when the driver host lease ends.

## What does NOT change

This does not change channel ingress, delivery, runtime-event contracts, installation credential handling, or local-agent reconciliation semantics. The driver still cannot mint permissions, approve actions, or execute an action outside the active local runtime context.

## Validation

- Full pre-push build, typecheck, SDK drift check, and repository test suite passed.
- Native-driver capsule materialization passed driver, runner, and typecheck validations.
- Focused registry, runtime-host, lifecycle, ambiguity, permission-denial, and SDK boundary tests passed.

## Risks

The main compatibility risk is a driver declaring the new host capability against an older host; startup fails closed with the existing host-capability error. Duplicate matching registrations intentionally hide the action until the ambiguity is removed.

## Rollback

Revert the two commits in this branch. Drivers can omit the additive host capability and continue using the existing ingress, delivery, reconciliation, and runtime-event surfaces.

## Follow-ups

Additional provider-specific actions remain separate driver changes and must define their own bounded arguments, local permission, and behavior tests.
