### PR TITLE
fix(sdk): tolerate bounded authority clock skew

### DIFF
--- a/packages/ravi-os-sdk/src/__tests__/execution-authority.test.ts
+++ b/packages/ravi-os-sdk/src/__tests__/execution-authority.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import {
   ApprovalConsumptionRecordSchema,
   BindingAuthorityEnvelopeClaimsSchema,
+  EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS,
   ExactExecutionEffectSchema,
   ExecutionCapabilityGrantClaimsSchema,
   LocalAuthorityAttenuationSchema,
@@ -327,6 +328,122 @@ describe("execution authority public contract", () => {
         }).success,
       ).toBe(true);
     }
+  });
+
+  it("tolerates bounded issuer clock skew without extending expiration", async () => {
+    const artifacts = await validArtifacts();
+    const authorityNow = "2026-07-26T18:01:00.000Z";
+    const runtimeNow = "2026-07-26T18:00:59.700Z";
+    const envelopeClaims = BindingAuthorityEnvelopeClaimsSchema.parse({
+      ...artifacts.envelopeClaims,
+      issuedAt: authorityNow,
+      notBefore: authorityNow,
+    });
+    const leaseClaims = SignedExecutionRouteLeaseSchema.shape.claims.parse({
+      ...artifacts.leaseClaims,
+      issuedAt: authorityNow,
+      notBefore: authorityNow,
+    });
+    const grantClaims = ExecutionCapabilityGrantClaimsSchema.parse({
+      ...artifacts.grantClaims,
+      issuedAt: authorityNow,
+      notBefore: authorityNow,
+    });
+    const approvalRequest = OperationApprovalRequestSchema.parse({
+      ...artifacts.approvalRequest,
+      issuedAt: authorityNow,
+      notBefore: authorityNow,
+    });
+    const decision = await approvalDecision(approvalRequest, {
+      decidedAt: authorityNow,
+      issuedAt: authorityNow,
+      notBefore: authorityNow,
+    });
+    const skewedKeySet = TrustedAuthorityKeySetSchema.parse({
+      ...keySet([
+        {
+          ...activeKey(),
+          notBefore: authorityNow,
+        },
+      ]),
+      acceptedAt: authorityNow,
+    });
+
+    await expect(
+      authorizeExecutionEffect({
+        ...artifacts.input,
+        now: runtimeNow,
+        keySet: skewedKeySet,
+        acceptedEnvelope: await signClaims(envelopeClaims),
+        routeLease: await signClaims(leaseClaims),
+        grant: await signClaims(grantClaims),
+        approval: {
+          required: true,
+          decision,
+          consumedApprovalIds: new Set(),
+        },
+      }),
+    ).resolves.toMatchObject({ allowed: true });
+
+    const beyondTolerance = new Date(
+      Date.parse(NOW) + EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS + 1,
+    ).toISOString();
+    const futureGrantClaims = ExecutionCapabilityGrantClaimsSchema.parse({
+      ...artifacts.grantClaims,
+      issuedAt: NOW,
+      notBefore: beyondTolerance,
+    });
+    await expect(
+      authorizeExecutionEffect({
+        ...artifacts.input,
+        grant: await signClaims(futureGrantClaims),
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "not_yet_valid" });
+
+    await expect(
+      authorizeExecutionEffect({
+        ...artifacts.input,
+        now: artifacts.grantClaims.expiresAt,
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "expired" });
+
+    const nextKeySet = TrustedAuthorityKeySetSchema.parse({
+      ...keySet(
+        [
+          {
+            ...activeKey(),
+            status: "retiring",
+            retiredAt: authorityNow,
+            acceptUntil: "2026-07-26T18:06:00.000Z",
+          },
+          {
+            ...activeKey(nextPublicKey, "hub-key-b"),
+            notBefore: authorityNow,
+          },
+        ],
+        "hub-key-b",
+        5,
+      ),
+      acceptedAt: authorityNow,
+    });
+    expect(
+      validateAuthorityKeySetAdvance(
+        artifacts.keySet,
+        nextKeySet,
+        runtimeNow,
+      ),
+    ).toEqual({ accepted: true });
+    expect(
+      validateAuthorityKeySetAdvance(
+        artifacts.keySet,
+        nextKeySet,
+        new Date(
+          Date.parse(authorityNow) -
+            EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS -
+            1,
+        ).toISOString(),
+      ),
+    ).toEqual({ accepted: false, reason: "active_key_invalid" });
   });
 
   it("fails closed for every exact-effect mismatch", async () => {

--- a/packages/ravi-os-sdk/src/execution-authority.ts
+++ b/packages/ravi-os-sdk/src/execution-authority.ts
@@ -11,6 +11,14 @@ export const MAX_EXECUTION_GRANT_LIFETIME_MS = 300_000;
 export const MAX_ROUTE_LEASE_LIFETIME_MS = 300_000;
 export const MAX_APPROVAL_LIFETIME_MS = 900_000;
 export const MAX_AUTHORITY_KEY_OVERLAP_MS = 900_000;
+/**
+ * Maximum tolerated positive difference between an authority issuer's clock
+ * and the runtime clock when evaluating start-of-validity boundaries.
+ *
+ * This tolerance never extends expiration, retirement, or revocation
+ * boundaries.
+ */
+export const EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS = 5_000;
 
 const textEncoder = new TextEncoder();
 
@@ -874,7 +882,12 @@ function checkArtifactTime(
   artifact: SignedAuthorityArtifact,
   nowMs: number,
 ): ExecutionAuthorityDenialReason | undefined {
-  if (nowMs < Date.parse(artifact.claims.notBefore)) return "not_yet_valid";
+  if (
+    nowMs + EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS <
+    Date.parse(artifact.claims.notBefore)
+  ) {
+    return "not_yet_valid";
+  }
   if (nowMs >= Date.parse(artifact.claims.expiresAt)) return "expired";
   return undefined;
 }
@@ -898,7 +911,7 @@ async function verifyArtifact(
   const keyEnd = Date.parse(key.notAfter);
   const artifactIssuedAt = Date.parse(artifact.claims.issuedAt);
   if (
-    nowMs < keyStart ||
+    nowMs + EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS < keyStart ||
     nowMs >= keyEnd ||
     artifactIssuedAt < keyStart ||
     artifactIssuedAt >= keyEnd
@@ -1116,7 +1129,10 @@ export async function authorizeExecutionEffect(
   if (trustedKeys.revision < exact.minimumKeySetRevision) {
     return denied("key_set_downgrade");
   }
-  if (nowMs < Date.parse(trustedKeys.acceptedAt)) {
+  if (
+    nowMs + EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS <
+    Date.parse(trustedKeys.acceptedAt)
+  ) {
     return denied("key_inactive");
   }
   if (
@@ -1463,7 +1479,8 @@ export function validateAuthorityKeySetAdvance(
   if (
     activeKey === undefined ||
     activeKey.status !== "active" ||
-    nowMs < Date.parse(activeKey.notBefore) ||
+    nowMs + EXECUTION_AUTHORITY_CLOCK_SKEW_TOLERANCE_MS <
+      Date.parse(activeKey.notBefore) ||
     nowMs >= Date.parse(activeKey.notAfter)
   ) {
     return { accepted: false, reason: "active_key_invalid" };

--- a/packages/ravi-os-sdk/src/generated/execution-authority.schema.json
+++ b/packages/ravi-os-sdk/src/generated/execution-authority.schema.json
@@ -2233,7 +2233,7 @@
   },
   "protocol": "ravi.execution.authority",
   "schemaVersion": 1,
-  "sourceDigest": "6b805f9e92d13a078daa09ac37383b290b92928925301401356ae6d8a71d791e",
+  "sourceDigest": "b157659a853cccc64e7586321c92c9b997bdfaa2b4f6fd4824311214901e58f6",
   "sourcePath": "packages/ravi-os-sdk/src/execution-authority.ts",
   "title": "Ravi neutral execution authority contract"
 }


### PR DESCRIPTION
## Objective

Allow neutral execution-authority artifacts issued by a trusted authority to cross a small distributed clock difference without opening expiry or revocation windows.

## Problem

- A runtime whose clock trails the issuer by a few hundred milliseconds rejects a freshly issued lease or grant as `not_yet_valid`.
- The same race affects trusted-key acceptance and key activation at the exact start boundary.
- This can fail a legitimate execution before local policy is evaluated.

## Solution

- Define a public 5-second clock-skew tolerance for start-of-validity checks.
- Apply it only to artifact `notBefore`, verification-key start, and trusted-key-set acceptance.
- Keep expiration, key end, retirement, revocation, artifact issuance, and local attenuation checks strict.
- Regenerate the public execution-authority schema digest.

## Practical impact

- Distributed runtimes can authorize freshly issued effects when their clock is slightly behind the issuer.
- Differences beyond 5 seconds still fail closed.

## What does NOT change

- No lifetime, expiration, revocation, retirement, replay, approval-consumption, or local-deny semantics change.
- The protocol schema version and wire shapes remain unchanged.

## Validation

- `bun test packages/ravi-os-sdk/src/__tests__/execution-authority.test.ts`
- `bun run sdk:execution-authority:check`
- `bun run sdk:check`
- Full pre-push build, typecheck, and test suite.

## Testing

- Accepts a complete signed authority decision when the runtime clock is 300 ms behind.
- Rejects a `notBefore` boundary more than the 5-second tolerance ahead.
- Rejects at the exact expiration boundary, proving the tolerance does not extend expiry.

## Risks

- A compromised issuer could make a start boundary effective up to 5 seconds earlier on a lagging runtime; the bound is fixed, public, and limited to already trusted signed authority.

## Rollback

- Revert this commit to restore strict same-millisecond start checks; no migration or stored-data rollback is required.

## Follow-ups

- None.
