### PR TITLE
Preserve Codex callback IDs and credential redaction

### DIFF
--- a/src/cloud-auth/redaction.test.ts
+++ b/src/cloud-auth/redaction.test.ts
@@ -17,6 +17,11 @@ describe("cloud auth redaction", () => {
         verificationUri: "https://console.example/device",
         clientSecret: "client-secret",
       },
+      installationCredential: {
+        material: {
+          privateKeyPem: "private-key-secret",
+        },
+      },
     };
 
     const redacted = redactCloudAuthPayload(payload);
@@ -25,11 +30,13 @@ describe("cloud auth redaction", () => {
     expect(encoded).not.toContain("access-secret");
     expect(encoded).not.toContain("refresh-secret");
     expect(encoded).not.toContain("client-secret");
+    expect(encoded).not.toContain("private-key-secret");
     expect(redacted.session.accessToken).toBe("[REDACTED]");
     expect(redacted.session.refreshToken).toBe("[REDACTED]");
     expect(redacted.session.accessTokenExpiresAt).toBe("2026-05-10T00:00:00.000Z");
     expect(redacted.session.refreshTokenExpiresAt).toBe("2026-06-10T00:00:00.000Z");
     expect(redacted.session.installation.id).toBe("ins_123");
     expect(redacted.auth.authorizationUrl).toBe("https://console.example/login?code=ABC");
+    expect(redacted.installationCredential.material as unknown).toBe("[REDACTED]");
   });
 });

--- a/src/cloud-auth/redaction.ts
+++ b/src/cloud-auth/redaction.ts
@@ -26,7 +26,11 @@ function isSecretKey(key: string): boolean {
     normalized === "idtoken" ||
     normalized === "provideraccesstoken" ||
     normalized === "authorization" ||
-    normalized === "cookie"
+    normalized === "cookie" ||
+    normalized === "material" ||
+    normalized.includes("privatekey") ||
+    normalized === "credentialmaterial" ||
+    normalized === "machinecredential"
   ) {
     return true;
   }

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -2220,12 +2220,11 @@ const finishIfReady = () => {
 rl.on("line", (line) => {
   const message = JSON.parse(line);
   if (message.id && !message.method) {
-    if (message.id === 77) {
-      if (message.jsonrpc !== "2.0") throw new Error("tool response must include jsonrpc 2.0");
-      if (typeof message.id !== "number") throw new Error("numeric tool request ids must remain numeric");
-      if (!Array.isArray(message.result?.contentItems)) throw new Error("tool response must use contentItems");
-      if (message.result?.content_items) throw new Error("tool response must not use content_items");
-    }
+    if (message.jsonrpc !== "2.0") throw new Error("tool response must include jsonrpc 2.0");
+    if (typeof message.id !== "number") throw new Error("numeric tool request ids must remain numeric");
+    if (message.id !== 77) throw new Error("tool response must preserve the original numeric request id");
+    if (!Array.isArray(message.result?.contentItems)) throw new Error("tool response must use contentItems");
+    if (message.result?.content_items) throw new Error("tool response must not use content_items");
     toolResponse = message.result;
     finishIfReady();
     return;

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -2220,8 +2220,9 @@ const finishIfReady = () => {
 rl.on("line", (line) => {
   const message = JSON.parse(line);
   if (message.id && !message.method) {
-    if (message.id === "tool_req") {
+    if (message.id === 77) {
       if (message.jsonrpc !== "2.0") throw new Error("tool response must include jsonrpc 2.0");
+      if (typeof message.id !== "number") throw new Error("numeric tool request ids must remain numeric");
       if (!Array.isArray(message.result?.contentItems)) throw new Error("tool response must use contentItems");
       if (message.result?.content_items) throw new Error("tool response must not use content_items");
     }
@@ -2253,7 +2254,7 @@ rl.on("line", (line) => {
     });
     send({
       jsonrpc: "2.0",
-      id: "tool_req",
+      id: 77,
       method: "item/tool/call",
       params: {
         callId: "dyn_tool_1",

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -1100,7 +1100,11 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     });
   }
 
-  async function handleServerRequest(id: string, method: string, params: Record<string, unknown>): Promise<void> {
+  async function handleServerRequest(
+    id: string | number,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<void> {
     if (isCodexApprovalRequestMethod(method)) {
       const request = buildRuntimeApprovalRequest(method, params, activeTurn, currentThreadId);
       activeTurn?.queue.push(buildApprovalTraceEvent("approval.requested", request));
@@ -1143,7 +1147,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     }
   }
 
-  async function handleDynamicToolCall(id: string, params: Record<string, unknown>): Promise<void> {
+  async function handleDynamicToolCall(id: string | number, params: Record<string, unknown>): Promise<void> {
     const request = buildRuntimeDynamicToolCallRequest(params, activeTurn, currentThreadId);
     activeTurn?.queue.push(buildDynamicToolTraceEvent("item.started", request));
 
@@ -1393,9 +1397,11 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
 
   function routeAppServerMessage(message: CodexJsonRpcMessage): void {
     if (typeof message.id === "string" || typeof message.id === "number") {
-      const requestId = String(message.id);
       if (typeof message.method === "string") {
-        void handleServerRequest(requestId, message.method, asRecord(message.params) ?? {}).catch((error) => {
+        // JSON-RPC request ids are type-sensitive in the Codex app-server
+        // callback registry. Preserve the original string/number representation
+        // when replying to a server-initiated request.
+        void handleServerRequest(message.id, message.method, asRecord(message.params) ?? {}).catch((error) => {
           if (activeTurn) {
             settleTurn(activeTurn, { exitCode: 1, stderr: getStderr() }, { failQueue: error });
           }
@@ -1403,6 +1409,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         return;
       }
 
+      const requestId = String(message.id);
       const pending = pendingRequests.get(requestId);
       if (pending) {
         pendingRequests.delete(requestId);


### PR DESCRIPTION
## Objective

Preserve protocol-correct Codex callback responses and prevent credential material from reaching logs.

## Problem

Server-initiated JSON-RPC callbacks may use numeric IDs, but the provider narrowed them to strings. Authentication redaction also missed credential-bearing fields introduced by the cloud auth flow.

## Solution

- Preserve string and numeric JSON-RPC IDs when replying to Codex callbacks.
- Redact `material`, `credentialMaterial`, `machineCredential`, and private-key-shaped fields recursively.
- Add focused regression coverage for both behaviors.

## Practical impact

Codex callbacks retain the exact correlation ID sent by the server, and authentication diagnostics remain content-free when credential-bearing payloads pass through the logger.

## What does NOT change

Codex dynamic tools remain disabled. The CLI command registry is not advertised to Codex and no host execution bridge is added. Ravi root login remains connected to Ravi Console.

## Validation

- Focused runtime, provider-contract, auth, storage, and CLI tests: 62 passed, 0 failed.
- Typecheck passed.
- Complete mandatory pre-push gate passed, including build, SDK drift checks, full tests, and generated-client verification.
- `git diff --check` passed.

## Risks

The callback type widens only to the JSON-RPC-compatible string-or-number domain. Redaction is intentionally conservative and may hide additional nested diagnostic values whose keys identify credential material.

## Rollback

Revert commit `74c23722` to restore the previous callback typing and redaction behavior.