### PR TITLE
fix(runtime): preserve capabilities after session reset

### DIFF
--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createContact } from "../contacts.js";
 import { canWithCapabilities } from "../permissions/provider-runtime.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
-import { dbCreateAgent, dbGetContext, dbUpdateAgent } from "../router/router-db.js";
-import { getOrCreateSession } from "../router/sessions.js";
+import { dbBindSessionToChat, dbCreateAgent, dbGetContext, dbUpdateAgent, dbUpsertChat } from "../router/router-db.js";
+import { getOrCreateSession, resetSession } from "../router/sessions.js";
 import { dbCreateTagDefinition } from "../tags/index.js";
 import { dbCreateTask, dbDispatchTask } from "../tasks/task-db.js";
 import type { AgentConfig } from "../router/index.js";
@@ -11,6 +11,7 @@ import type { TaskRuntimeResolution } from "../tasks/types.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { buildRuntimeRequestContext, refreshRuntimeRequestContextForTurn } from "./runtime-request-context.js";
 import { getRuntimeToolAccessMode } from "./host-services.js";
+import { resolveRuntimePromptSource } from "./runtime-request-builder.js";
 
 let stateDir: string | null = null;
 
@@ -103,6 +104,51 @@ describe("runtime request context authority", () => {
     } else {
       process.env.RAVI_TURN_SCOPED_AUTHORITY = previous;
     }
+  });
+
+  it("keeps agent capabilities when a reset session contributes only a reply surface", () => {
+    dbCreateAgent({ id: agent.id, cwd: agent.cwd });
+    const session = getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
+    const chat = dbUpsertChat({
+      channel: "whatsapp",
+      instanceId: "main",
+      platformChatId: "120363428243036323@g.us",
+      normalizedChatId: "group:120363428243036323",
+      chatType: "group",
+      title: "Runtime test",
+    });
+    dbBindSessionToChat({
+      sessionKey,
+      chatId: chat.id,
+      agentId: agent.id,
+      bindingReason: "test",
+    });
+    resetSession(sessionKey);
+
+    const prompt: RuntimeLaunchPrompt = { prompt: "internal post-reset prompt" };
+    const resolvedSource = resolveRuntimePromptSource(prompt, session);
+    const { runtimeContext } = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: agent.cwd,
+      agent,
+      prompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+      resolvedSource,
+    });
+
+    expect(resolvedSource?.canonicalChatId).toBe(chat.id);
+    expect(runtimeContext.metadata).toMatchObject({
+      actorPrincipal: "unknown",
+      actorResolution: "not_applicable",
+      surfacePrincipal: `chat:${chat.id}`,
+      agentIdentityCompartment: `chat:${chat.id}`,
+    });
+    expect(runtimeContext.capabilities.length).toBeGreaterThan(0);
+    expect(canWithCapabilities(runtimeContext.capabilities, "use", "tool", "Read")).toBe(true);
+    expect(canWithCapabilities(runtimeContext.capabilities, "use", "tool", "Bash")).toBe(true);
   });
 
   it("keeps actor and surface as audit-only branches in agent identity turns", () => {

--- a/src/runtime/runtime-request-context.ts
+++ b/src/runtime/runtime-request-context.ts
@@ -234,7 +234,11 @@ function buildAgentIdentityRuntimeContextInputForPrompt(options: {
   const surfacePrincipal = resolveSurfacePrincipal(actorMetadata);
   const actorDisplayName = cleanStringValue(actorMetadata?.senderName);
   const surfaceDisplayName = cleanStringValue(actorMetadata?.groupName);
-  const actorResolution = resolveActorResolution(actorMetadata, actorPrincipal);
+  const actorResolution = resolveActorResolution(
+    actorMetadata,
+    actorPrincipal,
+    hasPromptExternalAuthoritySurface(options.prompt),
+  );
 
   return buildAgentIdentityRuntimeContextInput({
     agentId: options.agentId,
@@ -423,10 +427,15 @@ function isExternalAuthoritySurface(
 function resolveActorResolution(
   actorMetadata: MessageActorMetadata | undefined,
   actorPrincipal: AuthorityPrincipal | null,
+  promptHasExternalAuthoritySurface: boolean,
 ): "resolved" | "missing_contact" | "not_applicable" {
   if (actorPrincipal) return "resolved";
-  if (isExternalAuthoritySurface(actorMetadata)) return "missing_contact";
+  if (promptHasExternalAuthoritySurface && isExternalAuthoritySurface(actorMetadata)) return "missing_contact";
   return "not_applicable";
+}
+
+function hasPromptExternalAuthoritySurface(prompt: RuntimeLaunchPrompt): boolean {
+  return isExternalAuthoritySurface(prompt.source) || isExternalAuthoritySurface(prompt.context);
 }
 
 function resolveActorPrincipal(actorMetadata: MessageActorMetadata | undefined): AuthorityPrincipal | null {


### PR DESCRIPTION
## Objective

Restore configured agent capabilities on the first internal turn after `ravi sessions reset` while preserving fail-closed handling for unresolved external actors.

## Problem

- A reset session can recover its bound chat as a reply surface even when the new prompt has no external caller.
- Authority resolution treated that fallback reply surface as an explicit external source with a missing contact, which materialized zero effective capabilities.

## Solution

- Distinguish an external source explicitly carried by the prompt from a reply surface inherited from the session binding.
- Keep the inherited chat as the surface and capability compartment for internal post-reset turns.
- Continue classifying prompts with an explicit unresolved external source as `missing_contact` and fail closed.
- Add a regression test that resets a chat-bound session and verifies its configured tools are materialized.

## Practical impact

- Agents retain their configured tools after `ravi sessions reset`.
- Unknown external callers do not gain capabilities.
- Chat-scoped capability isolation remains unchanged.

## What does NOT change

- Session reset persistence or provider session lifecycle.
- Capability grants, permission profiles, or chat compartment rules.
- Fail-closed behavior for prompts that explicitly originate from an unresolved external actor.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test src/runtime/runtime-request-context.test.ts`
- `bun run test`
- Full pre-push quality gate, including SDK drift check

## Risks

- The change is limited to authority classification when the prompt itself carries no external authority surface.
- Explicit external sources continue through the existing fail-closed path.

## Rollback

- Revert commit `a0c23fe8` to restore the previous authority classification.

## Follow-ups

- None in this PR.