### PR TITLE
spec: separate channel storage from runtime admission

### DIFF
--- a/.ravi/specs/channels/messages/CHECKS.md
+++ b/.ravi/specs/channels/messages/CHECKS.md
@@ -6,3 +6,7 @@
 - [ ] Edits and deletes MUST target an existing canonical message when one is known.
 - [ ] Inbound user messages MUST NOT be the default runtime status anchor.
 - [ ] New outbound messages from the same session and chat/thread SHOULD become the preferred runtime status anchor.
+- [ ] Persisting or replaying a channel message MUST NOT implicitly create a provider turn.
+- [ ] Only explicitly admitted provider ingress materializes a canonical prompt turn.
+- [ ] One stable admission identity MUST produce at most one turn across retries.
+- [ ] Generic ChannelBackend code MUST NOT infer provider-private execution intent.

--- a/.ravi/specs/channels/messages/SPEC.md
+++ b/.ravi/specs/channels/messages/SPEC.md
@@ -83,3 +83,26 @@ Replies, quotes and mentions MUST resolve to canonical references when possible 
 New outbound agent messages MUST preserve the stable origin session key as a
 queryable field. A mutable session-action target MUST NOT be inferred from
 agent identity alone.
+
+## Runtime Admission
+
+Canonical channel storage and runtime prompt admission are separate
+operations.
+
+- Receiving, storing, synchronizing, editing, reacting to, or delivering a
+  `ChannelMessage` MUST NOT by itself create a provider turn.
+- A native channel provider MUST explicitly admit an inbound message or
+  action to `ChannelBackend` before Ravi materializes a canonical prompt turn.
+- Provider admission SHOULD be based on explicit execution intent such as a
+  direct agent surface, mention, command, interactive action, or configured
+  automation.
+- Ordinary conversation that is not admitted MAY remain fully available to
+  the channel product without a Ravi session or provider invocation.
+- Replaying canonical channel history MUST NOT retroactively admit a prompt
+  turn.
+- Admission identity and idempotency MUST remain stable across delivery
+  retries. One admitted intent MUST materialize at most one canonical prompt
+  turn.
+- The provider decides whether a product message is execution intent; the
+  generic backend MUST NOT infer private product policy from text, channel
+  membership, or participant ordering.

--- a/.ravi/specs/permissions/delegation/CHECKS.md
+++ b/.ravi/specs/permissions/delegation/CHECKS.md
@@ -12,3 +12,10 @@
   in traces and provenance.
 - `bun test src/permissions/delegation.test.ts src/permissions/capability-context.test.ts`
   SHOULD pass after changing delegation behavior.
+- Externally governed authority is scoped to one explicit provider execution
+  compartment and never mutates ambient Agent permissions.
+- Signed turn grants cannot exceed the locally accepted provider ceiling or
+  local host/provider/runtime guards.
+- Wrong audience, binding revision, operation digest, expiry, replay identity,
+  or signature fails closed.
+- Provider-private Role vocabulary never enters the generic runtime contract.

--- a/.ravi/specs/permissions/delegation/SPEC.md
+++ b/.ravi/specs/permissions/delegation/SPEC.md
@@ -92,6 +92,37 @@ effective_caps = automation_caps INTERSECT agent_caps INTERSECT target_surface_c
 
 Internal execution MUST use an explicit `automation:<id>` or `system:<id>` principal. It MUST NOT silently inherit the last human speaker.
 
+## Externally Governed Compartments
+
+A provider MAY supply an authenticated, signed, short-lived authority grant
+for one externally governed execution. That grant MUST materialize as an
+explicit execution compartment; it MUST NOT rewrite the executor Agent's
+ambient permissions.
+
+For such a turn:
+
+```text
+effective_caps =
+  accepted_provider_ceiling
+  INTERSECT verified_turn_grant
+  INTERSECT local_host_and_provider_guards
+  INTERSECT applicable_approval
+  INTERSECT runtime_constraints
+```
+
+- The accepted provider ceiling is a locally persisted maximum for one
+  provider/subject binding and revision.
+- The verified turn grant MAY replace ordinary actor/surface role expansion
+  only inside that compartment.
+- A grant MUST be bound to provider audience, subject/binding revision,
+  operation or normalized arguments digest, expiry, and replay identity.
+- Revocation, expiry, stale binding revision, invalid signature, failed local
+  guard, missing approval, or runtime fencing MUST fail closed.
+- Compartment authority MUST NOT become visible to unrelated chats, sessions,
+  automations, providers, or direct local execution.
+- Generic Ravi contracts MUST remain provider-neutral and MUST NOT ingest the
+  provider's organizational Role vocabulary.
+
 For app execution:
 
 ```text


### PR DESCRIPTION
## Objective

Define a provider-neutral boundary between canonical channel-message persistence and explicit runtime prompt admission.

## Problem

Persisting or replaying an ordinary channel message could otherwise be interpreted as implicit authority to invoke an agent, while externally governed authority could be confused with the Agent's ambient local permissions.

## Solution

- Require native providers to explicitly admit direct agent surfaces, mentions, commands, interactive actions, or configured automations.
- Preserve one stable admission identity so delivery retries materialize at most one canonical prompt turn.
- Define externally governed execution as a signed, short-lived compartment bounded by a locally accepted provider ceiling, local guards, approvals, and runtime constraints.

## Practical impact

Channel products may retain ordinary human conversation without invoking Ravi. Explicit execution intent remains provider-owned, auditable, and idempotent. External authority can constrain one execution without importing private organizational Role vocabulary into generic Ravi contracts.

## What does NOT change

This PR changes normative specifications only. It does not change runtime code, generated SDK artifacts, provider behavior, release configuration, or the existing local authorization boundary.

## Validation

- `ravi specs sync` indexed all 218 specifications.
- The complete repository pre-push hook passed generated SDK drift checks, build, typecheck, all test suites, execution-authority schema checks, and SDK checks.

## Risks

The main risk is provider implementations adopting the contract inconsistently. The added checks make the required admission, idempotency, isolation, and fail-closed behavior explicit for subsequent implementation and conformance tests.

## Rollback

Revert commit `b1565bb8` to remove the four specification changes. No data migration, generated artifact rollback, or runtime deployment is required.
