### PR TITLE
fix(runtime): prioritize steering prompts after interrupts

### DIFF
--- a/.ravi/specs/runtime/delivery-queue/CHECKS.md
+++ b/.ravi/specs/runtime/delivery-queue/CHECKS.md
@@ -50,4 +50,6 @@
 - Immediate arrives while an unsafe tool is running and waits.
 - Operational event arrives during active task and waits for the task barrier.
 - Human channel input arrives during active text generation and can interrupt after safe barriers.
+- Human channel input that interrupts a turn is delivered next without replaying the superseded turn first.
+- Unexpected provider interruption without a newer prompt retains the active prompt for recovery replay.
 - Edited-message rebase prompt can interrupt as a documented exception.

--- a/.ravi/specs/runtime/delivery-queue/SPEC.md
+++ b/.ravi/specs/runtime/delivery-queue/SPEC.md
@@ -104,6 +104,16 @@ Within the same barrier lane, delivery SHOULD be FIFO.
 
 `after_tool` and `immediate_interrupt` prompt atoms MAY request interruption only through the session dispatcher's interrupt path, with trace events that explain the source, barrier, and safety state.
 
+When a later prompt atom intentionally interrupts an active provider turn, the
+atoms already yielded to that turn MUST be dequeued before the next provider
+turn. The interrupting atom MUST become the next eligible work according to its
+lane and FIFO order. The yielded atoms remain in durable conversation history;
+they are removed only from retry ownership so the superseded turn is not
+replayed ahead of the user's new direction.
+
+An unexpected provider or runtime interruption with no interrupting prompt MUST
+keep the yielded atoms eligible for recovery replay.
+
 ## Producer Contract
 
 Every producer that calls `publishSessionPrompt` MUST choose one of these strategies:
@@ -178,6 +188,8 @@ Each queued, released, batched, bypassed, or interrupted prompt SHOULD include:
 - Human channel input MAY interrupt after safe barriers because it represents live user intent.
 - Provider adapters MUST NOT implement their own delivery queue. Queueing and interruption are runtime responsibilities.
 - A queued prompt atom MUST survive provider interruption and daemon restart according to `runtime/session-continuity`.
+- A prompt-driven interruption MUST release the interrupting atom next instead of replaying the superseded turn first.
+- An unexpected provider interruption MUST retain the active turn for recovery replay.
 - A provider turn interrupted by a later prompt MUST still produce exactly one terminal event according to `runtime`.
 - Assistant messages MUST be persisted only for non-interrupted terminal turns.
 - Queue classification MUST be deterministic for the same payload and explicit options.
@@ -192,6 +204,8 @@ Each queued, released, batched, bypassed, or interrupted prompt SHOULD include:
 - `sessions answer` enters the follow-up lane by default, unless the call explicitly opts into immediate or belongs to a traced synchronous unblock flow.
 - Operational execute/heartbeat/trigger prompts do not interrupt active task work by default.
 - Human channel messages can still interrupt after safe tool barriers.
+- A human channel message that interrupts an active turn is the next provider input; the superseded turn is not replayed ahead of it.
+- A provider interruption without a newer prompt still replays the active prompt atom.
 - Equal-lane queued events are delivered FIFO.
 - Trace explains whether a prompt was queued, released, batched, blocked, bypassed, or used to interrupt.
 - Tests cover active text generation, tool-running, unsafe tool-running, active task, idle session, daemon restart, and explicit immediate delivery.

--- a/src/bot.runtime-guards.fixture.ts
+++ b/src/bot.runtime-guards.fixture.ts
@@ -1552,7 +1552,7 @@ describe("RaviBot runtime guards", () => {
     expect(interrupt).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses recoverable abort failures from internally interrupted turns", async () => {
+  it("suppresses recoverable abort failures and retries the successor after prompt interruption", async () => {
     const sessionKey = "agent:main:interrupted-abort-no-outbound";
     let releaseAfterTool: (() => void) | undefined;
     const afterTool = new Promise<void>((resolve) => {
@@ -1613,7 +1613,7 @@ describe("RaviBot runtime guards", () => {
         provider: providerId,
         events: (async function* () {
           const retry = await request.prompt.next();
-          expect(retry.value?.message.content).toBe("first\n\nsecond");
+          expect(retry.value?.message.content).toBe("second");
           releaseRetryPrompt?.();
           yield {
             type: "assistant.message",

--- a/src/runtime/delivery-queue.test.ts
+++ b/src/runtime/delivery-queue.test.ts
@@ -5,7 +5,11 @@ import {
   getDeliverableRuntimeMessages,
   shouldInterruptRuntimeForIncoming,
 } from "./delivery-queue.js";
-import { shutdownRuntimeStreamingSession } from "./host-session.js";
+import {
+  shutdownRuntimeStreamingSession,
+  stashCurrentTurnRuntimeMessages,
+  stashPendingRuntimeMessages,
+} from "./host-session.js";
 import type { RuntimeHostStreamingSession } from "./host-session.js";
 import { buildSessionRelayTurnOrigin } from "./turn-origin.js";
 import type { RuntimeSessionHandle } from "./types.js";
@@ -172,6 +176,84 @@ describe("runtime delivery queue", () => {
       interrupt: true,
       reason: "response",
     });
+  });
+
+  it("delivers the steering prompt next instead of replaying the superseded channel turn", async () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("implement the old plan", "turn-a"));
+    const steering = createQueuedRuntimeUserMessage(channelPrompt("stop and use the new plan", "turn-b"));
+    const session = makeStreamingSession({
+      pendingMessages: [active],
+    });
+    const generator = createRuntimeMessageGenerator({
+      sessionName: "dev",
+      session,
+      stashedMessages: new Map(),
+    });
+
+    const first = await generator.next();
+    expect(first.value).toMatchObject({
+      message: { content: "implement the old plan" },
+    });
+
+    session.pendingMessages.push(steering);
+    session.currentTurnSuperseded = true;
+    session.interrupted = true;
+    session.turnActive = false;
+    session.onTurnComplete?.();
+
+    const second = await generator.next();
+    expect(second.value).toMatchObject({
+      message: { content: "stop and use the new plan" },
+    });
+    expect(session.pendingMessages).toEqual([steering]);
+
+    session.done = true;
+    session.onTurnComplete?.();
+    await generator.return(undefined);
+  });
+
+  it("replays the active prompt after an unexpected provider interruption", async () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("keep this work", "turn-a"));
+    const session = makeStreamingSession({
+      pendingMessages: [active],
+    });
+    const generator = createRuntimeMessageGenerator({
+      sessionName: "dev",
+      session,
+      stashedMessages: new Map(),
+    });
+
+    await generator.next();
+    session.interrupted = true;
+    session.turnActive = false;
+    session.onTurnComplete?.();
+
+    const replay = await generator.next();
+    expect(replay.value).toMatchObject({
+      message: { content: "keep this work" },
+    });
+    expect(session.pendingMessages).toEqual([active]);
+
+    session.done = true;
+    session.onTurnComplete?.();
+    await generator.return(undefined);
+  });
+
+  it("stashes only the successor when an interrupted turn was intentionally superseded", () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("old work", "turn-a"));
+    const steering = createQueuedRuntimeUserMessage(channelPrompt("new direction", "turn-b"));
+    const session = makeStreamingSession({
+      pendingMessages: [active, steering],
+      currentTurnPendingIds: [active.pendingId!],
+      currentTurnSuperseded: true,
+    });
+    const pendingStash = new Map();
+    const currentTurnStash = new Map();
+
+    stashPendingRuntimeMessages("dev", session, pendingStash);
+    expect(pendingStash.get("dev")).toEqual([steering]);
+    expect(stashCurrentTurnRuntimeMessages("dev", session, currentTurnStash)).toBe(1);
+    expect(currentTurnStash.get("dev")).toEqual([steering]);
   });
 
   it("delivers at most one channel backend message in a local runtime turn", () => {

--- a/src/runtime/delivery-queue.ts
+++ b/src/runtime/delivery-queue.ts
@@ -2,7 +2,11 @@ import { DEFAULT_DELIVERY_BARRIER, type DeliveryBarrier } from "../delivery-barr
 import type { RuntimeTraceTurnStartResult } from "../session-trace/runtime-trace.js";
 import { dbHasActiveTaskForSession } from "../tasks/task-db.js";
 import { logger } from "../utils/logger.js";
-import type { RuntimeHostStreamingSession, RuntimeUserMessage } from "./host-session.js";
+import {
+  getReplayablePendingRuntimeMessages,
+  type RuntimeHostStreamingSession,
+  type RuntimeUserMessage,
+} from "./host-session.js";
 import type { RaviCommandPromptMetadata, RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimePromptMessage } from "./types.js";
 
@@ -225,6 +229,7 @@ export async function* createRuntimeMessageGenerator({
       deliverable.map((message) => message.pendingId).filter((pendingId): pendingId is string => Boolean(pendingId)),
     );
     session.currentTurnPendingIds = [...yieldedIds];
+    session.currentTurnSuperseded = false;
     const combined = deliverable.map((m) => m.message.content).join("\n\n");
     log.info("Generator: yielding", {
       sessionName,
@@ -280,8 +285,17 @@ export async function* createRuntimeMessageGenerator({
 
     await turnCompleted;
 
-    if (session.interrupted) {
-      log.info("Generator: turn interrupted, keeping queue", {
+    if (session.interrupted && session.currentTurnSuperseded) {
+      const queuedBefore = session.pendingMessages.length;
+      session.pendingMessages = getReplayablePendingRuntimeMessages(session);
+      log.info("Generator: superseded turn interrupted, releasing successor", {
+        sessionName,
+        cleared: queuedBefore - session.pendingMessages.length,
+        remaining: session.pendingMessages.length,
+      });
+      session.interrupted = false;
+    } else if (session.interrupted) {
+      log.info("Generator: provider interrupted unexpectedly, keeping queue for replay", {
         sessionName,
         count: session.pendingMessages.length,
       });
@@ -297,5 +311,6 @@ export async function* createRuntimeMessageGenerator({
       });
     }
     session.currentTurnPendingIds = undefined;
+    session.currentTurnSuperseded = false;
   }
 }

--- a/src/runtime/host-session.ts
+++ b/src/runtime/host-session.ts
@@ -118,6 +118,8 @@ export interface RuntimeHostStreamingSession {
   traceRunId?: string;
   /** Pending message ids yielded to the currently active provider turn. */
   currentTurnPendingIds?: string[];
+  /** Whether a newer prompt intentionally preempted the active provider turn. */
+  currentTurnSuperseded?: boolean;
   /** Whether the current provider turn has started at least one tool. Used to block unsafe replay. */
   currentTurnToolStarted?: boolean;
   /** Current Session Trace turn ID while a provider turn is active. */
@@ -150,13 +152,14 @@ export function stashPendingRuntimeMessages(
   session: RuntimeHostStreamingSession,
   stashedMessages: Map<string, RuntimeUserMessage[]>,
 ): void {
-  if (session.pendingMessages.length === 0) {
+  const replayableMessages = getReplayablePendingRuntimeMessages(session);
+  if (replayableMessages.length === 0) {
     return;
   }
 
   stashedMessages.set(
     sessionName,
-    session.pendingMessages.map((message) => ({ ...message })),
+    replayableMessages.map((message) => ({ ...message })),
   );
 }
 
@@ -170,9 +173,11 @@ export function stashCurrentTurnRuntimeMessages(
     return 0;
   }
 
-  const messages = session.pendingMessages
-    .filter((message) => message.pendingId && currentTurnPendingIds.has(message.pendingId))
-    .map((message) => ({ ...message }));
+  const messages = (
+    session.currentTurnSuperseded
+      ? getReplayablePendingRuntimeMessages(session)
+      : session.pendingMessages.filter((message) => message.pendingId && currentTurnPendingIds.has(message.pendingId))
+  ).map((message) => ({ ...message }));
 
   if (messages.length === 0) {
     return 0;
@@ -180,6 +185,21 @@ export function stashCurrentTurnRuntimeMessages(
 
   stashedMessages.set(sessionName, messages);
   return messages.length;
+}
+
+export function getReplayablePendingRuntimeMessages(session: RuntimeHostStreamingSession): RuntimeUserMessage[] {
+  if (!session.currentTurnSuperseded) {
+    return session.pendingMessages;
+  }
+
+  const currentTurnPendingIds = new Set(session.currentTurnPendingIds ?? []);
+  if (currentTurnPendingIds.size === 0) {
+    return session.pendingMessages;
+  }
+
+  return session.pendingMessages.filter(
+    (message) => !message.pendingId || !currentTurnPendingIds.has(message.pendingId),
+  );
 }
 
 export function shutdownRuntimeStreamingSession(session: RuntimeHostStreamingSession, reason?: string): void {

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -616,6 +616,14 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
       dbUpsertDaemonRestartEpoch({ restartEpoch: "epoch-active", reason: "test", createdAt: now });
 
       const dispatcher = createDispatcher(2);
+      const supersededMessage = createQueuedRuntimeUserMessage({
+        prompt: "superseded user work",
+        deliveryBarrier: "after_tool",
+      });
+      const queuedMessage = createQueuedRuntimeUserMessage({
+        prompt: "queued user work",
+        deliveryBarrier: "after_response",
+      });
       dispatcher.streamingSessions.set(
         "restart-active",
         createActiveSession({
@@ -632,12 +640,9 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
             rawSenderId: "178035101794451",
             normalizedSenderId: "5511947879044",
           },
-          pendingMessages: [
-            createQueuedRuntimeUserMessage({
-              prompt: "queued user work",
-              deliveryBarrier: "after_response",
-            }),
-          ],
+          pendingMessages: [supersededMessage, queuedMessage],
+          currentTurnPendingIds: [supersededMessage.pendingId!],
+          currentTurnSuperseded: true,
         }),
       );
       dispatcher.streamingSessions.set(
@@ -879,12 +884,19 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
         sourceMessageId: "1783105248.141999",
       };
       const interrupt = mock(async () => {});
+      const activeMessage = createQueuedRuntimeUserMessage({
+        prompt: "active work",
+        deliveryBarrier: "after_tool",
+        source: activeSource,
+      });
       const dispatcher = createDispatcher(2);
       const activeSession = createActiveSession({
         agentId: "main",
         turnActive: true,
         currentEffort: "xhigh",
         currentSource: activeSource,
+        pendingMessages: [activeMessage],
+        currentTurnPendingIds: [activeMessage.pendingId!],
         queryHandle: {
           provider: "codex",
           events: (async function* () {})(),
@@ -915,9 +927,10 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
       });
 
       expect(activeSession.currentSource).toEqual(activeSource);
-      expect(activeSession.pendingMessages).toHaveLength(1);
-      expect(activeSession.pendingMessages[0]?.deliveryBarrier).toBe("after_tool");
-      expect(activeSession.pendingMessages[0]?.launchPrompt?.source).toEqual(slackSource);
+      expect(activeSession.pendingMessages).toHaveLength(2);
+      expect(activeSession.pendingMessages[1]?.deliveryBarrier).toBe("after_tool");
+      expect(activeSession.pendingMessages[1]?.launchPrompt?.source).toEqual(slackSource);
+      expect(activeSession.currentTurnSuperseded).toBe(true);
       expect(activeSession.interrupted).toBe(true);
       expect(interrupt).toHaveBeenCalledTimes(1);
     } finally {

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -23,6 +23,7 @@ import {
 } from "./delivery-queue.js";
 import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
 import {
+  getReplayablePendingRuntimeMessages,
   shutdownRuntimeStreamingSession,
   stashPendingRuntimeMessages,
   type RuntimeHostStreamingSession,
@@ -194,7 +195,7 @@ export class RuntimeSessionDispatcher {
         });
         continue;
       }
-      const pendingMessages = session.pendingMessages.map(cloneRuntimeUserMessage);
+      const pendingMessages = getReplayablePendingRuntimeMessages(session).map(cloneRuntimeUserMessage);
       const nonIdle = isDaemonRestartNonIdleSession(session) || pendingMessages.length > 0;
       const snapshot = getAccumulator(sessionName, {
         agentId: session.agentId,
@@ -214,6 +215,7 @@ export class RuntimeSessionDispatcher {
           currentToolName: session.currentToolName ?? null,
           currentTaskBarrierTaskId: session.currentTaskBarrierTaskId ?? null,
           currentTurnPendingIds: session.currentTurnPendingIds ?? [],
+          currentTurnSuperseded: Boolean(session.currentTurnSuperseded),
         },
       });
       appendRestartPendingMessages(snapshot, pendingMessages);
@@ -971,6 +973,7 @@ export class RuntimeSessionDispatcher {
               this.scheduleIdleGapRecovery(sessionName, existing, sessionEntry?.sessionKey ?? sessionName);
             }
           } else {
+            existing.currentTurnSuperseded = true;
             nats
               .emit(`ravi.session.${sessionName}.runtime`, {
                 type: "turn.interrupt.requested",
@@ -1012,6 +1015,7 @@ export class RuntimeSessionDispatcher {
                 barrierSource: prompt.deliveryBarrierSource ?? null,
                 reason: decision.reason,
                 taskBarrierTaskId: prompt.taskBarrierTaskId ?? null,
+                currentTurnReplay: false,
               },
             });
             existing.interrupted = true;

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1246,6 +1246,42 @@ describe("runtime session trace instrumentation", () => {
     expect(getSessionTurn("turn-stream-closed-before-tool")?.status).toBe("aborted");
   });
 
+  it("restarts only the successor when a superseded provider turn closes without a terminal event", async () => {
+    const superseded = createQueuedRuntimeUserMessage({
+      prompt: "superseded work",
+      deliveryBarrier: "after_tool",
+      source,
+      _agentId: AGENT_ID,
+    });
+    const successor = createQueuedRuntimeUserMessage({
+      prompt: "new direction",
+      deliveryBarrier: "after_tool",
+      source,
+      _agentId: AGENT_ID,
+    });
+    const streaming = makeStreamingSession({
+      pendingMessages: [superseded, successor],
+      currentTurnPendingIds: superseded.pendingId ? [superseded.pendingId] : [],
+      currentTurnSuperseded: true,
+      currentTurnToolStarted: false,
+      toolRunning: false,
+      interrupted: true,
+    });
+    seedAdapterTrace(streaming, "turn-stream-closed-after-supersede");
+    const stashedMessages = new Map<string, RuntimeUserMessage[]>();
+    const restartRequests: Array<{ sessionName: string; reason: string }> = [];
+
+    await runTraceLoop(streaming, makeRuntimeSession([]), {
+      stashedMessages,
+      restartStashedSession: async (input) => {
+        restartRequests.push(input);
+      },
+    });
+
+    expect(stashedMessages.get(SESSION_NAME)?.map((message) => message.message.content)).toEqual(["new direction"]);
+    expect(restartRequests).toEqual([{ sessionName: SESSION_NAME, reason: "runtime_event_loop_closed" }]);
+  });
+
   it("records exhausted recovery without publishing a user-facing response", async () => {
     const alerts: RuntimeRecoveryExhaustedAlertInput[] = [];
     const runtimeEvents: Array<{ topic: string; data: Record<string, unknown> }> = [];


### PR DESCRIPTION
## Objective

Make prompt-driven interruption honor the newest user direction across every channel and runtime provider. A turn superseded by a later prompt must not be replayed ahead of that prompt, while genuine provider failures must remain recoverable.

## Problem

- The host queue treated every interruption as a recovery event and retained the already-yielded prompt for replay.
- After a newer prompt interrupted an active turn, the next provider turn could therefore receive the superseded prompt again before the newer direction.

## Solution

- Mark only prompt-driven host interruptions as superseding the active turn.
- Remove the active turn's yielded queue atoms from retry ownership when that interruption completes or the runtime restarts.
- Keep successor prompts ordered and eligible for immediate delivery.
- Preserve the existing replay behavior for unexpected provider or runtime interruptions.
- Document the queue invariant and cover normal completion, interruption, recovery stash, daemon restart, and unterminated provider paths.

## Practical impact

- New user direction sent during an interruptible active turn becomes the next provider input.
- The behavior is provider-neutral and channel-neutral.
- Recovery still replays active work when a provider stops unexpectedly without a newer prompt.

## What does NOT change

- Delivery barriers and unsafe-tool interruption rules.
- Native provider steering behavior.
- Durable conversation history for the superseded user message.
- FIFO ordering among remaining eligible prompts.

## Validation

- `bun test src/runtime/delivery-queue.test.ts src/runtime/session-dispatcher.test.ts src/bot.runtime-guards.test.ts`
- `bun test src/runtime/session-trace.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts`
- Repository pre-push gate: SDK drift check, build, typecheck, segmented test matrix, CLI tests, runtime guards, and SDK tests.

## Risks

- An intentionally interrupted turn is no longer retried. This is the required behavior; its durable history remains available to the next turn.
- Unexpected interruptions retain their previous recovery semantics and are covered separately.

## Rollback

- Revert the PR merge commit to restore the previous queue behavior.

## Follow-ups

- None.
