### PR TITLE
feat(channels): add durable provider-neutral ingress

### DIFF
--- a/.ravi/specs/channels/SPEC.md
+++ b/.ravi/specs/channels/SPEC.md
@@ -4,6 +4,7 @@ title: Channels
 kind: domain
 domain: channels
 capabilities:
+  - backend
   - chat-actions
   - chats
   - meetings
@@ -30,6 +31,12 @@ Ravi MUST abstract Omni as a transport/gateway adapter. Product and agent-facing
 ## Invariants
 
 - Ravi MUST own operational behavior such as routing, presence lifecycle, task notifications, and runtime-originated outbound intent.
+- Every native provider MUST enter Session/Turn execution through the
+  provider-neutral Channel Backend after provider normalization and Ravi route
+  resolution. A provider adapter MUST NOT publish an ordinary inbound prompt
+  directly.
+- The Channel Backend MUST durably accept canonical Chat/Message identity and
+  an idempotency receipt before prompt publication.
 - Transport adapters MUST only deliver channel-specific payloads and report delivery state.
 - Ravi MUST NOT patch transport code to compensate for broken runtime lifecycle or routing rules without evidence that the transport contract is wrong.
 - Omni/raw channel identifiers MUST remain stored as provenance and debugging data, but they MUST NOT be the primary product model exposed to agents or operators.
@@ -61,6 +68,10 @@ Ravi owns semantics:
 - event/audit shape consumed by agents and UI
 
 Feature code SHOULD depend on the Ravi semantic layer first. Direct Omni access is allowed only inside channel adapters, diagnostics, migration, and low-level debugging paths.
+
+## Children
+
+- `channels/backend`
 
 ## Validation
 

--- a/.ravi/specs/channels/adapters/slack/SPEC.md
+++ b/.ravi/specs/channels/adapters/slack/SPEC.md
@@ -28,6 +28,20 @@ The Slack adapter MUST support:
 - working presence via temporary reaction on the inbound Slack message;
 - delivery event emission.
 
+An eligible Message envelope MUST be persisted in a bounded, secret-redacted
+Slack inbox before Socket Mode acknowledgement. Inbox processing MUST use a
+leased claim, resume after failure or restart, and treat the backend receipt as
+the next durable boundary. Envelope payloads MUST NOT retain verification
+tokens, response URLs, or credential material.
+
+Normal admitted Slack messages MUST enter the provider-neutral Channel Backend
+after Slack normalization, actor resolution, route selection, canonical
+Chat/Message persistence, and thread lifecycle handling. The adapter MUST NOT
+publish the ordinary inbound Session prompt as a parallel path. Slack-specific
+identity, visibility, routing, thread, file, and policy facts remain adapter
+inputs; the backend owns durable ingress receipt, prompt publication claim,
+local binding, and runtime correlation.
+
 ## Socket Liveness
 
 The adapter MUST verify Socket Mode liveness independently of application

--- a/.ravi/specs/channels/backend/CHECKS.md
+++ b/.ravi/specs/channels/backend/CHECKS.md
@@ -1,0 +1,14 @@
+# Channel Backend / CHECKS
+
+- Every ordinary native inbound prompt crosses one Channel Backend.
+- Acceptance and publication claims are durable and idempotent.
+- Wire host scope cannot escape provider or Channel instance.
+- Resolved ingress reuses canonical Chat, Message, Session, Agent, and route.
+- Slack has no direct ordinary inbound `publishSessionPrompt` path.
+- Slack message envelopes are durable and secret-redacted before Socket Mode
+  acknowledgement.
+- Provider inbox retention prunes only processed records outside the
+  deduplication window.
+- Runtime events and output resolve from the accepted binding.
+- Local actions are bounded, unique, source-scoped, and locally authorized.
+- Public types contain no hosted product entities or private policy.

--- a/.ravi/specs/channels/backend/CHECKS.md
+++ b/.ravi/specs/channels/backend/CHECKS.md
@@ -1,14 +1,19 @@
 # Channel Backend / CHECKS
 
-- Every ordinary native inbound prompt crosses one Channel Backend.
-- Acceptance and publication claims are durable and idempotent.
-- Wire host scope cannot escape provider or Channel instance.
-- Resolved ingress reuses canonical Chat, Message, Session, Agent, and route.
-- Slack has no direct ordinary inbound `publishSessionPrompt` path.
-- Slack message envelopes are durable and secret-redacted before Socket Mode
-  acknowledgement.
-- Provider inbox retention prunes only processed records outside the
+- The gate passes only when every ordinary native inbound prompt crosses one
+  Channel Backend.
+- Acceptance and publication claims MUST remain durable and idempotent across
+  process restarts.
+- Wire host scope MUST NOT escape its provider or Channel instance.
+- Resolved ingress MUST reuse the canonical Chat, Message, Session, Agent, and
+  route.
+- The gate fails if Slack has a direct ordinary inbound
+  `publishSessionPrompt` path.
+- Slack message envelopes MUST be durable and secret-redacted before Socket
+  Mode acknowledgement.
+- Provider inbox retention MUST prune only processed records outside the
   deduplication window.
-- Runtime events and output resolve from the accepted binding.
-- Local actions are bounded, unique, source-scoped, and locally authorized.
-- Public types contain no hosted product entities or private policy.
+- Runtime events and output MUST resolve from the accepted binding.
+- Local actions MUST be bounded, unique, source-scoped, and locally
+  authorized.
+- Public types MUST contain no hosted product entities or private policy.

--- a/.ravi/specs/channels/backend/RUNBOOK.md
+++ b/.ravi/specs/channels/backend/RUNBOOK.md
@@ -1,0 +1,19 @@
+# Channel Backend / RUNBOOK
+
+1. Admit one fixture wire ingress and inspect its durable receipt, Message,
+   Session binding, Turn, and published correlation envelope.
+2. Retry the same ingress before and after process restart; confirm one
+   Message, one Turn, one prompt, and one stable binding.
+3. Reuse the idempotency key with another fingerprint and confirm a closed
+   conflict.
+4. Fail prompt publication, retry, and confirm the accepted receipt resumes.
+5. Admit one Slack root message and one thread reply through resolved ingress.
+6. Fail Slack processing after Socket Mode ack; confirm the redacted envelope
+   was durable before ack and is resumed without another provider delivery.
+7. Confirm Slack uses its existing canonical Chat/Message and preserves route,
+   subscription, actor, file, thread, and delivery-barrier metadata.
+8. Run a fixture native driver through host-scoped wire ingress.
+9. Project commentary, tool activity, terminal output, failure, and
+   interruption and verify ordered readback.
+10. Register two local actions with colliding scope/name and confirm discovery
+   fails closed; invoke an authorized unique action in its exact source.

--- a/.ravi/specs/channels/backend/SPEC.md
+++ b/.ravi/specs/channels/backend/SPEC.md
@@ -1,0 +1,168 @@
+---
+id: channels/backend
+title: "Channel Backend"
+kind: capability
+domain: channels
+capabilities:
+  - backend
+  - ingress
+  - runtime-events
+  - local-actions
+tags:
+  - native-channel
+  - idempotency
+  - durability
+applies_to:
+  - src/channels/backend.ts
+  - src/channels/runtime-events.ts
+  - src/channels/native/
+  - src/channels/slack/
+  - src/router/router-db.ts
+owners:
+  - dev
+status: active
+normative: true
+---
+
+# Channel Backend
+
+## Intent
+
+Provide one provider-neutral boundary from an admitted external Channel
+message to Ravi's canonical Chat, Message, Session, Turn, runtime events, and
+outbound correlation. Provider adapters retain transport-specific
+normalization and policy, but MUST NOT implement a second prompt-ingress
+backend.
+
+## Terms
+
+- `external identity`: provider, connection, conversation, sender, and Message
+  references retained as provenance.
+- `canonical binding`: Ravi Channel instance, Agent, Chat, Message, Session,
+  and Turn references accepted for one ingress.
+- `wire ingress`: a scoped native driver request whose local identity can be
+  derived by the backend.
+- `resolved ingress`: an in-process native adapter request that already has a
+  Ravi route, canonical Chat/Message, and Session.
+- `ingress receipt`: durable idempotency, binding, publication state, and
+  external correlation for one logical inbound Message.
+
+## Admission and Ownership
+
+- A native provider MUST normalize and admit transport input before calling
+  the backend.
+- Provider admission MAY include signature/envelope checks, deduplication,
+  account policy, thread policy, actor resolution, file processing, route
+  resolution, and canonical provider Chat/Message persistence.
+- Ravi route and local authorization decisions MUST remain outside transport
+  delivery code.
+- A wire ingress MUST be scoped by the native driver host to its configured
+  provider and Channel instance.
+- A resolved ingress MUST reference an existing canonical Chat, Message,
+  Session, and Agent that all match the accepted route.
+- The backend MUST reject missing Agents, mismatched canonical references,
+  malformed scope, and idempotency conflicts before publication.
+
+## Durable Acceptance
+
+For one `(channelInstanceId, idempotencyKey)`, the backend MUST atomically
+persist or resolve:
+
+- immutable request fingerprint;
+- initial request identity and external identity;
+- local actor and Agent;
+- canonical Chat and Message;
+- stable Session and Turn;
+- acceptance time;
+- publication state and bounded claim.
+
+Equivalent retries MUST return the same binding. Conflicting payload reuse
+MUST fail closed. Process restart or concurrent delivery MUST publish at most
+one claimed prompt for the accepted receipt. A publication failure MUST leave
+the receipt retryable without creating another Message or Turn.
+
+Transport acknowledgement is not backend acceptance. When a provider requires
+an acknowledgement before normalization can finish, the adapter MUST first
+persist a bounded provider inbox record that can retry the exact envelope and
+backend idempotency key. Provider inbox claims and backend publication claims
+MUST both recover after expiry or restart.
+
+## Canonical Prompt Path
+
+- Ordinary inbound messages from Slack, loaded native drivers, and future
+  native providers MUST converge on the same backend publication function.
+- A provider adapter MUST NOT call `publishSessionPrompt` directly for an
+  ordinary admitted inbound message.
+- The published prompt MUST preserve the provider-normalized human-readable
+  prompt, structured source/context, delivery barrier, active actor metadata,
+  and a backend correlation envelope.
+- The correlation envelope MUST bind the runtime Turn to the accepted ingress
+  receipt and external target without making provider IDs canonical.
+- Provider-specific system interactions that are not user prompt ingress MAY
+  use their own typed event paths.
+
+## Runtime and Output
+
+- Runtime events MUST use the accepted canonical binding and monotonically
+  increasing sequence.
+- Commentary, tool activity, deltas, terminal assistant content, failure, and
+  interruption MUST remain distinct typed events.
+- A terminal assistant result MUST persist before terminal completion is
+  reported.
+- Output sinks MUST be selected by provider and connection and MUST remain
+  bounded and explicitly registered.
+- Runtime status and delivery status MUST remain separate.
+
+## Local Agent Actions
+
+- A native driver MAY register bounded, typed local Agent actions through the
+  host ABI.
+- Registration and discovery MUST be scoped to provider, Channel instance,
+  source account, active Agent, Session, and current source context.
+- Duplicate ambiguous tool names MUST fail closed.
+- Invocation MUST require the runtime's normal local tool permission
+  immediately before the handler runs.
+- Descriptors and results MUST be bounded and provider-neutral. Product Roles,
+  memberships, hosted policy, and hosted product entities MUST NOT enter this
+  contract.
+
+## Provider Boundary
+
+The OSS backend MAY know:
+
+- provider/connection/conversation provenance;
+- canonical Ravi Chat, Message, Session, Turn, Agent, and actor context;
+- neutral content blocks, safe errors, runtime events, local actions, and
+  output targets.
+
+It MUST NOT know hosted Organizations, Members, Bots, product Channels, Roles,
+commercial policy, private endpoint schemas, or private authorization rules.
+
+## Validation
+
+- Wire ingress accepts once, retries across restart, and rejects conflicting
+  reuse.
+- Resolved ingress reuses the adapter's canonical Chat, Message, Session, and
+  Agent without creating a parallel Chat.
+- Concurrent accepted deliveries publish one prompt.
+- Publication failure resumes from the durable receipt.
+- Slack and a fixture native driver both produce backend receipts before
+  prompt publication.
+- Slack persists a secret-redacted bounded envelope before Socket Mode ack,
+  then resumes normalization and backend acceptance after failure or restart.
+- Processed provider inbox records are retained only for a bounded
+  deduplication window and are pruned without removing pending work.
+- Slack preserves thread, actor, file, route, subscription, and delivery
+  behavior after convergence.
+- Runtime readback and output correlation resolve from the accepted binding.
+- Local actions remain provider/account/source scoped and locally authorized.
+
+## Known Failure Modes
+
+- Treating provider envelope acknowledgement as backend acceptance.
+- Letting Slack or another adapter publish a parallel prompt directly.
+- Creating a second canonical Chat for a resolved provider message.
+- Deriving Session ownership from provider identity alone.
+- Allowing a driver to escape its provider or Channel-instance scope.
+- Retrying publication by creating another Message or Turn.
+- Putting hosted product policy or entities in the public ABI.

--- a/.ravi/specs/channels/backend/WHY.md
+++ b/.ravi/specs/channels/backend/WHY.md
@@ -1,0 +1,16 @@
+# Channel Backend / WHY
+
+Native providers need different transport admission, identity, thread, and
+policy logic, but those differences end before canonical Session/Turn
+execution. One durable backend prevents Slack, loaded drivers, and future
+providers from accumulating subtly different prompt, retry, runtime-event, and
+local-action semantics.
+
+Wire ingress serves externally loaded drivers. Resolved ingress lets an
+in-process adapter preserve its richer Ravi route and canonical provider Chat
+without duplicating the backend or creating a second Chat.
+
+A small provider inbox is still necessary when the provider's acknowledgement
+deadline is shorter than identity, file, route, or prompt normalization. It
+protects the transport edge; the backend receipt protects canonical
+Session/Turn publication.

--- a/src/channels/backend.test.ts
+++ b/src/channels/backend.test.ts
@@ -6,18 +6,23 @@ import {
   dbGetChannelBackendIngressReceipt,
   dbGetChatMessage,
   dbGetSessionChatBinding,
+  dbUpsertChat,
+  dbUpsertChatMessage,
 } from "../router/router-db.js";
-import { closeSessionStore } from "../router/sessions.js";
+import { closeSessionStore, getOrCreateSession } from "../router/sessions.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import {
   acceptChannelIngress,
+  acceptResolvedChannelIngress,
   CHANNEL_BACKEND_PROTOCOL,
   CHANNEL_BACKEND_SCHEMA_VERSION,
   ChannelOutputSinkRegistry,
+  resumePendingChannelIngressPublications,
   setChannelBackendPromptPublisherForTests,
   type ChannelBackendPromptPublisher,
   type ChannelIngressRequest,
   type ChannelOutputEnvelope,
+  type ResolvedChannelIngressRequest,
 } from "./backend.js";
 import {
   CHANNEL_RUNTIME_EVENTS_PROTOCOL,
@@ -293,6 +298,107 @@ describe("channel backend ingress", () => {
     expect(duplicate.disposition).toBe("duplicate");
     expect(publisher).toHaveBeenCalledTimes(1);
   });
+
+  it("reuses provider-normalized Chat, Message, Session, and prompt through resolved ingress", async () => {
+    const publishPrompt = mock(
+      async (_sessionName: string, _payload: Record<string, unknown>, _options?: { messageId?: string }) => {},
+    );
+    const resolved = resolvedRequest();
+
+    const result = await acceptResolvedChannelIngress(resolved, { publishPrompt });
+    const duplicate = await acceptResolvedChannelIngress(
+      {
+        ...resolved,
+        request: {
+          ...resolved.request,
+          requestId: "resolved-request-retry",
+        },
+      },
+      { publishPrompt },
+    );
+
+    expect(result).toMatchObject({
+      disposition: "accepted",
+      binding: {
+        chatId: resolved.canonical.chatId,
+        messageId: resolved.canonical.messageId,
+        sessionId: resolved.session.name,
+      },
+    });
+    expect(duplicate).toMatchObject({
+      disposition: "duplicate",
+      binding: result.binding,
+    });
+    expect(dbGetChatMessage(resolved.canonical.messageId)).toMatchObject({
+      chatId: resolved.canonical.chatId,
+      channel: "slack",
+      instanceId: "channel-instance-a",
+    });
+    expect(dbGetChannelBackendIngressReceipt("channel-instance-a", "resolved-idempotency-a")).toMatchObject({
+      state: "published",
+      chatId: resolved.canonical.chatId,
+      messageId: resolved.canonical.messageId,
+      sessionKey: resolved.session.key,
+      sessionName: resolved.session.name,
+      prompt: resolved.prompt,
+    });
+    expect(publishPrompt).toHaveBeenCalledTimes(1);
+    expect(publishPrompt.mock.calls[0]?.[1]).toMatchObject({
+      ...resolved.prompt,
+      _channelBackend: {
+        binding: result.binding,
+      },
+    });
+  });
+
+  it("resumes a durable resolved prompt after publication failure and process restart", async () => {
+    const rejected = await acceptResolvedChannelIngress(resolvedRequest(), {
+      publishPrompt: async () => {
+        throw new Error("publisher unavailable");
+      },
+    });
+    expect(rejected).toMatchObject({
+      disposition: "rejected",
+      error: {
+        code: "UNAVAILABLE",
+        retryable: true,
+      },
+    });
+    expect(dbGetChannelBackendIngressReceipt("channel-instance-a", "resolved-idempotency-a")).toMatchObject({
+      state: "accepted",
+      prompt: {
+        prompt: "normalized provider prompt",
+      },
+    });
+
+    closeSessionStore();
+    closeRouterDb();
+    const publishPrompt = mock(
+      async (_sessionName: string, _payload: Record<string, unknown>, _options?: { messageId?: string }) => {},
+    );
+    const resumed = await resumePendingChannelIngressPublications({ publishPrompt });
+
+    expect(resumed).toEqual({
+      scanned: 1,
+      published: 1,
+      busy: 0,
+      failed: 0,
+    });
+    expect(publishPrompt).toHaveBeenCalledTimes(1);
+    expect(publishPrompt.mock.calls[0]?.[1]).toMatchObject({
+      prompt: "normalized provider prompt",
+      _channelBackend: {
+        target: {
+          channelKind: "slack",
+          connectionId: "connection-a",
+          conversationId: "C123",
+        },
+      },
+    });
+    expect(dbGetChannelBackendIngressReceipt("channel-instance-a", "resolved-idempotency-a")).toMatchObject({
+      state: "published",
+    });
+  });
 });
 
 describe("channel backend output sinks", () => {
@@ -330,6 +436,86 @@ function request(overrides: Partial<ChannelIngressRequest> = {}): ChannelIngress
     content: [{ type: "text", text: "fixture input" }],
     receivedAt: "2026-07-24T18:00:00.000Z",
     ...overrides,
+  };
+}
+
+function resolvedRequest(): ResolvedChannelIngressRequest {
+  const chat = dbUpsertChat({
+    channel: "slack",
+    instanceId: "channel-instance-a",
+    platformChatId: "C123",
+    chatType: "group",
+    seenAt: Date.parse("2026-07-24T18:00:00.000Z"),
+  });
+  const message = dbUpsertChatMessage({
+    chatId: chat.id,
+    channel: "slack",
+    instanceId: "channel-instance-a",
+    providerMessageId: "1713000000.000100",
+    rawChatId: "C123",
+    rawSenderId: "U123",
+    normalizedSenderId: "U123",
+    actorType: "unknown",
+    content: {
+      type: "text",
+      text: "fixture input",
+    },
+    providerTimestamp: Date.parse("2026-07-24T18:00:00.000Z"),
+    ingestedAt: Date.parse("2026-07-24T18:00:00.000Z"),
+  });
+  const session = getOrCreateSession(
+    "agent:agent-a:slack:channel-instance-a:group:C123",
+    "agent-a",
+    "/tmp/ravi-channel-agent-a",
+    {
+      name: "resolved-session-a",
+      channel: "slack",
+      accountId: "connection-a",
+      chatType: "group",
+      lastChannel: "slack",
+      lastAccountId: "connection-a",
+      lastTo: "C123",
+    },
+  );
+  return {
+    request: request({
+      requestId: "resolved-request-a",
+      idempotencyKey: "resolved-idempotency-a",
+      external: {
+        channelKind: "slack",
+        connectionId: "connection-a",
+        conversationId: "C123",
+        senderId: "U123",
+        messageId: "1713000000.000100",
+      },
+    }),
+    canonical: {
+      chatId: chat.id,
+      messageId: message.canonicalMessageId,
+    },
+    session: {
+      key: session.sessionKey,
+      name: session.name!,
+    },
+    prompt: {
+      prompt: "normalized provider prompt",
+      source: {
+        channel: "slack",
+        accountId: "connection-a",
+        instanceId: "channel-instance-a",
+        chatId: "C123",
+        canonicalChatId: chat.id,
+      },
+      context: {
+        channelId: "slack",
+        accountId: "connection-a",
+        instanceId: "channel-instance-a",
+        chatId: "C123",
+        messageId: "1713000000.000100",
+      },
+      deliveryBarrier: "after_tool",
+      deliveryBarrierSource: "default",
+    },
   };
 }
 

--- a/src/channels/backend.ts
+++ b/src/channels/backend.ts
@@ -6,12 +6,14 @@ import {
   dbBindSessionToChat,
   dbClaimChannelBackendIngressPublication,
   dbGetAgent,
+  dbGetChatMessage,
+  dbListPendingChannelBackendIngressReceipts,
   dbMarkChannelBackendIngressPublished,
   dbReleaseChannelBackendIngressPublication,
   type ChannelBackendIngressReceiptRecord,
 } from "../router/router-db.js";
 import { getAgentCwd } from "../router/resolver.js";
-import { getOrCreateSession, updateSessionName } from "../router/sessions.js";
+import { getOrCreateSession, getSession, updateSessionName } from "../router/sessions.js";
 import type { ChannelBackendPromptMetadata, MessageContext, MessageTarget } from "../runtime/message-types.js";
 import { logger } from "../utils/logger.js";
 
@@ -19,6 +21,7 @@ export const CHANNEL_BACKEND_PROTOCOL = "ravi.channel.backend" as const;
 export const CHANNEL_BACKEND_SCHEMA_VERSION = 1 as const;
 export const CHANNEL_BACKEND_MAX_CONTENT_BLOCKS = 256;
 export const CHANNEL_BACKEND_MAX_TEXT_BYTES = 1_048_576;
+export const CHANNEL_BACKEND_PUBLICATION_RETRY_INTERVAL_MS = 5_000;
 
 const log = logger.child("channels:backend");
 const textEncoder = new TextEncoder();
@@ -111,6 +114,33 @@ export const ChannelIngressRequestSchema = z.object({
   receivedAt: z.string().datetime({ offset: true }),
 });
 
+export const ResolvedChannelIngressRequestSchema = z
+  .object({
+    request: ChannelIngressRequestSchema,
+    canonical: z
+      .object({
+        chatId: ChannelBackendOpaqueIdSchema,
+        messageId: ChannelBackendOpaqueIdSchema,
+      })
+      .strict(),
+    session: z
+      .object({
+        key: boundedUtf8String(512, "resolved Session key"),
+        name: ChannelBackendOpaqueIdSchema,
+      })
+      .strict(),
+    prompt: z
+      .object({
+        prompt: boundedUtf8String(CHANNEL_BACKEND_MAX_TEXT_BYTES, "resolved Channel prompt"),
+        source: z.record(z.string(), z.unknown()),
+        context: z.record(z.string(), z.unknown()),
+        deliveryBarrier: z.enum(["after_tool", "after_response"]).optional(),
+        deliveryBarrierSource: boundedUtf8String(64, "delivery barrier source").optional(),
+      })
+      .passthrough(),
+  })
+  .strict();
+
 export const ChannelIngressResultSchema = z
   .object({
     protocol: z.literal(CHANNEL_BACKEND_PROTOCOL),
@@ -184,6 +214,7 @@ export type ExternalChannelIdentity = z.infer<typeof ExternalChannelIdentitySche
 export type ExternalChannelTarget = z.infer<typeof ExternalChannelTargetSchema>;
 export type LocalChannelMessageBinding = z.infer<typeof LocalChannelMessageBindingSchema>;
 export type ChannelIngressRequest = z.infer<typeof ChannelIngressRequestSchema>;
+export type ResolvedChannelIngressRequest = z.infer<typeof ResolvedChannelIngressRequestSchema>;
 export type ChannelIngressResult = z.infer<typeof ChannelIngressResultSchema>;
 export type ChannelOutputEnvelope = z.infer<typeof ChannelOutputEnvelopeSchema>;
 
@@ -243,6 +274,24 @@ export function setChannelBackendPromptPublisherForTests(publisher?: ChannelBack
 
 export async function acceptChannelIngress(input: ChannelIngressRequest): Promise<ChannelIngressResult> {
   const request = ChannelIngressRequestSchema.parse(input);
+  return acceptParsedChannelIngress(request);
+}
+
+export async function acceptResolvedChannelIngress(
+  input: ResolvedChannelIngressRequest,
+  options: {
+    publishPrompt?: ChannelBackendPromptPublisher;
+  } = {},
+): Promise<ChannelIngressResult> {
+  const resolved = ResolvedChannelIngressRequestSchema.parse(input);
+  return acceptParsedChannelIngress(resolved.request, resolved, options.publishPrompt);
+}
+
+async function acceptParsedChannelIngress(
+  request: ChannelIngressRequest,
+  resolved?: ResolvedChannelIngressRequest,
+  promptPublisher: ChannelBackendPromptPublisher = channelBackendPromptPublisher,
+): Promise<ChannelIngressResult> {
   if (!dbGetAgent(request.agentId)) {
     return rejectedIngress(request, {
       code: "NOT_FOUND",
@@ -252,13 +301,21 @@ export async function acceptChannelIngress(input: ChannelIngressRequest): Promis
     });
   }
 
-  const identity = deriveLocalIdentity(request);
+  const derivedIdentity = deriveLocalIdentity(request);
+  const identity =
+    resolved === undefined
+      ? derivedIdentity
+      : {
+          ...derivedIdentity,
+          sessionKey: resolved.session.key,
+          sessionName: resolved.session.name,
+        };
   let acceptance: ReturnType<typeof dbAcceptChannelBackendIngress>;
   try {
     acceptance = dbAcceptChannelBackendIngress({
       channelInstanceId: request.channelInstanceId,
       idempotencyKey: request.idempotencyKey,
-      requestFingerprint: requestFingerprint(request),
+      requestFingerprint: requestFingerprint(request, resolved),
       requestId: request.requestId,
       localActorId: request.localActorId,
       agentId: request.agentId,
@@ -269,6 +326,12 @@ export async function acceptChannelIngress(input: ChannelIngressRequest): Promis
       external: request.external,
       content: { blocks: request.content },
       receivedAt: Date.parse(request.receivedAt),
+      ...(resolved === undefined
+        ? {}
+        : {
+            canonical: resolved.canonical,
+            prompt: resolved.prompt,
+          }),
     });
   } catch (error) {
     if (isIdempotencyConflict(error)) {
@@ -302,7 +365,11 @@ export async function acceptChannelIngress(input: ChannelIngressRequest): Promis
   }
 
   try {
-    ensureChannelBackendSession(acceptance.receipt);
+    if (resolved === undefined) {
+      ensureChannelBackendSession(acceptance.receipt);
+    } else {
+      assertResolvedChannelBackendSession(acceptance.receipt, resolved);
+    }
   } catch (error) {
     log.error("Channel ingress session binding failed", {
       requestId: request.requestId,
@@ -317,45 +384,21 @@ export async function acceptChannelIngress(input: ChannelIngressRequest): Promis
     });
   }
 
-  const claimId = randomUUID();
-  const claim = dbClaimChannelBackendIngressPublication({
-    receiptId: acceptance.receipt.id,
-    claimId,
-  });
-  let receipt = claim.receipt;
-  if (claim.status === "acquired") {
-    try {
-      await channelBackendPromptPublisher(receipt.sessionName, buildPromptPayload(receipt, request.content), {
-        messageId: receipt.id,
-      });
-      receipt = dbMarkChannelBackendIngressPublished({
-        receiptId: receipt.id,
-        claimId,
-      });
-    } catch (error) {
-      try {
-        dbReleaseChannelBackendIngressPublication({
-          receiptId: receipt.id,
-          claimId,
-        });
-      } catch (releaseError) {
-        log.error("Channel ingress publication claim release failed", {
-          receiptId: receipt.id,
-          errorKind: errorKind(releaseError),
-        });
-      }
-      log.warn("Channel ingress prompt publication failed", {
-        requestId: request.requestId,
-        receiptId: receipt.id,
-        errorKind: errorKind(error),
-      });
-      return rejectedIngress(request, {
-        code: "UNAVAILABLE",
-        category: "availability",
-        retryable: true,
-        correlationId: request.requestId,
-      });
-    }
+  let receipt = acceptance.receipt;
+  try {
+    receipt = (await publishAcceptedChannelIngressReceipt(receipt, promptPublisher)).receipt;
+  } catch (error) {
+    log.warn("Channel ingress prompt publication failed", {
+      requestId: request.requestId,
+      receiptId: receipt.id,
+      errorKind: errorKind(error),
+    });
+    return rejectedIngress(request, {
+      code: "UNAVAILABLE",
+      category: "availability",
+      retryable: true,
+      correlationId: request.requestId,
+    });
   }
 
   return ChannelIngressResultSchema.parse({
@@ -366,6 +409,147 @@ export async function acceptChannelIngress(input: ChannelIngressRequest): Promis
     binding: bindingFromReceipt(receipt),
     acceptedAt: new Date(receipt.acceptedAt).toISOString(),
   });
+}
+
+export interface ResumePendingChannelIngressPublicationsResult {
+  scanned: number;
+  published: number;
+  busy: number;
+  failed: number;
+}
+
+export async function resumePendingChannelIngressPublications(
+  options: { limit?: number; now?: number; publishPrompt?: ChannelBackendPromptPublisher } = {},
+): Promise<ResumePendingChannelIngressPublicationsResult> {
+  const pending = dbListPendingChannelBackendIngressReceipts({
+    ...(options.limit === undefined ? {} : { limit: options.limit }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+  const result: ResumePendingChannelIngressPublicationsResult = {
+    scanned: pending.length,
+    published: 0,
+    busy: 0,
+    failed: 0,
+  };
+  const publisher = options.publishPrompt ?? channelBackendPromptPublisher;
+  for (const receipt of pending) {
+    try {
+      assertPersistedChannelBackendSession(receipt);
+      const publication = await publishAcceptedChannelIngressReceipt(receipt, publisher);
+      if (publication.status === "busy") {
+        result.busy += 1;
+      } else {
+        result.published += 1;
+      }
+    } catch (error) {
+      result.failed += 1;
+      log.warn("Pending Channel ingress publication retry failed", {
+        receiptId: receipt.id,
+        errorKind: errorKind(error),
+      });
+    }
+  }
+  return result;
+}
+
+type ChannelBackendPublicationRetryTimer = ReturnType<typeof setInterval>;
+
+export function startChannelBackendPublicationReconciler(
+  options: {
+    intervalMs?: number;
+    limit?: number;
+    publishPrompt?: ChannelBackendPromptPublisher;
+    setInterval?: (callback: () => void, intervalMs: number) => ChannelBackendPublicationRetryTimer;
+    clearInterval?: (timer: ChannelBackendPublicationRetryTimer) => void;
+  } = {},
+): () => void {
+  const intervalMs = options.intervalMs ?? CHANNEL_BACKEND_PUBLICATION_RETRY_INTERVAL_MS;
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1_000) {
+    throw new Error("Channel backend publication retry interval must be at least 1000 milliseconds");
+  }
+  const scheduleInterval = options.setInterval ?? setInterval;
+  const cancelInterval = options.clearInterval ?? clearInterval;
+  let retrying = false;
+  const retry = () => {
+    if (retrying) return;
+    retrying = true;
+    void resumePendingChannelIngressPublications({
+      ...(options.limit === undefined ? {} : { limit: options.limit }),
+      ...(options.publishPrompt === undefined ? {} : { publishPrompt: options.publishPrompt }),
+    })
+      .catch((error) => {
+        log.warn("Channel ingress publication reconciliation failed", {
+          errorKind: errorKind(error),
+        });
+      })
+      .finally(() => {
+        retrying = false;
+      });
+  };
+  retry();
+  const timer = scheduleInterval(retry, intervalMs);
+  timer.unref?.();
+  return () => cancelInterval(timer);
+}
+
+async function publishAcceptedChannelIngressReceipt(
+  receipt: ChannelBackendIngressReceiptRecord,
+  promptPublisher: ChannelBackendPromptPublisher,
+): Promise<{
+  status: "published" | "busy";
+  receipt: ChannelBackendIngressReceiptRecord;
+}> {
+  const claimId = randomUUID();
+  const claim = dbClaimChannelBackendIngressPublication({
+    receiptId: receipt.id,
+    claimId,
+  });
+  if (claim.status === "published") {
+    return { status: "published", receipt: claim.receipt };
+  }
+  if (claim.status === "busy") {
+    return { status: "busy", receipt: claim.receipt };
+  }
+  try {
+    await promptPublisher(claim.receipt.sessionName, promptPayloadFromReceipt(claim.receipt), {
+      messageId: claim.receipt.id,
+    });
+    return {
+      status: "published",
+      receipt: dbMarkChannelBackendIngressPublished({
+        receiptId: claim.receipt.id,
+        claimId,
+      }),
+    };
+  } catch (error) {
+    try {
+      dbReleaseChannelBackendIngressPublication({
+        receiptId: claim.receipt.id,
+        claimId,
+      });
+    } catch (releaseError) {
+      log.error("Channel ingress publication claim release failed", {
+        receiptId: claim.receipt.id,
+        errorKind: errorKind(releaseError),
+      });
+    }
+    throw error;
+  }
+}
+
+function promptPayloadFromReceipt(receipt: ChannelBackendIngressReceiptRecord): Record<string, unknown> {
+  if (receipt.prompt) {
+    return {
+      ...receipt.prompt,
+      _channelBackend: backendPromptMetadata(receipt),
+    };
+  }
+  const message = dbGetChatMessage(receipt.messageId);
+  if (!message) {
+    throw new Error(`Channel backend ingress Message is unavailable: ${receipt.messageId}`);
+  }
+  const content = ChannelContentSchema.parse(message.content?.blocks);
+  return buildPromptPayload(receipt, content);
 }
 
 function deriveLocalIdentity(request: ChannelIngressRequest): {
@@ -394,7 +578,7 @@ function deriveLocalIdentity(request: ChannelIngressRequest): {
   };
 }
 
-function requestFingerprint(request: ChannelIngressRequest): string {
+function requestFingerprint(request: ChannelIngressRequest, resolved?: ResolvedChannelIngressRequest): string {
   return createHash("sha256")
     .update(
       canonicalJson({
@@ -403,6 +587,12 @@ function requestFingerprint(request: ChannelIngressRequest): string {
         agentId: request.agentId,
         external: request.external,
         content: request.content,
+        ...(resolved === undefined
+          ? {}
+          : {
+              canonical: resolved.canonical,
+              session: resolved.session,
+            }),
       }),
     )
     .digest("hex");
@@ -451,24 +641,36 @@ function ensureChannelBackendSession(receipt: ChannelBackendIngressReceiptRecord
   });
 }
 
+function assertResolvedChannelBackendSession(
+  receipt: ChannelBackendIngressReceiptRecord,
+  resolved: ResolvedChannelIngressRequest,
+): void {
+  if (
+    receipt.chatId !== resolved.canonical.chatId ||
+    receipt.messageId !== resolved.canonical.messageId ||
+    receipt.sessionKey !== resolved.session.key ||
+    receipt.sessionName !== resolved.session.name
+  ) {
+    throw new Error("Resolved Channel ingress binding mismatch");
+  }
+  const session = getSession(receipt.sessionKey);
+  if (session === null || session.agentId !== receipt.agentId || session.name !== receipt.sessionName) {
+    throw new Error("Resolved Channel ingress Session mismatch");
+  }
+}
+
+function assertPersistedChannelBackendSession(receipt: ChannelBackendIngressReceiptRecord): void {
+  const session = getSession(receipt.sessionKey);
+  if (session === null || session.agentId !== receipt.agentId || session.name !== receipt.sessionName) {
+    throw new Error("Persisted Channel ingress Session mismatch");
+  }
+}
+
 function buildPromptPayload(
   receipt: ChannelBackendIngressReceiptRecord,
   content: ChannelContent,
 ): Record<string, unknown> {
-  const binding = bindingFromReceipt(receipt);
-  const target = {
-    channelKind: receipt.external.channelKind,
-    connectionId: receipt.external.connectionId,
-    conversationId: receipt.external.conversationId,
-  };
-  const metadata: ChannelBackendPromptMetadata = {
-    protocol: CHANNEL_BACKEND_PROTOCOL,
-    schemaVersion: CHANNEL_BACKEND_SCHEMA_VERSION,
-    ingressRequestId: receipt.initialRequestId,
-    correlationId: receipt.initialRequestId,
-    binding,
-    target,
-  };
+  const metadata = backendPromptMetadata(receipt);
   const source: MessageTarget = {
     channel: receipt.external.channelKind,
     accountId: receipt.external.connectionId,
@@ -504,6 +706,21 @@ function buildPromptPayload(
     deliveryBarrierSource: "default",
     _agentId: receipt.agentId,
     _channelBackend: metadata,
+  };
+}
+
+function backendPromptMetadata(receipt: ChannelBackendIngressReceiptRecord): ChannelBackendPromptMetadata {
+  return {
+    protocol: CHANNEL_BACKEND_PROTOCOL,
+    schemaVersion: CHANNEL_BACKEND_SCHEMA_VERSION,
+    ingressRequestId: receipt.initialRequestId,
+    correlationId: receipt.initialRequestId,
+    binding: bindingFromReceipt(receipt),
+    target: {
+      channelKind: receipt.external.channelKind,
+      connectionId: receipt.external.connectionId,
+      conversationId: receipt.external.conversationId,
+    },
   };
 }
 

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -15,6 +15,7 @@ import {
   startChannelOutboundReceiptPruner,
 } from "./runner.js";
 import type { ChannelBackendEgressResponder, ChannelBackendEgressResponderConnection } from "./backend-egress.js";
+import type { ChannelOutputSink } from "./backend.js";
 import type {
   NativeInboundChannelActionResponder,
   NativeInboundChannelActionResponderConnection,
@@ -28,6 +29,7 @@ import {
 } from "./native/driver.js";
 import { nativeLocalAgentActions } from "./native/agent-actions.js";
 import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
+import type { ChannelRuntimeEventSink } from "./runtime-events.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 
 describe("channel runner native delivery registry", () => {
@@ -101,13 +103,26 @@ describe("channel runner native delivery registry", () => {
         })),
       },
     );
+    let outputSink: ChannelOutputSink | undefined;
+    let runtimeEventSink: ChannelRuntimeEventSink | undefined;
+    const unregisterOutputSink = mock(() => {});
+    const unregisterRuntimeEventSink = mock(() => {});
     const runtime = await driver.createRuntime({
       channel: {
         name: "slack-a",
         provider: "slack",
         credentialConnection: "connection-a",
       },
-      host: {} as never,
+      host: {
+        registerOutputSink: mock((_target, sink: ChannelOutputSink) => {
+          outputSink = sink;
+          return unregisterOutputSink;
+        }),
+        registerRuntimeEventSink: mock((_target, sink: ChannelRuntimeEventSink) => {
+          runtimeEventSink = sink;
+          return unregisterRuntimeEventSink;
+        }),
+      } as never,
     });
 
     expect(driver.descriptor).toMatchObject({
@@ -123,6 +138,41 @@ describe("channel runner native delivery registry", () => {
     expect(runtime.delivery).toBe(delivery);
     expect(runtime.actions).toBe(actions);
     expect(runtime.presence).toBe(presence);
+    expect(outputSink).toBeDefined();
+    expect(runtimeEventSink).toBeDefined();
+    await outputSink!.emit({
+      protocol: "ravi.channel.backend",
+      schemaVersion: 1,
+      outputId: "output-a",
+      correlationId: "correlation-a",
+      binding: {
+        channelInstanceId: "slack-a",
+        agentId: "agent-a",
+        chatId: "chat-a",
+        messageId: "message-a",
+        sessionId: "session-a",
+        turnId: "turn-a",
+      },
+      target: {
+        channelKind: "slack",
+        connectionId: "slack-a",
+        conversationId: "C123~1713000000.000100",
+      },
+      kind: "assistant_message",
+      content: [{ type: "text", text: "done" }],
+      emittedAt: "2026-07-29T12:00:00.000Z",
+    });
+    expect(delivery.deliverText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionName: "session-a",
+        idempotencyKey: "output-a",
+        text: "done",
+        target: expect.objectContaining({
+          chatId: "C123",
+          threadId: "1713000000.000100",
+        }),
+      }),
+    );
     await runtime.start();
     expect(start).toHaveBeenCalledTimes(1);
     expect(runtime.health()).toMatchObject({
@@ -132,6 +182,8 @@ describe("channel runner native delivery registry", () => {
     });
     await runtime.stop();
     expect(stop).toHaveBeenCalledTimes(1);
+    expect(unregisterOutputSink).toHaveBeenCalledTimes(1);
+    expect(unregisterRuntimeEventSink).toHaveBeenCalledTimes(1);
   });
 
   it("materializes one credential-backed native runtime without copying credential material", () => {

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -50,6 +50,7 @@ import {
   type ChannelBackendEgressResponder,
   type ChannelBackendEgressResponderConnection,
 } from "./backend-egress.js";
+import { startChannelBackendPublicationReconciler } from "./backend.js";
 import { createSlackNativeChannelDriver, slackNativeRuntimeHealth } from "./slack/driver.js";
 import type { SlackSocketModeStatus } from "./slack/index.js";
 
@@ -129,6 +130,7 @@ export class ChannelRunner {
   private stopReceiptPruner: (() => void) | null = null;
   private healthResponder: ChannelRunnerHealthResponder | null = null;
   private backendEgressResponder: ChannelBackendEgressResponder | null = null;
+  private stopBackendPublicationReconciler: (() => void) | null = null;
 
   constructor(private readonly options: ChannelRunnerOptions = {}) {}
 
@@ -162,6 +164,7 @@ export class ChannelRunner {
     });
 
     await this.startNativeChannels(env);
+    this.stopBackendPublicationReconciler = startChannelBackendPublicationReconciler();
     this.backendEgressResponder = startChannelRunnerBackendEgressResponder({
       connection: getNats(),
     });
@@ -202,6 +205,8 @@ export class ChannelRunner {
     this.healthResponder = null;
     this.stopReceiptPruner?.();
     this.stopReceiptPruner = null;
+    this.stopBackendPublicationReconciler?.();
+    this.stopBackendPublicationReconciler = null;
     log.info("Stopping channel runner", { pid: process.pid });
     await this.outboundPublishReconciler?.stop();
     this.outboundPublishReconciler = null;

--- a/src/channels/slack/driver.ts
+++ b/src/channels/slack/driver.ts
@@ -1,4 +1,5 @@
 import type { ChannelConfig } from "../../router/router-db.js";
+import type { ChannelOutputEnvelope } from "../backend.js";
 import {
   NATIVE_CHANNEL_DRIVER_PROTOCOL,
   NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
@@ -8,7 +9,12 @@ import {
   type NativeChannelDriver,
   type NativeChannelRuntimeHealth,
 } from "../native/driver.js";
-import { createSlackNativeRuntimeFromEnv, type SlackNativeRuntime, type SlackSocketModeStatus } from "./socket-mode.js";
+import {
+  createSlackNativeRuntimeFromEnv,
+  decodeSlackBackendConversationId,
+  type SlackNativeRuntime,
+  type SlackSocketModeStatus,
+} from "./socket-mode.js";
 
 export interface SlackNativeChannelDriverOptions {
   readonly createRuntime?: (
@@ -53,17 +59,78 @@ export function createSlackNativeChannelDriver(
         channelInstanceId: channel.name,
         capabilities: [...descriptor.capabilities],
       });
+      const unregisterOutputSink = context.host.registerOutputSink(
+        {
+          channelKind: descriptor.provider,
+          connectionId: native.accountId,
+        },
+        {
+          async emit(envelope) {
+            const target = decodeSlackBackendConversationId(envelope.target.conversationId);
+            await native.delivery.deliverText({
+              sessionName: envelope.binding.sessionId,
+              emitId: envelope.outputId,
+              idempotencyKey: envelope.outputId,
+              target: {
+                channel: descriptor.provider,
+                accountId: native.accountId,
+                instanceId: native.instanceId,
+                chatId: target.channelId,
+                ...(target.threadTs ? { threadId: target.threadTs } : {}),
+              },
+              text: renderSlackBackendOutput(envelope),
+            });
+          },
+        },
+      );
+      const unregisterRuntimeEventSink = context.host.registerRuntimeEventSink(
+        {
+          channelKind: descriptor.provider,
+          connectionId: native.accountId,
+        },
+        {
+          async emit() {
+            // Runtime events are durable in the backend even when Slack has no
+            // equivalent compact projection for an intermediate state.
+          },
+        },
+      );
+      let disposed = false;
+      const disposeBackendSinks = () => {
+        if (disposed) return;
+        disposed = true;
+        unregisterRuntimeEventSink();
+        unregisterOutputSink();
+      };
       return {
         descriptor: runtimeDescriptor,
         delivery: native.delivery,
         actions: native.actions,
         presence: native.presence,
         start: () => native.socketMode.start(),
-        stop: () => native.socketMode.stop(),
+        async stop() {
+          disposeBackendSinks();
+          await native.socketMode.stop();
+        },
         health: () => slackNativeRuntimeHealth(native.socketMode.status()),
       };
     },
   };
+}
+
+function renderSlackBackendOutput(envelope: ChannelOutputEnvelope): string {
+  if (envelope.kind === "safe_error") {
+    return `Unable to complete the request (${envelope.error?.code ?? "INTERNAL"}).`;
+  }
+  return (envelope.content ?? [])
+    .map((block) =>
+      block.type === "text"
+        ? block.text
+        : block.name
+          ? `[Attachment: ${block.name}]`
+          : `[Attachment: ${block.artifactId}]`,
+    )
+    .join("\n");
 }
 
 export function slackNativeRuntimeHealth(status: SlackSocketModeStatus): NativeChannelRuntimeHealth {

--- a/src/channels/slack/inbound-inbox.ts
+++ b/src/channels/slack/inbound-inbox.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import { getDb } from "../../router/router-db.js";
+import type { SlackSocketEnvelope } from "./types.js";
+
+export const SLACK_INBOUND_ENVELOPE_CLAIM_LEASE_MS = 5 * 60_000;
+export const SLACK_INBOUND_ENVELOPE_RECONCILE_LIMIT = 25;
+export const SLACK_INBOUND_ENVELOPE_RETENTION_MS = 14 * 24 * 60 * 60_000;
+
+export type SlackInboundEnvelopeState = "accepted" | "processing" | "processed";
+
+export interface SlackInboundEnvelopeRecord {
+  scopeId: string;
+  envelopeId: string;
+  requestFingerprint: string;
+  envelope: SlackSocketEnvelope;
+  state: SlackInboundEnvelopeState;
+  claimId?: string;
+  claimExpiresAt?: number;
+  acceptedAt: number;
+  processedAt?: number;
+  updatedAt: number;
+}
+
+interface SlackInboundEnvelopeRow {
+  scope_id: string;
+  envelope_id: string;
+  request_fingerprint: string;
+  envelope_json: string;
+  state: SlackInboundEnvelopeState;
+  claim_id: string | null;
+  claim_expires_at: number | null;
+  accepted_at: number;
+  processed_at: number | null;
+  updated_at: number;
+}
+
+export type AcceptSlackInboundEnvelopeResult =
+  | { status: "accepted" | "duplicate"; record: SlackInboundEnvelopeRecord }
+  | { status: "conflict"; record: SlackInboundEnvelopeRecord };
+
+export type ClaimSlackInboundEnvelopeResult =
+  | { status: "acquired"; record: SlackInboundEnvelopeRecord }
+  | { status: "busy"; record: SlackInboundEnvelopeRecord }
+  | { status: "processed"; record: SlackInboundEnvelopeRecord };
+
+export function acceptSlackInboundEnvelope(input: {
+  scopeId: string;
+  envelopeId: string;
+  envelope: SlackSocketEnvelope;
+  acceptedAt?: number;
+}): AcceptSlackInboundEnvelopeResult {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const envelopeId = requireText(input.envelopeId, "envelopeId");
+  const acceptedAt = validTimestamp(input.acceptedAt ?? Date.now(), "acceptedAt");
+  const envelopeJson = canonicalJson(input.envelope);
+  if (Buffer.byteLength(envelopeJson, "utf8") > 4 * 1024 * 1024) {
+    throw new Error("Slack inbound envelope exceeds the durable inbox limit");
+  }
+  const requestFingerprint = createHash("sha256").update(envelopeJson, "utf8").digest("hex");
+  const database = getDb();
+  return database.transaction((): AcceptSlackInboundEnvelopeResult => {
+    const inserted = database
+      .prepare(
+        `
+        INSERT OR IGNORE INTO slack_inbound_envelopes (
+          scope_id, envelope_id, request_fingerprint, envelope_json,
+          state, claim_id, claim_expires_at, accepted_at, processed_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, 'accepted', NULL, NULL, ?, NULL, ?)
+      `,
+      )
+      .run(scopeId, envelopeId, requestFingerprint, envelopeJson, acceptedAt, acceptedAt);
+    const record = requireSlackInboundEnvelope(scopeId, envelopeId);
+    if (record.requestFingerprint !== requestFingerprint) {
+      return { status: "conflict", record };
+    }
+    return {
+      status: inserted.changes > 0 ? "accepted" : "duplicate",
+      record,
+    };
+  })();
+}
+
+export function claimSlackInboundEnvelope(input: {
+  scopeId: string;
+  envelopeId: string;
+  claimId: string;
+  claimedAt?: number;
+  leaseMs?: number;
+}): ClaimSlackInboundEnvelopeResult {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const envelopeId = requireText(input.envelopeId, "envelopeId");
+  const claimId = requireText(input.claimId, "claimId");
+  const claimedAt = validTimestamp(input.claimedAt ?? Date.now(), "claimedAt");
+  const leaseMs = input.leaseMs ?? SLACK_INBOUND_ENVELOPE_CLAIM_LEASE_MS;
+  if (!Number.isSafeInteger(leaseMs) || leaseMs < 1_000 || leaseMs > 30 * 60_000) {
+    throw new Error("leaseMs must be an integer between 1000 and 1800000");
+  }
+  const database = getDb();
+  return database.transaction((): ClaimSlackInboundEnvelopeResult => {
+    const current = requireSlackInboundEnvelope(scopeId, envelopeId);
+    if (current.state === "processed") return { status: "processed", record: current };
+    if (current.state === "processing" && current.claimId !== claimId && (current.claimExpiresAt ?? 0) > claimedAt) {
+      return { status: "busy", record: current };
+    }
+    const claimExpiresAt = claimedAt + leaseMs;
+    const result = database
+      .prepare(
+        `
+        UPDATE slack_inbound_envelopes
+        SET state = 'processing',
+            claim_id = ?,
+            claim_expires_at = ?,
+            updated_at = ?
+        WHERE scope_id = ?
+          AND envelope_id = ?
+          AND state IN ('accepted', 'processing')
+          AND (
+            claim_id IS NULL
+            OR claim_id = ?
+            OR claim_expires_at IS NULL
+            OR claim_expires_at <= ?
+          )
+      `,
+      )
+      .run(claimId, claimExpiresAt, claimedAt, scopeId, envelopeId, claimId, claimedAt);
+    const record = requireSlackInboundEnvelope(scopeId, envelopeId);
+    return result.changes > 0 && record.claimId === claimId
+      ? { status: "acquired", record }
+      : record.state === "processed"
+        ? { status: "processed", record }
+        : { status: "busy", record };
+  })();
+}
+
+export function markSlackInboundEnvelopeProcessed(input: {
+  scopeId: string;
+  envelopeId: string;
+  claimId: string;
+  processedAt?: number;
+}): SlackInboundEnvelopeRecord {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const envelopeId = requireText(input.envelopeId, "envelopeId");
+  const claimId = requireText(input.claimId, "claimId");
+  const processedAt = validTimestamp(input.processedAt ?? Date.now(), "processedAt");
+  const result = getDb()
+    .prepare(
+      `
+      UPDATE slack_inbound_envelopes
+      SET state = 'processed',
+          claim_id = NULL,
+          claim_expires_at = NULL,
+          processed_at = COALESCE(processed_at, ?),
+          updated_at = ?
+      WHERE scope_id = ?
+        AND envelope_id = ?
+        AND state = 'processing'
+        AND claim_id = ?
+    `,
+    )
+    .run(processedAt, processedAt, scopeId, envelopeId, claimId);
+  if (result.changes === 0) {
+    throw new Error(`Slack inbound envelope claim is no longer owned: ${envelopeId}`);
+  }
+  return requireSlackInboundEnvelope(scopeId, envelopeId);
+}
+
+export function releaseSlackInboundEnvelopeClaim(input: {
+  scopeId: string;
+  envelopeId: string;
+  claimId: string;
+  releasedAt?: number;
+}): SlackInboundEnvelopeRecord {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const envelopeId = requireText(input.envelopeId, "envelopeId");
+  const claimId = requireText(input.claimId, "claimId");
+  const releasedAt = validTimestamp(input.releasedAt ?? Date.now(), "releasedAt");
+  getDb()
+    .prepare(
+      `
+      UPDATE slack_inbound_envelopes
+      SET state = CASE WHEN state = 'processing' THEN 'accepted' ELSE state END,
+          claim_id = NULL,
+          claim_expires_at = NULL,
+          updated_at = ?
+      WHERE scope_id = ?
+        AND envelope_id = ?
+        AND state = 'processing'
+        AND claim_id = ?
+    `,
+    )
+    .run(releasedAt, scopeId, envelopeId, claimId);
+  return requireSlackInboundEnvelope(scopeId, envelopeId);
+}
+
+export function listPendingSlackInboundEnvelopes(input: {
+  scopeId: string;
+  now?: number;
+  limit?: number;
+}): SlackInboundEnvelopeRecord[] {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const now = validTimestamp(input.now ?? Date.now(), "now");
+  const limit = input.limit ?? SLACK_INBOUND_ENVELOPE_RECONCILE_LIMIT;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("limit must be an integer between 1 and 100");
+  }
+  const rows = getDb()
+    .prepare(
+      `
+      SELECT *
+      FROM slack_inbound_envelopes
+      WHERE scope_id = ?
+        AND (
+          state = 'accepted'
+          OR (
+            state = 'processing'
+            AND (claim_expires_at IS NULL OR claim_expires_at <= ?)
+          )
+        )
+      ORDER BY accepted_at ASC, envelope_id ASC
+      LIMIT ?
+    `,
+    )
+    .all(scopeId, now, limit) as SlackInboundEnvelopeRow[];
+  return rows.map(rowToSlackInboundEnvelope);
+}
+
+export function pruneProcessedSlackInboundEnvelopes(input: { scopeId: string; olderThan: number }): number {
+  ensureSlackInboundInboxSchema();
+  const scopeId = requireText(input.scopeId, "scopeId");
+  const olderThan = validTimestamp(input.olderThan, "olderThan");
+  return getDb()
+    .prepare(
+      `
+      DELETE FROM slack_inbound_envelopes
+      WHERE scope_id = ?
+        AND state = 'processed'
+        AND processed_at IS NOT NULL
+        AND processed_at < ?
+    `,
+    )
+    .run(scopeId, olderThan).changes;
+}
+
+export function getSlackInboundEnvelope(scopeId: string, envelopeId: string): SlackInboundEnvelopeRecord | null {
+  ensureSlackInboundInboxSchema();
+  const row = selectSlackInboundEnvelope(requireText(scopeId, "scopeId"), requireText(envelopeId, "envelopeId"));
+  return row ? rowToSlackInboundEnvelope(row) : null;
+}
+
+function ensureSlackInboundInboxSchema(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS slack_inbound_envelopes (
+      scope_id TEXT NOT NULL,
+      envelope_id TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      envelope_json TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'accepted'
+        CHECK(state IN ('accepted', 'processing', 'processed')),
+      claim_id TEXT,
+      claim_expires_at INTEGER,
+      accepted_at INTEGER NOT NULL,
+      processed_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY(scope_id, envelope_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_slack_inbound_envelopes_pending
+      ON slack_inbound_envelopes(scope_id, state, claim_expires_at, accepted_at);
+  `);
+}
+
+function selectSlackInboundEnvelope(scopeId: string, envelopeId: string): SlackInboundEnvelopeRow | undefined {
+  return getDb()
+    .prepare(
+      `
+      SELECT *
+      FROM slack_inbound_envelopes
+      WHERE scope_id = ? AND envelope_id = ?
+    `,
+    )
+    .get(scopeId, envelopeId) as SlackInboundEnvelopeRow | undefined;
+}
+
+function requireSlackInboundEnvelope(scopeId: string, envelopeId: string): SlackInboundEnvelopeRecord {
+  const row = selectSlackInboundEnvelope(scopeId, envelopeId);
+  if (!row) throw new Error(`Slack inbound envelope not found: ${envelopeId}`);
+  return rowToSlackInboundEnvelope(row);
+}
+
+function rowToSlackInboundEnvelope(row: SlackInboundEnvelopeRow): SlackInboundEnvelopeRecord {
+  const envelope = JSON.parse(row.envelope_json) as SlackSocketEnvelope;
+  return {
+    scopeId: row.scope_id,
+    envelopeId: row.envelope_id,
+    requestFingerprint: row.request_fingerprint,
+    envelope,
+    state: row.state,
+    ...(row.claim_id ? { claimId: row.claim_id } : {}),
+    ...(row.claim_expires_at !== null ? { claimExpiresAt: row.claim_expires_at } : {}),
+    acceptedAt: row.accepted_at,
+    ...(row.processed_at !== null ? { processedAt: row.processed_at } : {}),
+    updatedAt: row.updated_at,
+  };
+}
+
+function requireText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 512 || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`${label} must be a non-empty control-free string of 512 characters or fewer`);
+  }
+  return normalized;
+}
+
+function validTimestamp(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative Unix millisecond timestamp`);
+  }
+  return value;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -20,6 +20,7 @@ import type { AgentConfig } from "../../router/index.js";
 import {
   dbFindChatMessage,
   dbGetChat,
+  dbGetChannelBackendIngressReceiptByTurnId,
   dbGetContext,
   dbListChatParticipants,
   dbUpsertChat,
@@ -44,6 +45,13 @@ import {
   createSlackNativeRuntimesFromEnv,
   slackClientMessageId,
 } from "./socket-mode.js";
+import {
+  acceptSlackInboundEnvelope,
+  claimSlackInboundEnvelope,
+  getSlackInboundEnvelope,
+  markSlackInboundEnvelopeProcessed,
+  pruneProcessedSlackInboundEnvelopes,
+} from "./inbound-inbox.js";
 import {
   createSlackThreadLifecycle,
   getSlackThreadLifecycle,
@@ -592,6 +600,15 @@ describe("Slack Socket Mode routing", () => {
         chatId: "C123",
         sourceMessageId: "1713000000.000100",
       },
+      _channelBackend: {
+        protocol: "ravi.channel.backend",
+        schemaVersion: 1,
+        target: {
+          channelKind: "slack",
+          connectionId: "ravi-rbbt-slack",
+          conversationId: "C123",
+        },
+      },
     });
     expect(
       (published[0]?.payload.source as { suppressPresence?: boolean } | undefined)?.suppressPresence,
@@ -604,6 +621,18 @@ describe("Slack Socket Mode routing", () => {
       instanceId: "slack-instance-1",
       platformChatId: "C123",
     });
+    const backend = published[0]?.payload._channelBackend as
+      | { binding?: { turnId?: string; chatId?: string; messageId?: string } }
+      | undefined;
+    expect(backend?.binding?.chatId).toBe(canonicalChatId);
+    expect(dbGetChannelBackendIngressReceiptByTurnId(backend?.binding?.turnId ?? "")).toMatchObject({
+      state: "published",
+      chatId: canonicalChatId,
+      messageId: backend?.binding?.messageId,
+      prompt: {
+        prompt: expect.stringContaining("<@U123>: ravi?"),
+      },
+    });
     const session = getSessionByName("ravi-hil");
     expect(typeof session?.sessionKey).toBe("string");
     expect(listSessionSubscriptions(session!.sessionKey)).toEqual([
@@ -613,6 +642,167 @@ describe("Slack Socket Mode routing", () => {
         speechMode: "speak",
       }),
     ]);
+  });
+
+  it("persists a message envelope before ack and resumes it after transient publication failure", async () => {
+    const config: RouterConfig = {
+      agents: {
+        "ravi-hil": {
+          id: "ravi-hil",
+          cwd: "/tmp/ravi-hil",
+          dmScope: "per-peer",
+        },
+      },
+      routes: [
+        {
+          pattern: "group:C123",
+          accountId: "ravi-rbbt-slack",
+          agent: "ravi-hil",
+          session: "ravi-hil",
+          priority: 100,
+          policy: "open",
+          channel: "slack",
+        },
+      ],
+      defaultAgent: "ravi-hil",
+      defaultDmScope: "per-peer",
+      accountAgents: { "ravi-rbbt-slack": "ravi-hil" },
+      instanceToAccount: {},
+      instances: {},
+    };
+    const envelope: SlackSocketEnvelope = {
+      envelope_id: "env-durable-a",
+      payload: {
+        token: "must-not-be-persisted",
+        team_id: "T1",
+        event_id: "Ev-durable-a",
+        event_time: 1_713_000_000,
+        event: {
+          type: "message",
+          channel: "C123",
+          channel_type: "channel",
+          user: "U123",
+          text: "durable?",
+          ts: "1713000000.000200",
+        },
+      },
+    };
+    const failing = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "slack-instance-1",
+      getRouterConfig: () => config,
+      publishPrompt: async () => {
+        throw new Error("publisher unavailable");
+      },
+      webClient: {} as never,
+    });
+    let acknowledged = false;
+
+    await expect(
+      failing.handleEnvelope(envelope, async (envelopeId) => {
+        acknowledged = true;
+        expect(envelopeId).toBe("env-durable-a");
+        expect(getSlackInboundEnvelope("slack-instance-1", envelopeId)).toMatchObject({
+          state: "accepted",
+        });
+        expect(JSON.stringify(getSlackInboundEnvelope("slack-instance-1", envelopeId)?.envelope)).not.toContain(
+          "must-not-be-persisted",
+        );
+      }),
+    ).rejects.toThrow("slack_channel_backend_unavailable");
+    expect(acknowledged).toBe(true);
+    expect(getSlackInboundEnvelope("slack-instance-1", "env-durable-a")).toMatchObject({
+      state: "accepted",
+    });
+
+    const published: Record<string, unknown>[] = [];
+    const recovered = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "ravi-rbbt-slack",
+      routeAccountId: "ravi-rbbt-slack",
+      instanceId: "slack-instance-1",
+      getRouterConfig: () => config,
+      publishPrompt: async (_sessionName, payload) => {
+        published.push(payload);
+      },
+      webClient: {} as never,
+    });
+
+    expect(await recovered.resumePendingInboundEnvelopes()).toEqual({
+      scanned: 1,
+      processed: 1,
+      busy: 0,
+      failed: 0,
+    });
+    expect(published).toHaveLength(1);
+    expect(getSlackInboundEnvelope("slack-instance-1", "env-durable-a")).toMatchObject({
+      state: "processed",
+    });
+  });
+
+  it("prunes only processed inbound envelopes outside the retention window", () => {
+    const envelope = (envelopeId: string): SlackSocketEnvelope => ({
+      envelope_id: envelopeId,
+      payload: {
+        event: {
+          type: "message",
+          channel: "C123",
+          user: "U123",
+          text: envelopeId,
+          ts: "1713000000.000200",
+        },
+      },
+    });
+    const processEnvelope = (envelopeId: string, acceptedAt: number, processedAt: number) => {
+      acceptSlackInboundEnvelope({
+        scopeId: "slack-instance-1",
+        envelopeId,
+        envelope: envelope(envelopeId),
+        acceptedAt,
+      });
+      const claimId = `claim-${envelopeId}`;
+      expect(
+        claimSlackInboundEnvelope({
+          scopeId: "slack-instance-1",
+          envelopeId,
+          claimId,
+          claimedAt: processedAt - 1,
+        }).status,
+      ).toBe("acquired");
+      markSlackInboundEnvelopeProcessed({
+        scopeId: "slack-instance-1",
+        envelopeId,
+        claimId,
+        processedAt,
+      });
+    };
+
+    processEnvelope("env-expired", 1_000, 3_000);
+    processEnvelope("env-retained", 4_000, 6_000);
+    acceptSlackInboundEnvelope({
+      scopeId: "slack-instance-1",
+      envelopeId: "env-pending",
+      envelope: envelope("env-pending"),
+      acceptedAt: 1_000,
+    });
+
+    expect(
+      pruneProcessedSlackInboundEnvelopes({
+        scopeId: "slack-instance-1",
+        olderThan: 4_000,
+      }),
+    ).toBe(1);
+    expect(getSlackInboundEnvelope("slack-instance-1", "env-expired")).toBeNull();
+    expect(getSlackInboundEnvelope("slack-instance-1", "env-retained")).toMatchObject({
+      state: "processed",
+    });
+    expect(getSlackInboundEnvelope("slack-instance-1", "env-pending")).toMatchObject({
+      state: "accepted",
+    });
   });
 
   it("routes Slack inbound to an existing chat subscription when no route matches", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { WebSocket as NodeWebSocket } from "ws";
 import { configStore } from "../../config-store.js";
 import { resolvePlatformIdentity, type PlatformIdentity } from "../../contacts.js";
@@ -37,6 +37,12 @@ import type {
   NativeTextDeliveryRequest,
   NativeTextDeliveryResult,
 } from "../native/types.js";
+import {
+  CHANNEL_BACKEND_PROTOCOL,
+  CHANNEL_BACKEND_SCHEMA_VERSION,
+  acceptResolvedChannelIngress,
+  type ChannelContent,
+} from "../backend.js";
 import { SlackWebApiClient } from "./client.js";
 import { resolveSlackCredentialConfigFromEnv, type SlackCredentialResolver } from "./credentials.js";
 import {
@@ -49,6 +55,16 @@ import {
   type SlackScopedIdentityResolution,
 } from "./instance-alias.js";
 import { storeSlackInteractionResponseUrl } from "./interactions.js";
+import {
+  acceptSlackInboundEnvelope,
+  claimSlackInboundEnvelope,
+  listPendingSlackInboundEnvelopes,
+  markSlackInboundEnvelopeProcessed,
+  pruneProcessedSlackInboundEnvelopes,
+  releaseSlackInboundEnvelopeClaim,
+  SLACK_INBOUND_ENVELOPE_RETENTION_MS,
+  type SlackInboundEnvelopeRecord,
+} from "./inbound-inbox.js";
 import { registerSlackThreadInboundLifecycle } from "./thread-lifecycle.js";
 import {
   cleanSlackId,
@@ -78,6 +94,8 @@ const DEFAULT_SLACK_AUTH_TEST_TIMEOUT_MS = 5_000;
 const DEFAULT_SLACK_HEARTBEAT_INTERVAL_MS = 10_000;
 const DEFAULT_SLACK_PONG_TIMEOUT_MS = 5_000;
 const DEFAULT_SLACK_HELLO_TIMEOUT_MS = 10_000;
+const DEFAULT_SLACK_INBOUND_RECONCILE_INTERVAL_MS = 5_000;
+const DEFAULT_SLACK_INBOUND_PRUNE_INTERVAL_MS = 6 * 60 * 60_000;
 const SLACK_FILE_INFO_RETRY_DELAYS_MS = [0, 250, 750, 1_500] as const;
 
 type PublishPrompt = typeof publishSessionPrompt;
@@ -580,6 +598,9 @@ export class SlackSocketModeService {
   private connectedAt: number | undefined;
   private lastPongAt: number | undefined;
   private reconnectCount = 0;
+  private inboundReconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcilingInbound = false;
+  private lastInboundPruneAt = 0;
 
   constructor(private readonly options: SlackSocketModeServiceOptions) {
     this.routingPolicy = normalizeSlackRoutingPolicy({
@@ -623,11 +644,16 @@ export class SlackSocketModeService {
     this.connectedAt = undefined;
     this.reconnectCount = 0;
     this.setLifecycle("connecting", "opening_socket");
+    this.startInboundReconciler();
     this.loopPromise = this.runLoop();
   }
 
   async stop(): Promise<void> {
     this.running = false;
+    if (this.inboundReconcileTimer) {
+      clearInterval(this.inboundReconcileTimer);
+      this.inboundReconcileTimer = null;
+    }
     this.interruptConnectionOpen?.();
     this.interruptConnectionOpen = null;
     this.interruptReconnectDelay?.();
@@ -657,6 +683,25 @@ export class SlackSocketModeService {
     ack: (envelopeId: string) => Promise<void> | void = async () => {},
   ): Promise<"duplicate" | "ignored" | "processed"> {
     const envelopeId = cleanSlackId(envelope.envelope_id);
+    const messageEvent = envelopeEvent(envelope);
+    if (envelopeId && messageEvent && isSlackMessageEventStructurallyEligible(messageEvent)) {
+      const accepted = acceptSlackInboundEnvelope({
+        scopeId: this.inboundScopeId(),
+        envelopeId,
+        envelope: durableSlackEnvelope(envelope),
+        acceptedAt: this.now(),
+      });
+      await ack(envelopeId);
+      if (accepted.status === "conflict") {
+        log.warn("Conflicting Slack Socket Mode envelope ignored", {
+          envelopeId,
+          accountId: this.options.accountId,
+        });
+        return "duplicate";
+      }
+      return this.processDurableInboundEnvelope(accepted.record);
+    }
+
     if (envelopeId) {
       await ack(envelopeId);
       if (this.seenEnvelopeIds.has(envelopeId)) {
@@ -683,6 +728,131 @@ export class SlackSocketModeService {
 
     await this.routeMessage(normalized);
     return "processed";
+  }
+
+  async resumePendingInboundEnvelopes(): Promise<{
+    scanned: number;
+    processed: number;
+    busy: number;
+    failed: number;
+  }> {
+    const pending = listPendingSlackInboundEnvelopes({
+      scopeId: this.inboundScopeId(),
+      now: this.now(),
+    });
+    const result = {
+      scanned: pending.length,
+      processed: 0,
+      busy: 0,
+      failed: 0,
+    };
+    for (const record of pending) {
+      try {
+        const disposition = await this.processDurableInboundEnvelope(record);
+        if (disposition === "duplicate") {
+          result.busy += 1;
+        } else {
+          result.processed += 1;
+        }
+      } catch (error) {
+        result.failed += 1;
+        log.warn("Pending Slack inbound envelope retry failed", {
+          envelopeId: record.envelopeId,
+          accountId: this.options.accountId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return result;
+  }
+
+  private async processDurableInboundEnvelope(
+    record: SlackInboundEnvelopeRecord,
+  ): Promise<"duplicate" | "ignored" | "processed"> {
+    const claimId = randomUUID();
+    const claim = claimSlackInboundEnvelope({
+      scopeId: record.scopeId,
+      envelopeId: record.envelopeId,
+      claimId,
+      claimedAt: this.now(),
+    });
+    if (claim.status !== "acquired") return "duplicate";
+    try {
+      const normalized = await this.normalizeEnvelope(claim.record.envelope);
+      if (!normalized) {
+        markSlackInboundEnvelopeProcessed({
+          scopeId: record.scopeId,
+          envelopeId: record.envelopeId,
+          claimId,
+          processedAt: this.now(),
+        });
+        return "ignored";
+      }
+      await this.routeMessage(normalized);
+      markSlackInboundEnvelopeProcessed({
+        scopeId: record.scopeId,
+        envelopeId: record.envelopeId,
+        claimId,
+        processedAt: this.now(),
+      });
+      return "processed";
+    } catch (error) {
+      try {
+        releaseSlackInboundEnvelopeClaim({
+          scopeId: record.scopeId,
+          envelopeId: record.envelopeId,
+          claimId,
+          releasedAt: this.now(),
+        });
+      } catch (releaseError) {
+        log.error("Slack inbound envelope claim release failed", {
+          envelopeId: record.envelopeId,
+          accountId: this.options.accountId,
+          error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+        });
+      }
+      throw error;
+    }
+  }
+
+  private inboundScopeId(): string {
+    return this.options.instanceId ?? this.options.accountId;
+  }
+
+  private startInboundReconciler(): void {
+    if (this.inboundReconcileTimer) return;
+    const reconcile = () => {
+      if (this.reconcilingInbound) return;
+      this.reconcilingInbound = true;
+      const now = this.now();
+      if (now - this.lastInboundPruneAt >= DEFAULT_SLACK_INBOUND_PRUNE_INTERVAL_MS) {
+        try {
+          pruneProcessedSlackInboundEnvelopes({
+            scopeId: this.inboundScopeId(),
+            olderThan: Math.max(0, now - SLACK_INBOUND_ENVELOPE_RETENTION_MS),
+          });
+          this.lastInboundPruneAt = now;
+        } catch (error) {
+          log.warn("Slack inbound envelope retention cleanup failed", {
+            accountId: this.options.accountId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      void this.resumePendingInboundEnvelopes()
+        .catch((error) => {
+          log.warn("Slack inbound envelope reconciliation failed", {
+            accountId: this.options.accountId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .finally(() => {
+          this.reconcilingInbound = false;
+        });
+    };
+    reconcile();
+    this.inboundReconcileTimer = setInterval(reconcile, DEFAULT_SLACK_INBOUND_RECONCILE_INTERVAL_MS);
+    this.inboundReconcileTimer.unref?.();
   }
 
   private async runLoop(): Promise<void> {
@@ -1280,7 +1450,7 @@ export class SlackSocketModeService {
       senderKind: message.senderKind,
     });
     const processedFiles = await this.processFiles(message, resolved.agent.cwd);
-    dbUpsertChatMessage({
+    const canonicalMessage = dbUpsertChatMessage({
       chatId: canonicalChat.id,
       channel: "slack",
       instanceId,
@@ -1409,13 +1579,55 @@ export class SlackSocketModeService {
       ...actorIdentity,
     };
 
-    await this.publishPrompt(sessionName, {
-      prompt: formatSlackPrompt(message, processedFiles),
-      source,
-      context,
-      deliveryBarrier: "after_tool",
-      deliveryBarrierSource: "default",
+    const backendIdentity = slackBackendIngressIdentity({
+      instanceId,
+      agentId: resolved.agent.id,
+      message,
+      actorIdentity,
     });
+    const ingress = await acceptResolvedChannelIngress(
+      {
+        request: {
+          protocol: CHANNEL_BACKEND_PROTOCOL,
+          schemaVersion: CHANNEL_BACKEND_SCHEMA_VERSION,
+          requestId: backendIdentity.requestId,
+          idempotencyKey: backendIdentity.idempotencyKey,
+          localActorId: backendIdentity.localActorId,
+          channelInstanceId: instanceId,
+          agentId: resolved.agent.id,
+          external: {
+            channelKind: "slack",
+            connectionId: this.options.accountId,
+            conversationId: slackBackendConversationId(message),
+            senderId: message.userId,
+            messageId: message.ts,
+          },
+          content: slackBackendContent(message, processedFiles),
+          receivedAt: new Date(message.eventTimeMs).toISOString(),
+        },
+        canonical: {
+          chatId: canonicalChat.id,
+          messageId: canonicalMessage.canonicalMessageId,
+        },
+        session: {
+          key: resolved.sessionKey,
+          name: sessionName,
+        },
+        prompt: {
+          prompt: formatSlackPrompt(message, processedFiles),
+          source: { ...source },
+          context: { ...context },
+          deliveryBarrier: "after_tool",
+          deliveryBarrierSource: "default",
+        },
+      },
+      {
+        publishPrompt: this.publishPrompt,
+      },
+    );
+    if (ingress.disposition === "rejected") {
+      throw new Error(`slack_channel_backend_${ingress.error?.code.toLowerCase() ?? "rejected"}`);
+    }
   }
 
   private async publishSlackThreadCreatedEvent(input: {
@@ -2175,6 +2387,101 @@ function formatSlackPrompt(message: SlackNormalizedMessage, files: readonly Proc
     new Date(message.eventTimeMs).toISOString(),
   ].filter(Boolean);
   return `[${parts.join(" ")}]\n<@${message.userId}>: ${formatSlackMessageBody(message, files)}`;
+}
+
+function slackBackendIngressIdentity(input: {
+  instanceId: string;
+  agentId: string;
+  message: SlackNormalizedMessage;
+  actorIdentity: SlackActorIdentity;
+}): {
+  requestId: string;
+  idempotencyKey: string;
+  localActorId: string;
+} {
+  const messageIdentity = slackBackendDigest([input.instanceId, input.message.channelId, input.message.ts]);
+  const requestIdentity = slackBackendDigest([
+    messageIdentity,
+    input.message.eventId ?? "",
+    input.message.envelopeId ?? "",
+  ]);
+  const actorIdentity = slackBackendDigest([
+    input.instanceId,
+    input.actorIdentity.actorType,
+    input.actorIdentity.contactId ??
+      input.actorIdentity.actorAgentId ??
+      input.actorIdentity.normalizedSenderId ??
+      input.message.userId,
+    input.agentId,
+  ]);
+  return {
+    requestId: `slack_request_${requestIdentity}`,
+    idempotencyKey: `slack_ingress_${messageIdentity}`,
+    localActorId: `slack_actor_${actorIdentity}`,
+  };
+}
+
+export function encodeSlackBackendConversationId(message: SlackNormalizedMessage): string {
+  return message.thread.outboundThreadTs
+    ? `${message.channelId}~${message.thread.outboundThreadTs}`
+    : message.channelId;
+}
+
+export function decodeSlackBackendConversationId(conversationId: string): {
+  channelId: string;
+  threadTs?: string;
+} {
+  const separator = conversationId.indexOf("~");
+  if (separator === -1) return { channelId: conversationId };
+  const channelId = conversationId.slice(0, separator);
+  const threadTs = conversationId.slice(separator + 1);
+  if (!channelId || !threadTs || threadTs.includes("~")) {
+    throw new Error("invalid_slack_backend_conversation");
+  }
+  return { channelId, threadTs };
+}
+
+function slackBackendConversationId(message: SlackNormalizedMessage): string {
+  return encodeSlackBackendConversationId(message);
+}
+
+function slackBackendContent(message: SlackNormalizedMessage, files: readonly ProcessedSlackFile[]): ChannelContent {
+  const content: ChannelContent = [];
+  const text = message.text.trim();
+  if (text) content.push({ type: "text", text });
+  for (const file of files) {
+    const name = fileDisplayName(file);
+    const mediaType = file.mimeType?.match(/^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$/)
+      ? file.mimeType
+      : undefined;
+    content.push({
+      type: "artifact",
+      artifactId: `slack_file_${slackBackendDigest([file.id])}`,
+      ...(name && Buffer.byteLength(name, "utf8") <= 256 ? { name } : {}),
+      ...(mediaType ? { mediaType } : {}),
+      ...(file.sizeBytes !== undefined && Number.isSafeInteger(file.sizeBytes) && file.sizeBytes >= 0
+        ? { sizeBytes: file.sizeBytes }
+        : {}),
+    });
+  }
+  if (content.length === 0) content.push({ type: "text", text: "[message]" });
+  return content;
+}
+
+function slackBackendDigest(parts: readonly string[]): string {
+  return createHash("sha256").update(parts.join("\u001f"), "utf8").digest("hex").slice(0, 32);
+}
+
+function durableSlackEnvelope(envelope: SlackSocketEnvelope): SlackSocketEnvelope {
+  return JSON.parse(
+    JSON.stringify(envelope, (key, value) => {
+      const normalizedKey = key.toLowerCase();
+      if (normalizedKey === "token" || normalizedKey === "response_url" || normalizedKey === "response_urls") {
+        return undefined;
+      }
+      return value;
+    }),
+  ) as SlackSocketEnvelope;
 }
 
 function positiveDuration(value: number | undefined, fallback: number): number {

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -338,6 +338,7 @@ interface ChannelBackendIngressReceiptRow {
   session_name: string;
   turn_id: string;
   external_json: string;
+  prompt_json: string | null;
   state: ChannelBackendIngressPublicationState;
   publish_claim_id: string | null;
   publish_claim_expires_at: number | null;
@@ -800,6 +801,7 @@ export interface ChannelBackendIngressReceiptRecord {
   sessionName: string;
   turnId: string;
   external: ChannelBackendExternalIdentityRecord;
+  prompt?: Record<string, unknown>;
   state: ChannelBackendIngressPublicationState;
   publishClaimId?: string;
   publishClaimExpiresAt?: number;
@@ -874,6 +876,11 @@ export interface AcceptChannelBackendIngressInput {
   content: Record<string, unknown>;
   receivedAt: number;
   acceptedAt?: number;
+  prompt?: Record<string, unknown>;
+  canonical?: {
+    chatId: string;
+    messageId: string;
+  };
 }
 
 export type AcceptChannelBackendIngressResult =
@@ -1500,6 +1507,7 @@ function getDb(): Database {
       session_name TEXT NOT NULL,
       turn_id TEXT NOT NULL,
       external_json TEXT NOT NULL,
+      prompt_json TEXT,
       state TEXT NOT NULL DEFAULT 'accepted'
         CHECK(state IN ('accepted', 'publishing', 'published')),
       publish_claim_id TEXT,
@@ -3017,6 +3025,7 @@ function getDb(): Database {
   );
   ensureColumn(db, "channel_backend_runtime_state", "runtime_generation_id", "TEXT");
   ensureColumn(db, "channel_backend_runtime_state", "terminal_error_json", "TEXT");
+  ensureColumn(db, "channel_backend_ingress_receipts", "prompt_json", "TEXT");
   ensureIdentityChatMigrations(db);
   ensureAgentVisibilityMigration(db);
   backfillChatModelOnce(db);
@@ -3913,6 +3922,7 @@ function rowToChatMessageWithSortKey(row: ChatMessageWithSortKeyRow): ChatMessag
 
 function rowToChannelBackendIngressReceipt(row: ChannelBackendIngressReceiptRow): ChannelBackendIngressReceiptRecord {
   const external = parseJsonRecord(row.external_json);
+  const prompt = parseJsonRecord(row.prompt_json);
   if (
     !external ||
     typeof external.channelKind !== "string" ||
@@ -3943,6 +3953,7 @@ function rowToChannelBackendIngressReceipt(row: ChannelBackendIngressReceiptRow)
       senderId: external.senderId,
       messageId: external.messageId,
     },
+    ...(prompt ? { prompt } : {}),
     state: row.state,
     ...(row.publish_claim_id ? { publishClaimId: row.publish_claim_id } : {}),
     ...(row.publish_claim_expires_at !== null ? { publishClaimExpiresAt: row.publish_claim_expires_at } : {}),
@@ -5113,20 +5124,36 @@ function acceptChannelBackendIngress(
     };
   }
 
-  const chatResult = ensureActorAgentChat(database, {
-    actorId: localActorId,
-    agentId,
-    clientRequestId: requestId,
-    seenAt: receivedAt,
-  });
-  const messageResult = createCanonicalActorMessage(database, {
-    chatId: chatResult.chat.id,
-    actorId: localActorId,
-    clientMessageId,
-    content: input.content,
-    messageType: "channel",
-    createdAt: receivedAt,
-  });
+  let chatId: string;
+  let message: ChatMessageWithSortKey;
+  if (input.canonical) {
+    chatId = normalizeCanonicalChatId(input.canonical.chatId);
+    const messageId = normalizeOpaqueCanonicalId(input.canonical.messageId, "canonical.messageId");
+    message = channelBackendMessageWithSortKey(database, messageId);
+    if (message.chatId !== chatId) {
+      throw new Error("Canonical Channel ingress Message does not belong to its Chat");
+    }
+    if (message.channel !== input.external.channelKind || message.instanceId !== channelInstanceId) {
+      throw new Error("Canonical Channel ingress Message does not match provider scope");
+    }
+  } else {
+    const chatResult = ensureActorAgentChat(database, {
+      actorId: localActorId,
+      agentId,
+      clientRequestId: requestId,
+      seenAt: receivedAt,
+    });
+    const messageResult = createCanonicalActorMessage(database, {
+      chatId: chatResult.chat.id,
+      actorId: localActorId,
+      clientMessageId,
+      content: input.content,
+      messageType: "channel",
+      createdAt: receivedAt,
+    });
+    chatId = chatResult.chat.id;
+    message = messageResult.message;
+  }
   const receiptId = semanticId("channel_ingress", [channelInstanceId, idempotencyKey]);
   database
     .prepare(
@@ -5135,6 +5162,7 @@ function acceptChannelBackendIngress(
         id, channel_instance_id, idempotency_key, request_fingerprint,
         initial_request_id, local_actor_id, agent_id, chat_id, message_id,
         session_key, session_name, turn_id, external_json, state,
+        prompt_json,
         publish_claim_id, publish_claim_expires_at, published_at,
         accepted_at, updated_at
       )
@@ -5142,6 +5170,7 @@ function acceptChannelBackendIngress(
         ?, ?, ?, ?,
         ?, ?, ?, ?, ?,
         ?, ?, ?, ?, 'accepted',
+        ?,
         NULL, NULL, NULL,
         ?, ?
       )
@@ -5155,12 +5184,13 @@ function acceptChannelBackendIngress(
       requestId,
       localActorId,
       agentId,
-      chatResult.chat.id,
-      messageResult.canonicalMessageId,
+      chatId,
+      message.id,
       sessionKey,
       sessionName,
       turnId,
       canonicalJsonRecord({ ...input.external }),
+      input.prompt === undefined ? null : canonicalJsonRecord(input.prompt),
       acceptedAt,
       acceptedAt,
     );
@@ -5170,7 +5200,7 @@ function acceptChannelBackendIngress(
   return {
     status: "accepted",
     receipt: rowToChannelBackendIngressReceipt(row),
-    message: messageResult.message,
+    message,
   };
 }
 
@@ -6672,6 +6702,39 @@ export function dbGetChannelBackendIngressReceiptByTurnId(turnId: string): Chann
     .prepare("SELECT * FROM channel_backend_ingress_receipts WHERE turn_id = ?")
     .get(normalizeOpaqueCanonicalId(turnId, "turnId")) as ChannelBackendIngressReceiptRow | undefined;
   return row ? rowToChannelBackendIngressReceipt(row) : null;
+}
+
+export function dbListPendingChannelBackendIngressReceipts(
+  input: { limit?: number; now?: number } = {},
+): ChannelBackendIngressReceiptRecord[] {
+  const limit = input.limit ?? 100;
+  const now = input.now ?? Date.now();
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000) {
+    throw new Error("limit must be an integer between 1 and 1000");
+  }
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new Error("now must be a non-negative Unix millisecond timestamp");
+  }
+  const rows = getDb()
+    .prepare(
+      `
+      SELECT *
+      FROM channel_backend_ingress_receipts
+      WHERE state = 'accepted'
+         OR (
+           state = 'publishing'
+           AND (
+             publish_claim_id IS NULL
+             OR publish_claim_expires_at IS NULL
+             OR publish_claim_expires_at <= ?
+           )
+         )
+      ORDER BY accepted_at ASC, id ASC
+      LIMIT ?
+    `,
+    )
+    .all(now, limit) as ChannelBackendIngressReceiptRow[];
+  return rows.map(rowToChannelBackendIngressReceipt);
 }
 
 export function dbGetChannelBackendRuntimeState(turnId: string): ChannelBackendRuntimeStateRecord | null {


### PR DESCRIPTION
## Objective

Converge provider-specific ingress on one durable, provider-neutral channel backend that can recover accepted work after process restarts without duplicating canonical messages or prompt publication.

## Problem

A provider could acknowledge delivery before local work was durably accepted. Direct prompt publication also left restart recovery and idempotent reuse of canonical chat and message identities difficult to prove across adapters.

## Solution

- add durable channel ingress receipts with atomic publication claims and restart reconciliation
- persist eligible Slack envelopes in a bounded, secret-redacted inbox before acknowledging them
- reuse canonical chat and message identities across retries and retain the first accepted normalized prompt
- register Slack output and runtime sinks through the shared channel backend lifecycle
- document the backend/adapter boundary, retention policy, and conformance gates

## Practical impact

Accepted provider messages survive transient publication failures and process restarts. New adapters can use the same canonical acceptance path while Slack keeps native delivery and thread behavior.

## What does NOT change

Slack routing, thread selection, actor resolution, file normalization, local policy, and native delivery semantics remain owned by the Slack adapter. Hosted product entities do not enter this public boundary.

## Validation

- `bun test src/channels/backend.test.ts src/channels/runner.test.ts src/channels/slack/socket-mode.test.ts` (84 passing)
- `bun test src/channels/` (256 passing)
- `bun run typecheck`
- `bun run lint`
- `bun run test:sdk` (67 passing)
- `bun run build`
- `ravi specs sync --json`

The repository-wide pre-push suite encountered the existing 5-second timeout in `src/cli/commands/daemon.test.ts` under aggregate load; the same file passed 7/7 immediately in isolation.

## Risks

The durable inbox adds bounded local storage and a reconciliation loop. Incorrect adapter normalization could still produce a stable but semantically wrong target, so provider-specific routing tests remain mandatory.

## Rollback

Revert commit `223b194e` to restore direct Slack prompt publication and remove the new inbox and reconciler. Existing canonical channel data remains valid because the change adds durability around the established identifiers.
