### PR TITLE
Bridge native agent actions across processes

### DIFF
--- a/.ravi/specs/channels/backend/CHECKS.md
+++ b/.ravi/specs/channels/backend/CHECKS.md
@@ -16,4 +16,9 @@
 - Runtime events and output MUST resolve from the accepted binding.
 - Local actions MUST be bounded, unique, source-scoped, and locally
   authorized.
+- Local-action descriptors MUST cross the runner/daemon boundary only inside
+  the trusted accepted-turn envelope.
+- Cross-process invocation MUST validate request/result correlation and fail
+  closed on missing, stale, ambiguous, or mismatched ownership.
+- Local-action failure MUST NOT fall back to shell or another mutation path.
 - Public types MUST contain no hosted product entities or private policy.

--- a/.ravi/specs/channels/backend/RUNBOOK.md
+++ b/.ravi/specs/channels/backend/RUNBOOK.md
@@ -17,3 +17,7 @@
    interruption and verify ordered readback.
 10. Register two local actions with colliding scope/name and confirm discovery
    fails closed; invoke an authorized unique action in its exact source.
+11. Run Channel runner and runtime host in separate processes. Confirm the
+    accepted prompt carries the matching descriptor, request/reply reaches the
+    runner-local handler once, and a copied source or stopped runner fails
+    closed without shell fallback.

--- a/.ravi/specs/channels/backend/SPEC.md
+++ b/.ravi/specs/channels/backend/SPEC.md
@@ -119,9 +119,21 @@ MUST both recover after expiry or restart.
   host ABI.
 - Registration and discovery MUST be scoped to provider, Channel instance,
   source account, active Agent, Session, and current source context.
+- The Channel runner and runtime daemon are separate processes. The backend
+  MUST snapshot only the matching bounded descriptors into its trusted
+  accepted-turn correlation envelope before prompt publication.
+- Runtime discovery MUST accept that snapshot only when its provider and
+  account exactly match the current turn source.
+- Invocation MAY cross an internal request/reply bridge to the runner-local
+  handler, but the bridge MUST carry no new authority and MUST validate the
+  complete typed request and correlated typed result.
 - Duplicate ambiguous tool names MUST fail closed.
 - Invocation MUST require the runtime's normal local tool permission
-  immediately before the handler runs.
+  immediately before the handler runs unless the descriptor explicitly makes
+  the driver handler the final authorization boundary.
+- No responder, timeout, malformed frame, correlation mismatch, source
+  mismatch, duplicate ownership, or runner restart MUST fail closed. Runtime
+  MUST NOT fall back to shell or another mutation surface.
 - Descriptors and results MUST be bounded and provider-neutral. Product Roles,
   memberships, hosted policy, and hosted product entities MUST NOT enter this
   contract.
@@ -156,6 +168,8 @@ commercial policy, private endpoint schemas, or private authorization rules.
   behavior after convergence.
 - Runtime readback and output correlation resolve from the accepted binding.
 - Local actions remain provider/account/source scoped and locally authorized.
+- A two-process fixture proves one accepted turn advertises the exact action,
+  invokes the runner-local handler once, and fails closed without a runner.
 
 ## Known Failure Modes
 

--- a/.ravi/specs/channels/backend/WHY.md
+++ b/.ravi/specs/channels/backend/WHY.md
@@ -10,6 +10,12 @@ Wire ingress serves externally loaded drivers. Resolved ingress lets an
 in-process adapter preserve its richer Ravi route and canonical provider Chat
 without duplicating the backend or creating a second Chat.
 
+Local Agent action handlers live beside their drivers in the Channel runner,
+while provider host services live in the runtime daemon. Carrying bounded
+descriptors in the already trusted accepted-turn envelope makes discovery
+durable and source-specific. A narrow internal request/reply bridge then
+forwards invocation without moving authorization or product policy into NATS.
+
 A small provider inbox is still necessary when the provider's acknowledgement
 deadline is shorter than identity, file, route, or prompt normalization. It
 protects the transport edge; the backend receipt protects canonical

--- a/.ravi/specs/channels/runner/CHECKS.md
+++ b/.ravi/specs/channels/runner/CHECKS.md
@@ -13,3 +13,6 @@
 - [ ] Runner shutdown MUST suppress late adapter callbacks and MUST leave every stopped Slack adapter disconnected.
 - [ ] PM2 process liveness alone MUST NOT be presented as Slack connection health.
 - [ ] A PM2 PID change during health probing MUST refresh the process snapshot and retry the replacement PID once.
+- [ ] Local-action descriptor resolution and request/reply responders MUST start after native driver action registration.
+- [ ] Runner shutdown MUST retire the local-action responder and resolver before closing NATS.
+- [ ] A two-process test MUST prove exact-source discovery, one invocation, and fail-closed behavior without shell fallback.

--- a/.ravi/specs/channels/runner/RUNBOOK.md
+++ b/.ravi/specs/channels/runner/RUNBOOK.md
@@ -46,3 +46,14 @@ On shutdown the runner must:
 3. Requeue or finish in-flight outbound jobs.
 4. Release scoped platform locks.
 5. Release runner process lock.
+
+## Debugging A Local Agent Action
+
+1. Confirm the native runtime registered one unique action for the expected
+   provider and account.
+2. Confirm Channel-Backend prompt metadata contains the bounded descriptor.
+3. Confirm runtime context source matches that descriptor envelope exactly.
+4. Confirm the internal requester reaches the runner responder and preserves
+   request/result correlation.
+5. Treat no responder, timeout, mismatch, or retired handler as unavailable;
+   never retry through shell.

--- a/.ravi/specs/channels/runner/SPEC.md
+++ b/.ravi/specs/channels/runner/SPEC.md
@@ -21,6 +21,12 @@ normative: true
 
 `ravi daemon` MUST own sessions, agents and runtime. It MUST NOT open Slack Socket Mode connections or resolve Slack transport credentials.
 
+Driver-owned local Agent action handlers MUST remain in `ravi channels`.
+The runner MUST expose their bounded descriptors to Channel-Backend turn
+publication and serve typed internal request/reply invocation from
+`ravi daemon`. The runner MUST NOT grant runtime capability or expose driver
+credentials through that bridge.
+
 ## Outbound
 
 User-visible native channel delivery MUST cross `CHANNEL_OUTBOUND` before adapter delivery.
@@ -66,3 +72,12 @@ PID as current.
 ## Locks
 
 Adapters SHOULD use process or credential-scoped locks before opening external sockets. Slack MUST prevent duplicate Socket Mode consumers for the same connection.
+
+## Local Action Lifecycle
+
+- Descriptor publication and invocation responders MUST start only after
+  native driver runtimes have registered their actions.
+- Publication reconciliation MUST observe the current runner-local registry.
+- Shutdown MUST stop the responder and descriptor resolver before disposing
+  driver runtimes and closing NATS.
+- Missing or retired handlers MUST fail closed with bounded safe results.

--- a/.ravi/specs/channels/runner/WHY.md
+++ b/.ravi/specs/channels/runner/WHY.md
@@ -19,3 +19,7 @@ This separation avoids three failure classes:
 
 The first implementation can be one channel runner process hosting Slack. The long-term design still needs instance-level locks so a future process-per-instance model does not change semantics.
 
+The same split means a process-local driver action registry is invisible to
+the runtime daemon. A turn-scoped descriptor snapshot plus typed request/reply
+keeps handlers and credentials in the runner while letting the daemon expose
+only actions admitted for the exact accepted Channel turn.

--- a/src/channels/backend.test.ts
+++ b/src/channels/backend.test.ts
@@ -17,6 +17,7 @@ import {
   CHANNEL_BACKEND_PROTOCOL,
   CHANNEL_BACKEND_SCHEMA_VERSION,
   ChannelOutputSinkRegistry,
+  registerChannelBackendLocalAgentActionDescriptorResolver,
   resumePendingChannelIngressPublications,
   setChannelBackendPromptPublisherForTests,
   type ChannelBackendPromptPublisher,
@@ -34,6 +35,7 @@ import {
 } from "./runtime-events.js";
 
 let stateDir: string | null = null;
+let disposeLocalAgentActionDescriptorResolver: (() => void) | null = null;
 
 beforeEach(async () => {
   stateDir = await createIsolatedRaviState("ravi-channel-backend-");
@@ -45,12 +47,61 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  disposeLocalAgentActionDescriptorResolver?.();
+  disposeLocalAgentActionDescriptorResolver = null;
   setChannelBackendPromptPublisherForTests();
   await cleanupIsolatedRaviState(stateDir);
   stateDir = null;
 });
 
 describe("channel backend ingress", () => {
+  it("snapshots matching local Agent actions into the accepted turn envelope", async () => {
+    const published: Array<Record<string, unknown>> = [];
+    setChannelBackendPromptPublisherForTests(async (_sessionName, payload) => {
+      published.push(payload);
+    });
+    disposeLocalAgentActionDescriptorResolver = registerChannelBackendLocalAgentActionDescriptorResolver((scope) => {
+      expect(scope).toEqual({
+        agentId: "agent-a",
+        sessionName: expect.stringMatching(/^channel-/),
+        source: {
+          channelKind: "custom",
+          channelInstanceId: "channel-instance-a",
+          accountId: "connection-a",
+          conversationId: "external-conversation-a",
+        },
+      });
+      return [
+        {
+          toolName: "custom_create_space",
+          description: "Create a provider-owned collaboration space.",
+          inputSchema: { type: "object", properties: {} },
+          sourceAccountId: "connection-a",
+          authorizationMode: "driver_handler",
+        },
+      ];
+    });
+
+    await acceptChannelIngress(request());
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?._channelBackend).toMatchObject({
+      localAgentActions: {
+        source: {
+          channelKind: "custom",
+          channelInstanceId: "channel-instance-a",
+          accountId: "connection-a",
+        },
+        descriptors: [
+          {
+            toolName: "custom_create_space",
+            authorizationMode: "driver_handler",
+          },
+        ],
+      },
+    });
+  });
+
   it("persists canonical local ids and publishes one content-bearing prompt", async () => {
     const published: Array<{
       sessionName: string;

--- a/src/channels/backend.ts
+++ b/src/channels/backend.ts
@@ -16,6 +16,7 @@ import { getAgentCwd } from "../router/resolver.js";
 import { getOrCreateSession, getSession, updateSessionName } from "../router/sessions.js";
 import type { ChannelBackendPromptMetadata, MessageContext, MessageTarget } from "../runtime/message-types.js";
 import { logger } from "../utils/logger.js";
+import type { NativeLocalAgentActionDescriptor } from "./native/driver.js";
 
 export const CHANNEL_BACKEND_PROTOCOL = "ravi.channel.backend" as const;
 export const CHANNEL_BACKEND_SCHEMA_VERSION = 1 as const;
@@ -267,6 +268,40 @@ export type ChannelBackendPromptPublisher = (
 ) => Promise<void>;
 
 let channelBackendPromptPublisher: ChannelBackendPromptPublisher = publishSessionPrompt;
+
+export interface ChannelBackendLocalAgentActionDescriptorScope {
+  readonly agentId: string;
+  readonly sessionName: string;
+  readonly source: {
+    readonly channelKind: string;
+    readonly channelInstanceId: string;
+    readonly accountId: string;
+    readonly conversationId: string;
+  };
+}
+
+export type ChannelBackendLocalAgentActionDescriptorResolver = (
+  scope: ChannelBackendLocalAgentActionDescriptorScope,
+) => readonly NativeLocalAgentActionDescriptor[];
+
+let channelBackendLocalAgentActionDescriptorResolver: ChannelBackendLocalAgentActionDescriptorResolver | undefined;
+
+export function registerChannelBackendLocalAgentActionDescriptorResolver(
+  resolver: ChannelBackendLocalAgentActionDescriptorResolver,
+): () => void {
+  if (channelBackendLocalAgentActionDescriptorResolver !== undefined) {
+    throw new Error("channel_backend_local_agent_action_descriptor_resolver_already_registered");
+  }
+  channelBackendLocalAgentActionDescriptorResolver = resolver;
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    if (channelBackendLocalAgentActionDescriptorResolver === resolver) {
+      channelBackendLocalAgentActionDescriptorResolver = undefined;
+    }
+  };
+}
 
 export function setChannelBackendPromptPublisherForTests(publisher?: ChannelBackendPromptPublisher): void {
   channelBackendPromptPublisher = publisher ?? publishSessionPrompt;
@@ -710,6 +745,7 @@ function buildPromptPayload(
 }
 
 function backendPromptMetadata(receipt: ChannelBackendIngressReceiptRecord): ChannelBackendPromptMetadata {
+  const localAgentActions = resolveChannelBackendLocalAgentActions(receipt);
   return {
     protocol: CHANNEL_BACKEND_PROTOCOL,
     schemaVersion: CHANNEL_BACKEND_SCHEMA_VERSION,
@@ -721,7 +757,39 @@ function backendPromptMetadata(receipt: ChannelBackendIngressReceiptRecord): Cha
       connectionId: receipt.external.connectionId,
       conversationId: receipt.external.conversationId,
     },
+    ...(localAgentActions === undefined ? {} : { localAgentActions }),
   };
+}
+
+function resolveChannelBackendLocalAgentActions(
+  receipt: ChannelBackendIngressReceiptRecord,
+): ChannelBackendPromptMetadata["localAgentActions"] {
+  const resolver = channelBackendLocalAgentActionDescriptorResolver;
+  if (resolver === undefined) return undefined;
+  const source = {
+    channelKind: receipt.external.channelKind,
+    channelInstanceId: receipt.channelInstanceId,
+    accountId: receipt.external.connectionId,
+    conversationId: receipt.external.conversationId,
+  };
+  try {
+    const descriptors = resolver({
+      agentId: receipt.agentId,
+      sessionName: receipt.sessionName,
+      source,
+    });
+    if (descriptors.length === 0 || descriptors.length > 32) return undefined;
+    return {
+      source: {
+        channelKind: source.channelKind,
+        channelInstanceId: source.channelInstanceId,
+        accountId: source.accountId,
+      },
+      descriptors: descriptors.map((descriptor) => structuredClone(descriptor)),
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function bindingFromReceipt(receipt: ChannelBackendIngressReceiptRecord): LocalChannelMessageBinding {

--- a/src/channels/native/agent-action-bridge.test.ts
+++ b/src/channels/native/agent-action-bridge.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { JSONCodec } from "nats";
+import type { ContextRecord } from "../../router/router-db.js";
+import { createRuntimeHostServices } from "../../runtime/host-services.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  type NativeLocalAgentActionDescriptor,
+} from "./driver.js";
+import {
+  NATIVE_LOCAL_AGENT_ACTION_BRIDGE_QUEUE,
+  NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SUBJECT,
+  requestNativeLocalAgentAction,
+  startNativeLocalAgentActionBridgeResponder,
+  type NativeLocalAgentActionBridgeMessage,
+  type NativeLocalAgentActionBridgeRequestConnection,
+  type NativeLocalAgentActionBridgeResponderConnection,
+  type NativeLocalAgentActionBridgeSubscription,
+} from "./agent-action-bridge.js";
+import { NativeLocalAgentActionRegistry, nativeLocalAgentActions } from "./agent-actions.js";
+
+const descriptor: NativeLocalAgentActionDescriptor = {
+  toolName: "example_create_space",
+  description: "Create a provider-owned collaboration space.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+  },
+  sourceAccountId: "account-1",
+  authorizationMode: "driver_handler",
+};
+
+afterEach(() => {
+  nativeLocalAgentActions.clearForTests();
+});
+
+describe("native local Agent action process bridge", () => {
+  it("discovers a turn-scoped descriptor in the daemon and invokes the isolated runner handler once", async () => {
+    const connection = new InMemoryRequestReplyConnection();
+    const runnerRegistry = new NativeLocalAgentActionRegistry();
+    const handler = mock(async (request) => ({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: request.requestId,
+      disposition: "completed" as const,
+      text: `Created ${String(request.arguments.name)}.`,
+      completedAt: "2026-07-30T03:00:01.000Z",
+    }));
+    runnerRegistry.register({
+      provider: "example",
+      channelInstanceId: "example-channel",
+      descriptor,
+      handler,
+    });
+    const responder = startNativeLocalAgentActionBridgeResponder({
+      connection,
+      registry: runnerRegistry,
+    });
+    const runtimeContext = context();
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+      nativeLocalAgentActionRequester: (input) => requestNativeLocalAgentAction(input, { connection, timeoutMs: 250 }),
+    });
+
+    try {
+      expect(nativeLocalAgentActions.list(runtimeContext)).toEqual([]);
+      expect(services.listDynamicTools().map(({ name }) => name)).toContain("example_create_space");
+      await expect(
+        services.executeDynamicTool({
+          toolName: "example_create_space",
+          callId: "action-request-1",
+          arguments: { name: "roadmap" },
+        }),
+      ).resolves.toEqual({
+        success: true,
+        contentItems: [{ type: "inputText", text: "Created roadmap." }],
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: "action-request-1",
+          agentId: "agent-1",
+          sessionName: "session-1",
+          source: {
+            channelKind: "example",
+            accountId: "account-1",
+            conversationId: "conversation-1",
+          },
+        }),
+      );
+      expect(connection.subscriptionOptions).toEqual({
+        subject: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SUBJECT,
+        queue: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_QUEUE,
+      });
+    } finally {
+      await responder.stop();
+    }
+  });
+
+  it("fails closed for a copied source, wrong Channel instance, and stopped runner", async () => {
+    const connection = new InMemoryRequestReplyConnection();
+    const runnerRegistry = new NativeLocalAgentActionRegistry();
+    const handler = mock(async (request) => ({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: request.requestId,
+      disposition: "completed" as const,
+      text: "Must not run.",
+      completedAt: "2026-07-30T03:00:01.000Z",
+    }));
+    runnerRegistry.register({
+      provider: "example",
+      channelInstanceId: "another-channel",
+      descriptor,
+      handler,
+    });
+    const responder = startNativeLocalAgentActionBridgeResponder({
+      connection,
+      registry: runnerRegistry,
+    });
+    const copiedContext = context({
+      source: {
+        channel: "example",
+        accountId: "account-2",
+        chatId: "conversation-1",
+      },
+    });
+    const copiedServices = createRuntimeHostServices({
+      context: copiedContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: copiedContext },
+    });
+    expect(copiedServices.listDynamicTools().map(({ name }) => name)).not.toContain("example_create_space");
+
+    const runtimeContext = context();
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+      nativeLocalAgentActionRequester: (input) => requestNativeLocalAgentAction(input, { connection, timeoutMs: 250 }),
+    });
+
+    await expect(
+      services.executeDynamicTool({
+        toolName: "example_create_space",
+        callId: "action-request-wrong-instance",
+        arguments: {},
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      reason: "UNAVAILABLE",
+    });
+    expect(handler).not.toHaveBeenCalled();
+
+    await responder.stop();
+    await expect(
+      services.executeDynamicTool({
+        toolName: "example_create_space",
+        callId: "action-request-stopped",
+        arguments: {},
+      }),
+    ).resolves.toEqual({
+      success: false,
+      reason: "native_local_agent_action_unavailable",
+      contentItems: [
+        {
+          type: "inputText",
+          text: "example_create_space is unavailable for this turn.",
+        },
+      ],
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("keeps runtime-context authorization ahead of a remote handler", async () => {
+    const connection = new InMemoryRequestReplyConnection();
+    const runnerRegistry = new NativeLocalAgentActionRegistry();
+    const runtimeAuthorizedDescriptor: NativeLocalAgentActionDescriptor = {
+      ...descriptor,
+      authorizationMode: "runtime_context",
+    };
+    const handler = mock(async (request) => ({
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId: request.requestId,
+      disposition: "completed" as const,
+      text: "Created.",
+      completedAt: "2026-07-30T03:00:01.000Z",
+    }));
+    runnerRegistry.register({
+      provider: "example",
+      channelInstanceId: "example-channel",
+      descriptor: runtimeAuthorizedDescriptor,
+      handler,
+    });
+    const responder = startNativeLocalAgentActionBridgeResponder({
+      connection,
+      registry: runnerRegistry,
+    });
+    const deniedContext = context({}, runtimeAuthorizedDescriptor);
+    const deniedServices = createRuntimeHostServices({
+      context: deniedContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: deniedContext },
+      nativeLocalAgentActionRequester: (input) => requestNativeLocalAgentAction(input, { connection, timeoutMs: 250 }),
+    });
+    const allowedContext = context(
+      {
+        capabilities: [
+          {
+            permission: "use",
+            objectType: "tool",
+            objectId: "example_create_space",
+            source: "test",
+          },
+        ],
+      },
+      runtimeAuthorizedDescriptor,
+    );
+    const allowedServices = createRuntimeHostServices({
+      context: allowedContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: allowedContext },
+      nativeLocalAgentActionRequester: (input) => requestNativeLocalAgentAction(input, { connection, timeoutMs: 250 }),
+    });
+
+    try {
+      expect(deniedServices.listDynamicTools().map(({ name }) => name)).not.toContain("example_create_space");
+      expect(allowedServices.listDynamicTools().map(({ name }) => name)).toContain("example_create_space");
+      await expect(
+        allowedServices.executeDynamicTool({
+          toolName: "example_create_space",
+          callId: "action-request-runtime-authorized",
+          arguments: {},
+        }),
+      ).resolves.toMatchObject({ success: true });
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      await responder.stop();
+    }
+  });
+
+  it("hides a tool when local and accepted-turn descriptors conflict", () => {
+    nativeLocalAgentActions.register({
+      provider: "example",
+      channelInstanceId: "example-channel",
+      descriptor,
+      handler: async (request) => ({
+        protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+        schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+        requestId: request.requestId,
+        disposition: "completed",
+        text: "Must not run.",
+        completedAt: "2026-07-30T03:00:01.000Z",
+      }),
+    });
+    const runtimeContext = context(
+      {},
+      {
+        ...descriptor,
+        description: "A conflicting descriptor for the same tool.",
+      },
+    );
+    const services = createRuntimeHostServices({
+      context: runtimeContext,
+      agentId: "agent-1",
+      sessionName: "session-1",
+      toolContext: { context: runtimeContext },
+    });
+
+    expect(services.listDynamicTools().map(({ name }) => name)).not.toContain("example_create_space");
+  });
+
+  it("returns only a bounded safe failure when the runner handler throws", async () => {
+    const connection = new InMemoryRequestReplyConnection();
+    const runnerRegistry = new NativeLocalAgentActionRegistry();
+    runnerRegistry.register({
+      provider: "example",
+      channelInstanceId: "example-channel",
+      descriptor,
+      handler: async () => {
+        throw new Error("provider credential and stack must remain private");
+      },
+    });
+    const responder = startNativeLocalAgentActionBridgeResponder({
+      connection,
+      registry: runnerRegistry,
+    });
+
+    try {
+      await expect(
+        requestNativeLocalAgentAction(bridgeRequest("action-request-throw"), {
+          connection,
+          timeoutMs: 250,
+        }),
+      ).resolves.toMatchObject({
+        requestId: "action-request-throw",
+        disposition: "rejected",
+        error: {
+          code: "INTERNAL",
+          category: "internal",
+          retryable: false,
+          correlationId: "action-request-throw",
+        },
+      });
+    } finally {
+      await responder.stop();
+    }
+  });
+
+  it("rejects malformed or mismatched bridge replies", async () => {
+    const codec = JSONCodec<unknown>();
+    const malformedConnection: NativeLocalAgentActionBridgeRequestConnection = {
+      async request() {
+        return { data: codec.encode({ unexpected: "payload" }) };
+      },
+    };
+    const mismatchedConnection: NativeLocalAgentActionBridgeRequestConnection = {
+      async request() {
+        return {
+          data: codec.encode({
+            protocol: "ravi.channel.native-local-action-bridge",
+            schemaVersion: 1,
+            requestId: "another-request",
+            result: {
+              protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+              schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+              requestId: "another-request",
+              disposition: "completed",
+              text: "Must not be accepted.",
+              completedAt: "2026-07-30T03:00:01.000Z",
+            },
+          }),
+        };
+      },
+    };
+
+    await expect(
+      requestNativeLocalAgentAction(bridgeRequest("action-request-malformed"), {
+        connection: malformedConnection,
+        timeoutMs: 250,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      requestNativeLocalAgentAction(bridgeRequest("action-request-mismatch"), {
+        connection: mismatchedConnection,
+        timeoutMs: 250,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+function context(
+  overrides: Partial<ContextRecord> = {},
+  turnDescriptor: NativeLocalAgentActionDescriptor = descriptor,
+): ContextRecord {
+  return {
+    contextId: "context-1",
+    contextKey: "context-key-1",
+    kind: "turn-runtime",
+    agentId: "agent-1",
+    sessionKey: "agent:agent-1:example",
+    sessionName: "session-1",
+    source: {
+      channel: "example",
+      accountId: "account-1",
+      chatId: "conversation-1",
+    },
+    capabilities: [],
+    metadata: {
+      nativeLocalAgentActions: {
+        source: {
+          channelKind: "example",
+          channelInstanceId: "example-channel",
+          accountId: "account-1",
+        },
+        descriptors: [turnDescriptor],
+      },
+    },
+    createdAt: Date.parse("2026-07-30T03:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function bridgeRequest(requestId: string) {
+  return {
+    channelInstanceId: "example-channel",
+    request: {
+      protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+      schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+      requestId,
+      toolName: "example_create_space",
+      arguments: {},
+      agentId: "agent-1",
+      sessionName: "session-1",
+      source: {
+        channelKind: "example",
+        accountId: "account-1",
+        conversationId: "conversation-1",
+      },
+      requestedAt: "2026-07-30T03:00:00.000Z",
+    },
+  } as const;
+}
+
+class InMemoryRequestReplyConnection
+  implements NativeLocalAgentActionBridgeResponderConnection, NativeLocalAgentActionBridgeRequestConnection
+{
+  private subscription?: InMemorySubscription;
+  subscriptionOptions?: { subject: string; queue?: string };
+
+  subscribe(subject: string, options?: { readonly queue?: string }): NativeLocalAgentActionBridgeSubscription {
+    this.subscriptionOptions = {
+      subject,
+      ...(options?.queue === undefined ? {} : { queue: options.queue }),
+    };
+    this.subscription = new InMemorySubscription();
+    return this.subscription;
+  }
+
+  async request(
+    _subject: string,
+    data: Uint8Array,
+    options: { readonly timeout: number },
+  ): Promise<{ readonly data: Uint8Array }> {
+    const subscription = this.subscription;
+    if (!subscription || subscription.closed) throw new Error("no responders");
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout")), options.timeout);
+      timer.unref?.();
+      subscription.push({
+        data,
+        respond(response) {
+          clearTimeout(timer);
+          resolve({ data: response });
+          return true;
+        },
+      });
+    });
+  }
+}
+
+class InMemorySubscription implements NativeLocalAgentActionBridgeSubscription {
+  private readonly messages: NativeLocalAgentActionBridgeMessage[] = [];
+  private wake: (() => void) | undefined;
+  closed = false;
+
+  push(message: NativeLocalAgentActionBridgeMessage): void {
+    this.messages.push(message);
+    this.wake?.();
+    this.wake = undefined;
+  }
+
+  unsubscribe(): void {
+    this.closed = true;
+    this.wake?.();
+    this.wake = undefined;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<NativeLocalAgentActionBridgeMessage> {
+    while (!this.closed || this.messages.length > 0) {
+      const message = this.messages.shift();
+      if (message) {
+        yield message;
+        continue;
+      }
+      await new Promise<void>((resolve) => {
+        this.wake = resolve;
+      });
+    }
+  }
+}

--- a/src/channels/native/agent-action-bridge.ts
+++ b/src/channels/native/agent-action-bridge.ts
@@ -1,0 +1,210 @@
+import { JSONCodec } from "nats";
+import { z } from "zod";
+import { ChannelBackendOpaqueIdSchema } from "../backend.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeLocalAgentActionRequestSchema,
+  NativeLocalAgentActionResultSchema,
+  type NativeLocalAgentActionRequest,
+  type NativeLocalAgentActionResult,
+} from "./driver.js";
+import { NativeLocalAgentActionRegistry, nativeLocalAgentActions } from "./agent-actions.js";
+
+export const NATIVE_LOCAL_AGENT_ACTION_BRIDGE_PROTOCOL = "ravi.channel.native-local-action-bridge" as const;
+export const NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SCHEMA_VERSION = 1 as const;
+export const NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SUBJECT = "_RAVI.channels.native-local-action" as const;
+export const NATIVE_LOCAL_AGENT_ACTION_BRIDGE_QUEUE = "ravi-native-local-agent-actions" as const;
+export const NATIVE_LOCAL_AGENT_ACTION_BRIDGE_TIMEOUT_MS = 10_000;
+
+const NativeLocalAgentActionBridgeRequestSchema = z
+  .object({
+    protocol: z.literal(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SCHEMA_VERSION),
+    channelInstanceId: ChannelBackendOpaqueIdSchema,
+    request: NativeLocalAgentActionRequestSchema,
+  })
+  .strict();
+
+const NativeLocalAgentActionBridgeResponseSchema = z
+  .object({
+    protocol: z.literal(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_PROTOCOL),
+    schemaVersion: z.literal(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SCHEMA_VERSION),
+    requestId: ChannelBackendOpaqueIdSchema,
+    result: NativeLocalAgentActionResultSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.requestId !== value.result.requestId) {
+      context.addIssue({
+        code: "custom",
+        path: ["requestId"],
+        message: "bridge response correlation must match the action result",
+      });
+    }
+  });
+
+export interface NativeLocalAgentActionBridgeRequest {
+  readonly channelInstanceId: string;
+  readonly request: NativeLocalAgentActionRequest;
+}
+
+export type NativeLocalAgentActionBridgeRequester = (
+  input: NativeLocalAgentActionBridgeRequest,
+) => Promise<NativeLocalAgentActionResult | null>;
+
+export interface NativeLocalAgentActionBridgeMessage {
+  readonly data: Uint8Array;
+  respond(data: Uint8Array): boolean;
+}
+
+export interface NativeLocalAgentActionBridgeSubscription extends AsyncIterable<NativeLocalAgentActionBridgeMessage> {
+  unsubscribe(): void;
+}
+
+export interface NativeLocalAgentActionBridgeResponderConnection {
+  subscribe(subject: string, options?: { readonly queue?: string }): NativeLocalAgentActionBridgeSubscription;
+}
+
+export interface NativeLocalAgentActionBridgeRequestConnection {
+  request(
+    subject: string,
+    data: Uint8Array,
+    options: { readonly timeout: number },
+  ): Promise<{ readonly data: Uint8Array }>;
+}
+
+export interface NativeLocalAgentActionBridgeResponder {
+  stop(): Promise<void>;
+}
+
+const codec = JSONCodec<unknown>();
+
+export function startNativeLocalAgentActionBridgeResponder(options: {
+  readonly connection: NativeLocalAgentActionBridgeResponderConnection;
+  readonly registry?: NativeLocalAgentActionRegistry;
+}): NativeLocalAgentActionBridgeResponder {
+  const registry = options.registry ?? nativeLocalAgentActions;
+  const subscription = options.connection.subscribe(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SUBJECT, {
+    queue: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_QUEUE,
+  });
+  let stopped = false;
+  const loop = (async () => {
+    for await (const message of subscription) {
+      if (stopped) break;
+      const request = decodeBridgeRequest(message.data);
+      if (request === undefined) continue;
+      const response = await dispatchNativeLocalAgentActionBridgeRequest(request, registry);
+      message.respond(codec.encode(response));
+    }
+  })();
+
+  return {
+    async stop(): Promise<void> {
+      if (stopped) return;
+      stopped = true;
+      subscription.unsubscribe();
+      await loop.catch(() => {});
+    },
+  };
+}
+
+export async function requestNativeLocalAgentAction(
+  input: NativeLocalAgentActionBridgeRequest,
+  options: {
+    readonly connection?: NativeLocalAgentActionBridgeRequestConnection;
+    readonly connect?: () => Promise<NativeLocalAgentActionBridgeRequestConnection>;
+    readonly timeoutMs?: number;
+  } = {},
+): Promise<NativeLocalAgentActionResult | null> {
+  const request = NativeLocalAgentActionBridgeRequestSchema.parse({
+    protocol: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_PROTOCOL,
+    schemaVersion: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SCHEMA_VERSION,
+    channelInstanceId: input.channelInstanceId,
+    request: input.request,
+  });
+  const timeout = options.timeoutMs ?? NATIVE_LOCAL_AGENT_ACTION_BRIDGE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeout) || timeout < 1 || timeout > 60_000) {
+    throw new RangeError("Native local Agent action bridge timeout is outside supported bounds.");
+  }
+  try {
+    const connection = options.connection ?? (await (options.connect ?? defaultRequestConnection)());
+    const message = await connection.request(NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SUBJECT, codec.encode(request), {
+      timeout,
+    });
+    const response = NativeLocalAgentActionBridgeResponseSchema.parse(codec.decode(message.data));
+    if (response.requestId !== request.request.requestId || response.result.requestId !== request.request.requestId) {
+      return null;
+    }
+    return response.result;
+  } catch {
+    return null;
+  }
+}
+
+async function dispatchNativeLocalAgentActionBridgeRequest(
+  input: z.infer<typeof NativeLocalAgentActionBridgeRequestSchema>,
+  registry: NativeLocalAgentActionRegistry,
+): Promise<z.infer<typeof NativeLocalAgentActionBridgeResponseSchema>> {
+  const request = NativeLocalAgentActionBridgeRequestSchema.parse(input);
+  let result: NativeLocalAgentActionResult;
+  try {
+    result =
+      (await registry.invokeRequest(request.request, {
+        channelInstanceId: request.channelInstanceId,
+      })) ?? unavailableResult(request.request.requestId);
+  } catch {
+    result = internalErrorResult(request.request.requestId);
+  }
+  return NativeLocalAgentActionBridgeResponseSchema.parse({
+    protocol: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_PROTOCOL,
+    schemaVersion: NATIVE_LOCAL_AGENT_ACTION_BRIDGE_SCHEMA_VERSION,
+    requestId: request.request.requestId,
+    result,
+  });
+}
+
+function decodeBridgeRequest(data: Uint8Array): z.infer<typeof NativeLocalAgentActionBridgeRequestSchema> | undefined {
+  try {
+    return NativeLocalAgentActionBridgeRequestSchema.parse(codec.decode(data));
+  } catch {
+    return undefined;
+  }
+}
+
+function unavailableResult(requestId: string): NativeLocalAgentActionResult {
+  return NativeLocalAgentActionResultSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId,
+    disposition: "rejected",
+    error: {
+      code: "UNAVAILABLE",
+      category: "availability",
+      retryable: true,
+      correlationId: requestId,
+    },
+    completedAt: new Date().toISOString(),
+  });
+}
+
+function internalErrorResult(requestId: string): NativeLocalAgentActionResult {
+  return NativeLocalAgentActionResultSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId,
+    disposition: "rejected",
+    error: {
+      code: "INTERNAL",
+      category: "internal",
+      retryable: false,
+      correlationId: requestId,
+    },
+    completedAt: new Date().toISOString(),
+  });
+}
+
+async function defaultRequestConnection(): Promise<NativeLocalAgentActionBridgeRequestConnection> {
+  const { ensureConnected } = await import("../../nats.js");
+  return await ensureConnected();
+}

--- a/src/channels/native/agent-action-turn.ts
+++ b/src/channels/native/agent-action-turn.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import type { ContextSource } from "../../router/router-db.js";
+import { ChannelBackendOpaqueIdSchema, ChannelBackendWireKindSchema } from "../backend.js";
+import { NativeLocalAgentActionDescriptorSchema, type NativeLocalAgentActionDescriptor } from "./driver.js";
+
+export const MAX_NATIVE_LOCAL_AGENT_ACTIONS_PER_TURN = 32;
+
+export const NativeLocalAgentActionTurnMetadataSchema = z
+  .object({
+    source: z
+      .object({
+        channelKind: ChannelBackendWireKindSchema,
+        channelInstanceId: ChannelBackendOpaqueIdSchema,
+        accountId: ChannelBackendOpaqueIdSchema,
+      })
+      .strict(),
+    descriptors: z
+      .array(NativeLocalAgentActionDescriptorSchema)
+      .max(MAX_NATIVE_LOCAL_AGENT_ACTIONS_PER_TURN)
+      .superRefine((descriptors, context) => {
+        const seen = new Set<string>();
+        for (const [index, descriptor] of descriptors.entries()) {
+          if (seen.has(descriptor.toolName)) {
+            context.addIssue({
+              code: "custom",
+              path: [index, "toolName"],
+              message: "turn-scoped local Agent action names must be unique",
+            });
+          }
+          seen.add(descriptor.toolName);
+        }
+      }),
+  })
+  .strict();
+
+export type NativeLocalAgentActionTurnMetadata = z.infer<typeof NativeLocalAgentActionTurnMetadataSchema>;
+
+export function resolveNativeLocalAgentActionTurnMetadata(
+  input: unknown,
+  source: Pick<ContextSource, "channel" | "accountId"> | undefined,
+): NativeLocalAgentActionTurnMetadata | undefined {
+  if (source === undefined) return undefined;
+  const parsed = NativeLocalAgentActionTurnMetadataSchema.safeParse(input);
+  if (!parsed.success) return undefined;
+  if (parsed.data.source.channelKind !== source.channel || parsed.data.source.accountId !== source.accountId) {
+    return undefined;
+  }
+  if (
+    parsed.data.descriptors.some(
+      (descriptor) =>
+        descriptor.sourceAccountId !== undefined && descriptor.sourceAccountId !== parsed.data.source.accountId,
+    )
+  ) {
+    return undefined;
+  }
+  return structuredClone(parsed.data);
+}
+
+export function mergeNativeLocalAgentActionDescriptors(
+  collections: readonly (readonly NativeLocalAgentActionDescriptor[])[],
+): NativeLocalAgentActionDescriptor[] {
+  const unique = new Map<
+    string,
+    { readonly descriptor: NativeLocalAgentActionDescriptor; readonly fingerprint: string; ambiguous: boolean }
+  >();
+  for (const collection of collections) {
+    for (const descriptorInput of collection) {
+      const descriptor = NativeLocalAgentActionDescriptorSchema.parse(descriptorInput);
+      const fingerprint = canonicalJson(descriptor);
+      const existing = unique.get(descriptor.toolName);
+      if (existing === undefined) {
+        unique.set(descriptor.toolName, { descriptor, fingerprint, ambiguous: false });
+        continue;
+      }
+      if (existing.fingerprint !== fingerprint) existing.ambiguous = true;
+    }
+  }
+  return [...unique.values()]
+    .filter(({ ambiguous }) => !ambiguous)
+    .map(({ descriptor }) => structuredClone(descriptor))
+    .sort((left, right) => left.toolName.localeCompare(right.toolName));
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/src/channels/native/agent-actions.test.ts
+++ b/src/channels/native/agent-actions.test.ts
@@ -21,11 +21,11 @@ function context(overrides: Partial<ContextRecord> = {}): ContextRecord {
   };
 }
 
-function register(sourceAccountId = "account-1") {
+function register(sourceAccountId = "account-1", channelInstanceId = "example-local") {
   const requests: unknown[] = [];
   const dispose = nativeLocalAgentActions.register({
     provider: "example",
-    channelInstanceId: "example-local",
+    channelInstanceId,
     descriptor: {
       toolName: "example_create_space",
       description: "Create a provider-owned collaboration space.",
@@ -112,5 +112,43 @@ describe("native local agent action registry", () => {
         arguments: { name: "roadmap" },
       }),
     ).toBeUndefined();
+  });
+
+  it("resolves otherwise ambiguous registrations by exact Channel instance for the process bridge", async () => {
+    register("account-1", "example-a");
+    const selected = register("account-1", "example-b");
+    expect(nativeLocalAgentActions.list(context())).toEqual([]);
+    expect(
+      nativeLocalAgentActions.listForSource({
+        provider: "example",
+        channelInstanceId: "example-b",
+        accountId: "account-1",
+      }),
+    ).toHaveLength(1);
+
+    await expect(
+      nativeLocalAgentActions.invokeRequest(
+        {
+          protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+          schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+          requestId: "request-exact-instance",
+          toolName: "example_create_space",
+          arguments: { name: "roadmap" },
+          agentId: "agent-1",
+          sessionName: "session-1",
+          source: {
+            channelKind: "example",
+            accountId: "account-1",
+            conversationId: "conversation-1",
+          },
+          requestedAt: "2026-07-26T12:00:00.000Z",
+        },
+        { channelInstanceId: "example-b" },
+      ),
+    ).resolves.toMatchObject({
+      requestId: "request-exact-instance",
+      disposition: "completed",
+    });
+    expect(selected.requests).toHaveLength(1);
   });
 });

--- a/src/channels/native/agent-actions.ts
+++ b/src/channels/native/agent-actions.ts
@@ -26,6 +26,12 @@ export interface RegisterNativeLocalAgentActionInput {
   readonly handler: NativeLocalAgentActionHandler;
 }
 
+export interface NativeLocalAgentActionRegistrationScope {
+  readonly provider: string;
+  readonly channelInstanceId?: string;
+  readonly accountId: string;
+}
+
 export class NativeLocalAgentActionRegistry {
   private readonly registrations = new Map<string, RegisteredNativeLocalAgentAction>();
 
@@ -51,8 +57,19 @@ export class NativeLocalAgentActionRegistry {
   }
 
   list(context: ContextRecord): NativeLocalAgentActionDescriptor[] {
+    const source = context.source;
+    if (source === undefined || context.agentId === undefined || context.sessionName === undefined) {
+      return [];
+    }
+    return this.listForSource({
+      provider: source.channel,
+      accountId: source.accountId,
+    });
+  }
+
+  listForSource(scope: NativeLocalAgentActionRegistrationScope): NativeLocalAgentActionDescriptor[] {
     const grouped = new Map<string, RegisteredNativeLocalAgentAction[]>();
-    for (const registration of this.matching(context)) {
+    for (const registration of this.matchingSource(scope)) {
       const entries = grouped.get(registration.descriptor.toolName) ?? [];
       entries.push(registration);
       grouped.set(registration.descriptor.toolName, entries);
@@ -70,8 +87,6 @@ export class NativeLocalAgentActionRegistry {
     readonly requestId?: string;
     readonly now?: () => string;
   }): Promise<NativeLocalAgentActionResult | undefined> {
-    const candidates = this.matching(input.context).filter(({ descriptor }) => descriptor.toolName === input.toolName);
-    if (candidates.length !== 1) return undefined;
     const agentId = input.context.agentId;
     const sessionName = input.context.sessionName;
     const source = input.context.source;
@@ -94,6 +109,20 @@ export class NativeLocalAgentActionRegistry {
       },
       requestedAt: (input.now ?? (() => new Date().toISOString()))(),
     });
+    return this.invokeRequest(request);
+  }
+
+  async invokeRequest(
+    input: Parameters<NativeLocalAgentActionHandler>[0],
+    scope: { readonly channelInstanceId?: string } = {},
+  ): Promise<NativeLocalAgentActionResult | undefined> {
+    const request = NativeLocalAgentActionRequestSchema.parse(input);
+    const candidates = this.matchingSource({
+      provider: request.source.channelKind,
+      accountId: request.source.accountId,
+      ...(scope.channelInstanceId === undefined ? {} : { channelInstanceId: scope.channelInstanceId }),
+    }).filter(({ descriptor }) => descriptor.toolName === request.toolName);
+    if (candidates.length !== 1) return undefined;
     const result = NativeLocalAgentActionResultSchema.parse(await candidates[0]!.handler(request));
     if (result.requestId !== request.requestId) {
       throw new Error("native_local_agent_action_request_mismatch");
@@ -105,15 +134,12 @@ export class NativeLocalAgentActionRegistry {
     this.registrations.clear();
   }
 
-  private matching(context: ContextRecord): RegisteredNativeLocalAgentAction[] {
-    const source = context.source;
-    if (source === undefined || context.agentId === undefined || context.sessionName === undefined) {
-      return [];
-    }
+  private matchingSource(scope: NativeLocalAgentActionRegistrationScope): RegisteredNativeLocalAgentAction[] {
     return [...this.registrations.values()].filter(
-      ({ provider, descriptor }) =>
-        provider === source.channel &&
-        (descriptor.sourceAccountId === undefined || descriptor.sourceAccountId === source.accountId),
+      ({ provider, channelInstanceId, descriptor }) =>
+        provider === scope.provider &&
+        (scope.channelInstanceId === undefined || channelInstanceId === scope.channelInstanceId) &&
+        (descriptor.sourceAccountId === undefined || descriptor.sourceAccountId === scope.accountId),
     );
   }
 }

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -9,6 +9,7 @@ import {
   pruneChannelOutboundPublishOutbox,
   pruneChannelOutboundReceiptLedger,
   runChannelOutboundLedgerMaintenance,
+  startChannelRunnerLocalAgentActionResponder,
   slackAdapterHealth,
   startChannelRunnerBackendEgressResponder,
   startChannelRunnerInboundActionResponder,
@@ -28,6 +29,10 @@ import {
   type NativeInboundChannelActionHandler,
 } from "./native/driver.js";
 import { nativeLocalAgentActions } from "./native/agent-actions.js";
+import type {
+  NativeLocalAgentActionBridgeResponder,
+  NativeLocalAgentActionBridgeResponderConnection,
+} from "./native/agent-action-bridge.js";
 import { installationChannelName, mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import type { ChannelRuntimeEventSink } from "./runtime-events.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
@@ -417,6 +422,26 @@ describe("channel runner native delivery registry", () => {
     expect(startResponder).toHaveBeenCalledWith({
       connection,
       handlers: [handler],
+    });
+  });
+
+  it("starts one local Agent action bridge responder with the runner registry", () => {
+    const connection = {} as NativeLocalAgentActionBridgeResponderConnection;
+    const responder = {
+      stop: mock(async () => {}),
+    } satisfies NativeLocalAgentActionBridgeResponder;
+    const startResponder = mock(() => responder);
+
+    expect(
+      startChannelRunnerLocalAgentActionResponder({
+        connection,
+        registry: nativeLocalAgentActions,
+        startResponder,
+      }),
+    ).toBe(responder);
+    expect(startResponder).toHaveBeenCalledWith({
+      connection,
+      registry: nativeLocalAgentActions,
     });
   });
 

--- a/src/channels/runner.ts
+++ b/src/channels/runner.ts
@@ -23,6 +23,12 @@ import {
   type NativeInboundChannelActionHandler,
   type NativeChannelDriverRuntime,
 } from "./native/driver.js";
+import {
+  startNativeLocalAgentActionBridgeResponder,
+  type NativeLocalAgentActionBridgeResponder,
+  type NativeLocalAgentActionBridgeResponderConnection,
+} from "./native/agent-action-bridge.js";
+import { NativeLocalAgentActionRegistry, nativeLocalAgentActions } from "./native/agent-actions.js";
 import { mergeInstallationCredentialChannels } from "./native/installation-channels.js";
 import type { NativeChatActionDelivery, NativePresenceDelivery, NativeTextDelivery } from "./native/types.js";
 import { ChannelOutboundConsumer } from "./outbound-consumer.js";
@@ -50,7 +56,10 @@ import {
   type ChannelBackendEgressResponder,
   type ChannelBackendEgressResponderConnection,
 } from "./backend-egress.js";
-import { startChannelBackendPublicationReconciler } from "./backend.js";
+import {
+  registerChannelBackendLocalAgentActionDescriptorResolver,
+  startChannelBackendPublicationReconciler,
+} from "./backend.js";
 import { createSlackNativeChannelDriver, slackNativeRuntimeHealth } from "./slack/driver.js";
 import type { SlackSocketModeStatus } from "./slack/index.js";
 
@@ -93,6 +102,29 @@ export function startChannelRunnerBackendEgressResponder(options: {
   });
 }
 
+export function startChannelRunnerLocalAgentActionResponder(options: {
+  connection: NativeLocalAgentActionBridgeResponderConnection;
+  registry?: NativeLocalAgentActionRegistry;
+  startResponder?: typeof startNativeLocalAgentActionBridgeResponder;
+}): NativeLocalAgentActionBridgeResponder {
+  return (options.startResponder ?? startNativeLocalAgentActionBridgeResponder)({
+    connection: options.connection,
+    registry: options.registry ?? nativeLocalAgentActions,
+  });
+}
+
+export function registerChannelRunnerLocalAgentActionDescriptors(
+  registry: NativeLocalAgentActionRegistry = nativeLocalAgentActions,
+): () => void {
+  return registerChannelBackendLocalAgentActionDescriptorResolver((scope) =>
+    registry.listForSource({
+      provider: scope.source.channelKind,
+      channelInstanceId: scope.source.channelInstanceId,
+      accountId: scope.source.accountId,
+    }),
+  );
+}
+
 type ReceiptPruneTimer = ReturnType<typeof setInterval>;
 
 export interface ChannelOutboundReceiptPrunerOptions {
@@ -131,6 +163,8 @@ export class ChannelRunner {
   private healthResponder: ChannelRunnerHealthResponder | null = null;
   private backendEgressResponder: ChannelBackendEgressResponder | null = null;
   private stopBackendPublicationReconciler: (() => void) | null = null;
+  private localAgentActionResponder: NativeLocalAgentActionBridgeResponder | null = null;
+  private stopLocalAgentActionDescriptorResolver: (() => void) | null = null;
 
   constructor(private readonly options: ChannelRunnerOptions = {}) {}
 
@@ -207,6 +241,8 @@ export class ChannelRunner {
     this.stopReceiptPruner = null;
     this.stopBackendPublicationReconciler?.();
     this.stopBackendPublicationReconciler = null;
+    this.stopLocalAgentActionDescriptorResolver?.();
+    this.stopLocalAgentActionDescriptorResolver = null;
     log.info("Stopping channel runner", { pid: process.pid });
     await this.outboundPublishReconciler?.stop();
     this.outboundPublishReconciler = null;
@@ -218,6 +254,8 @@ export class ChannelRunner {
     this.backendEgressResponder = null;
     await this.inboundActionResponder?.stop();
     this.inboundActionResponder = null;
+    await this.localAgentActionResponder?.stop();
+    this.localAgentActionResponder = null;
     await this.nativeChannelManager?.stop();
     this.nativeChannelManager = null;
     this.deliveries = [];
@@ -286,6 +324,10 @@ export class ChannelRunner {
       registry,
     });
     await this.nativeChannelManager.start();
+    this.stopLocalAgentActionDescriptorResolver = registerChannelRunnerLocalAgentActionDescriptors();
+    this.localAgentActionResponder = startChannelRunnerLocalAgentActionResponder({
+      connection: getNats(),
+    });
     this.inboundActionResponder = startChannelRunnerInboundActionResponder({
       connection: getNats(),
       handlers: this.nativeChannelManager.inboundActionHandlers(),

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { runWithContext } from "../cli/context.js";
 import { getAllCommandClasses, createSdkTools } from "../cli/tool-definitions.js";
 import { extractTools, type ExportedTool, type ToolResult } from "../cli/tools-export.js";
@@ -35,6 +36,20 @@ import type {
 } from "./types.js";
 import { evaluateRuntimeCommandSkillGate, evaluateRuntimeToolSkillGate } from "./skill-gate.js";
 import { nativeLocalAgentActions } from "../channels/native/agent-actions.js";
+import {
+  requestNativeLocalAgentAction,
+  type NativeLocalAgentActionBridgeRequester,
+} from "../channels/native/agent-action-bridge.js";
+import {
+  mergeNativeLocalAgentActionDescriptors,
+  resolveNativeLocalAgentActionTurnMetadata,
+} from "../channels/native/agent-action-turn.js";
+import {
+  NATIVE_CHANNEL_DRIVER_PROTOCOL,
+  NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+  NativeLocalAgentActionRequestSchema,
+  type NativeLocalAgentActionDescriptor,
+} from "../channels/native/driver.js";
 
 const RUNTIME_BUILTIN_EXECUTABLES = new Set(["ravi"]);
 const DYNAMIC_TOOL_TIMEOUT_MS = 60_000;
@@ -51,6 +66,7 @@ export interface RuntimeHostServicesOptions {
   approvalSource?: ApprovalTarget;
   toolContext: Record<string, unknown>;
   onSkillGatePersisted?: (skillVisibility: RuntimeSkillVisibilitySnapshot) => void;
+  nativeLocalAgentActionRequester?: NativeLocalAgentActionBridgeRequester;
 }
 
 function hasUnrestrictedToolExecution(agentId: string): boolean {
@@ -108,15 +124,15 @@ function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDy
 
   const commandTools = getRuntimeDynamicToolSpecs().filter((tool) => allowedToolNames.has(tool.name));
   const commandToolNames = new Set(getRuntimeDynamicToolDefinitions().map(({ name }) => name));
-  const nativeActions = nativeLocalAgentActions
-    .list(context)
+  const nativeActions = getNativeLocalAgentActionsForContext(context)
     .filter(
-      ({ toolName, authorizationMode }) =>
-        !commandToolNames.has(toolName) &&
-        (authorizationMode === "driver_handler" || canWithCapabilityContext(context, "use", "tool", toolName)),
+      ({ descriptor }) =>
+        !commandToolNames.has(descriptor.toolName) &&
+        (descriptor.authorizationMode === "driver_handler" ||
+          canWithCapabilityContext(context, "use", "tool", descriptor.toolName)),
     )
     .map(
-      ({ toolName, description, inputSchema }) =>
+      ({ descriptor: { toolName, description, inputSchema } }) =>
         ({
           name: toolName,
           description,
@@ -124,6 +140,26 @@ function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDy
         }) satisfies RuntimeDynamicToolSpec,
     );
   return [...commandTools, ...nativeActions].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+interface ResolvedNativeLocalAgentAction {
+  readonly descriptor: NativeLocalAgentActionDescriptor;
+  readonly channelInstanceId?: string;
+}
+
+function getNativeLocalAgentActionsForContext(context: ContextRecord): ResolvedNativeLocalAgentAction[] {
+  const localDescriptors = nativeLocalAgentActions.list(context);
+  const turnMetadata = resolveNativeLocalAgentActionTurnMetadata(
+    context.metadata?.nativeLocalAgentActions,
+    context.source,
+  );
+  const turnDescriptors = turnMetadata?.descriptors ?? [];
+  return mergeNativeLocalAgentActionDescriptors([localDescriptors, turnDescriptors]).map((descriptor) => ({
+    descriptor,
+    ...(turnDescriptors.some(({ toolName }) => toolName === descriptor.toolName) && turnMetadata
+      ? { channelInstanceId: turnMetadata.source.channelInstanceId }
+      : {}),
+  }));
 }
 
 function canAdvertiseRuntimeDynamicTool(context: ContextRecord, tool: ExportedTool): boolean {
@@ -259,7 +295,7 @@ async function authorizeRuntimeCapability(
 async function executeRuntimeDynamicTool(
   options: Pick<
     RuntimeHostServicesOptions,
-    "context" | "agentId" | "sessionName" | "toolContext" | "onSkillGatePersisted"
+    "context" | "agentId" | "sessionName" | "toolContext" | "onSkillGatePersisted" | "nativeLocalAgentActionRequester"
   >,
   request: RuntimeDynamicToolCallRequest,
   executionOptions?: RuntimeDynamicToolExecutionOptions,
@@ -309,11 +345,13 @@ async function executeRuntimeDynamicTool(
 }
 
 async function executeNativeLocalAgentAction(
-  options: Pick<RuntimeHostServicesOptions, "context" | "agentId" | "sessionName">,
+  options: Pick<RuntimeHostServicesOptions, "context" | "agentId" | "sessionName" | "nativeLocalAgentActionRequester">,
   request: RuntimeDynamicToolCallRequest,
   executionOptions?: RuntimeDynamicToolExecutionOptions,
 ): Promise<RuntimeDynamicToolCallResult> {
-  const action = nativeLocalAgentActions.list(options.context).find(({ toolName }) => toolName === request.toolName);
+  const action = getNativeLocalAgentActionsForContext(options.context).find(
+    ({ descriptor }) => descriptor.toolName === request.toolName,
+  );
   if (action === undefined) {
     return {
       success: false,
@@ -325,7 +363,7 @@ async function executeNativeLocalAgentAction(
       ],
     };
   }
-  if (action.authorizationMode !== "driver_handler") {
+  if (action.descriptor.authorizationMode !== "driver_handler") {
     const authorization = await authorizeRuntimeContext({
       context: options.context,
       permission: "use",
@@ -347,24 +385,25 @@ async function executeNativeLocalAgentAction(
     }
   }
   try {
-    const result = await runDynamicToolWithTimeout(request.toolName, () =>
-      nativeLocalAgentActions.invoke({
-        context: options.context,
-        toolName: request.toolName,
-        arguments: normalizeDynamicToolArguments(request.arguments),
-        ...(request.callId === undefined ? {} : { requestId: request.callId }),
-      }),
-    );
+    const actionRequest = buildNativeLocalAgentActionRequest(options.context, request);
+    if (actionRequest === undefined) {
+      return unavailableNativeLocalAgentActionResult(request.toolName);
+    }
+    const result = await runDynamicToolWithTimeout(request.toolName, async () => {
+      const localResult = await nativeLocalAgentActions.invokeRequest(actionRequest, {
+        ...(action.channelInstanceId === undefined ? {} : { channelInstanceId: action.channelInstanceId }),
+      });
+      if (localResult !== undefined) return localResult;
+      if (action.channelInstanceId === undefined) return undefined;
+      return (
+        (await (options.nativeLocalAgentActionRequester ?? requestNativeLocalAgentAction)({
+          channelInstanceId: action.channelInstanceId,
+          request: actionRequest,
+        })) ?? undefined
+      );
+    });
     if (result === undefined) {
-      return {
-        success: false,
-        contentItems: [
-          {
-            type: "inputText",
-            text: `${request.toolName} is unavailable for this turn.`,
-          },
-        ],
-      };
+      return unavailableNativeLocalAgentActionResult(request.toolName);
     }
     if (result.disposition === "rejected") {
       return {
@@ -394,6 +433,41 @@ async function executeNativeLocalAgentAction(
       ],
     };
   }
+}
+
+function buildNativeLocalAgentActionRequest(context: ContextRecord, request: RuntimeDynamicToolCallRequest) {
+  if (context.agentId === undefined || context.sessionName === undefined || context.source === undefined) {
+    return undefined;
+  }
+  return NativeLocalAgentActionRequestSchema.parse({
+    protocol: NATIVE_CHANNEL_DRIVER_PROTOCOL,
+    schemaVersion: NATIVE_CHANNEL_DRIVER_SCHEMA_VERSION,
+    requestId: request.callId ?? `action-${randomUUID()}`,
+    toolName: request.toolName,
+    arguments: normalizeDynamicToolArguments(request.arguments),
+    agentId: context.agentId,
+    sessionName: context.sessionName,
+    source: {
+      channelKind: context.source.channel,
+      accountId: context.source.accountId,
+      conversationId: context.source.chatId,
+      ...(context.source.threadId === undefined ? {} : { threadId: context.source.threadId }),
+    },
+    requestedAt: new Date().toISOString(),
+  });
+}
+
+function unavailableNativeLocalAgentActionResult(toolName: string): RuntimeDynamicToolCallResult {
+  return {
+    success: false,
+    reason: "native_local_agent_action_unavailable",
+    contentItems: [
+      {
+        type: "inputText",
+        text: `${toolName} is unavailable for this turn.`,
+      },
+    ],
+  };
 }
 
 async function authorizeRuntimeDynamicToolCall(

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -1,4 +1,5 @@
 import type { DeliveryBarrier, DeliveryBarrierSource } from "../delivery-barriers.js";
+import type { NativeLocalAgentActionTurnMetadata } from "../channels/native/agent-action-turn.js";
 import type { ThreadHandoffPromptMetadata } from "../threads/types.js";
 import type { RuntimeEventMetadata } from "./types.js";
 import type { RuntimeProviderId } from "./types.js";
@@ -119,6 +120,7 @@ export interface ChannelBackendPromptMetadata {
     connectionId: string;
     conversationId: string;
   };
+  localAgentActions?: NativeLocalAgentActionTurnMetadata;
 }
 
 export type SessionRelayAction = "send" | "ask" | "answer" | "execute" | "inform";

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -43,6 +43,82 @@ describe("runtime request context authority", () => {
     stateDir = null;
   });
 
+  it("carries only exact-source Channel-Backend local actions into the turn context", () => {
+    dbCreateAgent({ id: agent.id, cwd: agent.cwd });
+    getOrCreateSession(sessionKey, agent.id, agent.cwd, { name: sessionName });
+    const prompt: RuntimeLaunchPrompt = {
+      prompt: "create a collaboration space",
+      source: {
+        channel: "example",
+        accountId: "account-1",
+        chatId: "conversation-1",
+      },
+      _channelBackend: {
+        protocol: "ravi.channel.backend",
+        schemaVersion: 1,
+        ingressRequestId: "ingress-1",
+        correlationId: "ingress-1",
+        binding: {
+          channelInstanceId: "example-channel",
+          agentId: agent.id,
+          chatId: "chat-1",
+          messageId: "message-1",
+          sessionId: sessionName,
+          turnId: "turn-1",
+        },
+        target: {
+          channelKind: "example",
+          connectionId: "account-1",
+          conversationId: "conversation-1",
+        },
+        localAgentActions: {
+          source: {
+            channelKind: "example",
+            channelInstanceId: "example-channel",
+            accountId: "account-1",
+          },
+          descriptors: [
+            {
+              toolName: "example_create_space",
+              description: "Create a provider-owned collaboration space.",
+              inputSchema: { type: "object", properties: {} },
+              sourceAccountId: "account-1",
+              authorizationMode: "driver_handler",
+            },
+          ],
+        },
+      },
+    };
+    const { runtimeContext } = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: agent.cwd,
+      agent,
+      prompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+      resolvedSource: prompt.source,
+    });
+    const { runtimeContext: copiedContext } = buildRuntimeRequestContext({
+      dbSessionKey: sessionKey,
+      sessionName,
+      sessionCwd: agent.cwd,
+      agent,
+      prompt,
+      runtimeProviderId: "codex",
+      model: "gpt-5",
+      runtimeResolution,
+      resolvedSource: {
+        ...prompt.source!,
+        accountId: "account-2",
+      },
+    });
+
+    expect(runtimeContext.metadata?.nativeLocalAgentActions).toEqual(prompt._channelBackend!.localAgentActions);
+    expect(copiedContext.metadata?.nativeLocalAgentActions).toBeUndefined();
+  });
+
   it("uses agent identity authority by default when the env var is unset", () => {
     const previous = process.env.RAVI_TURN_SCOPED_AUTHORITY;
     delete process.env.RAVI_TURN_SCOPED_AUTHORITY;

--- a/src/runtime/runtime-request-context.ts
+++ b/src/runtime/runtime-request-context.ts
@@ -16,6 +16,7 @@ import {
 import { materializeSubjectCapabilities } from "../permissions/provider-runtime.js";
 import { dbResolveActiveTaskBindingForSession } from "../tasks/task-db.js";
 import type { TaskRuntimeResolution } from "../tasks/types.js";
+import { resolveNativeLocalAgentActionTurnMetadata } from "../channels/native/agent-action-turn.js";
 import { buildRuntimeEnv, buildTaskRuntimeEnv } from "./host-env.js";
 import type { RuntimeMessageTarget } from "./host-session.js";
 import type { MessageActorMetadata, RuntimeLaunchPrompt, RuntimeTurnOriginMetadata } from "./message-types.js";
@@ -502,6 +503,10 @@ function buildRuntimeContextMetadata(options: {
 }): Record<string, unknown> {
   const actorMetadata = buildRuntimeContextActorMetadata(options.prompt, options.resolvedSource);
   const turnOrigin = resolveRuntimeTurnOrigin(options.prompt._turnOrigin);
+  const nativeLocalAgentActions = resolveNativeLocalAgentActionTurnMetadata(
+    options.prompt._channelBackend?.localAgentActions,
+    options.resolvedSource,
+  );
   return {
     runtimeProvider: options.runtimeProviderId,
     runtimeModel: options.model,
@@ -524,6 +529,7 @@ function buildRuntimeContextMetadata(options: {
     ...(turnOrigin ? { turnOrigin } : {}),
     ...(options.prompt._observation ? { observation: { ...options.prompt._observation } } : {}),
     ...(options.prompt._thread ? { raviThread: options.prompt._thread } : {}),
+    ...(nativeLocalAgentActions ? { nativeLocalAgentActions } : {}),
   };
 }
 


### PR DESCRIPTION
## Objective

Allow provider-neutral native channel actions to be discovered and executed when the Channel Runner and Agent runtime run in separate processes.

## Problem

Native channel drivers register their handlers inside the Channel Runner, while runtime tools are materialized in the daemon. The process-local registry therefore made valid driver actions invisible and unavailable in the deployed topology.

## Solution

Snapshot bounded action descriptors onto accepted Channel-Backend turns, validate them against the exact source, and carry them into runtime context. Execute the typed action request through a correlated NATS request/reply bridge back to the exact Channel Runner instance. Ambiguity, source mismatch, timeout, malformed replies, and unavailable runners all fail closed.

## Practical impact

Drivers can expose native provider-owned actions to Agents in the real multi-process runtime. The action runs once through the owning driver handler instead of falling back to shell or a process-local assumption.

## What does NOT change

No new ambient capability is granted. Existing runtime-context authorization remains required when declared, driver_handler remains the final authorization boundary for driver-owned actions, and existing command tools keep their current behavior.

## Validation

- bun run lint
- bun run typecheck
- bun run build
- focused Channel, Runner, and runtime bridge suite: 69 passed
- quality gate suite: 38 passed
- SDK contract suite: 68 passed
- CLI command suite under a hermetic CI-equivalent PATH
- generated SDK drift check and specs sync
- unrelated task restart-recovery timeout reproduced in isolation: passed in 0.43s

## Risks

The bridge introduces an internal request/reply dependency on NATS and a bounded timeout. Stale or conflicting descriptors could otherwise target the wrong handler, so the implementation binds descriptors to the accepted source and exact Channel instance and rejects conflicts.

## Rollback

Revert this commit to remove turn-scoped descriptors and the internal bridge. Drivers then return to the previous process-local action behavior without schema migration or persisted-state cleanup.