### PR TITLE
fix(runtime): enforce channel turn isolation boundaries

### DIFF
--- a/src/channels/context.ts
+++ b/src/channels/context.ts
@@ -1,0 +1,29 @@
+/**
+ * Stable presentation metadata persisted for reply routing. Actor identity is
+ * deliberately excluded and must never be reconstructed from this snapshot.
+ */
+export interface ChannelContext {
+  channelId: string;
+  channelName: string;
+  isGroup: boolean;
+  groupName?: string;
+  groupId?: string;
+  groupMembers?: string[];
+  botTag?: string;
+}
+
+/**
+ * Copy only the persisted channel fields at the storage boundary. Callers may
+ * pass a richer message context, but actor and message identity never survive.
+ */
+export function toPersistedChannelContext(context: ChannelContext): ChannelContext {
+  return {
+    channelId: context.channelId,
+    channelName: context.channelName,
+    isGroup: context.isGroup,
+    ...(context.groupName !== undefined ? { groupName: context.groupName } : {}),
+    ...(context.groupId !== undefined ? { groupId: context.groupId } : {}),
+    ...(context.groupMembers !== undefined ? { groupMembers: [...context.groupMembers] } : {}),
+    ...(context.botTag !== undefined ? { botTag: context.botTag } : {}),
+  };
+}

--- a/src/channels/session-prompt.test.ts
+++ b/src/channels/session-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { PublishSessionPromptOptions } from "../omni/session-stream.js";
+import { toPersistedChannelContext, type ChannelContext } from "./context.js";
 import { publishChannelSessionPrompt } from "./session-prompt.js";
 
 describe("channel session prompt", () => {
@@ -81,6 +82,31 @@ describe("channel session prompt", () => {
       producer: "channel",
       action: "session.return",
       principal: { type: "automation", id: "channels:session.return" },
+    });
+  });
+
+  it("keeps persisted channel context limited to presentation metadata", () => {
+    const persisted = toPersistedChannelContext({
+      channelId: "slack",
+      channelName: "Slack",
+      isGroup: true,
+      groupId: "group-1",
+      groupName: "Support",
+      groupMembers: ["Alice", "Bob"],
+      botTag: "@ravi",
+      actorId: "actor-1",
+      senderId: "sender-1",
+      messageId: "message-1",
+    } as ChannelContext & Record<string, unknown>);
+
+    expect(persisted).toEqual({
+      channelId: "slack",
+      channelName: "Slack",
+      isGroup: true,
+      groupId: "group-1",
+      groupName: "Support",
+      groupMembers: ["Alice", "Bob"],
+      botTag: "@ravi",
     });
   });
 });

--- a/src/channels/session-prompt.ts
+++ b/src/channels/session-prompt.ts
@@ -19,6 +19,7 @@ export interface PublishChannelSessionPromptInput {
 /**
  * Canonical publisher for channel-generated internal turns. Channel-specific
  * data stays in source/context; authority provenance stays provider-neutral.
+ * This publisher is for trusted Ravi channel code, not untrusted client input.
  */
 export async function publishChannelSessionPrompt(
   input: PublishChannelSessionPromptInput,

--- a/src/channels/slack/thread-lifecycle.test.ts
+++ b/src/channels/slack/thread-lifecycle.test.ts
@@ -103,6 +103,13 @@ describe("Slack thread lifecycle", () => {
       lastAccountId: "ravi-slack",
       lastThreadId: fixture.threadTs,
     });
+    expect(JSON.parse(child!.lastContext!)).toEqual({
+      channelId: "slack",
+      channelName: "Slack",
+      isGroup: true,
+      groupName: "C123",
+      groupId: "C123",
+    });
     expect(listSessionSubscriptions(child!.sessionKey)).toEqual([
       expect.objectContaining({
         role: "primary",

--- a/src/channels/slack/thread-lifecycle.ts
+++ b/src/channels/slack/thread-lifecycle.ts
@@ -465,7 +465,7 @@ function materializeSlackThreadChild(record: SlackThreadLifecycleRecord): {
     setOutputTarget: true,
   });
   const context = buildSlackThreadMessageContext(record, threadChat.id, child.agentId);
-  updateSessionContext(child.sessionKey, JSON.stringify(context));
+  updateSessionContext(child.sessionKey, context);
   return {
     childSessionKey: child.sessionKey,
     childSessionName: child.name ?? childSessionName,

--- a/src/cli/commands/meetings.ts
+++ b/src/cli/commands/meetings.ts
@@ -452,25 +452,13 @@ function buildNativeMeetingRuntimeSessionPlan(input: {
       lastAccountId: GOOGLE_MEET_PROVIDER_ID,
       lastTo: providerMeetingId,
     });
-    updateSessionContext(
-      sessionKey,
-      JSON.stringify({
-        channelId: MEETING_CHANNEL_ID,
-        channelName: "Meet",
-        isGroup: true,
-        groupId: providerMeetingId,
-        groupName: title,
-        meeting: {
-          provider: GOOGLE_MEET_PROVIDER_ID,
-          providerMeetingId,
-          url: input.url,
-          bridgeDir,
-          originSessionKey: input.origin.sessionKey ?? null,
-          originSessionName: input.origin.sessionName ?? null,
-          originAgentId: input.origin.agentId ?? null,
-        },
-      }),
-    );
+    updateSessionContext(sessionKey, {
+      channelId: MEETING_CHANNEL_ID,
+      channelName: "Meet",
+      isGroup: true,
+      groupId: providerMeetingId,
+      groupName: title,
+    });
   }
 
   return {

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -600,7 +600,39 @@ describe("SessionCommands delivery barriers", () => {
     });
   });
 
-  it("publishes authenticated origin for every session relay action", async () => {
+  it("strips historical actor identity before republishing stored channel context", async () => {
+    resolvedSession = {
+      ...resolvedSession,
+      lastChannel: "slack",
+      lastAccountId: "main",
+      lastTo: "C123",
+      lastContext: JSON.stringify({
+        channelId: "slack",
+        channelName: "Slack",
+        isGroup: true,
+        groupId: "C123",
+        groupName: "Engineering",
+        senderId: "agent:operator:main",
+        actorType: "agent",
+        actorAgentId: "operator",
+      }),
+    };
+    const commands = new SessionCommands();
+
+    await captureLogsAsync(async () => {
+      await commands.send("dev", "hello");
+    });
+
+    expect(publishedPrompts[0]?.payload.context).toEqual({
+      channelId: "slack",
+      channelName: "Slack",
+      isGroup: true,
+      groupName: "Engineering",
+      groupId: "C123",
+    });
+  });
+
+  it("publishes validated internal origin for every session relay action", async () => {
     toolContext = {
       suppressCliOutput: true,
       agentId: "origin-agent",

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -67,6 +67,7 @@ import {
 import { getDefaultModelForProvider } from "../../runtime/model-catalog.js";
 import type { ChannelContext, ResponseMessage, SessionRelayAction } from "../../runtime/message-types.js";
 import { buildSessionRelayTurnOrigin } from "../../runtime/turn-origin.js";
+import { toPersistedChannelContext } from "../../channels/context.js";
 import {
   CHAT_ACTION_DESCRIPTORS,
   resolveChatActionAvailability,
@@ -5255,7 +5256,7 @@ export class SessionCommands {
 
     if (session.lastContext) {
       try {
-        context = JSON.parse(session.lastContext) as ChannelContext;
+        context = toPersistedChannelContext(JSON.parse(session.lastContext) as ChannelContext);
       } catch {
         /* ignore */
       }

--- a/src/router/sessions.test.ts
+++ b/src/router/sessions.test.ts
@@ -3,10 +3,12 @@ import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-
 import {
   getOrCreateSession,
   getSession,
+  updateSessionContext,
   updateSessionEffortOverride,
   updateSessionRuntimeProviderOverride,
   updateSessionThreadId,
 } from "./sessions.js";
+import type { MessageContext } from "../runtime/message-types.js";
 
 let stateDir: string | null = null;
 
@@ -73,5 +75,40 @@ describe("sessions store", () => {
 
     updateSessionThreadId(session.sessionKey, null);
     expect(getSession(session.sessionKey)?.lastThreadId).toBeUndefined();
+  });
+
+  it("persists only stable channel presentation fields from richer message context", () => {
+    const session = getOrCreateSession("agent:dev:channel-context", "dev", "/tmp/dev");
+    const messageContext: MessageContext = {
+      channelId: "slack",
+      channelName: "Slack",
+      accountId: "main",
+      instanceId: "slack-main",
+      chatId: "C123",
+      canonicalChatId: "chat-123",
+      messageId: "m-1",
+      senderId: "agent:operator:main",
+      senderName: "Operator",
+      actorType: "agent",
+      actorAgentId: "operator",
+      isGroup: true,
+      groupId: "C123",
+      groupName: "Engineering",
+      groupMembers: ["Operator", "Ravi"],
+      botTag: "@ravi",
+      timestamp: 1,
+    };
+
+    updateSessionContext(session.sessionKey, messageContext);
+
+    expect(JSON.parse(getSession(session.sessionKey)!.lastContext!)).toEqual({
+      channelId: "slack",
+      channelName: "Slack",
+      isGroup: true,
+      groupName: "Engineering",
+      groupId: "C123",
+      groupMembers: ["Operator", "Ravi"],
+      botTag: "@ravi",
+    });
   });
 });

--- a/src/router/sessions.ts
+++ b/src/router/sessions.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Statement } from "bun:sqlite";
+import { toPersistedChannelContext, type ChannelContext } from "../channels/context.js";
 import type { SessionEntry } from "./types.js";
 import {
   dbCreateSessionChatSubscription,
@@ -755,9 +756,9 @@ export function updateSessionDisplayName(sessionKey: string, displayName: string
 /**
  * Update session's channel context (stable group/channel metadata as JSON)
  */
-export function updateSessionContext(sessionKey: string, contextJson: string): void {
+export function updateSessionContext(sessionKey: string, context: ChannelContext): void {
   const s = getStatements();
-  s.updateContext.run(contextJson, Date.now(), sessionKey);
+  s.updateContext.run(JSON.stringify(toPersistedChannelContext(context)), Date.now(), sessionKey);
 }
 
 /**

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -249,7 +249,7 @@ export interface SessionEntry {
   lastTo?: string;
   lastAccountId?: string;
   lastThreadId?: string;
-  lastContext?: string; // JSON-serialized MessageContext
+  lastContext?: string; // JSON-serialized ChannelContext
 
   // Overrides
   thinkingLevel?: "off" | "normal" | "verbose";

--- a/src/runtime/delivery-queue.ts
+++ b/src/runtime/delivery-queue.ts
@@ -35,6 +35,12 @@ export function createQueuedRuntimeUserMessage(prompt: RuntimePromptDeliveryMess
   };
 }
 
+export function hasIsolatedRuntimeTurnEnvelope(
+  prompt: Pick<RuntimeLaunchPrompt, "_channelBackend" | "_turnOrigin"> | null | undefined,
+): boolean {
+  return prompt?._channelBackend !== undefined || prompt?._turnOrigin !== undefined;
+}
+
 function cloneRuntimeLaunchPrompt(prompt: RuntimePromptDeliveryMessage): RuntimeLaunchPrompt {
   return {
     ...prompt,
@@ -97,9 +103,9 @@ export function getDeliverableRuntimeMessages(
     ),
   );
   // These envelopes bind authority to one logical turn. Never let adjacent
-  // messages borrow their channel binding or authenticated origin.
-  const firstIsolatedTurnIndex = deliverable.findIndex(
-    (message) => message.launchPrompt?._channelBackend !== undefined || message.launchPrompt?._turnOrigin !== undefined,
+  // messages borrow their channel binding or validated internal origin.
+  const firstIsolatedTurnIndex = deliverable.findIndex((message) =>
+    hasIsolatedRuntimeTurnEnvelope(message.launchPrompt),
   );
   if (firstIsolatedTurnIndex === 0) {
     return deliverable.slice(0, 1);

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -3,6 +3,8 @@ import type { ThreadHandoffPromptMetadata } from "../threads/types.js";
 import type { RuntimeEventMetadata } from "./types.js";
 import type { RuntimeProviderId } from "./types.js";
 
+export type { ChannelContext } from "../channels/context.js";
+
 export interface MessageActorMetadata {
   /** Canonical chat id from the Ravi chat model. Raw chat ids remain in chatId as provenance. */
   canonicalChatId?: string;
@@ -47,20 +49,6 @@ export interface MessageContext extends MessageActorMetadata {
   isMentioned?: boolean;
   botTag?: string;
   timestamp: number;
-}
-
-/**
- * Stable presentation metadata persisted for reply routing. Actor identity is
- * deliberately excluded and must never be reconstructed from this snapshot.
- */
-export interface ChannelContext {
-  channelId: string;
-  channelName: string;
-  isGroup: boolean;
-  groupName?: string;
-  groupId?: string;
-  groupMembers?: string[];
-  botTag?: string;
 }
 
 /** Message routing target */
@@ -163,8 +151,9 @@ export interface ChannelTurnOriginMetadata extends RuntimeTurnOriginEnvelope {
 }
 
 /**
- * Authenticated cause of an internal turn. This is authority provenance only;
- * `source` and `context` continue to describe its reply surface.
+ * Validated cause asserted by a trusted internal prompt producer. This is not
+ * a credential: access to the internal prompt bus is the trust boundary.
+ * `source` and `context` continue to describe the reply surface.
  */
 export type RuntimeTurnOriginMetadata = SessionRelayTurnOriginMetadata | ChannelTurnOriginMetadata;
 
@@ -224,7 +213,7 @@ export interface PromptMessage {
   _daemonRestartResume?: DaemonRestartResumePromptMetadata;
   /** Provider-neutral identity for prompts accepted through a channel backend. */
   _channelBackend?: ChannelBackendPromptMetadata;
-  /** Authenticated provenance for internal producers whose reply surface is not their actor. */
+  /** Validated provenance asserted by a trusted internal producer; not a credential. */
   _turnOrigin?: RuntimeTurnOriginMetadata;
 }
 

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -746,7 +746,7 @@ describe("runtime request context authority", () => {
     expect(canWithCapabilities(runtimeContext.capabilities, "admin", "system", "*")).toBe(false);
   });
 
-  it("uses authenticated relay origin while keeping the target chat as the compartment", () => {
+  it("uses validated internal relay origin while keeping the target chat as the compartment", () => {
     dbCreateAgent({ id: agent.id, cwd: agent.cwd });
     getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
 

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -194,6 +194,78 @@ describe("RuntimeSessionDispatcher debounce", () => {
     });
   });
 
+  it("keeps each channel backend binding in its own debounced turn", async () => {
+    const dispatcher = createDispatcher();
+    const prompts: RuntimeLaunchPrompt[] = [];
+    (
+      dispatcher as unknown as { handlePromptImmediate: typeof dispatcher.handlePromptImmediate }
+    ).handlePromptImmediate = mock(async (_sessionName: string, prompt: RuntimeLaunchPrompt) => {
+      prompts.push(prompt);
+    });
+
+    const source = { channel: "custom", accountId: "connection-a", chatId: "conversation-a" };
+    dispatcher.handlePromptWithDebounce(
+      "session",
+      {
+        prompt: "primeiro turno",
+        source,
+        _agentId: "agent-a",
+        _channelBackend: channelBackendMetadata("turn-1"),
+      },
+      60_000,
+    );
+    dispatcher.handlePromptWithDebounce(
+      "session",
+      {
+        prompt: "segundo turno",
+        source,
+        _agentId: "agent-a",
+        _channelBackend: channelBackendMetadata("turn-2"),
+      },
+      60_000,
+    );
+
+    await dispatcher.flushDebounce("session");
+
+    expect(prompts.map((prompt) => prompt.prompt)).toEqual(["primeiro turno", "segundo turno"]);
+    expect(prompts.map((prompt) => prompt._channelBackend?.binding.turnId)).toEqual(["turn-1", "turn-2"]);
+  });
+
+  it("keeps repeated typed origins in separate debounced turns", async () => {
+    const dispatcher = createDispatcher();
+    const prompts: RuntimeLaunchPrompt[] = [];
+    (
+      dispatcher as unknown as { handlePromptImmediate: typeof dispatcher.handlePromptImmediate }
+    ).handlePromptImmediate = mock(async (_sessionName: string, prompt: RuntimeLaunchPrompt) => {
+      prompts.push(prompt);
+    });
+    const originContext = {
+      agentId: "origin-agent",
+      sessionKey: "agent:origin-agent:main",
+    };
+
+    dispatcher.handlePromptWithDebounce(
+      "session",
+      {
+        prompt: "primeiro inform",
+        _turnOrigin: buildSessionRelayTurnOrigin("inform", originContext),
+      },
+      60_000,
+    );
+    dispatcher.handlePromptWithDebounce(
+      "session",
+      {
+        prompt: "segundo inform",
+        _turnOrigin: buildSessionRelayTurnOrigin("inform", originContext),
+      },
+      60_000,
+    );
+
+    await dispatcher.flushDebounce("session");
+
+    expect(prompts.map((prompt) => prompt.prompt)).toEqual(["primeiro inform", "segundo inform"]);
+  });
+
   it("cancels debounce timers and pending starts during shutdown", async () => {
     const dispatcher = createDispatcher();
     const handlePromptImmediate = mock(async () => {});
@@ -255,6 +327,28 @@ describe("RuntimeSessionDispatcher debounce", () => {
     expect(second[1]?.deliveryBarrier).toBe("after_response");
   });
 });
+
+function channelBackendMetadata(turnId: string): NonNullable<RuntimeLaunchPrompt["_channelBackend"]> {
+  return {
+    protocol: "ravi.channel.backend",
+    schemaVersion: 1,
+    ingressRequestId: `request-${turnId}`,
+    correlationId: `correlation-${turnId}`,
+    binding: {
+      channelInstanceId: "channel-instance-a",
+      agentId: "agent-a",
+      chatId: "chat-a",
+      messageId: `message-${turnId}`,
+      sessionId: "session-a",
+      turnId,
+    },
+    target: {
+      channelKind: "custom",
+      connectionId: "connection-a",
+      conversationId: "conversation-a",
+    },
+  };
+}
 
 describe("RuntimeSessionDispatcher runtime recovery", () => {
   afterEach(() => mock.restore());

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -16,6 +16,7 @@ import { revokeAgentRuntimeContextsForSession } from "./context-registry.js";
 import {
   createQueuedRuntimeUserMessage,
   getRuntimePromptDeliveryBarrier,
+  hasIsolatedRuntimeTurnEnvelope,
   hasDeliverableRuntimeMessages,
   shouldInterruptRuntimeForIncoming,
   wakeRuntimeSessionIfDeliverable,
@@ -42,7 +43,6 @@ import {
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimeRecoveryExhaustedAlertInput } from "./runtime-recovery-alert.js";
 import { resolveRuntimeForPrompt, runtimePromptRequiresRestart } from "./task-runtime-context.js";
-import { resolveRuntimeTurnOrigin } from "./turn-origin.js";
 import {
   buildRuntimeSessionPoolSnapshot,
   classifyRuntimeSessionStartLane,
@@ -1779,6 +1779,16 @@ function buildDebouncedRuntimePrompts(messages: RuntimeLaunchPrompt[]): RuntimeL
   let currentKey: string | null = null;
 
   for (const message of messages) {
+    if (hasIsolatedRuntimeTurnEnvelope(message)) {
+      if (currentBatch.length > 0) {
+        batches.push(currentBatch);
+        currentBatch = [];
+      }
+      batches.push([message]);
+      currentKey = null;
+      continue;
+    }
+
     const key = getDebounceCompatibilityKey(message);
     if (currentBatch.length > 0 && currentKey !== key) {
       batches.push(currentBatch);
@@ -1824,13 +1834,7 @@ function getDebounceCompatibilityKey(prompt: RuntimeLaunchPrompt): string {
     deliveryClass,
     source: prompt.source ? getMessageTargetKey(prompt.source) : "",
     approvalSource: prompt._approvalSource ? getMessageTargetKey(prompt._approvalSource) : "",
-    turnOrigin: getDebounceTurnOriginKey(prompt),
   });
-}
-
-function getDebounceTurnOriginKey(prompt: RuntimeLaunchPrompt): string {
-  if (prompt._turnOrigin === undefined) return "";
-  return JSON.stringify(resolveRuntimeTurnOrigin(prompt._turnOrigin) ?? { invalid: true });
 }
 
 function getMessageTargetKey(target: RuntimeMessageTarget): string {

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -20,7 +20,7 @@ import {
   type RuntimeHostStreamingSession,
   type RuntimeUserMessage,
 } from "./host-session.js";
-import type { ChannelContext, RuntimeLaunchPrompt } from "./message-types.js";
+import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { shouldUseTurnScopedAuthorityForPrompt } from "./runtime-request-context.js";
 import { buildRuntimeStartRequest, resolveRuntimePromptSource } from "./runtime-request-builder.js";
 import { resolveRuntimeSession } from "./session-resolver.js";
@@ -56,15 +56,7 @@ export function updateRuntimeSessionMetadata(sessionKey: string, prompt: Runtime
   }
 
   if (prompt.context?.senderId) {
-    const channelCtx: ChannelContext = {
-      channelId: prompt.context.channelId,
-      channelName: prompt.context.channelName,
-      isGroup: prompt.context.isGroup,
-      groupName: prompt.context.groupName,
-      groupId: prompt.context.groupId,
-      groupMembers: prompt.context.groupMembers,
-    };
-    updateSessionContext(sessionKey, JSON.stringify(channelCtx));
+    updateSessionContext(sessionKey, prompt.context);
     if (prompt.context.groupName) {
       updateSessionDisplayName(sessionKey, prompt.context.groupName);
     }

--- a/src/runtime/turn-origin.ts
+++ b/src/runtime/turn-origin.ts
@@ -66,7 +66,9 @@ export function buildChannelTurnOrigin(
 
 /**
  * Validate the wire envelope before it can affect authority or turn
- * classification. Extra fields are intentionally discarded.
+ * classification. Extra fields are intentionally discarded. This validates
+ * shape, not producer identity: authenticity comes from restricting the
+ * internal session-prompt bus to trusted Ravi producers.
  */
 export function resolveRuntimeTurnOrigin(value: unknown): RuntimeTurnOriginMetadata | null {
   if (!isRecord(value)) return null;


### PR DESCRIPTION
## Objective

Make channel-originated runtime turns preserve their own correlation and keep persisted channel context limited to stable presentation metadata.

## Problem

Adjacent channel backend prompts could be debounced into one turn while only the final binding survived. Persistence also accepted richer message context, and the origin contract overstated shape validation as authentication.

## Solution

Treat every channel backend or internal-origin envelope as a singleton turn in both debounce and queued delivery. Centralize a persisted ChannelContext allowlist, sanitize historical replay, and document the internal prompt bus as the trust boundary.

## Practical impact

Each channel ingress keeps the correct turn and correlation binding. Actor and message identity cannot be replayed from persisted presentation context, and the behavior stays provider- and channel-neutral.

## What does NOT change

Channel routing, provider selection, user-visible message formatting, permission evaluation, and ordinary untyped prompt debounce behavior remain unchanged.

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun src/ci/run-quality-gate.ts`

## Risks

Turn isolation may reduce batching for typed internal envelopes by design. The risk is bounded by targeted debounce, queue, routing, Slack lifecycle, CLI replay, and authority regression tests.

## Rollback

Revert this pull request's merge commit to restore the previous debounce and persistence behavior. The change has no schema migration or irreversible stored-state mutation.
