### PR TITLE
Support handler-authorized native actions

### DIFF
--- a/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json
+++ b/packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json
@@ -1,4 +1,5 @@
 {
+  "authorizationMode": "driver_handler",
   "description": "Create a provider-owned collaboration space.",
   "inputSchema": {
     "properties": {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.capsule.json
@@ -21,8 +21,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/installation-credential.json"
     },
     {
-      "sha256": "062b8df900ed52f13b9fe68329a11a76c711ceae33e71dcaffdf75981b4eefb0",
-      "sizeBytes": 299,
+      "sha256": "e757ac3d0abb6fe0ae15e33644832a588a9f019d054ed2f6fef3a4db0bf4bf77",
+      "sizeBytes": 340,
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/local-agent-action-descriptor.json"
     },
     {
@@ -46,8 +46,8 @@
       "targetPath": "packages/ravi-os-sdk/src/__tests__/fixtures/native-channel-driver/runtime-descriptor.json"
     },
     {
-      "sha256": "104e326cdb967bd518d9dcc2592594fb18918b077fbcc6140a9fae3a57f5241b",
-      "sizeBytes": 19586,
+      "sha256": "a70a2fbd36af62bdaee46cec9d0aac4276507fa120a39698e4847271fe136f76",
+      "sizeBytes": 19969,
       "targetPath": "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
     }
   ],
@@ -76,7 +76,7 @@
     "packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json"
   ],
   "formatVersion": 1,
-  "outputDigest": "15151358749e25b525f5bb4bfae815c5204379c1fc31c6d1de4db4528cbb4dac",
+  "outputDigest": "1173f81fdbe6bf30fd9db61862f07f89722ee8063628389635b2f3641cf7fd2b",
   "rationale": "Channel runners need a versioned provider-neutral boundary to load explicitly configured local channel drivers, bind matching installation credentials, reconcile locally managed agents, register source-scoped local actions without exporting runtime authorization, and include runtimes in lifecycle and health.",
   "schemaAllowlist": [
     {
@@ -173,11 +173,16 @@
       "schema": "NativeLocalAgentActionToolName"
     },
     {
+      "fields": [],
+      "schema": "NativeLocalAgentActionAuthorizationMode"
+    },
+    {
       "fields": [
         "toolName",
         "description",
         "inputSchema",
-        "sourceAccountId"
+        "sourceAccountId",
+        "authorizationMode"
       ],
       "schema": "NativeLocalAgentActionDescriptor"
     },
@@ -227,7 +232,7 @@
       "schema": "RemoteInstallationCredential"
     }
   ],
-  "sourceDigest": "838e646ed2c4ab9d5d631231355cf7275f779ce99612154a4cd37aa9a827f212",
+  "sourceDigest": "aefbbeba765dd9293320b992b9d171ab7ec278596b6db4b82f17e0aefb820913",
   "targetRepository": "filipexyz/ravi",
   "validations": [
     {

--- a/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
+++ b/packages/ravi-os-sdk/src/generated/native-channel-driver.schema.json
@@ -410,10 +410,25 @@
       ],
       "type": "object"
     },
+    "NativeLocalAgentActionAuthorizationMode": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "enum": [
+        "runtime_context",
+        "driver_handler"
+      ],
+      "type": "string"
+    },
     "NativeLocalAgentActionDescriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
       "properties": {
+        "authorizationMode": {
+          "enum": [
+            "runtime_context",
+            "driver_handler"
+          ],
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
@@ -687,6 +702,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "capsuleVersion": 1,
   "compatibilityProfile": "additive-v1",
-  "sourceDigest": "838e646ed2c4ab9d5d631231355cf7275f779ce99612154a4cd37aa9a827f212",
+  "sourceDigest": "aefbbeba765dd9293320b992b9d171ab7ec278596b6db4b82f17e0aefb820913",
   "title": "native-channel-driver channel capability"
 }

--- a/packages/ravi-os-sdk/src/native-channel-driver.ts
+++ b/packages/ravi-os-sdk/src/native-channel-driver.ts
@@ -107,6 +107,11 @@ export const NativeLocalAgentActionToolNameSchema = z
     "local agent action tool name must be lowercase snake case",
   );
 
+export const NativeLocalAgentActionAuthorizationModeSchema = z.enum([
+  "runtime_context",
+  "driver_handler",
+]);
+
 const NativeLocalAgentActionArgumentsSchema = z
   .record(z.string(), z.unknown())
   .refine(
@@ -136,6 +141,7 @@ export const NativeLocalAgentActionDescriptorSchema = z
         "local agent action input schema is too large",
       ),
     sourceAccountId: ChannelBackendOpaqueIdSchema.optional(),
+    authorizationMode: NativeLocalAgentActionAuthorizationModeSchema.optional(),
   })
   .strict();
 

--- a/src/channels/native/driver.ts
+++ b/src/channels/native/driver.ts
@@ -94,6 +94,8 @@ export const NativeLocalAgentActionToolNameSchema = z
   .string()
   .regex(/^[a-z][a-z0-9_]{0,127}$/, "local agent action tool name must be lowercase snake case");
 
+export const NativeLocalAgentActionAuthorizationModeSchema = z.enum(["runtime_context", "driver_handler"]);
+
 const NativeLocalAgentActionArgumentsSchema = z
   .record(z.string(), z.unknown())
   .refine(
@@ -115,6 +117,7 @@ export const NativeLocalAgentActionDescriptorSchema = z
         "local agent action input schema is too large",
       ),
     sourceAccountId: ChannelBackendOpaqueIdSchema.optional(),
+    authorizationMode: NativeLocalAgentActionAuthorizationModeSchema.optional(),
   })
   .strict();
 

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -309,6 +309,17 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/channels/", "src/router/"]);
   });
 
+  it("accepts native local action coverage across channel and runtime changes", () => {
+    const result = runCoverageGate([
+      "src/channels/native/driver.ts",
+      "src/runtime/host-services.ts",
+      "src/runtime/native-local-agent-actions.test.ts",
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/channels/", "src/runtime/"]);
+  });
+
   it("requires a focused native channel test in the diff", () => {
     const missing = runCoverageGate(["src/channels/slack/socket-mode.ts"]);
     const covered = runCoverageGate(["src/channels/slack/socket-mode.ts", "src/channels/slack/socket-mode.test.ts"]);

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -30,6 +30,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/channels/session-prompt.test.ts",
     "src/channels/slack/media.test.ts",
     "src/channels/slack/socket-mode.test.ts",
+    "src/runtime/native-local-agent-actions.test.ts",
   ],
   "src/omni/": [
     "src/omni/consumer-context.test.ts",
@@ -52,6 +53,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/channels/backend.test.ts",
     "src/runtime/index.test.ts",
     "src/runtime/model-catalog.test.ts",
+    "src/runtime/native-local-agent-actions.test.ts",
     "src/runtime/context-registry.test.ts",
     "src/runtime/observation-plane.test.ts",
     "src/runtime/runtime-request-context.test.ts",

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -111,7 +111,9 @@ function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDy
   const nativeActions = nativeLocalAgentActions
     .list(context)
     .filter(
-      ({ toolName }) => !commandToolNames.has(toolName) && canWithCapabilityContext(context, "use", "tool", toolName),
+      ({ toolName, authorizationMode }) =>
+        !commandToolNames.has(toolName) &&
+        (authorizationMode === "driver_handler" || canWithCapabilityContext(context, "use", "tool", toolName)),
     )
     .map(
       ({ toolName, description, inputSchema }) =>
@@ -311,8 +313,8 @@ async function executeNativeLocalAgentAction(
   request: RuntimeDynamicToolCallRequest,
   executionOptions?: RuntimeDynamicToolExecutionOptions,
 ): Promise<RuntimeDynamicToolCallResult> {
-  const available = nativeLocalAgentActions.list(options.context).some(({ toolName }) => toolName === request.toolName);
-  if (!available) {
+  const action = nativeLocalAgentActions.list(options.context).find(({ toolName }) => toolName === request.toolName);
+  if (action === undefined) {
     return {
       success: false,
       contentItems: [
@@ -323,24 +325,26 @@ async function executeNativeLocalAgentAction(
       ],
     };
   }
-  const authorization = await authorizeRuntimeContext({
-    context: options.context,
-    permission: "use",
-    objectType: "tool",
-    objectId: request.toolName,
-    eventData: executionOptions?.eventData,
-  });
-  if (!authorization.allowed) {
-    return {
-      success: false,
-      reason: authorization.reason,
-      contentItems: [
-        {
-          type: "inputText",
-          text: authorization.reason ?? `${request.toolName} tool permission denied.`,
-        },
-      ],
-    };
+  if (action.authorizationMode !== "driver_handler") {
+    const authorization = await authorizeRuntimeContext({
+      context: options.context,
+      permission: "use",
+      objectType: "tool",
+      objectId: request.toolName,
+      eventData: executionOptions?.eventData,
+    });
+    if (!authorization.allowed) {
+      return {
+        success: false,
+        reason: authorization.reason,
+        contentItems: [
+          {
+            type: "inputText",
+            text: authorization.reason ?? `${request.toolName} tool permission denied.`,
+          },
+        ],
+      };
+    }
   }
   try {
     const result = await runDynamicToolWithTimeout(request.toolName, () =>

--- a/src/runtime/native-local-agent-actions.test.ts
+++ b/src/runtime/native-local-agent-actions.test.ts
@@ -65,6 +65,105 @@ describe("runtime native local agent actions", () => {
     expect(services.listDynamicTools().some(({ name }) => name === "example_create_space")).toBe(false);
   });
 
+  it("delegates explicit driver-handler action authorization without ambient turn capabilities", async () => {
+    let invoked = 0;
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+        sourceAccountId: "account-1",
+        authorizationMode: "driver_handler",
+      },
+      handler: async (request) => {
+        invoked += 1;
+        return {
+          protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+          schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+          requestId: request.requestId,
+          disposition: "completed",
+          text: "Created.",
+          completedAt: "2026-07-26T12:00:01.000Z",
+        };
+      },
+    });
+    const runtimeContext = context(false);
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+
+    expect(services.listDynamicTools().map(({ name }) => name)).toContain("example_create_space");
+    expect(
+      await services.executeDynamicTool({
+        toolName: "example_create_space",
+        callId: "request-handler-authorized",
+        arguments: { name: "roadmap" },
+      }),
+    ).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "Created." }],
+    });
+    expect(invoked).toBe(1);
+  });
+
+  it("keeps the driver handler denial final", async () => {
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-local",
+      descriptor: {
+        toolName: "example_create_space",
+        description: "Create a provider-owned collaboration space.",
+        inputSchema: { type: "object", properties: {} },
+        sourceAccountId: "account-1",
+        authorizationMode: "driver_handler",
+      },
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "rejected",
+        error: {
+          code: "LOCAL_PERMISSION_DENIED",
+          category: "authorization",
+          retryable: false,
+        },
+        completedAt: "2026-07-26T12:00:01.000Z",
+      }),
+    });
+    const runtimeContext = context(false);
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+
+    expect(
+      await services.executeDynamicTool({
+        toolName: "example_create_space",
+        callId: "request-handler-denied",
+        arguments: {},
+      }),
+    ).toEqual({
+      success: false,
+      reason: "LOCAL_PERMISSION_DENIED",
+      contentItems: [
+        {
+          type: "inputText",
+          text: "Action rejected: LOCAL_PERMISSION_DENIED",
+        },
+      ],
+    });
+  });
+
   it("does not advertise a driver action that collides with any built-in command", () => {
     nativeLocalAgentActions.register({
       provider: "example",


### PR DESCRIPTION
## Objective

Allow a native channel driver to declare that its registered handler is the final authorization boundary for one source-scoped local action. This supports drivers whose delegated turns intentionally carry no ambient tool capability while preserving the existing behavior by default.

## Problem

A local action was advertised only when the delegated runtime context contained a matching tool capability. Drivers that validate signed, current authority inside their own effect handler could therefore never expose the action to a zero-capability delegated turn, even though the handler remained able to deny it safely.

## Solution

- Add an explicit `driver_handler` authorization mode to the provider-neutral action descriptor.
- Keep runtime-context capability authorization as the default when the field is absent.
- Expose and invoke handler-authorized actions only through the matching registered driver and source account.
- Regenerate the public schema, capsule, and canonical fixture.

## Practical impact

Native channel drivers can expose narrowly registered actions to delegated turns without materializing broad agent permissions. Existing drivers and callers continue to use runtime-context authorization unless they explicitly opt into the new mode.

## What does NOT change

Action registration, source scoping, schema validation, and handler execution remain mandatory. Handler denials are still final, and the new mode does not grant ambient capabilities or authorize any other tool.

## Validation

- Focused native local action and runtime tests passed.
- Native channel driver SDK contract tests passed.
- Typecheck and generated artifact checks passed.
- The repository full pre-push test suite passed.

## Risks

A driver that opts into handler authorization must implement a fail-closed handler because the ambient runtime capability check no longer decides that specific action. The mode is explicit and source-scoped to contain this risk, while omission preserves the prior behavior.

## Rollback

Revert this commit to remove the optional descriptor mode and restore runtime-context authorization for every local action. No persisted state or migration needs reversal.

## Follow-ups

Additional native actions can adopt this mode only when their driver handler independently enforces the complete effect policy.