### PR TITLE
Add crash recovery contract and persistent ledger

### DIFF
--- a/.ravi/specs/daemon/restart/crash-recovery/CHECKS.md
+++ b/.ravi/specs/daemon/restart/crash-recovery/CHECKS.md
@@ -1,0 +1,73 @@
+---
+id: daemon/restart/crash-recovery/checks
+title: Abrupt Crash Recovery Checks
+kind: checks
+domain: daemon
+capability: restart
+feature: crash-recovery
+status: active
+normative: false
+---
+
+# Abrupt Crash Recovery Checks
+
+## Contract And Schema
+
+- The spec inherits `daemon/restart` and explicitly complements graceful active-session resume.
+- `session_turns.status=running` alone never authorizes replay.
+- Every provider delivery has an `attempt_id`; `turn_id` may repeat across attempts.
+- Boot state is one of `active`, `graceful_stopped`, or `abandoned`; active ownership has a heartbeat/lease and terminal transitions are monotonic.
+- Attempt state is terminal once it leaves `running`.
+- Tool-started and output-materialized markers only move from false to true.
+- Prompt atoms retain session, lane, sequence, envelope, origin, delivery barrier, task barrier, pending id, dedupe key, and lease ownership.
+- Recovery audit retains run, candidate, decision, reason, proposed action, claim, action status, and result.
+- Claim identity is globally unique by logical candidate, not only within one run.
+- Candidate keys are derived from their durable source identity, not accepted as caller-defined aliases.
+- Boot abandonment and queue ownership changes are fenced by the exact observed lease state.
+
+## Storage Behavior
+
+- Reopening an initialized DB does not fail or recreate incompatible tables.
+- Creating an attempt requires an active owning boot.
+- A heartbeat cannot revive a terminal attempt or move its lease backwards.
+- Attempt and queue leases cannot outlive their boot lease.
+- An identical prompt enqueue retry is idempotent.
+- A divergent prompt enqueue using the same dedupe key fails.
+- Same-lane queue reads are FIFO by durable sequence, including equal timestamps.
+- Queue lifecycle updates use compare-and-set semantics.
+- An owner-bound queue update requires the observed boot, owner token, and lease expiry; stale owners lose the CAS.
+- Queue delivery follows `leased -> starting -> delivered`; queued work cannot skip ownership and delivered work cannot be leased again.
+- Queue transitions preserve immutable enqueue metadata and cannot deliver after the observed queue lease expires.
+- A delivered queue row cannot reference an attempt from another session or boot owner.
+- Delivery rejects target attempts that are terminal, expired, or already recovery-claimed.
+- A persisted prompt atom is rejected if its recomputed immutable fingerprint differs, even when the modified JSON remains valid.
+- A dry-run or inspect run cannot acquire a recovery claim.
+- Two apply runs claiming the same candidate produce one durable winner.
+- A two-process race against the same candidate produces one durable winner.
+- The two-process race uses distinct live boots and a start barrier so global uniqueness is exercised across overlapping apply runs.
+- Completing a claim does not make the candidate claimable again.
+- A claimed attempt or queue row rejects normal owner mutations; only its recovery claim may advance recovery projections.
+- Claim completion rejects partial attempt and queue projection divergence while preserving transactional rollback.
+- Completing a recovery run decodes every candidate and fails closed on an unknown lifecycle value.
+- Persisted safety booleans accept only `0` or `1` and otherwise fail closed.
+- Divergent terminal retries, regressive timestamps, corrupt safety enums, and missing source projections fail closed.
+- An apply run cannot complete with pending or claimed candidates.
+
+## Scope Guard
+
+- No daemon startup hook is added in the first child.
+- No provider or event-loop instrumentation is added in the first child.
+- No live dispatcher queue is persisted in the first child.
+- No classifier, sweeper, resume, requeue, or operator apply CLI is added in the first child.
+- No exactly-once claim is made for external side effects.
+
+## Commands
+
+```bash
+ravi specs sync --json
+ravi specs get daemon/restart/crash-recovery --mode full --json
+ravi specs get daemon/restart/crash-recovery --mode checks --json
+bun test src/runtime/crash-recovery-store.test.ts
+bun run typecheck
+bun run build
+```

--- a/.ravi/specs/daemon/restart/crash-recovery/RUNBOOK.md
+++ b/.ravi/specs/daemon/restart/crash-recovery/RUNBOOK.md
@@ -1,0 +1,63 @@
+---
+id: daemon/restart/crash-recovery/runbook
+title: Abrupt Crash Recovery Runbook
+kind: runbook
+domain: daemon
+capability: restart
+feature: crash-recovery
+status: active
+normative: false
+---
+
+# Abrupt Crash Recovery Runbook
+
+## Current Phase
+
+The contract-and-ledger child is storage-only. It does not run a startup sweep and does not resume sessions. Until the later inspect/apply CLI exists, do not mutate live recovery rows manually to force a replay.
+
+## When A Crash Leaves Running Turns
+
+1. Preserve the database and runtime trace; do not delete stale `session_turns` rows.
+2. Determine whether shutdown was graceful. Graceful restart remains governed by `daemon/restart/active-session-resume`.
+3. Treat a `running` trace row without an abandoned boot, expired attempt lease, durable request/checkpoint, and safe markers as inspection evidence only.
+4. If a tool may have started, output may have materialized, ownership is ambiguous, or the producer is recurring, fail closed and wait for the later recovery classifier/manual-review surface.
+5. Send any manually authorized continuation back through the session dispatcher. Never invoke a provider directly.
+
+## Ledger Diagnosis
+
+For development and hermetic tests, verify these relationships:
+
+- `runtime_boot_epochs.boot_epoch` owns attempt and queue leases.
+- `runtime_turn_attempts.attempt_id` identifies a delivery attempt; `turn_id` is not unique.
+- `runtime_prompt_queue.queue_sequence` establishes durable FIFO order inside `session_key + lane_key`.
+- `runtime_recovery_candidates` records each run's evaluation.
+- `runtime_recovery_claims.candidate_key` is globally unique across apply runs.
+
+An apply claim is valid only when:
+
+- the recovery run is `running` and mode `apply`;
+- the claiming boot is active and its lease remains live;
+- the candidate belongs to that run;
+- the underlying attempt or queue item is still unclaimed.
+
+Once the claim is acquired, the source is fenced from normal heartbeat, safety, terminal, and queue-CAS mutations. Do not clear `recovery_claim_id` or mutate the source manually to let an old owner continue; finish or fail the durable claim instead.
+
+Abandon a prior boot only with the heartbeat and lease values read during the same inspection decision. If either value changed, re-read and reclassify. Likewise, an owner-bound queue transition must carry the observed boot, lease owner token, and lease expiry; a lost CAS is a normal signal to stop, not a reason to force the update.
+
+Queue delivery must advance through lease and starting ownership before `delivered`, and its target attempt must still be running, unexpired, and unclaimed. Never move a delivered row back to `leased`; a later attempt must be represented by the recovery ledger and the later dispatcher integration. Treat an immutable-fingerprint mismatch, an invalid persisted lifecycle value, or a partial claim projection as corruption requiring inspection, never as safe replay evidence.
+
+Candidate keys are generated from durable source identity. Do not invent aliases or recycle a key across an attempt and queue item. A recovery run is terminal only after all apply candidates are `applied`, `failed`, or `not_applied`.
+
+Inspect and dry-run must never create a claim.
+
+## Development Validation
+
+```bash
+ravi specs sync --json
+ravi specs get daemon/restart/crash-recovery --mode full --json
+bun test src/runtime/crash-recovery-store.test.ts
+bun run typecheck
+bun run build
+```
+
+The later feature phases add dispatcher, session trace, CLI, and crash-harness validation. Do not report those as covered by the ledger-only child.

--- a/.ravi/specs/daemon/restart/crash-recovery/SPEC.md
+++ b/.ravi/specs/daemon/restart/crash-recovery/SPEC.md
@@ -1,0 +1,149 @@
+---
+id: daemon/restart/crash-recovery
+title: Abrupt Crash Recovery
+kind: feature
+domain: daemon
+capability: restart
+feature: crash-recovery
+capabilities:
+  - restart
+  - runtime-context
+  - session-continuity
+  - delivery-queue
+tags:
+  - daemon
+  - crash-recovery
+  - runtime
+  - ledger
+applies_to:
+  - src/router/router-db.ts
+  - src/runtime/crash-recovery-store.ts
+  - src/runtime/crash-recovery.ts
+  - src/runtime/session-dispatcher.ts
+  - src/runtime/host-event-loop.ts
+  - src/daemon.ts
+owners:
+  - dev
+status: active
+normative: true
+---
+
+# Abrupt Crash Recovery
+
+## Intent
+
+Ravi must recover durable runtime work after an abrupt daemon or machine crash without treating historical trace rows as permission to replay side effects.
+
+This feature complements `daemon/restart/active-session-resume`: graceful restart snapshots describe process memory captured during an intentional shutdown, while abrupt crash recovery relies on durable boot ownership, leases, immutable prompt atoms, safety markers, and transactional claims.
+
+## Source Of Truth Boundaries
+
+- `session_turns` remains the historical trace and cost surface. A recent `session_turns.status=running` row alone MUST NOT authorize replay.
+- The crash-recovery ledger is the source of truth for boot ownership, provider attempts, durable queued prompt atoms, recovery claims, and audited recovery decisions.
+- Provider adapters MUST NOT own recovery policy. Safe work MUST re-enter through `RuntimeSessionDispatcher` and its normal pool, queue, task-barrier, delivery-barrier, and interruption rules.
+- Recovery MUST NOT delete or rewrite historical turn trace rows to hide stale state.
+
+## Durable Contract
+
+### Boot epochs
+
+Every daemon process MUST have a durable `boot_epoch`, scoped to an instance and process id, with one of these states:
+
+- `active`
+- `graceful_stopped`
+- `abandoned`
+
+An active boot MUST renew a durable heartbeat and lease. Abandonment MUST compare-and-set the exact heartbeat and lease previously observed, and MUST NOT occur before that observed lease expires. An expired lease is evidence for later classification, not sufficient by itself to replay work. Terminal boot state is monotonic. A graceful boot MUST NOT later become abandoned, and an abandoned boot MUST NOT later become graceful.
+
+### Turn attempts
+
+Every provider delivery attempt MUST have its own durable `attempt_id`; multiple attempts MAY reference the same logical `turn_id`, and a recovered attempt SHOULD reference the preceding attempt explicitly.
+
+The attempt MUST record:
+
+- owning boot epoch, session, run/turn identity, provider, and model;
+- start time, last heartbeat, and lease expiry;
+- durable request/prompt/checkpoint references sufficient for later classification;
+- source, turn provenance, delivery barrier, task barrier, and pending ids;
+- monotonic `started_tool` and `materialized_output` safety markers;
+- terminal state and recovery claim/result references.
+
+Every attempt MUST carry a durable request blob reference or provider checkpoint, and attempt/queue leases MUST NOT outlive the owning boot lease. An attempt owned by a live boot or with an unexpired lease MUST NOT be classified as an orphan. Terminal attempts MUST NOT return to `running`.
+
+### Prompt queue
+
+Every durable queue row represents one immutable prompt atom. It MUST retain:
+
+- a stable queue item id and dedupe key;
+- session and lane identity plus a durable monotonic sequence;
+- the original prompt envelope and runtime message metadata;
+- origin, delivery barrier, task barrier, pending id, and boot/lease ownership;
+- lifecycle, recovery claim, and result metadata.
+
+Reusing a dedupe key with different immutable content MUST fail. Queue reads MUST preserve FIFO within a session lane by durable sequence, not timestamp alone.
+
+Every owner-bound queue transition MUST compare the observed boot, lease owner token, and lease expiry. A stale worker MUST receive a lost-CAS result and MUST NOT advance or replace another owner's lease. Delivery MUST bind the prompt to a running, unexpired, unclaimed attempt from the same session and boot owner.
+
+Queue lifecycle MUST follow an explicit forward transition graph. A prompt MUST be leased before it starts, MUST be starting under a fenced live owner before delivery, and MUST NOT return from `delivered` to a leaseable state. Enqueue metadata is part of the immutable prompt atom and lifecycle transitions MUST preserve it. The immutable fingerprint MUST be recomputed from the persisted prompt atom whenever the row is read or deduplicated; valid-but-divergent JSON is ledger corruption, not a new prompt value.
+
+### Recovery runs, candidates, and claims
+
+Each inspect, dry-run, or apply pass MUST have a durable recovery run. Each evaluated candidate MUST record a stable candidate key, decision, reason code, proposed action, action status, claim, and result.
+
+Candidate keys MUST be derived canonically from the attempt, queue item, or legacy session+turn identity; caller-defined aliases MUST NOT decide global uniqueness. Claims MUST be transactional and globally unique by logical candidate key. Repeated or concurrent apply passes MUST acquire at most one claim for a candidate. A failed claimed action remains auditable and MUST NOT silently become replayable again.
+
+Inspect and dry-run modes MUST NOT acquire claims or produce runtime side effects.
+
+Terminal writes are strongly idempotent: an exact retry returns the durable row, while a retry with a different timestamp, result, reason, summary, or immutable projection MUST fail closed. An apply run MUST NOT become terminal while a candidate remains pending or claimed.
+
+Acquiring a recovery claim fences the underlying attempt or queue row immediately. Normal owner mutations MUST reject a claimed source and their SQL compare-and-set MUST include an unclaimed-source predicate. Only the recovery claim projection may advance recovery result fields for that claim, and completion MUST compare every claimed source projection instead of repairing partial divergence. Persisted safety booleans and lifecycle enums MUST be decoded strictly before a mutating decision; an unknown value MUST fail closed as ledger corruption.
+
+## Recovery Policy
+
+The classifier and sweeper are later phases, but their contract is fixed here:
+
+- candidates MUST come from expired non-terminal attempts owned by an abandoned boot or durable queued work without a live owner;
+- ambiguous ownership, missing checkpoint/request data, unsafe tool execution, or materialized output MUST fail closed;
+- recurring cron, heartbeat, follow-up, and sweep work SHOULD defer to the next schedule unless the producer explicitly opts into crash resume;
+- stable decisions are `resume`, `requeue`, `reconcile_interrupted`, `defer_next_schedule`, `ignore_stale`, and `manual_review`;
+- recovery MUST NOT promise exactly-once external effects without a producer-owned durable idempotency key;
+- resumed or requeued work MUST NOT call a provider directly.
+
+## First Delivery Cut: Contract And Ledger
+
+The first implementation child is intentionally limited to:
+
+- this normative specification;
+- persistent boot, turn-attempt, prompt-queue, recovery-run, candidate, and claim tables;
+- typed storage APIs with monotonic state changes, immutable dedupe, FIFO reads, and transactional claim semantics;
+- focused persistence and idempotency tests.
+
+It MUST NOT start a recovery sweep, instrument daemon/provider lifecycle, persist the live dispatcher queue, classify candidates, resume work, add CLI apply surfaces, or claim crash/reboot E2E coverage. Those are later children.
+
+## Acceptance Criteria
+
+- Schema creation is idempotent on an existing Ravi database.
+- Boot and attempt terminal state cannot be reversed.
+- Tool/output safety markers are monotonic.
+- Prompt dedupe accepts an identical retry and rejects divergent content.
+- Same-lane prompt rows are returned in durable FIFO order.
+- Inspect/dry-run recovery runs cannot acquire a claim.
+- Repeated or concurrent apply claims return one winner and the original durable claim to all losers.
+- A real two-process claim race persists one global claim.
+- Boot abandonment and owner-bound queue transitions use observed lease fencing.
+- Queue delivery requires the forward `leased -> starting -> delivered` lifecycle and delivered rows cannot be leased again.
+- Recovery claims fence normal attempt and queue mutation before an action can be applied.
+- Delivery rejects terminal, expired, or recovery-claimed target attempts.
+- Claim completion rejects partial source-projection divergence, and run completion decodes every candidate before deciding no work remains.
+- Persisted prompt fingerprints are revalidated against row contents, including valid JSON tampering.
+- Regressive timestamps, divergent terminal retries, cross-session delivery, unknown safety enums, and incomplete source projections fail closed.
+- Candidate audit exposes decision, reason, proposed action, claim, action status, and result without deleting history.
+- No startup, dispatcher, provider, or channel behavior changes in this cut.
+
+## Validation
+
+- `ravi specs sync --json`
+- `ravi specs get daemon/restart/crash-recovery --mode full --json`
+- `bun test src/runtime/crash-recovery-store.test.ts`
+- `bun run typecheck`
+- `bun run build`

--- a/.ravi/specs/daemon/restart/crash-recovery/WHY.md
+++ b/.ravi/specs/daemon/restart/crash-recovery/WHY.md
@@ -1,0 +1,66 @@
+---
+id: daemon/restart/crash-recovery/why
+title: Why Abrupt Crash Recovery Uses A Separate Ledger
+kind: why
+domain: daemon
+capability: restart
+feature: crash-recovery
+status: active
+normative: false
+---
+
+# Why Abrupt Crash Recovery Uses A Separate Ledger
+
+## Problem
+
+An intentional restart can snapshot the dispatcher's in-memory state. An abrupt process or machine crash cannot. After reboot, Ravi may still have a `running` trace row even though ownership, pending prompt atoms, tool state, and external effects are unknown.
+
+Replaying that row is unsafe. It may duplicate a tool call or response, resume recurring work that should wait for its next schedule, or race another live boot.
+
+## Decision
+
+Use an append-oriented ledger separate from `session_turns`:
+
+- boot epochs prove process ownership and whether shutdown was graceful;
+- per-delivery attempts carry leases and monotonic safety markers;
+- prompt atoms retain their original ordering and barriers;
+- recovery runs and candidates retain decisions and results;
+- a global transactional claim prevents duplicate apply across sweeps.
+
+`session_turns` remains valuable evidence, but evidence is not replay authority.
+
+## Why Attempts Are Not Turns
+
+A logical turn may be delivered more than once across provider or process recovery. Making `turn_id` the attempt primary key would collapse distinct ownership and safety histories. The ledger therefore assigns an `attempt_id` to each delivery while retaining `turn_id` as a reference.
+
+## Why Queue Order Is Explicit
+
+Timestamps can collide and do not encode a stable SQLite insertion order. A durable monotonic sequence lets the runtime preserve FIFO within a lane after reboot while still allowing the dispatcher to apply its documented cross-lane barrier policy.
+
+## Why Claims Are Separate
+
+Candidate audit is per recovery run, so the same candidate can appear in inspect, dry-run, and later apply histories. Claim ownership must span those runs. A separate claim keyed by logical candidate makes apply idempotent without erasing prior evaluations.
+
+The key is derived from the durable source identity. Letting a caller choose aliases would turn an accidental collision into lost work or let one source acquire multiple claims under different names.
+
+## Why Lease Fencing Is Explicit
+
+Checking only `status=active` cannot distinguish a current owner from a stale process after renewal or takeover. Boot abandonment compares the exact observed heartbeat and lease, and owner-bound queue transitions compare the boot, owner token, and lease expiry. This makes stale observations lose safely under SQLite's transactional write boundary.
+
+A recovery claim is also a fence: once recovery owns a source, the original attempt or queue owner cannot keep heartbeating, terminalize it, or advance delivery concurrently. The normal mutation SQL repeats the unclaimed predicate so a check/update race also loses safely.
+
+## Why Prompt Fingerprints Are Revalidated
+
+Comparing a retry only with the fingerprint column would trust the digest and payload columns to remain synchronized. Recomputing the fingerprint from each persisted prompt atom detects valid JSON that changed independently and prevents a corrupt payload from being treated as the original deduplicated work.
+
+## Alternatives Rejected
+
+- **Replay every recent running turn:** cannot distinguish live, stale, unsafe, or already materialized work.
+- **Reuse graceful restart snapshots only:** those snapshots do not exist after an abrupt crash.
+- **Delete stale trace rows:** destroys evidence and does not make replay safe.
+- **Let providers resume themselves:** leaks Ravi queue, task, and delivery policy into adapters.
+- **Exactly-once promise:** impossible for arbitrary external effects without producer-owned idempotency.
+
+## Sequencing
+
+The ledger lands before instrumentation, queue persistence, classifier, sweeper, CLI, and crash harness. This keeps the first change inert at runtime while fixing the data contract those later phases depend on.

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -286,6 +286,17 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/router/"]);
   });
 
+  it("accepts crash recovery store coverage across router persistence and runtime changes", () => {
+    const result = runCoverageGate([
+      "src/router/router-db.ts",
+      "src/runtime/crash-recovery-store.ts",
+      "src/runtime/crash-recovery-store.test.ts",
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/router/", "src/runtime/"]);
+  });
+
   it("accepts channel backend coverage across channel, router, and runtime changes", () => {
     const result = runCoverageGate([
       "src/channels/backend.ts",

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -43,6 +43,8 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/router/chat-schema.test.ts",
     "src/router/sessions.test.ts",
     "src/router/resolver.test.ts",
+    // Crash-recovery storage covers both the router schema and its typed runtime DAO.
+    "src/runtime/crash-recovery-store.test.ts",
     "src/runtime/session-goals.test.ts",
     // Skill-grant store (dbUpsert/List/DeleteSkillGrant*) is exercised here.
     "src/cli/commands/skills.test.ts",
@@ -54,6 +56,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/runtime/index.test.ts",
     "src/runtime/model-catalog.test.ts",
     "src/runtime/context-registry.test.ts",
+    "src/runtime/crash-recovery-store.test.ts",
     "src/runtime/observation-plane.test.ts",
     "src/runtime/runtime-request-context.test.ts",
     "src/runtime/session-goals.test.ts",

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -2113,6 +2113,247 @@ function getDb(): Database {
     CREATE INDEX IF NOT EXISTS idx_session_turns_run
       ON session_turns(run_id, started_at);
 
+    CREATE TABLE IF NOT EXISTS runtime_boot_epochs (
+      boot_epoch TEXT PRIMARY KEY,
+      instance_id TEXT NOT NULL,
+      pid INTEGER NOT NULL CHECK(pid > 0),
+      status TEXT NOT NULL CHECK(status IN ('active','graceful_stopped','abandoned')),
+      started_at INTEGER NOT NULL,
+      last_heartbeat_at INTEGER NOT NULL,
+      lease_expires_at INTEGER NOT NULL,
+      graceful_stopped_at INTEGER,
+      abandoned_at INTEGER,
+      stop_reason TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      CHECK(
+        (status = 'active' AND graceful_stopped_at IS NULL AND abandoned_at IS NULL)
+        OR (status = 'graceful_stopped' AND graceful_stopped_at IS NOT NULL AND abandoned_at IS NULL)
+        OR (status = 'abandoned' AND abandoned_at IS NOT NULL AND graceful_stopped_at IS NULL)
+      ),
+      CHECK(last_heartbeat_at >= started_at),
+      CHECK(lease_expires_at > last_heartbeat_at),
+      CHECK(graceful_stopped_at IS NULL OR graceful_stopped_at >= last_heartbeat_at),
+      CHECK(abandoned_at IS NULL OR abandoned_at >= lease_expires_at),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_boot_epochs_status
+      ON runtime_boot_epochs(instance_id, status, lease_expires_at, started_at DESC);
+
+    CREATE TABLE IF NOT EXISTS runtime_recovery_runs (
+      recovery_run_id TEXT PRIMARY KEY,
+      mode TEXT NOT NULL CHECK(mode IN ('inspect','dry-run','apply')),
+      boot_epoch TEXT,
+      status TEXT NOT NULL CHECK(status IN ('running','complete','failed')),
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      summary_json TEXT,
+      error TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(boot_epoch) REFERENCES runtime_boot_epochs(boot_epoch) ON DELETE RESTRICT,
+      CHECK(
+        (status = 'running' AND completed_at IS NULL)
+        OR (status != 'running' AND completed_at IS NOT NULL)
+      ),
+      CHECK(completed_at IS NULL OR completed_at >= started_at),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_recovery_runs_started
+      ON runtime_recovery_runs(started_at DESC);
+
+    CREATE TABLE IF NOT EXISTS runtime_turn_attempts (
+      attempt_id TEXT PRIMARY KEY,
+      turn_id TEXT NOT NULL,
+      recovered_from_attempt_id TEXT,
+      run_id TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      session_name TEXT,
+      agent_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      boot_epoch TEXT NOT NULL,
+      status TEXT NOT NULL CHECK(status IN ('running','complete','failed','interrupted','timeout','aborted')),
+      started_at INTEGER NOT NULL,
+      lease_expires_at INTEGER NOT NULL,
+      last_heartbeat_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      request_blob_sha256 TEXT,
+      user_prompt_sha256 TEXT,
+      system_prompt_sha256 TEXT,
+      checkpoint_json TEXT,
+      origin_kind TEXT NOT NULL CHECK(origin_kind IN ('human','cron','trigger','session-followup','heartbeat','observer','task','routine','daemon-restart','automation','agent','system','background','unknown')),
+      source_json TEXT,
+      turn_provenance_json TEXT,
+      task_barrier_task_id TEXT,
+      delivery_barrier TEXT NOT NULL CHECK(delivery_barrier IN ('immediate_interrupt','after_tool','after_response','after_task')),
+      pending_ids_json TEXT,
+      started_tool INTEGER NOT NULL DEFAULT 0 CHECK(started_tool IN (0,1)),
+      materialized_output INTEGER NOT NULL DEFAULT 0 CHECK(materialized_output IN (0,1)),
+      recovery_claim_id TEXT,
+      recovery_status TEXT,
+      recovery_reason TEXT,
+      recovery_run_id TEXT,
+      recovered_at INTEGER,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(boot_epoch) REFERENCES runtime_boot_epochs(boot_epoch) ON DELETE RESTRICT,
+      FOREIGN KEY(recovered_from_attempt_id) REFERENCES runtime_turn_attempts(attempt_id) ON DELETE RESTRICT,
+      FOREIGN KEY(recovery_run_id) REFERENCES runtime_recovery_runs(recovery_run_id) ON DELETE RESTRICT,
+      FOREIGN KEY(recovery_claim_id) REFERENCES runtime_recovery_claims(claim_id) ON DELETE RESTRICT,
+      CHECK(
+        (status = 'running' AND completed_at IS NULL)
+        OR (status != 'running' AND completed_at IS NOT NULL)
+      ),
+      CHECK(last_heartbeat_at >= started_at),
+      CHECK(lease_expires_at > last_heartbeat_at),
+      CHECK(completed_at IS NULL OR completed_at >= last_heartbeat_at),
+      CHECK(request_blob_sha256 IS NOT NULL OR checkpoint_json IS NOT NULL),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_turn_attempts_recovery
+      ON runtime_turn_attempts(status, boot_epoch, lease_expires_at, recovery_status);
+    CREATE INDEX IF NOT EXISTS idx_runtime_turn_attempts_session
+      ON runtime_turn_attempts(session_key, started_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_runtime_turn_attempts_turn
+      ON runtime_turn_attempts(turn_id, started_at DESC);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_runtime_turn_attempts_claim
+      ON runtime_turn_attempts(recovery_claim_id)
+      WHERE recovery_claim_id IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS runtime_prompt_queue (
+      queue_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      queue_item_id TEXT NOT NULL UNIQUE,
+      dedupe_key TEXT NOT NULL UNIQUE,
+      immutable_fingerprint TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      session_name TEXT,
+      agent_id TEXT,
+      lane_key TEXT NOT NULL CHECK(lane_key IN ('immediate_interrupt','after_tool','after_response','after_task')),
+      boot_epoch TEXT,
+      status TEXT NOT NULL CHECK(status IN ('queued','leased','starting','delivered','complete','cancelled','superseded','failed','requeued','deferred')),
+      origin_kind TEXT NOT NULL CHECK(origin_kind IN ('human','cron','trigger','session-followup','heartbeat','observer','task','routine','daemon-restart','automation','agent','system','background','unknown')),
+      delivery_barrier TEXT NOT NULL CHECK(delivery_barrier IN ('immediate_interrupt','after_tool','after_response','after_task')),
+      task_barrier_task_id TEXT,
+      pending_id TEXT,
+      prompt_json TEXT NOT NULL,
+      runtime_message_json TEXT NOT NULL,
+      queued_at INTEGER NOT NULL,
+      lease_owner TEXT,
+      lease_expires_at INTEGER,
+      delivered_attempt_id TEXT,
+      delivered_turn_id TEXT,
+      completed_at INTEGER,
+      recovery_claim_id TEXT,
+      recovery_status TEXT,
+      recovery_reason TEXT,
+      recovery_run_id TEXT,
+      recovered_at INTEGER,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(boot_epoch) REFERENCES runtime_boot_epochs(boot_epoch) ON DELETE RESTRICT,
+      FOREIGN KEY(delivered_attempt_id) REFERENCES runtime_turn_attempts(attempt_id) ON DELETE RESTRICT,
+      FOREIGN KEY(recovery_run_id) REFERENCES runtime_recovery_runs(recovery_run_id) ON DELETE RESTRICT,
+      FOREIGN KEY(recovery_claim_id) REFERENCES runtime_recovery_claims(claim_id) ON DELETE RESTRICT,
+      CHECK((status IN ('complete','cancelled','superseded','failed') AND completed_at IS NOT NULL) OR (status NOT IN ('complete','cancelled','superseded','failed') AND completed_at IS NULL)),
+      CHECK(lease_expires_at IS NULL OR lease_owner IS NOT NULL),
+      CHECK(status NOT IN ('leased','starting') OR (boot_epoch IS NOT NULL AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)),
+      CHECK(status != 'delivered' OR (delivered_attempt_id IS NOT NULL AND delivered_turn_id IS NOT NULL)),
+      CHECK(completed_at IS NULL OR completed_at >= queued_at),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_prompt_queue_status
+      ON runtime_prompt_queue(status, boot_epoch, queue_sequence);
+    CREATE INDEX IF NOT EXISTS idx_runtime_prompt_queue_session_lane
+      ON runtime_prompt_queue(session_key, lane_key, queue_sequence);
+    CREATE INDEX IF NOT EXISTS idx_runtime_prompt_queue_pending
+      ON runtime_prompt_queue(session_key, pending_id);
+    CREATE INDEX IF NOT EXISTS idx_runtime_prompt_queue_lease
+      ON runtime_prompt_queue(status, lease_expires_at)
+      WHERE lease_expires_at IS NOT NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_runtime_prompt_queue_claim
+      ON runtime_prompt_queue(recovery_claim_id)
+      WHERE recovery_claim_id IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS runtime_recovery_candidates (
+      recovery_run_id TEXT NOT NULL,
+      candidate_key TEXT NOT NULL,
+      candidate_type TEXT NOT NULL CHECK(candidate_type IN ('turn_attempt','prompt_queue','legacy_session_turn')),
+      session_key TEXT NOT NULL,
+      session_name TEXT,
+      attempt_id TEXT,
+      turn_id TEXT,
+      queue_item_id TEXT,
+      decision TEXT NOT NULL CHECK(decision IN ('resume','requeue','reconcile_interrupted','defer_next_schedule','ignore_stale','manual_review')),
+      reason_code TEXT NOT NULL,
+      action TEXT NOT NULL,
+      action_status TEXT NOT NULL CHECK(action_status IN ('pending','not_applied','claimed','applied','failed')),
+      claim_id TEXT,
+      details_json TEXT,
+      result_json TEXT,
+      action_completed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (recovery_run_id, candidate_key),
+      FOREIGN KEY(recovery_run_id) REFERENCES runtime_recovery_runs(recovery_run_id) ON DELETE RESTRICT,
+      FOREIGN KEY(attempt_id) REFERENCES runtime_turn_attempts(attempt_id) ON DELETE RESTRICT,
+      FOREIGN KEY(queue_item_id) REFERENCES runtime_prompt_queue(queue_item_id) ON DELETE RESTRICT,
+      FOREIGN KEY(claim_id) REFERENCES runtime_recovery_claims(claim_id) ON DELETE RESTRICT,
+      CHECK(
+        (candidate_type = 'turn_attempt' AND attempt_id IS NOT NULL AND queue_item_id IS NULL)
+        OR (candidate_type = 'prompt_queue' AND queue_item_id IS NOT NULL AND attempt_id IS NULL)
+        OR (candidate_type = 'legacy_session_turn' AND attempt_id IS NULL AND queue_item_id IS NULL AND turn_id IS NOT NULL)
+      ),
+      CHECK(
+        (action_status = 'pending' AND claim_id IS NULL AND action_completed_at IS NULL)
+        OR (action_status = 'claimed' AND claim_id IS NOT NULL AND action_completed_at IS NULL)
+        OR (action_status IN ('applied','failed') AND claim_id IS NOT NULL AND action_completed_at IS NOT NULL)
+        OR (action_status = 'not_applied' AND action_completed_at IS NOT NULL)
+      ),
+      CHECK(action_completed_at IS NULL OR action_completed_at >= created_at),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_recovery_candidates_session
+      ON runtime_recovery_candidates(session_key, created_at);
+
+    CREATE TABLE IF NOT EXISTS runtime_recovery_claims (
+      candidate_key TEXT PRIMARY KEY,
+      claim_id TEXT NOT NULL UNIQUE,
+      candidate_type TEXT NOT NULL CHECK(candidate_type IN ('turn_attempt','prompt_queue')),
+      session_key TEXT NOT NULL,
+      attempt_id TEXT,
+      queue_item_id TEXT,
+      recovery_run_id TEXT NOT NULL,
+      claimed_by_boot_epoch TEXT NOT NULL,
+      status TEXT NOT NULL CHECK(status IN ('claimed','applied','failed')),
+      claimed_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      result_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(recovery_run_id, candidate_key) REFERENCES runtime_recovery_candidates(recovery_run_id, candidate_key) ON DELETE RESTRICT,
+      FOREIGN KEY(recovery_run_id) REFERENCES runtime_recovery_runs(recovery_run_id) ON DELETE RESTRICT,
+      FOREIGN KEY(claimed_by_boot_epoch) REFERENCES runtime_boot_epochs(boot_epoch) ON DELETE RESTRICT,
+      FOREIGN KEY(attempt_id) REFERENCES runtime_turn_attempts(attempt_id) ON DELETE RESTRICT,
+      FOREIGN KEY(queue_item_id) REFERENCES runtime_prompt_queue(queue_item_id) ON DELETE RESTRICT,
+      CHECK(
+        (candidate_type = 'turn_attempt' AND attempt_id IS NOT NULL AND queue_item_id IS NULL)
+        OR (candidate_type = 'prompt_queue' AND queue_item_id IS NOT NULL AND attempt_id IS NULL)
+      ),
+      CHECK(
+        (status = 'claimed' AND completed_at IS NULL)
+        OR (status != 'claimed' AND completed_at IS NOT NULL)
+      ),
+      CHECK(completed_at IS NULL OR completed_at >= claimed_at),
+      CHECK(updated_at >= created_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_runtime_recovery_claims_run
+      ON runtime_recovery_claims(recovery_run_id, claimed_at);
+
     CREATE TABLE IF NOT EXISTS daemon_restart_epochs (
       restart_epoch TEXT PRIMARY KEY,
       reason TEXT NOT NULL,

--- a/src/runtime/crash-recovery-store.test.ts
+++ b/src/runtime/crash-recovery-store.test.ts
@@ -1,0 +1,1405 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { file, sleep, spawn, write } from "bun";
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { closeRouterDb, getDb } from "../router/router-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import {
+  acquireRuntimeRecoveryClaim,
+  CrashRecoveryLedgerConflictError,
+  CrashRecoveryLedgerCorruptionError,
+  compareAndSetRuntimePromptQueueStatus,
+  completeRuntimeRecoveryClaim,
+  completeRuntimeRecoveryRun,
+  createRuntimeBootEpoch,
+  createRuntimeRecoveryRun,
+  createRuntimeTurnAttempt,
+  enqueueRuntimePrompt,
+  getRuntimeBootEpoch,
+  getRuntimePromptQueueItem,
+  getRuntimeRecoveryCandidate,
+  getRuntimeRecoveryClaimByCandidate,
+  getRuntimeRecoveryRun,
+  getRuntimeTurnAttempt,
+  heartbeatRuntimeBootEpoch,
+  heartbeatRuntimeTurnAttempt,
+  listRuntimePromptQueue,
+  listRuntimeRecoveryCandidates,
+  listRuntimeTurnAttempts,
+  markRuntimeBootEpochAbandoned,
+  markRuntimeBootEpochGracefulStopped,
+  markRuntimeTurnAttemptSafety,
+  recordRuntimeRecoveryCandidate,
+  terminalizeRuntimeTurnAttempt,
+} from "./crash-recovery-store.js";
+
+let stateDir: string | null = null;
+
+beforeEach(async () => {
+  stateDir = await createIsolatedRaviState("ravi-crash-recovery-store-");
+});
+
+afterEach(async () => {
+  await cleanupIsolatedRaviState(stateDir);
+  stateDir = null;
+});
+
+function createBoot(bootEpoch = "boot-a", startedAt = 100) {
+  return createRuntimeBootEpoch({
+    bootEpoch,
+    instanceId: "local",
+    pid: 1234,
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    leaseExpiresAt: startedAt + 10_000,
+    metadata: { host: "test" },
+  });
+}
+
+function createAttempt(input: {
+  attemptId: string;
+  turnId?: string;
+  bootEpoch?: string;
+  recoveredFromAttemptId?: string;
+  startedAt?: number;
+  sessionKey?: string;
+}) {
+  const startedAt = input.startedAt ?? 200;
+  return createRuntimeTurnAttempt({
+    attemptId: input.attemptId,
+    turnId: input.turnId ?? "turn-a",
+    recoveredFromAttemptId: input.recoveredFromAttemptId,
+    runId: "run-a",
+    sessionKey: input.sessionKey ?? "agent:dev:main",
+    sessionName: "main",
+    agentId: "dev",
+    provider: "codex",
+    model: "gpt-test",
+    bootEpoch: input.bootEpoch ?? "boot-a",
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    leaseExpiresAt: startedAt + 1_000,
+    requestBlobSha256: "request-sha",
+    userPromptSha256: "user-sha",
+    systemPromptSha256: "system-sha",
+    checkpoint: { providerSessionId: "provider-session-a" },
+    originKind: "human",
+    source: { channel: "slack", chatId: "chat-a" },
+    turnProvenance: { origin: "human", reason: "test" },
+    taskBarrierTaskId: "task-a",
+    deliveryBarrier: "after_response",
+    pendingIds: ["pending-a"],
+    metadata: { fixture: true },
+  });
+}
+
+function enqueuePrompt(input: {
+  dedupeKey: string;
+  queueItemId?: string;
+  queuedAt?: number;
+  prompt?: Record<string, unknown>;
+}) {
+  return enqueueRuntimePrompt({
+    queueItemId: input.queueItemId,
+    dedupeKey: input.dedupeKey,
+    sessionKey: "agent:dev:main",
+    sessionName: "main",
+    agentId: "dev",
+    laneKey: "after_response",
+    bootEpoch: "boot-a",
+    originKind: "human",
+    deliveryBarrier: "after_response",
+    taskBarrierTaskId: "task-a",
+    pendingId: `pending:${input.dedupeKey}`,
+    prompt: input.prompt ?? { message: "hello", nested: { a: 1, b: 2 } },
+    runtimeMessage: { content: "hello", role: "user" },
+    queuedAt: input.queuedAt ?? 300,
+    metadata: { source: "test" },
+  });
+}
+
+function createStartingQueue(input: { queueItemId: string; startingAt: number; leaseExpiresAt?: number }) {
+  const leaseOwner = `lease:${input.queueItemId}`;
+  const leaseExpiresAt = input.leaseExpiresAt ?? 2_000;
+  enqueuePrompt({ dedupeKey: input.queueItemId, queueItemId: input.queueItemId, queuedAt: 500 });
+  compareAndSetRuntimePromptQueueStatus({
+    queueItemId: input.queueItemId,
+    expectedStatus: "queued",
+    status: "leased",
+    bootEpoch: "boot-a",
+    leaseOwner,
+    leaseExpiresAt,
+    updatedAt: 600,
+  });
+  compareAndSetRuntimePromptQueueStatus({
+    queueItemId: input.queueItemId,
+    expectedStatus: "leased",
+    expectedBootEpoch: "boot-a",
+    expectedLeaseOwner: leaseOwner,
+    expectedLeaseExpiresAt: leaseExpiresAt,
+    status: "starting",
+    updatedAt: input.startingAt,
+  });
+  return { leaseOwner, leaseExpiresAt };
+}
+
+async function acquireClaimInChildProcess(input: {
+  recoveryRunId: string;
+  candidateKey: string;
+  claimedByBootEpoch: string;
+  claimId: string;
+  claimedAt: number;
+  readyPath: string;
+  releasePath: string;
+}) {
+  const storeModuleUrl = pathToFileURL(join(import.meta.dir, "crash-recovery-store.ts")).href;
+  const workerScript = `
+    import { acquireRuntimeRecoveryClaim } from ${JSON.stringify(storeModuleUrl)};
+    const [, recoveryRunId, candidateKey, claimedByBootEpoch, claimId, claimedAt, readyPath, releasePath] = Bun.argv;
+    try {
+      await Bun.write(readyPath, "ready");
+      while (!(await Bun.file(releasePath).exists())) {
+        await Bun.sleep(5);
+      }
+      const result = acquireRuntimeRecoveryClaim({
+        recoveryRunId,
+        candidateKey,
+        claimedByBootEpoch,
+        claimId,
+        claimedAt: Number(claimedAt),
+      });
+      console.log("CLAIM_RESULT=" + JSON.stringify(result));
+    } catch (error) {
+      console.error(error instanceof Error ? error.stack : String(error));
+      process.exitCode = 1;
+    }
+  `;
+  const child = spawn(
+    [
+      "bun",
+      "-e",
+      workerScript,
+      input.recoveryRunId,
+      input.candidateKey,
+      input.claimedByBootEpoch,
+      input.claimId,
+      String(input.claimedAt),
+      input.readyPath,
+      input.releasePath,
+    ],
+    {
+      cwd: import.meta.dir,
+      env: {
+        ...process.env,
+        RAVI_STATE_DIR: stateDir!,
+        RAVI_LOG_LEVEL: "error",
+        RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`Claim child failed (${exitCode}): ${stderr || stdout}`);
+  const resultLine = stdout.split("\n").find((line) => line.startsWith("CLAIM_RESULT="));
+  if (!resultLine) throw new Error(`Claim child returned no result: ${stdout}`);
+  return JSON.parse(resultLine.slice("CLAIM_RESULT=".length)) as {
+    status: "acquired" | "existing";
+    claim: { claimId: string };
+  };
+}
+
+async function waitForFile(path: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await file(path).exists()) return;
+    await sleep(5);
+  }
+  throw new Error(`Timed out waiting for child readiness file: ${path}`);
+}
+
+describe("crash recovery ledger", () => {
+  it("creates and reopens the complete schema with foreign keys and indexes", () => {
+    const baselineDb = new Database(join(stateDir!, "ravi.db"));
+    baselineDb.exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL)`);
+    baselineDb.prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)").run("baseline", "kept", 1);
+    baselineDb.close();
+
+    const db = getDb();
+    expect(db.prepare("SELECT value FROM settings WHERE key = ?").get("baseline")).toEqual({ value: "kept" });
+    const tableRows = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name IN (
+           'runtime_boot_epochs',
+           'runtime_turn_attempts',
+           'runtime_prompt_queue',
+           'runtime_recovery_runs',
+           'runtime_recovery_candidates',
+           'runtime_recovery_claims'
+         ) ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(tableRows.map((row) => row.name)).toEqual([
+      "runtime_boot_epochs",
+      "runtime_prompt_queue",
+      "runtime_recovery_candidates",
+      "runtime_recovery_claims",
+      "runtime_recovery_runs",
+      "runtime_turn_attempts",
+    ]);
+
+    const queueIndexes = db.prepare("PRAGMA index_list(runtime_prompt_queue)").all() as Array<{ name: string }>;
+    expect(queueIndexes.map((row) => row.name)).toContain("idx_runtime_prompt_queue_session_lane");
+    expect(queueIndexes.map((row) => row.name)).toContain("idx_runtime_prompt_queue_lease");
+
+    const claimForeignKeys = db.prepare("PRAGMA foreign_key_list(runtime_recovery_claims)").all() as Array<{
+      table: string;
+    }>;
+    expect(claimForeignKeys.map((row) => row.table)).toContain("runtime_recovery_candidates");
+    expect(claimForeignKeys.map((row) => row.table)).toContain("runtime_boot_epochs");
+
+    createBoot();
+    const first = enqueuePrompt({ dedupeKey: "dedupe-a", queuedAt: 500 }).item;
+    closeRouterDb();
+    const second = enqueuePrompt({ dedupeKey: "dedupe-b", queuedAt: 500 }).item;
+    expect(second.queueSequence).toBeGreaterThan(first.queueSequence);
+    expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("keeps boot heartbeat, lease, and terminal state monotonic", () => {
+    const created = createBoot();
+    const duplicate = createBoot();
+    expect(duplicate).toEqual(created);
+
+    const heartbeat = heartbeatRuntimeBootEpoch({
+      bootEpoch: "boot-a",
+      heartbeatAt: 150,
+      leaseExpiresAt: 11_500,
+    });
+    expect(heartbeat.lastHeartbeatAt).toBe(150);
+    expect(heartbeat.leaseExpiresAt).toBe(11_500);
+    expect(() => heartbeatRuntimeBootEpoch({ bootEpoch: "boot-a", heartbeatAt: 149, leaseExpiresAt: 11_500 })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+    expect(() => heartbeatRuntimeBootEpoch({ bootEpoch: "boot-a", heartbeatAt: 160, leaseExpiresAt: 11_499 })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+
+    const stopped = markRuntimeBootEpochGracefulStopped({
+      bootEpoch: "boot-a",
+      stoppedAt: 2_000,
+      reason: "operator restart",
+    });
+    expect(stopped.status).toBe("graceful_stopped");
+    expect(markRuntimeBootEpochGracefulStopped({ bootEpoch: "boot-a", stoppedAt: 2_000 })).toEqual(stopped);
+    expect(() => markRuntimeBootEpochGracefulStopped({ bootEpoch: "boot-a", stoppedAt: 2_100 })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+    expect(() =>
+      markRuntimeBootEpochAbandoned({
+        bootEpoch: "boot-a",
+        abandonedAt: 11_500,
+        expectedLastHeartbeatAt: 150,
+        expectedLeaseExpiresAt: 11_500,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() => heartbeatRuntimeBootEpoch({ bootEpoch: "boot-a", heartbeatAt: 2_100, leaseExpiresAt: 3_100 })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+    expect(() => createAttempt({ attemptId: "attempt-after-stop" })).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("abandons a boot only after the exact observed lease expires", () => {
+    createBoot();
+    expect(() =>
+      markRuntimeBootEpochAbandoned({
+        bootEpoch: "boot-a",
+        abandonedAt: 10_099,
+        expectedLastHeartbeatAt: 100,
+        expectedLeaseExpiresAt: 10_100,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    heartbeatRuntimeBootEpoch({ bootEpoch: "boot-a", heartbeatAt: 200, leaseExpiresAt: 10_200 });
+    expect(() =>
+      markRuntimeBootEpochAbandoned({
+        bootEpoch: "boot-a",
+        abandonedAt: 10_200,
+        expectedLastHeartbeatAt: 100,
+        expectedLeaseExpiresAt: 10_100,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    expect(
+      markRuntimeBootEpochAbandoned({
+        bootEpoch: "boot-a",
+        abandonedAt: 10_200,
+        expectedLastHeartbeatAt: 200,
+        expectedLeaseExpiresAt: 10_200,
+      }).status,
+    ).toBe("abandoned");
+  });
+
+  it("tracks independent attempts for one turn with irreversible safety and terminal state", () => {
+    createBoot();
+    const first = createAttempt({ attemptId: "attempt-1" });
+    expect(first.checkpoint).toEqual({ providerSessionId: "provider-session-a" });
+    expect(first.pendingIds).toEqual(["pending-a"]);
+
+    const heartbeat = heartbeatRuntimeTurnAttempt({
+      attemptId: "attempt-1",
+      bootEpoch: "boot-a",
+      heartbeatAt: 250,
+      leaseExpiresAt: 1_500,
+    });
+    expect(heartbeat.lastHeartbeatAt).toBe(250);
+    expect(() =>
+      heartbeatRuntimeTurnAttempt({
+        attemptId: "attempt-1",
+        bootEpoch: "boot-a",
+        heartbeatAt: 249,
+        leaseExpiresAt: 1_500,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const toolStarted = markRuntimeTurnAttemptSafety({ attemptId: "attempt-1", startedTool: true, markedAt: 260 });
+    expect(toolStarted.startedTool).toBe(true);
+    expect(toolStarted.materializedOutput).toBe(false);
+    const output = markRuntimeTurnAttemptSafety({
+      attemptId: "attempt-1",
+      materializedOutput: true,
+      markedAt: 270,
+    });
+    expect(output.startedTool).toBe(true);
+    expect(output.materializedOutput).toBe(true);
+    expect(() =>
+      heartbeatRuntimeTurnAttempt({
+        attemptId: "attempt-1",
+        bootEpoch: "boot-a",
+        heartbeatAt: 265,
+        leaseExpiresAt: 1_600,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      terminalizeRuntimeTurnAttempt({ attemptId: "attempt-1", status: "interrupted", completedAt: 269 }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const interrupted = terminalizeRuntimeTurnAttempt({
+      attemptId: "attempt-1",
+      status: "interrupted",
+      completedAt: 300,
+    });
+    expect(interrupted.status).toBe("interrupted");
+    expect(terminalizeRuntimeTurnAttempt({ attemptId: "attempt-1", status: "interrupted", completedAt: 300 })).toEqual(
+      interrupted,
+    );
+    expect(() =>
+      terminalizeRuntimeTurnAttempt({ attemptId: "attempt-1", status: "interrupted", completedAt: 350 }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      terminalizeRuntimeTurnAttempt({ attemptId: "attempt-1", status: "complete", completedAt: 350 }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() => markRuntimeTurnAttemptSafety({ attemptId: "attempt-1", startedTool: true })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+    expect(() =>
+      heartbeatRuntimeTurnAttempt({
+        attemptId: "attempt-1",
+        bootEpoch: "boot-a",
+        heartbeatAt: 350,
+        leaseExpiresAt: 1_600,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const second = createAttempt({
+      attemptId: "attempt-2",
+      recoveredFromAttemptId: "attempt-1",
+      startedAt: 400,
+    });
+    expect(second.turnId).toBe(first.turnId);
+    expect(second.recoveredFromAttemptId).toBe("attempt-1");
+    expect(listRuntimeTurnAttempts({ turnId: "turn-a" }).map((attempt) => attempt.attemptId)).toEqual([
+      "attempt-2",
+      "attempt-1",
+    ]);
+  });
+
+  it("deduplicates immutable prompt atoms and preserves FIFO with equal timestamps", () => {
+    createBoot();
+    const first = enqueuePrompt({ dedupeKey: "dedupe-a", queueItemId: "queue-a", queuedAt: 500 });
+    const retry = enqueueRuntimePrompt({
+      dedupeKey: "dedupe-a",
+      sessionKey: "agent:dev:main",
+      sessionName: "main",
+      agentId: "dev",
+      laneKey: "after_response",
+      bootEpoch: "boot-a",
+      originKind: "human",
+      deliveryBarrier: "after_response",
+      taskBarrierTaskId: "task-a",
+      pendingId: "pending:dedupe-a",
+      prompt: { nested: { b: 2, a: 1 }, message: "hello" },
+      runtimeMessage: { role: "user", content: "hello" },
+      queuedAt: 999,
+      metadata: { source: "test" },
+    });
+    expect(first.created).toBe(true);
+    expect(retry.created).toBe(false);
+    expect(retry.item.queueItemId).toBe("queue-a");
+    expect(retry.item.queueSequence).toBe(first.item.queueSequence);
+    expect(retry.item.queuedAt).toBe(500);
+
+    expect(() => enqueuePrompt({ dedupeKey: "dedupe-a", prompt: { message: "different" }, queuedAt: 500 })).toThrow(
+      CrashRecoveryLedgerConflictError,
+    );
+
+    const second = enqueuePrompt({ dedupeKey: "dedupe-b", queueItemId: "queue-b", queuedAt: 500 }).item;
+    expect(second.queueSequence).toBeGreaterThan(first.item.queueSequence);
+    expect(
+      listRuntimePromptQueue({ sessionKey: "agent:dev:main", laneKey: "after_response" }).map(
+        (item) => item.queueItemId,
+      ),
+    ).toEqual(["queue-a", "queue-b"]);
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-a",
+        expectedStatus: "queued",
+        status: "leased",
+        bootEpoch: "boot-a",
+        leaseOwner: "worker-a",
+        leaseExpiresAt: 2_000,
+        updatedAt: 499,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const leased = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-a",
+      expectedStatus: "queued",
+      status: "leased",
+      bootEpoch: "boot-a",
+      leaseOwner: "worker-a",
+      leaseExpiresAt: 2_000,
+      updatedAt: 600,
+    });
+    expect(leased.applied).toBe(true);
+    expect(leased.item.status).toBe("leased");
+    const stale = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-a",
+      expectedStatus: "queued",
+      status: "cancelled",
+      updatedAt: 610,
+    });
+    expect(stale.applied).toBe(false);
+    expect(stale.item.status).toBe("leased");
+
+    const staleOwner = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-a",
+      expectedStatus: "leased",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "worker-stale",
+      expectedLeaseExpiresAt: 2_000,
+      status: "starting",
+      updatedAt: 610,
+    });
+    expect(staleOwner.applied).toBe(false);
+    expect(staleOwner.item.status).toBe("leased");
+
+    const cancelled = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-a",
+      expectedStatus: "leased",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "worker-a",
+      expectedLeaseExpiresAt: 2_000,
+      status: "cancelled",
+      completedAt: 620,
+      updatedAt: 620,
+    });
+    expect(cancelled.item.completedAt).toBe(620);
+    expect(
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-a",
+        expectedStatus: "cancelled",
+        status: "cancelled",
+        completedAt: 620,
+        updatedAt: 620,
+      }).applied,
+    ).toBe(false);
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-a",
+        expectedStatus: "cancelled",
+        status: "cancelled",
+        completedAt: 621,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-a",
+        expectedStatus: "cancelled",
+        status: "requeued",
+        updatedAt: 630,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("fences queue ownership and forbids delivery through another session", () => {
+    createBoot();
+    enqueuePrompt({ dedupeKey: "queue-session", queueItemId: "queue-session", queuedAt: 500 });
+    createAttempt({ attemptId: "attempt-other-session", sessionKey: "agent:dev:other", startedAt: 550 });
+    compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-session",
+      expectedStatus: "queued",
+      status: "leased",
+      bootEpoch: "boot-a",
+      leaseOwner: "lease-token-a",
+      leaseExpiresAt: 2_000,
+      updatedAt: 600,
+    });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-session",
+        expectedStatus: "leased",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: "lease-token-a",
+        expectedLeaseExpiresAt: 2_000,
+        status: "delivered",
+        deliveredAttemptId: "attempt-other-session",
+        deliveredTurnId: "turn-a",
+        updatedAt: 650,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const requeued = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-session",
+      expectedStatus: "leased",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "lease-token-a",
+      expectedLeaseExpiresAt: 2_000,
+      status: "requeued",
+      updatedAt: 650,
+    });
+    expect(requeued.item).toMatchObject({
+      status: "requeued",
+      bootEpoch: null,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+  });
+
+  it("requires a live lease for first delivery and forbids delivered-item redelivery", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-delivery-1" });
+    createAttempt({ attemptId: "attempt-delivery-2" });
+    enqueuePrompt({ dedupeKey: "queue-delivery", queueItemId: "queue-delivery", queuedAt: 500 });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery",
+        expectedStatus: "queued",
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-1",
+        deliveredTurnId: "turn-a",
+        updatedAt: 600,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "queued",
+      status: "leased",
+      bootEpoch: "boot-a",
+      leaseOwner: "lease-token-a",
+      leaseExpiresAt: 2_000,
+      updatedAt: 600,
+    });
+    compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "leased",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "lease-token-a",
+      expectedLeaseExpiresAt: 2_000,
+      status: "requeued",
+      updatedAt: 650,
+    });
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery",
+        expectedStatus: "requeued",
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-1",
+        deliveredTurnId: "turn-a",
+        updatedAt: 700,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "requeued",
+      status: "leased",
+      bootEpoch: "boot-a",
+      leaseOwner: "lease-token-b",
+      leaseExpiresAt: 2_000,
+      updatedAt: 700,
+    });
+    compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "leased",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "lease-token-b",
+      expectedLeaseExpiresAt: 2_000,
+      status: "starting",
+      updatedAt: 750,
+    });
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery",
+        expectedStatus: "starting",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: "lease-token-b",
+        expectedLeaseExpiresAt: 2_000,
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-1",
+        deliveredTurnId: "turn-a",
+        updatedAt: 2_001,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    const delivered = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "starting",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "lease-token-b",
+      expectedLeaseExpiresAt: 2_000,
+      status: "delivered",
+      deliveredAttemptId: "attempt-delivery-1",
+      deliveredTurnId: "turn-a",
+      updatedAt: 800,
+    });
+    expect(delivered.item).toMatchObject({
+      status: "delivered",
+      deliveredAttemptId: "attempt-delivery-1",
+      metadata: { source: "test" },
+    });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery",
+        expectedStatus: "delivered",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: "lease-token-b",
+        expectedLeaseExpiresAt: 2_000,
+        status: "leased",
+        bootEpoch: "boot-a",
+        leaseOwner: "lease-token-b",
+        leaseExpiresAt: 2_000,
+        updatedAt: 810,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery",
+        expectedStatus: "delivered",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: "lease-token-b",
+        expectedLeaseExpiresAt: 2_000,
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-2",
+        deliveredTurnId: "turn-a",
+        updatedAt: 820,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    terminalizeRuntimeTurnAttempt({
+      attemptId: "attempt-delivery-1",
+      status: "complete",
+      completedAt: 900,
+    });
+    const completed = compareAndSetRuntimePromptQueueStatus({
+      queueItemId: "queue-delivery",
+      expectedStatus: "delivered",
+      expectedBootEpoch: "boot-a",
+      expectedLeaseOwner: "lease-token-b",
+      expectedLeaseExpiresAt: 2_000,
+      status: "complete",
+      completedAt: 2_100,
+      updatedAt: 2_100,
+    });
+    expect(completed.item).toMatchObject({ status: "complete", completedAt: 2_100 });
+  });
+
+  it("rejects delivery into a terminal attempt", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-delivery-terminal" });
+    terminalizeRuntimeTurnAttempt({
+      attemptId: "attempt-delivery-terminal",
+      status: "complete",
+      completedAt: 300,
+    });
+    const lease = createStartingQueue({ queueItemId: "queue-delivery-terminal", startingAt: 650 });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery-terminal",
+        expectedStatus: "starting",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: lease.leaseOwner,
+        expectedLeaseExpiresAt: lease.leaseExpiresAt,
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-terminal",
+        deliveredTurnId: "turn-a",
+        updatedAt: 700,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("rejects delivery into an attempt whose lease expired", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-delivery-expired" });
+    const lease = createStartingQueue({ queueItemId: "queue-delivery-expired", startingAt: 1_100 });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery-expired",
+        expectedStatus: "starting",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: lease.leaseOwner,
+        expectedLeaseExpiresAt: lease.leaseExpiresAt,
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-expired",
+        deliveredTurnId: "turn-a",
+        updatedAt: 1_200,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("rejects delivery into a recovery-claimed attempt", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-delivery-claimed" });
+    const lease = createStartingQueue({ queueItemId: "queue-delivery-claimed", startingAt: 900 });
+    createRuntimeRecoveryRun({
+      recoveryRunId: "apply-delivery-claimed",
+      mode: "apply",
+      bootEpoch: "boot-a",
+      startedAt: 1_000,
+    });
+    const candidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-delivery-claimed",
+      candidateType: "turn_attempt",
+      sessionKey: "agent:dev:main",
+      attemptId: "attempt-delivery-claimed",
+      decision: "resume",
+      reasonCode: "safe",
+      action: "resume_through_dispatcher",
+      recordedAt: 1_010,
+    });
+    acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-delivery-claimed",
+      candidateKey: candidate.candidateKey,
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-delivery-claimed",
+      claimedAt: 1_020,
+    });
+
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-delivery-claimed",
+        expectedStatus: "starting",
+        expectedBootEpoch: "boot-a",
+        expectedLeaseOwner: lease.leaseOwner,
+        expectedLeaseExpiresAt: lease.leaseExpiresAt,
+        status: "delivered",
+        deliveredAttemptId: "attempt-delivery-claimed",
+        deliveredTurnId: "turn-a",
+        updatedAt: 1_030,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("audits inspect and dry-run candidates without allowing claims", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-inspect" });
+    for (const mode of ["inspect", "dry-run"] as const) {
+      const runId = `run-${mode}`;
+      createRuntimeRecoveryRun({ recoveryRunId: runId, mode, bootEpoch: "boot-a", startedAt: 1_000 });
+      const candidate = recordRuntimeRecoveryCandidate({
+        recoveryRunId: runId,
+        candidateType: "turn_attempt",
+        sessionKey: "agent:dev:main",
+        attemptId: "attempt-inspect",
+        decision: "manual_review",
+        reasonCode: "inspect_only",
+        action: "none",
+        details: { mode },
+        recordedAt: 1_010,
+      });
+      expect(candidate.actionStatus).toBe("not_applied");
+      expect(candidate.actionCompletedAt).toBe(1_010);
+      expect(() =>
+        acquireRuntimeRecoveryClaim({
+          recoveryRunId: runId,
+          candidateKey: "attempt:attempt-inspect",
+          claimedByBootEpoch: "boot-a",
+          claimedAt: 1_020,
+        }),
+      ).toThrow(CrashRecoveryLedgerConflictError);
+      expect(listRuntimeRecoveryCandidates(runId)).toHaveLength(1);
+      completeRuntimeRecoveryRun({
+        recoveryRunId: runId,
+        status: "complete",
+        summary: { candidates: 1 },
+        completedAt: 1_030,
+      });
+      expect(() =>
+        recordRuntimeRecoveryCandidate({
+          recoveryRunId: runId,
+          candidateType: "turn_attempt",
+          sessionKey: "agent:dev:main",
+          attemptId: "attempt-inspect",
+          decision: "manual_review",
+          reasonCode: "late",
+          action: "none",
+          recordedAt: 1_040,
+        }),
+      ).toThrow(CrashRecoveryLedgerConflictError);
+    }
+  });
+
+  it("keeps legacy trace evidence inspect-only even inside an apply run", () => {
+    createBoot();
+    createRuntimeRecoveryRun({ recoveryRunId: "apply-legacy", mode: "apply", bootEpoch: "boot-a", startedAt: 1_000 });
+    const candidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-legacy",
+      candidateType: "legacy_session_turn",
+      sessionKey: "agent:dev:main",
+      turnId: "legacy-turn",
+      decision: "manual_review",
+      reasonCode: "legacy_trace_only",
+      action: "none",
+      recordedAt: 1_010,
+    });
+    expect(candidate).toMatchObject({ actionStatus: "not_applied", actionCompletedAt: 1_010 });
+    expect(() =>
+      acquireRuntimeRecoveryClaim({
+        recoveryRunId: "apply-legacy",
+        candidateKey: candidate.candidateKey,
+        claimedByBootEpoch: "boot-a",
+        claimedAt: 1_020,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(
+      completeRuntimeRecoveryRun({
+        recoveryRunId: "apply-legacy",
+        status: "complete",
+        summary: { inspected: 1 },
+        completedAt: 1_030,
+      }).status,
+    ).toBe("complete");
+  });
+
+  it("grants one global claim across apply runs and projects the terminal result atomically", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-claim" });
+    for (const runId of ["apply-1", "apply-2"]) {
+      createRuntimeRecoveryRun({ recoveryRunId: runId, mode: "apply", bootEpoch: "boot-a", startedAt: 1_000 });
+      recordRuntimeRecoveryCandidate({
+        recoveryRunId: runId,
+        candidateKey: "attempt:attempt-claim",
+        candidateType: "turn_attempt",
+        sessionKey: "agent:dev:main",
+        attemptId: "attempt-claim",
+        decision: "resume",
+        reasonCode: "expired_abandoned_attempt",
+        action: "resume_through_dispatcher",
+        details: { safe: true },
+        recordedAt: 1_010,
+      });
+    }
+
+    expect(() =>
+      completeRuntimeRecoveryRun({
+        recoveryRunId: "apply-1",
+        status: "complete",
+        completedAt: 1_015,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const winner = acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-1",
+      candidateKey: "attempt:attempt-claim",
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-a",
+      claimedAt: 1_020,
+    });
+    const loser = acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-2",
+      candidateKey: "attempt:attempt-claim",
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-b",
+      claimedAt: 1_021,
+    });
+    expect(winner.status).toBe("acquired");
+    expect(loser.status).toBe("existing");
+    expect(loser.claim.claimId).toBe("claim-a");
+    expect(getRuntimeRecoveryCandidate("apply-1", "attempt:attempt-claim")?.actionStatus).toBe("claimed");
+    expect(getRuntimeRecoveryCandidate("apply-2", "attempt:attempt-claim")).toMatchObject({
+      actionStatus: "not_applied",
+      claimId: "claim-a",
+      result: { code: "already_claimed", claimId: "claim-a", recoveryRunId: "apply-1" },
+    });
+    expect(getRuntimeTurnAttempt("attempt-claim")).toMatchObject({
+      recoveryClaimId: "claim-a",
+      recoveryRunId: "apply-1",
+      recoveryStatus: "claimed",
+    });
+
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-a",
+        status: "applied",
+        result: { dispatched: true },
+        completedAt: 1_019,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    const completed = completeRuntimeRecoveryClaim({
+      claimId: "claim-a",
+      status: "applied",
+      result: { dispatched: true },
+      completedAt: 1_100,
+    });
+    expect(completed.claim).toMatchObject({ status: "applied", result: { dispatched: true } });
+    expect(completed.candidate).toMatchObject({
+      actionStatus: "applied",
+      result: { dispatched: true },
+      actionCompletedAt: 1_100,
+    });
+    expect(getRuntimeTurnAttempt("attempt-claim")).toMatchObject({
+      recoveryStatus: "resume",
+      recoveryReason: "expired_abandoned_attempt",
+      recoveredAt: 1_100,
+    });
+    expect(
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-a",
+        status: "applied",
+        result: { dispatched: true },
+        completedAt: 1_100,
+      }).claim.status,
+    ).toBe("applied");
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-a",
+        status: "applied",
+        result: { dispatched: false },
+        completedAt: 1_100,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-a",
+        status: "applied",
+        result: { dispatched: true },
+        completedAt: 1_200,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-a",
+        status: "failed",
+        result: { error: "late" },
+        completedAt: 1_200,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(getRuntimeRecoveryClaimByCandidate("attempt:attempt-claim")?.claimId).toBe("claim-a");
+    expect(
+      completeRuntimeRecoveryRun({ recoveryRunId: "apply-1", status: "complete", completedAt: 1_200 }).status,
+    ).toBe("complete");
+    expect(
+      completeRuntimeRecoveryRun({ recoveryRunId: "apply-2", status: "complete", completedAt: 1_200 }).status,
+    ).toBe("complete");
+    expect(getDb().prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("fences normal attempt and queue mutations after a recovery claim", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-fenced" });
+    const queueItem = enqueuePrompt({ dedupeKey: "queue-fenced", queueItemId: "queue-fenced" }).item;
+    createRuntimeRecoveryRun({ recoveryRunId: "apply-fenced", mode: "apply", bootEpoch: "boot-a", startedAt: 1_000 });
+
+    const attemptCandidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-fenced",
+      candidateType: "turn_attempt",
+      sessionKey: "agent:dev:main",
+      attemptId: "attempt-fenced",
+      decision: "resume",
+      reasonCode: "safe",
+      action: "resume_through_dispatcher",
+      recordedAt: 1_010,
+    });
+    const queueCandidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-fenced",
+      candidateType: "prompt_queue",
+      sessionKey: queueItem.sessionKey,
+      queueItemId: queueItem.queueItemId,
+      decision: "requeue",
+      reasonCode: "orphaned_queue_item",
+      action: "requeue_through_dispatcher",
+      recordedAt: 1_011,
+    });
+    acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-fenced",
+      candidateKey: attemptCandidate.candidateKey,
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-attempt-fenced",
+      claimedAt: 1_020,
+    });
+    acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-fenced",
+      candidateKey: queueCandidate.candidateKey,
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-queue-fenced",
+      claimedAt: 1_021,
+    });
+
+    expect(() =>
+      heartbeatRuntimeTurnAttempt({
+        attemptId: "attempt-fenced",
+        bootEpoch: "boot-a",
+        heartbeatAt: 1_030,
+        leaseExpiresAt: 1_300,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      markRuntimeTurnAttemptSafety({ attemptId: "attempt-fenced", startedTool: true, markedAt: 1_030 }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      terminalizeRuntimeTurnAttempt({ attemptId: "attempt-fenced", status: "complete", completedAt: 1_030 }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      compareAndSetRuntimePromptQueueStatus({
+        queueItemId: "queue-fenced",
+        expectedStatus: "queued",
+        status: "requeued",
+        updatedAt: 1_030,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    expect(getRuntimeTurnAttempt("attempt-fenced")).toMatchObject({
+      status: "running",
+      startedTool: false,
+      materializedOutput: false,
+      recoveryClaimId: "claim-attempt-fenced",
+    });
+    expect(getRuntimePromptQueueItem("queue-fenced")).toMatchObject({
+      status: "queued",
+      recoveryClaimId: "claim-queue-fenced",
+    });
+  });
+
+  it("grants one global claim under a real two-process race", async () => {
+    createBoot();
+    createBoot("boot-race-1");
+    createBoot("boot-race-2");
+    createAttempt({ attemptId: "attempt-race" });
+    for (const [runId, bootEpoch] of [
+      ["race-1", "boot-race-1"],
+      ["race-2", "boot-race-2"],
+    ] as const) {
+      createRuntimeRecoveryRun({ recoveryRunId: runId, mode: "apply", bootEpoch, startedAt: 1_000 });
+      recordRuntimeRecoveryCandidate({
+        recoveryRunId: runId,
+        candidateType: "turn_attempt",
+        sessionKey: "agent:dev:main",
+        attemptId: "attempt-race",
+        decision: "resume",
+        reasonCode: "expired_abandoned_attempt",
+        action: "resume_through_dispatcher",
+        recordedAt: 1_010,
+      });
+    }
+
+    const releasePath = join(stateDir!, "claim-race-release");
+    const readyPaths = [join(stateDir!, "claim-race-ready-1"), join(stateDir!, "claim-race-ready-2")];
+    const resultPromises = [
+      acquireClaimInChildProcess({
+        recoveryRunId: "race-1",
+        candidateKey: "attempt:attempt-race",
+        claimedByBootEpoch: "boot-race-1",
+        claimId: "claim-race-1",
+        claimedAt: 1_020,
+        readyPath: readyPaths[0]!,
+        releasePath,
+      }),
+      acquireClaimInChildProcess({
+        recoveryRunId: "race-2",
+        candidateKey: "attempt:attempt-race",
+        claimedByBootEpoch: "boot-race-2",
+        claimId: "claim-race-2",
+        claimedAt: 1_020,
+        readyPath: readyPaths[1]!,
+        releasePath,
+      }),
+    ];
+    await Promise.all(readyPaths.map((path) => waitForFile(path)));
+    await write(releasePath, "release");
+    const results = await Promise.all(resultPromises);
+    expect(results.map((result) => result.status).sort()).toEqual(["acquired", "existing"]);
+    expect(new Set(results.map((result) => result.claim.claimId)).size).toBe(1);
+    expect(
+      (getDb().prepare("SELECT COUNT(*) AS count FROM runtime_recovery_claims").get() as { count: number }).count,
+    ).toBe(1);
+    expect(getRuntimeTurnAttempt("attempt-race")?.recoveryClaimId).toBe(results[0]?.claim.claimId);
+  });
+
+  it("projects a failed queue claim without making the prompt claimable again", () => {
+    createBoot();
+    const queueItem = enqueuePrompt({ dedupeKey: "queue-claim", queueItemId: "queue-claim" }).item;
+    createRuntimeRecoveryRun({ recoveryRunId: "apply-queue", mode: "apply", bootEpoch: "boot-a", startedAt: 1_000 });
+    recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-queue",
+      candidateKey: "queue:queue-claim",
+      candidateType: "prompt_queue",
+      sessionKey: queueItem.sessionKey,
+      queueItemId: queueItem.queueItemId,
+      decision: "requeue",
+      reasonCode: "orphaned_queue_item",
+      action: "requeue_through_dispatcher",
+      recordedAt: 1_010,
+    });
+    const acquired = acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-queue",
+      candidateKey: "queue:queue-claim",
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-queue",
+      claimedAt: 1_020,
+    });
+    expect(acquired.status).toBe("acquired");
+    completeRuntimeRecoveryClaim({
+      claimId: "claim-queue",
+      status: "failed",
+      result: { error: "dispatcher unavailable" },
+      completedAt: 1_030,
+    });
+    expect(getRuntimePromptQueueItem("queue-claim")).toMatchObject({
+      recoveryClaimId: "claim-queue",
+      recoveryStatus: "action_failed",
+      recoveryReason: "orphaned_queue_item",
+      recoveredAt: 1_030,
+    });
+    expect(
+      acquireRuntimeRecoveryClaim({
+        recoveryRunId: "apply-queue",
+        candidateKey: "queue:queue-claim",
+        claimedByBootEpoch: "boot-a",
+        claimedAt: 1_040,
+      }),
+    ).toMatchObject({ status: "existing", claim: { claimId: "claim-queue", status: "failed" } });
+  });
+
+  it("rolls back claim completion when attempt or queue source projections partially diverge", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-diverged" });
+    const queueItem = enqueuePrompt({ dedupeKey: "queue-diverged", queueItemId: "queue-diverged" }).item;
+    createRuntimeRecoveryRun({ recoveryRunId: "apply-diverged", mode: "apply", bootEpoch: "boot-a", startedAt: 1_000 });
+    const attemptCandidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-diverged",
+      candidateType: "turn_attempt",
+      sessionKey: "agent:dev:main",
+      attemptId: "attempt-diverged",
+      decision: "resume",
+      reasonCode: "safe",
+      action: "resume_through_dispatcher",
+      recordedAt: 1_010,
+    });
+    const queueCandidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-diverged",
+      candidateType: "prompt_queue",
+      sessionKey: queueItem.sessionKey,
+      queueItemId: queueItem.queueItemId,
+      decision: "requeue",
+      reasonCode: "orphaned_queue_item",
+      action: "requeue_through_dispatcher",
+      recordedAt: 1_011,
+    });
+    acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-diverged",
+      candidateKey: attemptCandidate.candidateKey,
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-attempt-diverged",
+      claimedAt: 1_020,
+    });
+    acquireRuntimeRecoveryClaim({
+      recoveryRunId: "apply-diverged",
+      candidateKey: queueCandidate.candidateKey,
+      claimedByBootEpoch: "boot-a",
+      claimId: "claim-queue-diverged",
+      claimedAt: 1_021,
+    });
+    const db = getDb();
+    db.prepare("UPDATE runtime_turn_attempts SET recovery_status = NULL WHERE attempt_id = ?").run("attempt-diverged");
+    db.prepare("UPDATE runtime_prompt_queue SET recovery_reason = ? WHERE queue_item_id = ?").run(
+      "diverged-reason",
+      "queue-diverged",
+    );
+
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-attempt-diverged",
+        status: "applied",
+        result: { dispatched: true },
+        completedAt: 1_030,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+    expect(() =>
+      completeRuntimeRecoveryClaim({
+        claimId: "claim-queue-diverged",
+        status: "failed",
+        result: { error: "dispatcher unavailable" },
+        completedAt: 1_031,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+
+    expect(getRuntimeRecoveryClaimByCandidate("attempt:attempt-diverged")?.status).toBe("claimed");
+    expect(getRuntimeRecoveryCandidate("apply-diverged", "attempt:attempt-diverged")?.actionStatus).toBe("claimed");
+    expect(getRuntimeTurnAttempt("attempt-diverged")).toMatchObject({
+      recoveryClaimId: "claim-attempt-diverged",
+      recoveryStatus: null,
+    });
+    expect(getRuntimeRecoveryClaimByCandidate("queue:queue-diverged")?.status).toBe("claimed");
+    expect(getRuntimeRecoveryCandidate("apply-diverged", "queue:queue-diverged")?.actionStatus).toBe("claimed");
+    expect(getRuntimePromptQueueItem("queue-diverged")).toMatchObject({
+      recoveryClaimId: "claim-queue-diverged",
+      recoveryReason: "diverged-reason",
+    });
+  });
+
+  it("derives canonical candidate keys and rejects caller-defined collisions", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-canonical" });
+    createRuntimeRecoveryRun({
+      recoveryRunId: "apply-canonical",
+      mode: "apply",
+      bootEpoch: "boot-a",
+      startedAt: 1_000,
+    });
+    expect(() =>
+      recordRuntimeRecoveryCandidate({
+        recoveryRunId: "apply-canonical",
+        candidateKey: "attempt:some-other-source",
+        candidateType: "turn_attempt",
+        sessionKey: "agent:dev:main",
+        attemptId: "attempt-canonical",
+        decision: "resume",
+        reasonCode: "safe",
+        action: "resume_through_dispatcher",
+        recordedAt: 1_010,
+      }),
+    ).toThrow(CrashRecoveryLedgerConflictError);
+  });
+
+  it("fails closed instead of completing a run with a corrupt candidate action status", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-corrupt-candidate-status" });
+    createRuntimeRecoveryRun({
+      recoveryRunId: "apply-corrupt-candidate-status",
+      mode: "apply",
+      bootEpoch: "boot-a",
+      startedAt: 1_000,
+    });
+    const candidate = recordRuntimeRecoveryCandidate({
+      recoveryRunId: "apply-corrupt-candidate-status",
+      candidateType: "turn_attempt",
+      sessionKey: "agent:dev:main",
+      attemptId: "attempt-corrupt-candidate-status",
+      decision: "resume",
+      reasonCode: "safe",
+      action: "resume_through_dispatcher",
+      recordedAt: 1_010,
+    });
+    const db = getDb();
+    db.exec("PRAGMA ignore_check_constraints = ON");
+    try {
+      db.prepare(
+        `UPDATE runtime_recovery_candidates SET action_status = ?
+         WHERE recovery_run_id = ? AND candidate_key = ?`,
+      ).run("corrupt-status", "apply-corrupt-candidate-status", candidate.candidateKey);
+    } finally {
+      db.exec("PRAGMA ignore_check_constraints = OFF");
+    }
+
+    expect(() =>
+      completeRuntimeRecoveryRun({
+        recoveryRunId: "apply-corrupt-candidate-status",
+        status: "complete",
+        completedAt: 1_020,
+      }),
+    ).toThrow(CrashRecoveryLedgerCorruptionError);
+    expect(getRuntimeRecoveryRun("apply-corrupt-candidate-status")?.status).toBe("running");
+  });
+
+  it("fails closed when persisted safety enums are corrupt", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-corrupt-origin" });
+    getDb().exec("PRAGMA ignore_check_constraints = ON");
+    getDb()
+      .prepare("UPDATE runtime_turn_attempts SET origin_kind = ? WHERE attempt_id = ?")
+      .run("not-a-real-origin", "attempt-corrupt-origin");
+    getDb().exec("PRAGMA ignore_check_constraints = OFF");
+    expect(() => getRuntimeTurnAttempt("attempt-corrupt-origin")).toThrow(CrashRecoveryLedgerCorruptionError);
+  });
+
+  it("fails closed when persisted safety markers are not binary", () => {
+    createBoot();
+    createAttempt({ attemptId: "attempt-corrupt-started-tool" });
+    createAttempt({ attemptId: "attempt-corrupt-materialized-output" });
+    const db = getDb();
+    db.exec("PRAGMA ignore_check_constraints = ON");
+    try {
+      db.prepare("UPDATE runtime_turn_attempts SET started_tool = ? WHERE attempt_id = ?").run(
+        2,
+        "attempt-corrupt-started-tool",
+      );
+      db.prepare("UPDATE runtime_turn_attempts SET materialized_output = ? WHERE attempt_id = ?").run(
+        -1,
+        "attempt-corrupt-materialized-output",
+      );
+    } finally {
+      db.exec("PRAGMA ignore_check_constraints = OFF");
+    }
+
+    expect(() => getRuntimeTurnAttempt("attempt-corrupt-started-tool")).toThrow(CrashRecoveryLedgerCorruptionError);
+    expect(() => getRuntimeTurnAttempt("attempt-corrupt-materialized-output")).toThrow(
+      CrashRecoveryLedgerCorruptionError,
+    );
+  });
+
+  it("detects valid-JSON prompt tampering on reads and identical enqueue retries", () => {
+    createBoot();
+    enqueuePrompt({ dedupeKey: "tampered", queueItemId: "queue-tampered" });
+    getDb()
+      .prepare("UPDATE runtime_prompt_queue SET prompt_json = ? WHERE queue_item_id = ?")
+      .run(JSON.stringify({ message: "tampered but valid" }), "queue-tampered");
+
+    expect(() => getRuntimePromptQueueItem("queue-tampered")).toThrow(CrashRecoveryLedgerCorruptionError);
+    expect(() => enqueuePrompt({ dedupeKey: "tampered", queueItemId: "queue-tampered" })).toThrow(
+      CrashRecoveryLedgerCorruptionError,
+    );
+  });
+
+  it("fails closed when required prompt JSON is corrupt", () => {
+    createBoot();
+    enqueuePrompt({ dedupeKey: "corrupt", queueItemId: "queue-corrupt" });
+    getDb()
+      .prepare("UPDATE runtime_prompt_queue SET prompt_json = ? WHERE queue_item_id = ?")
+      .run("{bad", "queue-corrupt");
+    expect(() => getRuntimePromptQueueItem("queue-corrupt")).toThrow(CrashRecoveryLedgerCorruptionError);
+    expect(getRuntimeBootEpoch("boot-a")?.status).toBe("active");
+  });
+});

--- a/src/runtime/crash-recovery-store.ts
+++ b/src/runtime/crash-recovery-store.ts
@@ -1,0 +1,2676 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Database, SQLQueryBindings } from "bun:sqlite";
+import { executeWrite } from "../db/write-retry.js";
+import { DELIVERY_BARRIER_VALUES, type DeliveryBarrier } from "../delivery-barriers.js";
+import { getDb } from "../router/router-db.js";
+import type { TurnOrigin } from "./turn-provenance.js";
+
+const TURN_ORIGIN_VALUES = [
+  "human",
+  "cron",
+  "trigger",
+  "session-followup",
+  "heartbeat",
+  "observer",
+  "task",
+  "routine",
+  "daemon-restart",
+  "automation",
+  "agent",
+  "system",
+  "background",
+  "unknown",
+] as const satisfies readonly TurnOrigin[];
+
+export const RUNTIME_BOOT_EPOCH_STATUSES = ["active", "graceful_stopped", "abandoned"] as const;
+export type RuntimeBootEpochStatus = (typeof RUNTIME_BOOT_EPOCH_STATUSES)[number];
+
+export const RUNTIME_TURN_ATTEMPT_STATUSES = [
+  "running",
+  "complete",
+  "failed",
+  "interrupted",
+  "timeout",
+  "aborted",
+] as const;
+export type RuntimeTurnAttemptStatus = (typeof RUNTIME_TURN_ATTEMPT_STATUSES)[number];
+export type RuntimeTurnAttemptTerminalStatus = Exclude<RuntimeTurnAttemptStatus, "running">;
+
+export const RUNTIME_PROMPT_QUEUE_STATUSES = [
+  "queued",
+  "leased",
+  "starting",
+  "delivered",
+  "complete",
+  "cancelled",
+  "superseded",
+  "failed",
+  "requeued",
+  "deferred",
+] as const;
+export type RuntimePromptQueueStatus = (typeof RUNTIME_PROMPT_QUEUE_STATUSES)[number];
+
+export const RUNTIME_RECOVERY_RUN_MODES = ["inspect", "dry-run", "apply"] as const;
+export type RuntimeRecoveryRunMode = (typeof RUNTIME_RECOVERY_RUN_MODES)[number];
+export type RuntimeRecoveryRunStatus = "running" | "complete" | "failed";
+
+export const RUNTIME_RECOVERY_CANDIDATE_TYPES = ["turn_attempt", "prompt_queue", "legacy_session_turn"] as const;
+export type RuntimeRecoveryCandidateType = (typeof RUNTIME_RECOVERY_CANDIDATE_TYPES)[number];
+
+export const RUNTIME_RECOVERY_DECISIONS = [
+  "resume",
+  "requeue",
+  "reconcile_interrupted",
+  "defer_next_schedule",
+  "ignore_stale",
+  "manual_review",
+] as const;
+export type RuntimeRecoveryDecision = (typeof RUNTIME_RECOVERY_DECISIONS)[number];
+export type RuntimeRecoveryActionStatus = "pending" | "not_applied" | "claimed" | "applied" | "failed";
+export type RuntimeRecoveryClaimStatus = "claimed" | "applied" | "failed";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface RuntimeBootEpochRecord {
+  bootEpoch: string;
+  instanceId: string;
+  pid: number;
+  status: RuntimeBootEpochStatus;
+  startedAt: number;
+  lastHeartbeatAt: number;
+  leaseExpiresAt: number;
+  gracefulStoppedAt: number | null;
+  abandonedAt: number | null;
+  stopReason: string | null;
+  metadata: JsonRecord | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreateRuntimeBootEpochInput {
+  bootEpoch?: string;
+  instanceId: string;
+  pid: number;
+  startedAt?: number;
+  lastHeartbeatAt?: number;
+  leaseExpiresAt: number;
+  metadata?: JsonRecord | null;
+}
+
+export interface RuntimeTurnAttemptRecord {
+  attemptId: string;
+  turnId: string;
+  recoveredFromAttemptId: string | null;
+  runId: string;
+  sessionKey: string;
+  sessionName: string | null;
+  agentId: string;
+  provider: string;
+  model: string;
+  bootEpoch: string;
+  status: RuntimeTurnAttemptStatus;
+  startedAt: number;
+  leaseExpiresAt: number;
+  lastHeartbeatAt: number;
+  completedAt: number | null;
+  requestBlobSha256: string | null;
+  userPromptSha256: string | null;
+  systemPromptSha256: string | null;
+  checkpoint: unknown | null;
+  originKind: TurnOrigin;
+  source: unknown | null;
+  turnProvenance: unknown | null;
+  taskBarrierTaskId: string | null;
+  deliveryBarrier: DeliveryBarrier;
+  pendingIds: string[];
+  startedTool: boolean;
+  materializedOutput: boolean;
+  recoveryClaimId: string | null;
+  recoveryStatus: string | null;
+  recoveryReason: string | null;
+  recoveryRunId: string | null;
+  recoveredAt: number | null;
+  metadata: JsonRecord | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreateRuntimeTurnAttemptInput {
+  attemptId?: string;
+  turnId: string;
+  recoveredFromAttemptId?: string | null;
+  runId: string;
+  sessionKey: string;
+  sessionName?: string | null;
+  agentId: string;
+  provider: string;
+  model: string;
+  bootEpoch: string;
+  startedAt?: number;
+  lastHeartbeatAt?: number;
+  leaseExpiresAt: number;
+  requestBlobSha256?: string | null;
+  userPromptSha256?: string | null;
+  systemPromptSha256?: string | null;
+  checkpoint?: unknown;
+  originKind: TurnOrigin;
+  source?: unknown;
+  turnProvenance?: unknown;
+  taskBarrierTaskId?: string | null;
+  deliveryBarrier: DeliveryBarrier;
+  pendingIds?: string[];
+  metadata?: JsonRecord | null;
+}
+
+export interface RuntimePromptQueueRecord {
+  queueSequence: number;
+  queueItemId: string;
+  dedupeKey: string;
+  immutableFingerprint: string;
+  sessionKey: string;
+  sessionName: string | null;
+  agentId: string | null;
+  laneKey: DeliveryBarrier;
+  bootEpoch: string | null;
+  status: RuntimePromptQueueStatus;
+  originKind: TurnOrigin;
+  deliveryBarrier: DeliveryBarrier;
+  taskBarrierTaskId: string | null;
+  pendingId: string | null;
+  prompt: unknown;
+  runtimeMessage: unknown;
+  queuedAt: number;
+  leaseOwner: string | null;
+  leaseExpiresAt: number | null;
+  deliveredAttemptId: string | null;
+  deliveredTurnId: string | null;
+  completedAt: number | null;
+  recoveryClaimId: string | null;
+  recoveryStatus: string | null;
+  recoveryReason: string | null;
+  recoveryRunId: string | null;
+  recoveredAt: number | null;
+  metadata: JsonRecord | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface EnqueueRuntimePromptInput {
+  queueItemId?: string;
+  dedupeKey: string;
+  sessionKey: string;
+  sessionName?: string | null;
+  agentId?: string | null;
+  laneKey: DeliveryBarrier;
+  bootEpoch?: string | null;
+  originKind: TurnOrigin;
+  deliveryBarrier: DeliveryBarrier;
+  taskBarrierTaskId?: string | null;
+  pendingId?: string | null;
+  prompt: unknown;
+  runtimeMessage: unknown;
+  queuedAt?: number;
+  metadata?: JsonRecord | null;
+}
+
+export interface RuntimeRecoveryRunRecord {
+  recoveryRunId: string;
+  mode: RuntimeRecoveryRunMode;
+  bootEpoch: string | null;
+  status: RuntimeRecoveryRunStatus;
+  startedAt: number;
+  completedAt: number | null;
+  summary: JsonRecord | null;
+  error: string | null;
+  metadata: JsonRecord | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RuntimeRecoveryCandidateRecord {
+  recoveryRunId: string;
+  candidateKey: string;
+  candidateType: RuntimeRecoveryCandidateType;
+  sessionKey: string;
+  sessionName: string | null;
+  attemptId: string | null;
+  turnId: string | null;
+  queueItemId: string | null;
+  decision: RuntimeRecoveryDecision;
+  reasonCode: string;
+  action: string;
+  actionStatus: RuntimeRecoveryActionStatus;
+  claimId: string | null;
+  details: JsonRecord | null;
+  result: JsonRecord | null;
+  actionCompletedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RecordRuntimeRecoveryCandidateInput {
+  recoveryRunId: string;
+  candidateKey?: string;
+  candidateType: RuntimeRecoveryCandidateType;
+  sessionKey: string;
+  sessionName?: string | null;
+  attemptId?: string | null;
+  turnId?: string | null;
+  queueItemId?: string | null;
+  decision: RuntimeRecoveryDecision;
+  reasonCode: string;
+  action: string;
+  details?: JsonRecord | null;
+  recordedAt?: number;
+}
+
+export interface RuntimeRecoveryClaimRecord {
+  candidateKey: string;
+  claimId: string;
+  candidateType: Exclude<RuntimeRecoveryCandidateType, "legacy_session_turn">;
+  sessionKey: string;
+  attemptId: string | null;
+  queueItemId: string | null;
+  recoveryRunId: string;
+  claimedByBootEpoch: string;
+  status: RuntimeRecoveryClaimStatus;
+  claimedAt: number;
+  completedAt: number | null;
+  result: JsonRecord | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export class CrashRecoveryLedgerConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CrashRecoveryLedgerConflictError";
+  }
+}
+
+export class CrashRecoveryLedgerCorruptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CrashRecoveryLedgerCorruptionError";
+  }
+}
+
+export class CrashRecoveryLedgerNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CrashRecoveryLedgerNotFoundError";
+  }
+}
+
+interface RuntimeBootEpochRow {
+  boot_epoch: string;
+  instance_id: string;
+  pid: number;
+  status: RuntimeBootEpochStatus;
+  started_at: number;
+  last_heartbeat_at: number;
+  lease_expires_at: number;
+  graceful_stopped_at: number | null;
+  abandoned_at: number | null;
+  stop_reason: string | null;
+  metadata_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RuntimeTurnAttemptRow {
+  attempt_id: string;
+  turn_id: string;
+  recovered_from_attempt_id: string | null;
+  run_id: string;
+  session_key: string;
+  session_name: string | null;
+  agent_id: string;
+  provider: string;
+  model: string;
+  boot_epoch: string;
+  status: RuntimeTurnAttemptStatus;
+  started_at: number;
+  lease_expires_at: number;
+  last_heartbeat_at: number;
+  completed_at: number | null;
+  request_blob_sha256: string | null;
+  user_prompt_sha256: string | null;
+  system_prompt_sha256: string | null;
+  checkpoint_json: string | null;
+  origin_kind: string;
+  source_json: string | null;
+  turn_provenance_json: string | null;
+  task_barrier_task_id: string | null;
+  delivery_barrier: string;
+  pending_ids_json: string | null;
+  started_tool: number;
+  materialized_output: number;
+  recovery_claim_id: string | null;
+  recovery_status: string | null;
+  recovery_reason: string | null;
+  recovery_run_id: string | null;
+  recovered_at: number | null;
+  metadata_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RuntimePromptQueueRow {
+  queue_sequence: number;
+  queue_item_id: string;
+  dedupe_key: string;
+  immutable_fingerprint: string;
+  session_key: string;
+  session_name: string | null;
+  agent_id: string | null;
+  lane_key: string;
+  boot_epoch: string | null;
+  status: RuntimePromptQueueStatus;
+  origin_kind: string;
+  delivery_barrier: string;
+  task_barrier_task_id: string | null;
+  pending_id: string | null;
+  prompt_json: string;
+  runtime_message_json: string;
+  queued_at: number;
+  lease_owner: string | null;
+  lease_expires_at: number | null;
+  delivered_attempt_id: string | null;
+  delivered_turn_id: string | null;
+  completed_at: number | null;
+  recovery_claim_id: string | null;
+  recovery_status: string | null;
+  recovery_reason: string | null;
+  recovery_run_id: string | null;
+  recovered_at: number | null;
+  metadata_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RuntimeRecoveryRunRow {
+  recovery_run_id: string;
+  mode: RuntimeRecoveryRunMode;
+  boot_epoch: string | null;
+  status: RuntimeRecoveryRunStatus;
+  started_at: number;
+  completed_at: number | null;
+  summary_json: string | null;
+  error: string | null;
+  metadata_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RuntimeRecoveryCandidateRow {
+  recovery_run_id: string;
+  candidate_key: string;
+  candidate_type: RuntimeRecoveryCandidateType;
+  session_key: string;
+  session_name: string | null;
+  attempt_id: string | null;
+  turn_id: string | null;
+  queue_item_id: string | null;
+  decision: RuntimeRecoveryDecision;
+  reason_code: string;
+  action: string;
+  action_status: RuntimeRecoveryActionStatus;
+  claim_id: string | null;
+  details_json: string | null;
+  result_json: string | null;
+  action_completed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RuntimeRecoveryClaimRow {
+  candidate_key: string;
+  claim_id: string;
+  candidate_type: Exclude<RuntimeRecoveryCandidateType, "legacy_session_turn">;
+  session_key: string;
+  attempt_id: string | null;
+  queue_item_id: string | null;
+  recovery_run_id: string;
+  claimed_by_boot_epoch: string;
+  status: RuntimeRecoveryClaimStatus;
+  claimed_at: number;
+  completed_at: number | null;
+  result_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+const TERMINAL_QUEUE_STATUSES = new Set<RuntimePromptQueueStatus>(["complete", "cancelled", "superseded", "failed"]);
+const RUNTIME_BOOT_EPOCH_STATUS_SET = new Set<string>(RUNTIME_BOOT_EPOCH_STATUSES);
+const RUNTIME_TURN_ATTEMPT_STATUS_SET = new Set<string>(RUNTIME_TURN_ATTEMPT_STATUSES);
+const RUNTIME_PROMPT_QUEUE_STATUS_SET = new Set<string>(RUNTIME_PROMPT_QUEUE_STATUSES);
+const RUNTIME_RECOVERY_RUN_MODE_SET = new Set<string>(RUNTIME_RECOVERY_RUN_MODES);
+const RUNTIME_RECOVERY_RUN_STATUS_SET = new Set<string>(["running", "complete", "failed"]);
+const RUNTIME_RECOVERY_CANDIDATE_TYPE_SET = new Set<string>(RUNTIME_RECOVERY_CANDIDATE_TYPES);
+const RUNTIME_RECOVERY_CLAIM_CANDIDATE_TYPE_SET = new Set<string>(["turn_attempt", "prompt_queue"]);
+const RUNTIME_RECOVERY_DECISION_SET = new Set<string>(RUNTIME_RECOVERY_DECISIONS);
+const RUNTIME_RECOVERY_ACTION_STATUS_SET = new Set<string>(["pending", "not_applied", "claimed", "applied", "failed"]);
+const RUNTIME_RECOVERY_CLAIM_STATUS_SET = new Set<string>(["claimed", "applied", "failed"]);
+const ALLOWED_QUEUE_STATUS_TRANSITIONS: Readonly<
+  Record<RuntimePromptQueueStatus, ReadonlySet<RuntimePromptQueueStatus>>
+> = {
+  queued: new Set(["queued", "leased", "deferred", "cancelled", "superseded", "failed"]),
+  leased: new Set(["leased", "starting", "requeued", "deferred", "cancelled", "superseded", "failed"]),
+  starting: new Set(["starting", "delivered", "requeued", "deferred", "cancelled", "superseded", "failed"]),
+  delivered: new Set(["delivered", "complete", "failed"]),
+  complete: new Set(["complete"]),
+  cancelled: new Set(["cancelled"]),
+  superseded: new Set(["superseded"]),
+  failed: new Set(["failed"]),
+  requeued: new Set(["requeued", "leased", "deferred", "cancelled", "superseded", "failed"]),
+  deferred: new Set(["deferred", "queued", "requeued", "leased", "cancelled", "superseded", "failed"]),
+};
+const TURN_ORIGIN_SET = new Set<string>(TURN_ORIGIN_VALUES);
+const DELIVERY_BARRIER_SET = new Set<string>(DELIVERY_BARRIER_VALUES);
+
+function requiredText(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function optionalText(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function assertTimestamp(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative Unix millisecond timestamp`);
+  }
+  return value;
+}
+
+function assertPositiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`);
+  return value;
+}
+
+function assertLimit(value: number | undefined): number {
+  const limit = value ?? 100;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
+    throw new Error("limit must be an integer between 1 and 1000");
+  }
+  return limit;
+}
+
+function requireTurnOrigin(value: unknown, label: string): TurnOrigin {
+  if (typeof value !== "string" || !TURN_ORIGIN_SET.has(value)) {
+    throw new Error(`${label} must be a canonical runtime turn origin`);
+  }
+  return value as TurnOrigin;
+}
+
+function requireDeliveryBarrier(value: unknown, label: string): DeliveryBarrier {
+  if (typeof value !== "string" || !DELIVERY_BARRIER_SET.has(value)) {
+    throw new Error(`${label} must be a canonical delivery barrier`);
+  }
+  return value as DeliveryBarrier;
+}
+
+function parsePersistedTurnOrigin(value: unknown, label: string): TurnOrigin {
+  try {
+    return requireTurnOrigin(value, label);
+  } catch {
+    throw new CrashRecoveryLedgerCorruptionError(`Invalid ${label} in crash recovery ledger`);
+  }
+}
+
+function parsePersistedDeliveryBarrier(value: unknown, label: string): DeliveryBarrier {
+  try {
+    return requireDeliveryBarrier(value, label);
+  } catch {
+    throw new CrashRecoveryLedgerCorruptionError(`Invalid ${label} in crash recovery ledger`);
+  }
+}
+
+function parsePersistedEnum<T extends string>(value: unknown, allowed: ReadonlySet<string>, label: string): T {
+  if (typeof value !== "string" || !allowed.has(value)) {
+    throw new CrashRecoveryLedgerCorruptionError(`Invalid ${label} in crash recovery ledger`);
+  }
+  return value as T;
+}
+
+function parsePersistedBoolean(value: unknown, label: string): boolean {
+  if (value !== 0 && value !== 1) {
+    throw new CrashRecoveryLedgerCorruptionError(`Invalid ${label} in crash recovery ledger`);
+  }
+  return value === 1;
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value !== null && typeof value === "object") {
+    const sorted: JsonRecord = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortJson((value as JsonRecord)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function stringifyRequiredJson(value: unknown, label: string): string {
+  if (value === null || value === undefined) throw new Error(`${label} is required`);
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new Error(`${label} must be JSON serializable`);
+  return JSON.stringify(sortJson(JSON.parse(serialized) as unknown));
+}
+
+function stringifyOptionalJson(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return stringifyRequiredJson(value, "JSON value");
+}
+
+function parseRequiredJson(value: string, label: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw new CrashRecoveryLedgerCorruptionError(`Invalid ${label} JSON in crash recovery ledger`);
+  }
+}
+
+function parseOptionalJson(value: string | null, label: string): unknown | null {
+  return value === null ? null : parseRequiredJson(value, label);
+}
+
+function parseOptionalRecord(value: string | null, label: string): JsonRecord | null {
+  const parsed = parseOptionalJson(value, label);
+  if (parsed === null) return null;
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CrashRecoveryLedgerCorruptionError(`${label} must be a JSON object in crash recovery ledger`);
+  }
+  return parsed as JsonRecord;
+}
+
+function parseStringArray(value: string | null, label: string): string[] {
+  if (value === null) return [];
+  const parsed = parseRequiredJson(value, label);
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+    throw new CrashRecoveryLedgerCorruptionError(`${label} must be a JSON string array in crash recovery ledger`);
+  }
+  return parsed as string[];
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function buildRuntimeRecoveryCandidateKey(input: {
+  candidateType: RuntimeRecoveryCandidateType;
+  sessionKey: string;
+  attemptId?: string | null;
+  turnId?: string | null;
+  queueItemId?: string | null;
+}): string {
+  const sessionKey = requiredText(input.sessionKey, "sessionKey");
+  if (input.candidateType === "turn_attempt") {
+    return `attempt:${requiredText(input.attemptId ?? "", "attemptId")}`;
+  }
+  if (input.candidateType === "prompt_queue") {
+    return `queue:${requiredText(input.queueItemId ?? "", "queueItemId")}`;
+  }
+  const turnId = requiredText(input.turnId ?? "", "turnId");
+  return `legacy:${sha256(`${sessionKey}\u0000${turnId}`)}`;
+}
+
+function rowToBootEpoch(row: RuntimeBootEpochRow): RuntimeBootEpochRecord {
+  return {
+    bootEpoch: row.boot_epoch,
+    instanceId: row.instance_id,
+    pid: row.pid,
+    status: parsePersistedEnum<RuntimeBootEpochStatus>(
+      row.status,
+      RUNTIME_BOOT_EPOCH_STATUS_SET,
+      "runtime_boot_epochs.status",
+    ),
+    startedAt: row.started_at,
+    lastHeartbeatAt: row.last_heartbeat_at,
+    leaseExpiresAt: row.lease_expires_at,
+    gracefulStoppedAt: row.graceful_stopped_at,
+    abandonedAt: row.abandoned_at,
+    stopReason: row.stop_reason,
+    metadata: parseOptionalRecord(row.metadata_json, "runtime_boot_epochs.metadata_json"),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToTurnAttempt(row: RuntimeTurnAttemptRow): RuntimeTurnAttemptRecord {
+  return {
+    attemptId: row.attempt_id,
+    turnId: row.turn_id,
+    recoveredFromAttemptId: row.recovered_from_attempt_id,
+    runId: row.run_id,
+    sessionKey: row.session_key,
+    sessionName: row.session_name,
+    agentId: row.agent_id,
+    provider: row.provider,
+    model: row.model,
+    bootEpoch: row.boot_epoch,
+    status: parsePersistedEnum<RuntimeTurnAttemptStatus>(
+      row.status,
+      RUNTIME_TURN_ATTEMPT_STATUS_SET,
+      "runtime_turn_attempts.status",
+    ),
+    startedAt: row.started_at,
+    leaseExpiresAt: row.lease_expires_at,
+    lastHeartbeatAt: row.last_heartbeat_at,
+    completedAt: row.completed_at,
+    requestBlobSha256: row.request_blob_sha256,
+    userPromptSha256: row.user_prompt_sha256,
+    systemPromptSha256: row.system_prompt_sha256,
+    checkpoint: parseOptionalJson(row.checkpoint_json, "runtime_turn_attempts.checkpoint_json"),
+    originKind: parsePersistedTurnOrigin(row.origin_kind, "runtime_turn_attempts.origin_kind"),
+    source: parseOptionalJson(row.source_json, "runtime_turn_attempts.source_json"),
+    turnProvenance: parseOptionalJson(row.turn_provenance_json, "runtime_turn_attempts.turn_provenance_json"),
+    taskBarrierTaskId: row.task_barrier_task_id,
+    deliveryBarrier: parsePersistedDeliveryBarrier(row.delivery_barrier, "runtime_turn_attempts.delivery_barrier"),
+    pendingIds: parseStringArray(row.pending_ids_json, "runtime_turn_attempts.pending_ids_json"),
+    startedTool: parsePersistedBoolean(row.started_tool, "runtime_turn_attempts.started_tool"),
+    materializedOutput: parsePersistedBoolean(row.materialized_output, "runtime_turn_attempts.materialized_output"),
+    recoveryClaimId: row.recovery_claim_id,
+    recoveryStatus: row.recovery_status,
+    recoveryReason: row.recovery_reason,
+    recoveryRunId: row.recovery_run_id,
+    recoveredAt: row.recovered_at,
+    metadata: parseOptionalRecord(row.metadata_json, "runtime_turn_attempts.metadata_json"),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToPromptQueue(row: RuntimePromptQueueRow): RuntimePromptQueueRecord {
+  const laneKey = parsePersistedDeliveryBarrier(row.lane_key, "runtime_prompt_queue.lane_key");
+  const status = parsePersistedEnum<RuntimePromptQueueStatus>(
+    row.status,
+    RUNTIME_PROMPT_QUEUE_STATUS_SET,
+    "runtime_prompt_queue.status",
+  );
+  const originKind = parsePersistedTurnOrigin(row.origin_kind, "runtime_prompt_queue.origin_kind");
+  const deliveryBarrier = parsePersistedDeliveryBarrier(row.delivery_barrier, "runtime_prompt_queue.delivery_barrier");
+  const prompt = parseRequiredJson(row.prompt_json, "runtime_prompt_queue.prompt_json");
+  const runtimeMessage = parseRequiredJson(row.runtime_message_json, "runtime_prompt_queue.runtime_message_json");
+  const metadata = parseOptionalRecord(row.metadata_json, "runtime_prompt_queue.metadata_json");
+  const ownerBound = status === "leased" || status === "starting" || status === "delivered";
+  if (ownerBound && (row.boot_epoch === null || row.lease_owner === null || row.lease_expires_at === null)) {
+    throw new CrashRecoveryLedgerCorruptionError(
+      `Owner-bound runtime prompt queue item ${row.queue_item_id} has an incomplete lease`,
+    );
+  }
+  if ((row.lease_owner === null) !== (row.lease_expires_at === null)) {
+    throw new CrashRecoveryLedgerCorruptionError(
+      `Runtime prompt queue item ${row.queue_item_id} has a partial lease fence`,
+    );
+  }
+  if (status === "delivered" && (row.delivered_attempt_id === null || row.delivered_turn_id === null)) {
+    throw new CrashRecoveryLedgerCorruptionError(
+      `Delivered runtime prompt queue item ${row.queue_item_id} has no delivery identity`,
+    );
+  }
+  if (TERMINAL_QUEUE_STATUSES.has(status) !== (row.completed_at !== null)) {
+    throw new CrashRecoveryLedgerCorruptionError(
+      `Runtime prompt queue item ${row.queue_item_id} has inconsistent terminal timestamps`,
+    );
+  }
+  const persistedFingerprint = promptQueueFingerprint({
+    dedupeKey: row.dedupe_key,
+    sessionKey: row.session_key,
+    sessionName: row.session_name,
+    agentId: row.agent_id,
+    laneKey,
+    originKind,
+    deliveryBarrier,
+    taskBarrierTaskId: row.task_barrier_task_id,
+    pendingId: row.pending_id,
+    promptJson: row.prompt_json,
+    runtimeMessageJson: row.runtime_message_json,
+    metadataJson: row.metadata_json,
+  });
+  if (persistedFingerprint !== row.immutable_fingerprint) {
+    throw new CrashRecoveryLedgerCorruptionError(
+      `Immutable fingerprint mismatch for runtime prompt queue item ${row.queue_item_id}`,
+    );
+  }
+  return {
+    queueSequence: row.queue_sequence,
+    queueItemId: row.queue_item_id,
+    dedupeKey: row.dedupe_key,
+    immutableFingerprint: row.immutable_fingerprint,
+    sessionKey: row.session_key,
+    sessionName: row.session_name,
+    agentId: row.agent_id,
+    laneKey,
+    bootEpoch: row.boot_epoch,
+    status,
+    originKind,
+    deliveryBarrier,
+    taskBarrierTaskId: row.task_barrier_task_id,
+    pendingId: row.pending_id,
+    prompt,
+    runtimeMessage,
+    queuedAt: row.queued_at,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt: row.lease_expires_at,
+    deliveredAttemptId: row.delivered_attempt_id,
+    deliveredTurnId: row.delivered_turn_id,
+    completedAt: row.completed_at,
+    recoveryClaimId: row.recovery_claim_id,
+    recoveryStatus: row.recovery_status,
+    recoveryReason: row.recovery_reason,
+    recoveryRunId: row.recovery_run_id,
+    recoveredAt: row.recovered_at,
+    metadata,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToRecoveryRun(row: RuntimeRecoveryRunRow): RuntimeRecoveryRunRecord {
+  return {
+    recoveryRunId: row.recovery_run_id,
+    mode: parsePersistedEnum<RuntimeRecoveryRunMode>(
+      row.mode,
+      RUNTIME_RECOVERY_RUN_MODE_SET,
+      "runtime_recovery_runs.mode",
+    ),
+    bootEpoch: row.boot_epoch,
+    status: parsePersistedEnum<RuntimeRecoveryRunStatus>(
+      row.status,
+      RUNTIME_RECOVERY_RUN_STATUS_SET,
+      "runtime_recovery_runs.status",
+    ),
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    summary: parseOptionalRecord(row.summary_json, "runtime_recovery_runs.summary_json"),
+    error: row.error,
+    metadata: parseOptionalRecord(row.metadata_json, "runtime_recovery_runs.metadata_json"),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToRecoveryCandidate(row: RuntimeRecoveryCandidateRow): RuntimeRecoveryCandidateRecord {
+  return {
+    recoveryRunId: row.recovery_run_id,
+    candidateKey: row.candidate_key,
+    candidateType: parsePersistedEnum<RuntimeRecoveryCandidateType>(
+      row.candidate_type,
+      RUNTIME_RECOVERY_CANDIDATE_TYPE_SET,
+      "runtime_recovery_candidates.candidate_type",
+    ),
+    sessionKey: row.session_key,
+    sessionName: row.session_name,
+    attemptId: row.attempt_id,
+    turnId: row.turn_id,
+    queueItemId: row.queue_item_id,
+    decision: parsePersistedEnum<RuntimeRecoveryDecision>(
+      row.decision,
+      RUNTIME_RECOVERY_DECISION_SET,
+      "runtime_recovery_candidates.decision",
+    ),
+    reasonCode: row.reason_code,
+    action: row.action,
+    actionStatus: parsePersistedEnum<RuntimeRecoveryActionStatus>(
+      row.action_status,
+      RUNTIME_RECOVERY_ACTION_STATUS_SET,
+      "runtime_recovery_candidates.action_status",
+    ),
+    claimId: row.claim_id,
+    details: parseOptionalRecord(row.details_json, "runtime_recovery_candidates.details_json"),
+    result: parseOptionalRecord(row.result_json, "runtime_recovery_candidates.result_json"),
+    actionCompletedAt: row.action_completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToRecoveryClaim(row: RuntimeRecoveryClaimRow): RuntimeRecoveryClaimRecord {
+  return {
+    candidateKey: row.candidate_key,
+    claimId: row.claim_id,
+    candidateType: parsePersistedEnum<Exclude<RuntimeRecoveryCandidateType, "legacy_session_turn">>(
+      row.candidate_type,
+      RUNTIME_RECOVERY_CLAIM_CANDIDATE_TYPE_SET,
+      "runtime_recovery_claims.candidate_type",
+    ),
+    sessionKey: row.session_key,
+    attemptId: row.attempt_id,
+    queueItemId: row.queue_item_id,
+    recoveryRunId: row.recovery_run_id,
+    claimedByBootEpoch: row.claimed_by_boot_epoch,
+    status: parsePersistedEnum<RuntimeRecoveryClaimStatus>(
+      row.status,
+      RUNTIME_RECOVERY_CLAIM_STATUS_SET,
+      "runtime_recovery_claims.status",
+    ),
+    claimedAt: row.claimed_at,
+    completedAt: row.completed_at,
+    result: parseOptionalRecord(row.result_json, "runtime_recovery_claims.result_json"),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function getBootEpochRow(database: Database, bootEpoch: string): RuntimeBootEpochRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_boot_epochs WHERE boot_epoch = ?").get(bootEpoch) as
+      | RuntimeBootEpochRow
+      | undefined) ?? null
+  );
+}
+
+function getTurnAttemptRow(database: Database, attemptId: string): RuntimeTurnAttemptRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_turn_attempts WHERE attempt_id = ?").get(attemptId) as
+      | RuntimeTurnAttemptRow
+      | undefined) ?? null
+  );
+}
+
+function getPromptQueueRow(database: Database, queueItemId: string): RuntimePromptQueueRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_prompt_queue WHERE queue_item_id = ?").get(queueItemId) as
+      | RuntimePromptQueueRow
+      | undefined) ?? null
+  );
+}
+
+function getRecoveryRunRow(database: Database, recoveryRunId: string): RuntimeRecoveryRunRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_recovery_runs WHERE recovery_run_id = ?").get(recoveryRunId) as
+      | RuntimeRecoveryRunRow
+      | undefined) ?? null
+  );
+}
+
+function getRecoveryCandidateRow(
+  database: Database,
+  recoveryRunId: string,
+  candidateKey: string,
+): RuntimeRecoveryCandidateRow | null {
+  return (
+    (database
+      .prepare("SELECT * FROM runtime_recovery_candidates WHERE recovery_run_id = ? AND candidate_key = ?")
+      .get(recoveryRunId, candidateKey) as RuntimeRecoveryCandidateRow | undefined) ?? null
+  );
+}
+
+function getRecoveryClaimByCandidateRow(database: Database, candidateKey: string): RuntimeRecoveryClaimRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_recovery_claims WHERE candidate_key = ?").get(candidateKey) as
+      | RuntimeRecoveryClaimRow
+      | undefined) ?? null
+  );
+}
+
+export function createRuntimeBootEpoch(input: CreateRuntimeBootEpochInput): RuntimeBootEpochRecord {
+  const bootEpoch = requiredText(input.bootEpoch ?? `boot_${randomUUID()}`, "bootEpoch");
+  const instanceId = requiredText(input.instanceId, "instanceId");
+  const pid = assertPositiveInteger(input.pid, "pid");
+  const startedAt = assertTimestamp(input.startedAt ?? Date.now(), "startedAt");
+  const lastHeartbeatAt = assertTimestamp(input.lastHeartbeatAt ?? startedAt, "lastHeartbeatAt");
+  const leaseExpiresAt = assertTimestamp(input.leaseExpiresAt, "leaseExpiresAt");
+  if (lastHeartbeatAt < startedAt) throw new Error("lastHeartbeatAt cannot precede startedAt");
+  if (leaseExpiresAt <= lastHeartbeatAt) throw new Error("leaseExpiresAt must be after lastHeartbeatAt");
+  const metadataJson = stringifyOptionalJson(input.metadata);
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const existing = getBootEpochRow(database, bootEpoch);
+      if (existing) {
+        const matches =
+          existing.instance_id === instanceId &&
+          existing.pid === pid &&
+          existing.started_at === startedAt &&
+          existing.last_heartbeat_at === lastHeartbeatAt &&
+          existing.lease_expires_at === leaseExpiresAt &&
+          existing.metadata_json === metadataJson;
+        if (!matches) {
+          throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} already exists with different identity`);
+        }
+        return rowToBootEpoch(existing);
+      }
+
+      database
+        .prepare(
+          `INSERT INTO runtime_boot_epochs (
+             boot_epoch, instance_id, pid, status, started_at, last_heartbeat_at, lease_expires_at,
+             metadata_json, created_at, updated_at
+           ) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          bootEpoch,
+          instanceId,
+          pid,
+          startedAt,
+          lastHeartbeatAt,
+          leaseExpiresAt,
+          metadataJson,
+          startedAt,
+          startedAt,
+        );
+      const row = getBootEpochRow(database, bootEpoch);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Boot epoch ${bootEpoch} missing after insert`);
+      return rowToBootEpoch(row);
+    },
+    { label: "runtime-crash-recovery-create-boot" },
+  );
+}
+
+export function getRuntimeBootEpoch(bootEpoch: string): RuntimeBootEpochRecord | null {
+  const row = getBootEpochRow(getDb(), requiredText(bootEpoch, "bootEpoch"));
+  return row ? rowToBootEpoch(row) : null;
+}
+
+export function listRuntimeBootEpochs(
+  options: { instanceId?: string; status?: RuntimeBootEpochStatus; limit?: number } = {},
+): RuntimeBootEpochRecord[] {
+  const where: string[] = [];
+  const params: SQLQueryBindings[] = [];
+  if (options.instanceId) {
+    where.push("instance_id = ?");
+    params.push(requiredText(options.instanceId, "instanceId"));
+  }
+  if (options.status) {
+    where.push("status = ?");
+    params.push(options.status);
+  }
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+  const rows = getDb()
+    .prepare(`SELECT * FROM runtime_boot_epochs ${whereSql} ORDER BY started_at DESC, boot_epoch DESC LIMIT ?`)
+    .all(...params, assertLimit(options.limit)) as RuntimeBootEpochRow[];
+  return rows.map(rowToBootEpoch);
+}
+
+export function heartbeatRuntimeBootEpoch(input: {
+  bootEpoch: string;
+  heartbeatAt?: number;
+  leaseExpiresAt: number;
+}): RuntimeBootEpochRecord {
+  const bootEpoch = requiredText(input.bootEpoch, "bootEpoch");
+  const heartbeatAt = assertTimestamp(input.heartbeatAt ?? Date.now(), "heartbeatAt");
+  const leaseExpiresAt = assertTimestamp(input.leaseExpiresAt, "leaseExpiresAt");
+  if (leaseExpiresAt <= heartbeatAt) throw new Error("leaseExpiresAt must be after heartbeatAt");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getBootEpochRow(database, bootEpoch);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Boot epoch not found: ${bootEpoch}`);
+      if (current.status !== "active") {
+        throw new CrashRecoveryLedgerConflictError(`Cannot heartbeat terminal boot epoch ${bootEpoch}`);
+      }
+      if (
+        heartbeatAt < current.last_heartbeat_at ||
+        heartbeatAt < current.updated_at ||
+        leaseExpiresAt < current.lease_expires_at
+      ) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot move boot epoch ${bootEpoch} heartbeat or lease backwards`);
+      }
+      if (heartbeatAt === current.last_heartbeat_at && leaseExpiresAt === current.lease_expires_at) {
+        return rowToBootEpoch(current);
+      }
+      const result = database
+        .prepare(
+          `UPDATE runtime_boot_epochs
+           SET last_heartbeat_at = ?, lease_expires_at = ?, updated_at = ?
+           WHERE boot_epoch = ? AND status = 'active'`,
+        )
+        .run(heartbeatAt, leaseExpiresAt, heartbeatAt, bootEpoch);
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} lost its heartbeat transition race`);
+      }
+      const row = getBootEpochRow(database, bootEpoch);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Boot epoch not found after heartbeat: ${bootEpoch}`);
+      return rowToBootEpoch(row);
+    },
+    { label: "runtime-crash-recovery-heartbeat-boot" },
+  );
+}
+
+function terminalizeRuntimeBootEpoch(input: {
+  bootEpoch: string;
+  status: Exclude<RuntimeBootEpochStatus, "active">;
+  terminalAt?: number;
+  reason?: string | null;
+  expectedLastHeartbeatAt?: number;
+  expectedLeaseExpiresAt?: number;
+}): RuntimeBootEpochRecord {
+  const bootEpoch = requiredText(input.bootEpoch, "bootEpoch");
+  const terminalAt = assertTimestamp(input.terminalAt ?? Date.now(), "terminalAt");
+  const reason = optionalText(input.reason);
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getBootEpochRow(database, bootEpoch);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Boot epoch not found: ${bootEpoch}`);
+      if (current.status === input.status) {
+        const currentTerminalAt =
+          input.status === "graceful_stopped" ? current.graceful_stopped_at : current.abandoned_at;
+        if (input.terminalAt !== undefined && terminalAt !== currentTerminalAt) {
+          throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} already has a different terminal time`);
+        }
+        if (input.reason !== undefined && reason !== current.stop_reason) {
+          throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} already has a different stop reason`);
+        }
+        return rowToBootEpoch(current);
+      }
+      if (current.status !== "active") {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot transition boot epoch ${bootEpoch} from ${current.status} to ${input.status}`,
+        );
+      }
+      if (terminalAt < current.last_heartbeat_at || terminalAt < current.updated_at) {
+        throw new CrashRecoveryLedgerConflictError("terminalAt cannot precede the latest boot observation");
+      }
+      if (input.status === "abandoned") {
+        if (input.expectedLastHeartbeatAt === undefined || input.expectedLeaseExpiresAt === undefined) {
+          throw new Error("Abandoning a boot requires the observed heartbeat and lease fence");
+        }
+        const expectedHeartbeat = assertTimestamp(input.expectedLastHeartbeatAt, "expectedLastHeartbeatAt");
+        const expectedLease = assertTimestamp(input.expectedLeaseExpiresAt, "expectedLeaseExpiresAt");
+        if (current.last_heartbeat_at !== expectedHeartbeat || current.lease_expires_at !== expectedLease) {
+          throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} changed after it was observed`);
+        }
+        if (terminalAt < expectedLease) {
+          throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} cannot be abandoned before lease expiry`);
+        }
+      }
+      const gracefulStoppedAt = input.status === "graceful_stopped" ? terminalAt : null;
+      const abandonedAt = input.status === "abandoned" ? terminalAt : null;
+      const result = database
+        .prepare(
+          `UPDATE runtime_boot_epochs
+           SET status = ?, graceful_stopped_at = ?, abandoned_at = ?, stop_reason = ?, updated_at = ?
+           WHERE boot_epoch = ? AND status = 'active'
+             AND last_heartbeat_at = ? AND lease_expires_at = ?`,
+        )
+        .run(
+          input.status,
+          gracefulStoppedAt,
+          abandonedAt,
+          reason,
+          terminalAt,
+          bootEpoch,
+          current.last_heartbeat_at,
+          current.lease_expires_at,
+        );
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Boot epoch ${bootEpoch} lost its terminal transition race`);
+      }
+      const row = getBootEpochRow(database, bootEpoch);
+      if (!row)
+        throw new CrashRecoveryLedgerNotFoundError(`Boot epoch not found after terminal transition: ${bootEpoch}`);
+      return rowToBootEpoch(row);
+    },
+    { label: `runtime-crash-recovery-${input.status}-boot` },
+  );
+}
+
+export function markRuntimeBootEpochGracefulStopped(input: {
+  bootEpoch: string;
+  stoppedAt?: number;
+  reason?: string | null;
+}): RuntimeBootEpochRecord {
+  return terminalizeRuntimeBootEpoch({
+    bootEpoch: input.bootEpoch,
+    status: "graceful_stopped",
+    terminalAt: input.stoppedAt,
+    reason: input.reason,
+  });
+}
+
+export function markRuntimeBootEpochAbandoned(input: {
+  bootEpoch: string;
+  abandonedAt?: number;
+  reason?: string | null;
+  expectedLastHeartbeatAt: number;
+  expectedLeaseExpiresAt: number;
+}): RuntimeBootEpochRecord {
+  return terminalizeRuntimeBootEpoch({
+    bootEpoch: input.bootEpoch,
+    status: "abandoned",
+    terminalAt: input.abandonedAt,
+    reason: input.reason,
+    expectedLastHeartbeatAt: input.expectedLastHeartbeatAt,
+    expectedLeaseExpiresAt: input.expectedLeaseExpiresAt,
+  });
+}
+
+export function createRuntimeTurnAttempt(input: CreateRuntimeTurnAttemptInput): RuntimeTurnAttemptRecord {
+  const attemptId = requiredText(input.attemptId ?? `attempt_${randomUUID()}`, "attemptId");
+  const turnId = requiredText(input.turnId, "turnId");
+  const recoveredFromAttemptId = optionalText(input.recoveredFromAttemptId);
+  const runId = requiredText(input.runId, "runId");
+  const sessionKey = requiredText(input.sessionKey, "sessionKey");
+  const sessionName = optionalText(input.sessionName);
+  const agentId = requiredText(input.agentId, "agentId");
+  const provider = requiredText(input.provider, "provider");
+  const model = requiredText(input.model, "model");
+  const bootEpoch = requiredText(input.bootEpoch, "bootEpoch");
+  const startedAt = assertTimestamp(input.startedAt ?? Date.now(), "startedAt");
+  const lastHeartbeatAt = assertTimestamp(input.lastHeartbeatAt ?? startedAt, "lastHeartbeatAt");
+  const leaseExpiresAt = assertTimestamp(input.leaseExpiresAt, "leaseExpiresAt");
+  if (lastHeartbeatAt < startedAt) throw new Error("lastHeartbeatAt cannot precede startedAt");
+  if (leaseExpiresAt <= lastHeartbeatAt) throw new Error("leaseExpiresAt must be after lastHeartbeatAt");
+  const requestBlobSha256 = optionalText(input.requestBlobSha256);
+  const userPromptSha256 = optionalText(input.userPromptSha256);
+  const systemPromptSha256 = optionalText(input.systemPromptSha256);
+  const checkpointJson = stringifyOptionalJson(input.checkpoint);
+  if (!requestBlobSha256 && !checkpointJson) {
+    throw new Error("Turn attempt requires a durable request blob hash or provider checkpoint");
+  }
+  const originKind = requireTurnOrigin(input.originKind, "originKind");
+  const sourceJson = stringifyOptionalJson(input.source);
+  const provenanceJson = stringifyOptionalJson(input.turnProvenance);
+  const taskBarrierTaskId = optionalText(input.taskBarrierTaskId);
+  const deliveryBarrier = requireDeliveryBarrier(input.deliveryBarrier, "deliveryBarrier");
+  const pendingIdsJson = input.pendingIds?.length ? stringifyRequiredJson(input.pendingIds, "pendingIds") : null;
+  const metadataJson = stringifyOptionalJson(input.metadata);
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const existing = getTurnAttemptRow(database, attemptId);
+      if (existing) {
+        const matches =
+          existing.turn_id === turnId &&
+          existing.recovered_from_attempt_id === recoveredFromAttemptId &&
+          existing.run_id === runId &&
+          existing.session_key === sessionKey &&
+          existing.session_name === sessionName &&
+          existing.agent_id === agentId &&
+          existing.provider === provider &&
+          existing.model === model &&
+          existing.boot_epoch === bootEpoch &&
+          existing.started_at === startedAt &&
+          existing.lease_expires_at === leaseExpiresAt &&
+          existing.last_heartbeat_at === lastHeartbeatAt &&
+          existing.request_blob_sha256 === requestBlobSha256 &&
+          existing.user_prompt_sha256 === userPromptSha256 &&
+          existing.system_prompt_sha256 === systemPromptSha256 &&
+          existing.checkpoint_json === checkpointJson &&
+          existing.origin_kind === originKind &&
+          existing.source_json === sourceJson &&
+          existing.turn_provenance_json === provenanceJson &&
+          existing.task_barrier_task_id === taskBarrierTaskId &&
+          existing.delivery_barrier === deliveryBarrier &&
+          existing.pending_ids_json === pendingIdsJson &&
+          existing.metadata_json === metadataJson;
+        if (!matches) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Attempt ${attemptId} already exists with different immutable data`,
+          );
+        }
+        return rowToTurnAttempt(existing);
+      }
+      const boot = getBootEpochRow(database, bootEpoch);
+      if (!boot) throw new CrashRecoveryLedgerNotFoundError(`Owning boot epoch not found: ${bootEpoch}`);
+      if (boot.status !== "active") {
+        throw new CrashRecoveryLedgerConflictError(`Cannot create attempt for terminal boot epoch ${bootEpoch}`);
+      }
+      if (startedAt < boot.started_at || boot.lease_expires_at <= startedAt) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot create attempt outside the live lease for boot ${bootEpoch}`,
+        );
+      }
+      if (leaseExpiresAt > boot.lease_expires_at) {
+        throw new CrashRecoveryLedgerConflictError("Attempt lease cannot outlive its owning boot lease");
+      }
+      if (recoveredFromAttemptId) {
+        const previous = getTurnAttemptRow(database, recoveredFromAttemptId);
+        if (!previous) {
+          throw new CrashRecoveryLedgerNotFoundError(`Recovered-from attempt not found: ${recoveredFromAttemptId}`);
+        }
+        if (previous.status === "running") {
+          throw new CrashRecoveryLedgerConflictError(
+            `Recovered-from attempt ${recoveredFromAttemptId} is still running`,
+          );
+        }
+        if (previous.turn_id !== turnId) {
+          throw new CrashRecoveryLedgerConflictError("Recovered attempt must retain the same logical turnId");
+        }
+      }
+      database
+        .prepare(
+          `INSERT INTO runtime_turn_attempts (
+             attempt_id, turn_id, recovered_from_attempt_id, run_id, session_key, session_name, agent_id,
+             provider, model, boot_epoch, status, started_at, lease_expires_at, last_heartbeat_at,
+             request_blob_sha256, user_prompt_sha256, system_prompt_sha256, checkpoint_json, origin_kind,
+             source_json, turn_provenance_json, task_barrier_task_id, delivery_barrier, pending_ids_json,
+             metadata_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          attemptId,
+          turnId,
+          recoveredFromAttemptId,
+          runId,
+          sessionKey,
+          sessionName,
+          agentId,
+          provider,
+          model,
+          bootEpoch,
+          startedAt,
+          leaseExpiresAt,
+          lastHeartbeatAt,
+          requestBlobSha256,
+          userPromptSha256,
+          systemPromptSha256,
+          checkpointJson,
+          originKind,
+          sourceJson,
+          provenanceJson,
+          taskBarrierTaskId,
+          deliveryBarrier,
+          pendingIdsJson,
+          metadataJson,
+          startedAt,
+          startedAt,
+        );
+      const row = getTurnAttemptRow(database, attemptId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Attempt ${attemptId} missing after insert`);
+      return rowToTurnAttempt(row);
+    },
+    { label: "runtime-crash-recovery-create-attempt" },
+  );
+}
+
+export function getRuntimeTurnAttempt(attemptId: string): RuntimeTurnAttemptRecord | null {
+  const row = getTurnAttemptRow(getDb(), requiredText(attemptId, "attemptId"));
+  return row ? rowToTurnAttempt(row) : null;
+}
+
+export function listRuntimeTurnAttempts(
+  options: {
+    bootEpoch?: string;
+    sessionKey?: string;
+    turnId?: string;
+    status?: RuntimeTurnAttemptStatus;
+    limit?: number;
+  } = {},
+): RuntimeTurnAttemptRecord[] {
+  const where: string[] = [];
+  const params: SQLQueryBindings[] = [];
+  if (options.bootEpoch) {
+    where.push("boot_epoch = ?");
+    params.push(requiredText(options.bootEpoch, "bootEpoch"));
+  }
+  if (options.sessionKey) {
+    where.push("session_key = ?");
+    params.push(requiredText(options.sessionKey, "sessionKey"));
+  }
+  if (options.turnId) {
+    where.push("turn_id = ?");
+    params.push(requiredText(options.turnId, "turnId"));
+  }
+  if (options.status) {
+    where.push("status = ?");
+    params.push(options.status);
+  }
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+  const rows = getDb()
+    .prepare(`SELECT * FROM runtime_turn_attempts ${whereSql} ORDER BY started_at DESC, attempt_id DESC LIMIT ?`)
+    .all(...params, assertLimit(options.limit)) as RuntimeTurnAttemptRow[];
+  return rows.map(rowToTurnAttempt);
+}
+
+export function heartbeatRuntimeTurnAttempt(input: {
+  attemptId: string;
+  bootEpoch: string;
+  heartbeatAt?: number;
+  leaseExpiresAt: number;
+}): RuntimeTurnAttemptRecord {
+  const attemptId = requiredText(input.attemptId, "attemptId");
+  const bootEpoch = requiredText(input.bootEpoch, "bootEpoch");
+  const heartbeatAt = assertTimestamp(input.heartbeatAt ?? Date.now(), "heartbeatAt");
+  const leaseExpiresAt = assertTimestamp(input.leaseExpiresAt, "leaseExpiresAt");
+  if (leaseExpiresAt <= heartbeatAt) throw new Error("leaseExpiresAt must be after heartbeatAt");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getTurnAttemptRow(database, attemptId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found: ${attemptId}`);
+      if (current.boot_epoch !== bootEpoch) {
+        throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} is owned by a different boot epoch`);
+      }
+      if (current.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError(`Cannot heartbeat terminal attempt ${attemptId}`);
+      }
+      if (current.recovery_claim_id !== null) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot heartbeat recovery-claimed attempt ${attemptId}`);
+      }
+      const boot = getBootEpochRow(database, bootEpoch);
+      if (!boot || boot.status !== "active" || boot.lease_expires_at <= heartbeatAt) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot heartbeat attempt owned by inactive boot ${bootEpoch}`);
+      }
+      if (leaseExpiresAt > boot.lease_expires_at) {
+        throw new CrashRecoveryLedgerConflictError("Attempt lease cannot outlive its owning boot lease");
+      }
+      if (
+        heartbeatAt < current.last_heartbeat_at ||
+        heartbeatAt < current.updated_at ||
+        leaseExpiresAt < current.lease_expires_at
+      ) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot move attempt ${attemptId} heartbeat or lease backwards`);
+      }
+      if (heartbeatAt === current.last_heartbeat_at && leaseExpiresAt === current.lease_expires_at) {
+        return rowToTurnAttempt(current);
+      }
+      const result = database
+        .prepare(
+          `UPDATE runtime_turn_attempts
+           SET last_heartbeat_at = ?, lease_expires_at = ?, updated_at = ?
+           WHERE attempt_id = ? AND boot_epoch = ? AND status = 'running' AND recovery_claim_id IS NULL`,
+        )
+        .run(heartbeatAt, leaseExpiresAt, heartbeatAt, attemptId, bootEpoch);
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} lost its heartbeat fence`);
+      }
+      const row = getTurnAttemptRow(database, attemptId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found after heartbeat: ${attemptId}`);
+      return rowToTurnAttempt(row);
+    },
+    { label: "runtime-crash-recovery-heartbeat-attempt" },
+  );
+}
+
+export function markRuntimeTurnAttemptSafety(input: {
+  attemptId: string;
+  startedTool?: true;
+  materializedOutput?: true;
+  markedAt?: number;
+}): RuntimeTurnAttemptRecord {
+  if (!input.startedTool && !input.materializedOutput) {
+    throw new Error("At least one monotonic safety marker must be set");
+  }
+  const attemptId = requiredText(input.attemptId, "attemptId");
+  const markedAt = assertTimestamp(input.markedAt ?? Date.now(), "markedAt");
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getTurnAttemptRow(database, attemptId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found: ${attemptId}`);
+      if (current.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError(`Cannot change safety markers on terminal attempt ${attemptId}`);
+      }
+      if (current.recovery_claim_id !== null) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot change safety markers on recovery-claimed attempt ${attemptId}`,
+        );
+      }
+      if (markedAt < current.updated_at) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot move attempt ${attemptId} safety timestamp backwards`);
+      }
+      const result = database
+        .prepare(
+          `UPDATE runtime_turn_attempts
+           SET started_tool = MAX(started_tool, ?),
+               materialized_output = MAX(materialized_output, ?),
+               updated_at = MAX(updated_at, ?)
+           WHERE attempt_id = ? AND status = 'running' AND recovery_claim_id IS NULL`,
+        )
+        .run(input.startedTool ? 1 : 0, input.materializedOutput ? 1 : 0, markedAt, attemptId);
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} lost its safety marker fence`);
+      }
+      const row = getTurnAttemptRow(database, attemptId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found after safety update: ${attemptId}`);
+      return rowToTurnAttempt(row);
+    },
+    { label: "runtime-crash-recovery-attempt-safety" },
+  );
+}
+
+export function terminalizeRuntimeTurnAttempt(input: {
+  attemptId: string;
+  status: RuntimeTurnAttemptTerminalStatus;
+  completedAt?: number;
+  metadata?: JsonRecord | null;
+}): RuntimeTurnAttemptRecord {
+  const attemptId = requiredText(input.attemptId, "attemptId");
+  const completedAt = assertTimestamp(input.completedAt ?? Date.now(), "completedAt");
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getTurnAttemptRow(database, attemptId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found: ${attemptId}`);
+      if (current.status === input.status) {
+        if (input.completedAt !== undefined && completedAt !== current.completed_at) {
+          throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} already has a different completion time`);
+        }
+        if (input.metadata !== undefined && input.metadata !== null) {
+          const existingMetadata =
+            parseOptionalRecord(current.metadata_json, "runtime_turn_attempts.metadata_json") ?? {};
+          const retriedMetadata = stringifyOptionalJson({ ...existingMetadata, ...input.metadata });
+          if (retriedMetadata !== current.metadata_json) {
+            throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} already has different terminal metadata`);
+          }
+        }
+        return rowToTurnAttempt(current);
+      }
+      if (current.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot transition attempt ${attemptId} from ${current.status} to ${input.status}`,
+        );
+      }
+      if (current.recovery_claim_id !== null) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot terminalize recovery-claimed attempt ${attemptId}`);
+      }
+      if (completedAt < current.last_heartbeat_at || completedAt < current.updated_at) {
+        throw new CrashRecoveryLedgerConflictError("completedAt cannot precede the latest attempt observation");
+      }
+      const existingMetadata = parseOptionalRecord(current.metadata_json, "runtime_turn_attempts.metadata_json") ?? {};
+      const metadataJson = stringifyOptionalJson(
+        input.metadata === undefined || input.metadata === null
+          ? existingMetadata
+          : { ...existingMetadata, ...input.metadata },
+      );
+      const result = database
+        .prepare(
+          `UPDATE runtime_turn_attempts
+           SET status = ?, completed_at = ?, metadata_json = ?, updated_at = ?
+           WHERE attempt_id = ? AND status = 'running' AND recovery_claim_id IS NULL`,
+        )
+        .run(input.status, completedAt, metadataJson, completedAt, attemptId);
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Attempt ${attemptId} lost its terminal transition race`);
+      }
+      const row = getTurnAttemptRow(database, attemptId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Attempt not found after terminal transition: ${attemptId}`);
+      return rowToTurnAttempt(row);
+    },
+    { label: "runtime-crash-recovery-terminalize-attempt" },
+  );
+}
+
+function promptQueueFingerprint(input: {
+  dedupeKey: string;
+  sessionKey: string;
+  sessionName: string | null;
+  agentId: string | null;
+  laneKey: DeliveryBarrier;
+  originKind: TurnOrigin;
+  deliveryBarrier: DeliveryBarrier;
+  taskBarrierTaskId: string | null;
+  pendingId: string | null;
+  promptJson: string;
+  runtimeMessageJson: string;
+  metadataJson: string | null;
+}): string {
+  return sha256(
+    stringifyRequiredJson(
+      {
+        dedupeKey: input.dedupeKey,
+        sessionKey: input.sessionKey,
+        sessionName: input.sessionName,
+        agentId: input.agentId,
+        laneKey: input.laneKey,
+        originKind: input.originKind,
+        deliveryBarrier: input.deliveryBarrier,
+        taskBarrierTaskId: input.taskBarrierTaskId,
+        pendingId: input.pendingId,
+        prompt: parseRequiredJson(input.promptJson, "prompt fingerprint"),
+        runtimeMessage: parseRequiredJson(input.runtimeMessageJson, "runtime message fingerprint"),
+        metadata: parseOptionalJson(input.metadataJson, "metadata fingerprint"),
+      },
+      "prompt queue fingerprint",
+    ),
+  );
+}
+
+export function enqueueRuntimePrompt(input: EnqueueRuntimePromptInput): {
+  created: boolean;
+  item: RuntimePromptQueueRecord;
+} {
+  const requestedQueueItemId = optionalText(input.queueItemId);
+  const dedupeKey = requiredText(input.dedupeKey, "dedupeKey");
+  const sessionKey = requiredText(input.sessionKey, "sessionKey");
+  const sessionName = optionalText(input.sessionName);
+  const agentId = optionalText(input.agentId);
+  const laneKey = requireDeliveryBarrier(input.laneKey, "laneKey");
+  const bootEpoch = optionalText(input.bootEpoch);
+  const originKind = requireTurnOrigin(input.originKind, "originKind");
+  const deliveryBarrier = requireDeliveryBarrier(input.deliveryBarrier, "deliveryBarrier");
+  const taskBarrierTaskId = optionalText(input.taskBarrierTaskId);
+  const pendingId = optionalText(input.pendingId);
+  const promptJson = stringifyRequiredJson(input.prompt, "prompt");
+  const runtimeMessageJson = stringifyRequiredJson(input.runtimeMessage, "runtimeMessage");
+  const queuedAt = assertTimestamp(input.queuedAt ?? Date.now(), "queuedAt");
+  const metadataJson = stringifyOptionalJson(input.metadata);
+  const immutableFingerprint = promptQueueFingerprint({
+    dedupeKey,
+    sessionKey,
+    sessionName,
+    agentId,
+    laneKey,
+    originKind,
+    deliveryBarrier,
+    taskBarrierTaskId,
+    pendingId,
+    promptJson,
+    runtimeMessageJson,
+    metadataJson,
+  });
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const existing = database.prepare("SELECT * FROM runtime_prompt_queue WHERE dedupe_key = ?").get(dedupeKey) as
+        | RuntimePromptQueueRow
+        | undefined;
+      if (existing) {
+        if (existing.immutable_fingerprint !== immutableFingerprint) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Prompt dedupe key ${dedupeKey} already exists with different immutable content`,
+          );
+        }
+        if (requestedQueueItemId && existing.queue_item_id !== requestedQueueItemId) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Prompt dedupe key ${dedupeKey} already belongs to queue item ${existing.queue_item_id}`,
+          );
+        }
+        return { created: false, item: rowToPromptQueue(existing) };
+      }
+      if (bootEpoch) {
+        const boot = getBootEpochRow(database, bootEpoch);
+        if (!boot) throw new CrashRecoveryLedgerNotFoundError(`Queue boot epoch not found: ${bootEpoch}`);
+        if (boot.status !== "active") {
+          throw new CrashRecoveryLedgerConflictError(`Cannot enqueue from terminal boot epoch ${bootEpoch}`);
+        }
+        if (queuedAt < boot.started_at || boot.lease_expires_at <= queuedAt) {
+          throw new CrashRecoveryLedgerConflictError(`Cannot enqueue outside the live lease for boot ${bootEpoch}`);
+        }
+      }
+      const queueItemId = requestedQueueItemId ?? `queue_${randomUUID()}`;
+      database
+        .prepare(
+          `INSERT INTO runtime_prompt_queue (
+             queue_item_id, dedupe_key, immutable_fingerprint, session_key, session_name, agent_id,
+             lane_key, boot_epoch, status, origin_kind, delivery_barrier, task_barrier_task_id,
+             pending_id, prompt_json, runtime_message_json, queued_at, metadata_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          queueItemId,
+          dedupeKey,
+          immutableFingerprint,
+          sessionKey,
+          sessionName,
+          agentId,
+          laneKey,
+          bootEpoch,
+          originKind,
+          deliveryBarrier,
+          taskBarrierTaskId,
+          pendingId,
+          promptJson,
+          runtimeMessageJson,
+          queuedAt,
+          metadataJson,
+          queuedAt,
+          queuedAt,
+        );
+      const row = getPromptQueueRow(database, queueItemId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Prompt queue item ${queueItemId} missing after insert`);
+      return { created: true, item: rowToPromptQueue(row) };
+    },
+    { label: "runtime-crash-recovery-enqueue-prompt" },
+  );
+}
+
+export function getRuntimePromptQueueItem(queueItemId: string): RuntimePromptQueueRecord | null {
+  const row = getPromptQueueRow(getDb(), requiredText(queueItemId, "queueItemId"));
+  return row ? rowToPromptQueue(row) : null;
+}
+
+export function listRuntimePromptQueue(
+  options: {
+    sessionKey?: string;
+    laneKey?: DeliveryBarrier;
+    statuses?: RuntimePromptQueueStatus[];
+    limit?: number;
+  } = {},
+): RuntimePromptQueueRecord[] {
+  const where: string[] = [];
+  const params: SQLQueryBindings[] = [];
+  if (options.sessionKey) {
+    where.push("session_key = ?");
+    params.push(requiredText(options.sessionKey, "sessionKey"));
+  }
+  if (options.laneKey) {
+    where.push("lane_key = ?");
+    params.push(options.laneKey);
+  }
+  if (options.statuses?.length) {
+    where.push(`status IN (${options.statuses.map(() => "?").join(", ")})`);
+    params.push(...options.statuses);
+  }
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+  const rows = getDb()
+    .prepare(`SELECT * FROM runtime_prompt_queue ${whereSql} ORDER BY queue_sequence ASC LIMIT ?`)
+    .all(...params, assertLimit(options.limit)) as RuntimePromptQueueRow[];
+  return rows.map(rowToPromptQueue);
+}
+
+export function compareAndSetRuntimePromptQueueStatus(input: {
+  queueItemId: string;
+  expectedStatus: RuntimePromptQueueStatus | RuntimePromptQueueStatus[];
+  expectedBootEpoch?: string | null;
+  expectedLeaseOwner?: string | null;
+  expectedLeaseExpiresAt?: number | null;
+  status: RuntimePromptQueueStatus;
+  bootEpoch?: string | null;
+  leaseOwner?: string | null;
+  leaseExpiresAt?: number | null;
+  deliveredAttemptId?: string | null;
+  deliveredTurnId?: string | null;
+  completedAt?: number | null;
+  updatedAt?: number;
+}): { applied: boolean; item: RuntimePromptQueueRecord } {
+  const queueItemId = requiredText(input.queueItemId, "queueItemId");
+  const expected = Array.isArray(input.expectedStatus) ? input.expectedStatus : [input.expectedStatus];
+  if (expected.length === 0) throw new Error("expectedStatus cannot be empty");
+  const updatedAt = assertTimestamp(input.updatedAt ?? Date.now(), "updatedAt");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getPromptQueueRow(database, queueItemId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Prompt queue item not found: ${queueItemId}`);
+      const currentRecord = rowToPromptQueue(current);
+      const currentStatus = currentRecord.status;
+      if (current.recovery_claim_id !== null) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot mutate recovery-claimed prompt queue item ${queueItemId}`);
+      }
+      if (!expected.includes(currentStatus)) return { applied: false, item: currentRecord };
+      const metadataJson = current.metadata_json;
+
+      if (TERMINAL_QUEUE_STATUSES.has(currentStatus)) {
+        if (currentStatus !== input.status) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Cannot transition terminal prompt queue item ${queueItemId} from ${currentStatus} to ${input.status}`,
+          );
+        }
+        const providedValuesMatch =
+          (input.bootEpoch === undefined || optionalText(input.bootEpoch) === current.boot_epoch) &&
+          (input.leaseOwner === undefined || optionalText(input.leaseOwner) === current.lease_owner) &&
+          (input.leaseExpiresAt === undefined || input.leaseExpiresAt === current.lease_expires_at) &&
+          (input.deliveredAttemptId === undefined ||
+            optionalText(input.deliveredAttemptId) === current.delivered_attempt_id) &&
+          (input.deliveredTurnId === undefined || optionalText(input.deliveredTurnId) === current.delivered_turn_id) &&
+          (input.completedAt === undefined || input.completedAt === current.completed_at) &&
+          (input.updatedAt === undefined || input.updatedAt === current.updated_at) &&
+          metadataJson === current.metadata_json;
+        if (!providedValuesMatch) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Terminal prompt queue item ${queueItemId} already has different durable data`,
+          );
+        }
+        return { applied: false, item: currentRecord };
+      }
+      if (!ALLOWED_QUEUE_STATUS_TRANSITIONS[currentStatus].has(input.status)) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot transition prompt queue item ${queueItemId} from ${currentStatus} to ${input.status}`,
+        );
+      }
+      if (currentStatus === "delivered" && input.status === "delivered") {
+        const providedValuesMatch =
+          (input.bootEpoch === undefined || optionalText(input.bootEpoch) === current.boot_epoch) &&
+          (input.leaseOwner === undefined || optionalText(input.leaseOwner) === current.lease_owner) &&
+          (input.leaseExpiresAt === undefined || input.leaseExpiresAt === current.lease_expires_at) &&
+          (input.deliveredAttemptId === undefined ||
+            optionalText(input.deliveredAttemptId) === current.delivered_attempt_id) &&
+          (input.deliveredTurnId === undefined || optionalText(input.deliveredTurnId) === current.delivered_turn_id) &&
+          (input.completedAt === undefined || input.completedAt === current.completed_at) &&
+          metadataJson === current.metadata_json;
+        if (!providedValuesMatch) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Delivered prompt queue item ${queueItemId} already has different durable data`,
+          );
+        }
+        return { applied: false, item: currentRecord };
+      }
+      if (updatedAt < current.updated_at) {
+        throw new CrashRecoveryLedgerConflictError(`Cannot move prompt queue item ${queueItemId} time backwards`);
+      }
+
+      if (current.lease_owner !== null) {
+        if (
+          input.expectedBootEpoch === undefined ||
+          input.expectedLeaseOwner === undefined ||
+          input.expectedLeaseExpiresAt === undefined
+        ) {
+          throw new Error("Owner-bound prompt queue transition requires the observed boot, owner, and lease fence");
+        }
+        const expectedBootEpoch = optionalText(input.expectedBootEpoch);
+        const expectedLeaseOwner = optionalText(input.expectedLeaseOwner);
+        const expectedLeaseExpiresAt = input.expectedLeaseExpiresAt;
+        if (
+          expectedBootEpoch !== current.boot_epoch ||
+          expectedLeaseOwner !== current.lease_owner ||
+          expectedLeaseExpiresAt !== current.lease_expires_at
+        ) {
+          return { applied: false, item: currentRecord };
+        }
+      }
+
+      let nextBootEpoch = input.bootEpoch === undefined ? current.boot_epoch : optionalText(input.bootEpoch);
+      let nextLeaseOwner = input.leaseOwner === undefined ? current.lease_owner : optionalText(input.leaseOwner);
+      let nextLeaseExpiresAt = input.leaseExpiresAt === undefined ? current.lease_expires_at : input.leaseExpiresAt;
+      const nextDeliveredAttemptId =
+        input.deliveredAttemptId === undefined ? current.delivered_attempt_id : optionalText(input.deliveredAttemptId);
+      const nextDeliveredTurnId =
+        input.deliveredTurnId === undefined ? current.delivered_turn_id : optionalText(input.deliveredTurnId);
+      let nextCompletedAt = input.completedAt === undefined ? current.completed_at : input.completedAt;
+
+      if (["queued", "requeued", "deferred"].includes(input.status)) {
+        nextBootEpoch = null;
+        nextLeaseOwner = null;
+        nextLeaseExpiresAt = null;
+      }
+      if (input.status === "leased" || input.status === "starting") {
+        if (!nextBootEpoch || !nextLeaseOwner || nextLeaseExpiresAt === null) {
+          throw new CrashRecoveryLedgerConflictError(
+            `${input.status} prompt queue item requires bootEpoch, leaseOwner, and leaseExpiresAt`,
+          );
+        }
+        const leaseExpiresAt = assertTimestamp(nextLeaseExpiresAt, "leaseExpiresAt");
+        if (leaseExpiresAt <= updatedAt) {
+          throw new CrashRecoveryLedgerConflictError(`${input.status} prompt queue lease must expire in the future`);
+        }
+      }
+      if (input.status === "delivered") {
+        if (!nextBootEpoch || !nextLeaseOwner || nextLeaseExpiresAt === null) {
+          throw new CrashRecoveryLedgerConflictError(
+            "Delivered prompt queue item requires bootEpoch, leaseOwner, and leaseExpiresAt",
+          );
+        }
+        if (!nextDeliveredAttemptId || !nextDeliveredTurnId) {
+          throw new CrashRecoveryLedgerConflictError(
+            "Delivered prompt queue item requires deliveredAttemptId and deliveredTurnId",
+          );
+        }
+        if (assertTimestamp(nextLeaseExpiresAt, "leaseExpiresAt") <= updatedAt) {
+          throw new CrashRecoveryLedgerConflictError("Cannot deliver a prompt queue item after its lease expires");
+        }
+      }
+      if (TERMINAL_QUEUE_STATUSES.has(input.status)) {
+        nextCompletedAt = assertTimestamp(nextCompletedAt ?? updatedAt, "completedAt");
+        if (
+          nextCompletedAt < current.updated_at ||
+          nextCompletedAt < current.queued_at ||
+          updatedAt < nextCompletedAt
+        ) {
+          throw new CrashRecoveryLedgerConflictError("Prompt queue completion would create a regressive timeline");
+        }
+      } else if (nextCompletedAt !== null) {
+        throw new CrashRecoveryLedgerConflictError(`Non-terminal queue status ${input.status} cannot have completedAt`);
+      }
+      if (nextLeaseExpiresAt !== null) assertTimestamp(nextLeaseExpiresAt, "leaseExpiresAt");
+      if (nextBootEpoch) {
+        const boot = getBootEpochRow(database, nextBootEpoch);
+        if (!boot) throw new CrashRecoveryLedgerNotFoundError(`Queue boot epoch not found: ${nextBootEpoch}`);
+        if (
+          ["leased", "starting", "delivered"].includes(input.status) &&
+          (boot.status !== "active" || boot.lease_expires_at <= updatedAt)
+        ) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Cannot assign prompt queue item to inactive boot ${nextBootEpoch}`,
+          );
+        }
+        if (nextLeaseExpiresAt !== null && nextLeaseExpiresAt > boot.lease_expires_at) {
+          throw new CrashRecoveryLedgerConflictError("Prompt queue lease cannot outlive its owning boot lease");
+        }
+      }
+      if (nextDeliveredAttemptId) {
+        const attempt = getTurnAttemptRow(database, nextDeliveredAttemptId);
+        if (!attempt) {
+          throw new CrashRecoveryLedgerNotFoundError(`Delivered attempt not found: ${nextDeliveredAttemptId}`);
+        }
+        rowToTurnAttempt(attempt);
+        if (input.status === "delivered") {
+          if (attempt.status !== "running") {
+            throw new CrashRecoveryLedgerConflictError("Cannot deliver a prompt queue item to a terminal attempt");
+          }
+          if (attempt.recovery_claim_id !== null) {
+            throw new CrashRecoveryLedgerConflictError(
+              "Cannot deliver a prompt queue item to a recovery-claimed attempt",
+            );
+          }
+          if (attempt.lease_expires_at <= updatedAt) {
+            throw new CrashRecoveryLedgerConflictError("Cannot deliver a prompt queue item to an expired attempt");
+          }
+          if (updatedAt < attempt.updated_at) {
+            throw new CrashRecoveryLedgerConflictError("Prompt delivery cannot precede its attempt observation");
+          }
+        }
+        if (nextDeliveredTurnId && attempt.turn_id !== nextDeliveredTurnId) {
+          throw new CrashRecoveryLedgerConflictError("Delivered attempt and delivered turn do not match");
+        }
+        if (attempt.session_key !== current.session_key) {
+          throw new CrashRecoveryLedgerConflictError("Delivered attempt and prompt queue session do not match");
+        }
+        if (nextBootEpoch && attempt.boot_epoch !== nextBootEpoch) {
+          throw new CrashRecoveryLedgerConflictError("Delivered attempt and prompt queue boot owner do not match");
+        }
+      }
+
+      const result = database
+        .prepare(
+          `UPDATE runtime_prompt_queue
+           SET status = ?, boot_epoch = ?, lease_owner = ?, lease_expires_at = ?,
+               delivered_attempt_id = ?, delivered_turn_id = ?, completed_at = ?, metadata_json = ?, updated_at = ?
+           WHERE queue_item_id = ? AND status = ? AND recovery_claim_id IS NULL`,
+        )
+        .run(
+          input.status,
+          nextBootEpoch,
+          nextLeaseOwner,
+          nextLeaseExpiresAt,
+          nextDeliveredAttemptId,
+          nextDeliveredTurnId,
+          nextCompletedAt,
+          metadataJson,
+          updatedAt,
+          queueItemId,
+          currentStatus,
+        );
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Prompt queue item ${queueItemId} lost its transition race`);
+      }
+      const row = getPromptQueueRow(database, queueItemId);
+      if (!row)
+        throw new CrashRecoveryLedgerNotFoundError(`Prompt queue item missing after transition: ${queueItemId}`);
+      return { applied: true, item: rowToPromptQueue(row) };
+    },
+    { label: "runtime-crash-recovery-cas-prompt" },
+  );
+}
+
+export function createRuntimeRecoveryRun(input: {
+  recoveryRunId?: string;
+  mode: RuntimeRecoveryRunMode;
+  bootEpoch?: string | null;
+  startedAt?: number;
+  metadata?: JsonRecord | null;
+}): RuntimeRecoveryRunRecord {
+  const recoveryRunId = requiredText(input.recoveryRunId ?? `recovery_${randomUUID()}`, "recoveryRunId");
+  const bootEpoch = optionalText(input.bootEpoch);
+  const startedAt = assertTimestamp(input.startedAt ?? Date.now(), "startedAt");
+  const metadataJson = stringifyOptionalJson(input.metadata);
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const existing = getRecoveryRunRow(database, recoveryRunId);
+      if (existing) {
+        const matches =
+          existing.mode === input.mode &&
+          existing.boot_epoch === bootEpoch &&
+          existing.started_at === startedAt &&
+          existing.metadata_json === metadataJson;
+        if (!matches) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Recovery run ${recoveryRunId} already exists with different immutable data`,
+          );
+        }
+        return rowToRecoveryRun(existing);
+      }
+      if (bootEpoch) {
+        const boot = getBootEpochRow(database, bootEpoch);
+        if (!boot) throw new CrashRecoveryLedgerNotFoundError(`Recovery boot epoch not found: ${bootEpoch}`);
+        if (
+          input.mode === "apply" &&
+          (boot.status !== "active" || startedAt < boot.started_at || boot.lease_expires_at <= startedAt)
+        ) {
+          throw new CrashRecoveryLedgerConflictError(`Apply recovery run requires an active boot epoch`);
+        }
+      } else if (input.mode === "apply") {
+        throw new CrashRecoveryLedgerConflictError("Apply recovery run requires bootEpoch");
+      }
+
+      database
+        .prepare(
+          `INSERT INTO runtime_recovery_runs (
+             recovery_run_id, mode, boot_epoch, status, started_at, metadata_json, created_at, updated_at
+           ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)`,
+        )
+        .run(recoveryRunId, input.mode, bootEpoch, startedAt, metadataJson, startedAt, startedAt);
+      const row = getRecoveryRunRow(database, recoveryRunId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Recovery run ${recoveryRunId} missing after insert`);
+      return rowToRecoveryRun(row);
+    },
+    { label: "runtime-crash-recovery-create-run" },
+  );
+}
+
+export function getRuntimeRecoveryRun(recoveryRunId: string): RuntimeRecoveryRunRecord | null {
+  const row = getRecoveryRunRow(getDb(), requiredText(recoveryRunId, "recoveryRunId"));
+  return row ? rowToRecoveryRun(row) : null;
+}
+
+export function listRuntimeRecoveryRuns(
+  options: { mode?: RuntimeRecoveryRunMode; status?: RuntimeRecoveryRunStatus; limit?: number } = {},
+): RuntimeRecoveryRunRecord[] {
+  const where: string[] = [];
+  const params: SQLQueryBindings[] = [];
+  if (options.mode) {
+    where.push("mode = ?");
+    params.push(options.mode);
+  }
+  if (options.status) {
+    where.push("status = ?");
+    params.push(options.status);
+  }
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+  const rows = getDb()
+    .prepare(`SELECT * FROM runtime_recovery_runs ${whereSql} ORDER BY started_at DESC, recovery_run_id DESC LIMIT ?`)
+    .all(...params, assertLimit(options.limit)) as RuntimeRecoveryRunRow[];
+  return rows.map(rowToRecoveryRun);
+}
+
+export function completeRuntimeRecoveryRun(input: {
+  recoveryRunId: string;
+  status: Exclude<RuntimeRecoveryRunStatus, "running">;
+  summary?: JsonRecord | null;
+  error?: string | null;
+  completedAt?: number;
+}): RuntimeRecoveryRunRecord {
+  const recoveryRunId = requiredText(input.recoveryRunId, "recoveryRunId");
+  const completedAt = assertTimestamp(input.completedAt ?? Date.now(), "completedAt");
+  const summaryJson = stringifyOptionalJson(input.summary);
+  const error = optionalText(input.error);
+  if (input.status === "failed" && !error) throw new Error("Failed recovery run requires an error");
+  if (input.status === "complete" && error) throw new Error("Completed recovery run cannot include an error");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getRecoveryRunRow(database, recoveryRunId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Recovery run not found: ${recoveryRunId}`);
+      rowToRecoveryRun(current);
+      const candidateRows = database
+        .prepare("SELECT * FROM runtime_recovery_candidates WHERE recovery_run_id = ?")
+        .all(recoveryRunId) as RuntimeRecoveryCandidateRow[];
+      const candidates = candidateRows.map(rowToRecoveryCandidate);
+      if (current.status === input.status) {
+        const sameCompletion = input.completedAt === undefined || completedAt === current.completed_at;
+        const sameSummary = input.summary === undefined || summaryJson === current.summary_json;
+        const sameError = input.error === undefined || error === current.error;
+        if (!sameCompletion || !sameSummary || !sameError) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Recovery run ${recoveryRunId} already has different terminal data`,
+          );
+        }
+        return rowToRecoveryRun(current);
+      }
+      if (current.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot transition recovery run ${recoveryRunId} from ${current.status} to ${input.status}`,
+        );
+      }
+      if (completedAt < current.updated_at) {
+        throw new CrashRecoveryLedgerConflictError("completedAt cannot precede the latest recovery run update");
+      }
+      const openCandidate = candidates.find(
+        (candidate) => candidate.actionStatus === "pending" || candidate.actionStatus === "claimed",
+      );
+      if (openCandidate) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Recovery run ${recoveryRunId} still has open candidate ${openCandidate.candidateKey}`,
+        );
+      }
+      const latestCandidateUpdatedAt = candidates.reduce<number | null>(
+        (latest, candidate) => (latest === null ? candidate.updatedAt : Math.max(latest, candidate.updatedAt)),
+        null,
+      );
+      if (latestCandidateUpdatedAt !== null && completedAt < latestCandidateUpdatedAt) {
+        throw new CrashRecoveryLedgerConflictError("completedAt cannot precede the latest candidate update");
+      }
+      const result = database
+        .prepare(
+          `UPDATE runtime_recovery_runs
+           SET status = ?, completed_at = ?, summary_json = ?, error = ?, updated_at = ?
+           WHERE recovery_run_id = ? AND status = 'running'`,
+        )
+        .run(input.status, completedAt, summaryJson, error, completedAt, recoveryRunId);
+      if (result.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery run ${recoveryRunId} lost its terminal transition race`);
+      }
+      const row = getRecoveryRunRow(database, recoveryRunId);
+      if (!row) throw new CrashRecoveryLedgerNotFoundError(`Recovery run missing after completion: ${recoveryRunId}`);
+      return rowToRecoveryRun(row);
+    },
+    { label: "runtime-crash-recovery-complete-run" },
+  );
+}
+
+export function recordRuntimeRecoveryCandidate(
+  input: RecordRuntimeRecoveryCandidateInput,
+): RuntimeRecoveryCandidateRecord {
+  const recoveryRunId = requiredText(input.recoveryRunId, "recoveryRunId");
+  const requestedCandidateKey = optionalText(input.candidateKey);
+  const sessionKey = requiredText(input.sessionKey, "sessionKey");
+  let sessionName = optionalText(input.sessionName);
+  let attemptId = optionalText(input.attemptId);
+  let turnId = optionalText(input.turnId);
+  let queueItemId = optionalText(input.queueItemId);
+  const reasonCode = requiredText(input.reasonCode, "reasonCode");
+  const action = requiredText(input.action, "action");
+  const detailsJson = stringifyOptionalJson(input.details);
+  const recordedAt = assertTimestamp(input.recordedAt ?? Date.now(), "recordedAt");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const run = getRecoveryRunRow(database, recoveryRunId);
+      if (!run) throw new CrashRecoveryLedgerNotFoundError(`Recovery run not found: ${recoveryRunId}`);
+      rowToRecoveryRun(run);
+      if (run.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError(`Cannot append candidate to terminal recovery run ${recoveryRunId}`);
+      }
+      if (recordedAt < run.started_at) {
+        throw new CrashRecoveryLedgerConflictError("Recovery candidate cannot precede its recovery run");
+      }
+
+      if (input.candidateType === "turn_attempt") {
+        if (!attemptId || queueItemId) {
+          throw new Error("turn_attempt candidate requires attemptId and forbids queueItemId");
+        }
+        const attempt = getTurnAttemptRow(database, attemptId);
+        if (!attempt) throw new CrashRecoveryLedgerNotFoundError(`Candidate attempt not found: ${attemptId}`);
+        rowToTurnAttempt(attempt);
+        if (attempt.session_key !== sessionKey) {
+          throw new CrashRecoveryLedgerConflictError("Candidate sessionKey does not match attempt sessionKey");
+        }
+        if (turnId && turnId !== attempt.turn_id) {
+          throw new CrashRecoveryLedgerConflictError("Candidate turnId does not match attempt turnId");
+        }
+        turnId = attempt.turn_id;
+        sessionName ??= attempt.session_name;
+        queueItemId = null;
+      } else if (input.candidateType === "prompt_queue") {
+        if (!queueItemId || attemptId) {
+          throw new Error("prompt_queue candidate requires queueItemId and forbids attemptId");
+        }
+        const queueItem = getPromptQueueRow(database, queueItemId);
+        if (!queueItem) throw new CrashRecoveryLedgerNotFoundError(`Candidate queue item not found: ${queueItemId}`);
+        rowToPromptQueue(queueItem);
+        if (queueItem.session_key !== sessionKey) {
+          throw new CrashRecoveryLedgerConflictError("Candidate sessionKey does not match queue item sessionKey");
+        }
+        if (turnId && queueItem.delivered_turn_id && turnId !== queueItem.delivered_turn_id) {
+          throw new CrashRecoveryLedgerConflictError("Candidate turnId does not match queue item delivered turnId");
+        }
+        turnId ??= queueItem.delivered_turn_id;
+        sessionName ??= queueItem.session_name;
+        attemptId = null;
+      } else {
+        if (!turnId || attemptId || queueItemId) {
+          throw new Error("legacy_session_turn candidate requires turnId and forbids attemptId and queueItemId");
+        }
+      }
+
+      const candidateKey = buildRuntimeRecoveryCandidateKey({
+        candidateType: input.candidateType,
+        sessionKey,
+        attemptId,
+        turnId,
+        queueItemId,
+      });
+      if (requestedCandidateKey && requestedCandidateKey !== candidateKey) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Recovery candidate key must be canonical: expected ${candidateKey}`,
+        );
+      }
+      const claimable = run.mode === "apply" && input.candidateType !== "legacy_session_turn";
+      const actionStatus: RuntimeRecoveryActionStatus = claimable ? "pending" : "not_applied";
+      const actionCompletedAt = claimable ? null : recordedAt;
+      const existing = getRecoveryCandidateRow(database, recoveryRunId, candidateKey);
+      if (existing) {
+        const matches =
+          existing.candidate_type === input.candidateType &&
+          existing.session_key === sessionKey &&
+          existing.session_name === sessionName &&
+          existing.attempt_id === attemptId &&
+          existing.turn_id === turnId &&
+          existing.queue_item_id === queueItemId &&
+          existing.decision === input.decision &&
+          existing.reason_code === reasonCode &&
+          existing.action === action &&
+          existing.details_json === detailsJson;
+        if (!matches) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Recovery candidate ${candidateKey} already exists in run ${recoveryRunId} with different immutable data`,
+          );
+        }
+        return rowToRecoveryCandidate(existing);
+      }
+
+      database
+        .prepare(
+          `INSERT INTO runtime_recovery_candidates (
+             recovery_run_id, candidate_key, candidate_type, session_key, session_name, attempt_id,
+             turn_id, queue_item_id, decision, reason_code, action, action_status, details_json,
+             action_completed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          recoveryRunId,
+          candidateKey,
+          input.candidateType,
+          sessionKey,
+          sessionName,
+          attemptId,
+          turnId,
+          queueItemId,
+          input.decision,
+          reasonCode,
+          action,
+          actionStatus,
+          detailsJson,
+          actionCompletedAt,
+          recordedAt,
+          recordedAt,
+        );
+      const row = getRecoveryCandidateRow(database, recoveryRunId, candidateKey);
+      if (!row) {
+        throw new CrashRecoveryLedgerNotFoundError(
+          `Recovery candidate ${candidateKey} missing after insert in run ${recoveryRunId}`,
+        );
+      }
+      return rowToRecoveryCandidate(row);
+    },
+    { label: "runtime-crash-recovery-record-candidate" },
+  );
+}
+
+export function getRuntimeRecoveryCandidate(
+  recoveryRunId: string,
+  candidateKey: string,
+): RuntimeRecoveryCandidateRecord | null {
+  const row = getRecoveryCandidateRow(
+    getDb(),
+    requiredText(recoveryRunId, "recoveryRunId"),
+    requiredText(candidateKey, "candidateKey"),
+  );
+  return row ? rowToRecoveryCandidate(row) : null;
+}
+
+export function listRuntimeRecoveryCandidates(recoveryRunId: string): RuntimeRecoveryCandidateRecord[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT * FROM runtime_recovery_candidates
+       WHERE recovery_run_id = ?
+       ORDER BY created_at ASC, candidate_key ASC`,
+    )
+    .all(requiredText(recoveryRunId, "recoveryRunId")) as RuntimeRecoveryCandidateRow[];
+  return rows.map(rowToRecoveryCandidate);
+}
+
+export function acquireRuntimeRecoveryClaim(input: {
+  recoveryRunId: string;
+  candidateKey: string;
+  claimedByBootEpoch: string;
+  claimId?: string;
+  claimedAt?: number;
+}): { status: "acquired" | "existing"; claim: RuntimeRecoveryClaimRecord } {
+  const recoveryRunId = requiredText(input.recoveryRunId, "recoveryRunId");
+  const candidateKey = requiredText(input.candidateKey, "candidateKey");
+  const claimedByBootEpoch = requiredText(input.claimedByBootEpoch, "claimedByBootEpoch");
+  const requestedClaimId = requiredText(input.claimId ?? `claim_${randomUUID()}`, "claimId");
+  const claimedAt = assertTimestamp(input.claimedAt ?? Date.now(), "claimedAt");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const run = getRecoveryRunRow(database, recoveryRunId);
+      if (!run) throw new CrashRecoveryLedgerNotFoundError(`Recovery run not found: ${recoveryRunId}`);
+      rowToRecoveryRun(run);
+      if (run.mode !== "apply" || run.status !== "running") {
+        throw new CrashRecoveryLedgerConflictError("Only a running apply recovery run may acquire claims");
+      }
+      const boot = getBootEpochRow(database, claimedByBootEpoch);
+      if (!boot) throw new CrashRecoveryLedgerNotFoundError(`Claiming boot epoch not found: ${claimedByBootEpoch}`);
+      rowToBootEpoch(boot);
+      if (boot.status !== "active" || boot.lease_expires_at <= claimedAt) {
+        throw new CrashRecoveryLedgerConflictError("Recovery claim requires an active claiming boot epoch");
+      }
+      if (run.boot_epoch !== claimedByBootEpoch) {
+        throw new CrashRecoveryLedgerConflictError("Recovery claim must be owned by the apply run boot epoch");
+      }
+      const candidate = getRecoveryCandidateRow(database, recoveryRunId, candidateKey);
+      if (!candidate) {
+        throw new CrashRecoveryLedgerNotFoundError(
+          `Recovery candidate ${candidateKey} not found in run ${recoveryRunId}`,
+        );
+      }
+      rowToRecoveryCandidate(candidate);
+      if (candidate.candidate_type === "legacy_session_turn") {
+        throw new CrashRecoveryLedgerConflictError(
+          "Legacy session turn candidates are inspect-only and cannot be claimed",
+        );
+      }
+      if (claimedAt < candidate.updated_at || claimedAt < run.started_at) {
+        throw new CrashRecoveryLedgerConflictError("Recovery claim cannot precede its run or candidate");
+      }
+
+      const existing = getRecoveryClaimByCandidateRow(database, candidateKey);
+      if (existing) {
+        const sameLogicalCandidate =
+          existing.candidate_type === candidate.candidate_type &&
+          existing.session_key === candidate.session_key &&
+          existing.attempt_id === candidate.attempt_id &&
+          existing.queue_item_id === candidate.queue_item_id;
+        if (!sameLogicalCandidate) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Recovery candidate key ${candidateKey} collides with a different logical source`,
+          );
+        }
+        if (candidate.action_status === "pending") {
+          const resultJson = stringifyRequiredJson(
+            {
+              code: "already_claimed",
+              claimId: existing.claim_id,
+              recoveryRunId: existing.recovery_run_id,
+            },
+            "existing claim result",
+          );
+          const loserUpdate = database
+            .prepare(
+              `UPDATE runtime_recovery_candidates
+               SET action_status = 'not_applied', claim_id = ?, result_json = ?, action_completed_at = ?, updated_at = ?
+               WHERE recovery_run_id = ? AND candidate_key = ? AND action_status = 'pending'`,
+            )
+            .run(existing.claim_id, resultJson, claimedAt, claimedAt, recoveryRunId, candidateKey);
+          if (loserUpdate.changes !== 1) {
+            throw new CrashRecoveryLedgerConflictError(`Recovery candidate ${candidateKey} lost its audit update race`);
+          }
+        }
+        return { status: "existing", claim: rowToRecoveryClaim(existing) };
+      }
+      if (candidate.action_status !== "pending" || candidate.claim_id !== null) {
+        throw new CrashRecoveryLedgerConflictError(
+          `Recovery candidate ${candidateKey} is not pending an unclaimed apply action`,
+        );
+      }
+
+      if (candidate.candidate_type === "turn_attempt") {
+        const attempt = candidate.attempt_id ? getTurnAttemptRow(database, candidate.attempt_id) : null;
+        if (!attempt) throw new CrashRecoveryLedgerNotFoundError(`Candidate attempt is missing for ${candidateKey}`);
+        rowToTurnAttempt(attempt);
+        if (attempt.status !== "running" || attempt.recovery_claim_id !== null) {
+          throw new CrashRecoveryLedgerConflictError(`Candidate attempt ${attempt.attempt_id} is no longer claimable`);
+        }
+      } else {
+        const queueItem = candidate.queue_item_id ? getPromptQueueRow(database, candidate.queue_item_id) : null;
+        if (!queueItem)
+          throw new CrashRecoveryLedgerNotFoundError(`Candidate queue item is missing for ${candidateKey}`);
+        rowToPromptQueue(queueItem);
+        if (TERMINAL_QUEUE_STATUSES.has(queueItem.status) || queueItem.recovery_claim_id !== null) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Candidate queue item ${queueItem.queue_item_id} is no longer claimable`,
+          );
+        }
+      }
+
+      database
+        .prepare(
+          `INSERT INTO runtime_recovery_claims (
+             candidate_key, claim_id, candidate_type, session_key, attempt_id, queue_item_id,
+             recovery_run_id, claimed_by_boot_epoch, status, claimed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'claimed', ?, ?, ?)`,
+        )
+        .run(
+          candidateKey,
+          requestedClaimId,
+          candidate.candidate_type,
+          candidate.session_key,
+          candidate.attempt_id,
+          candidate.queue_item_id,
+          recoveryRunId,
+          claimedByBootEpoch,
+          claimedAt,
+          claimedAt,
+          claimedAt,
+        );
+
+      if (candidate.candidate_type === "turn_attempt") {
+        const updated = database
+          .prepare(
+            `UPDATE runtime_turn_attempts
+             SET recovery_claim_id = ?, recovery_status = 'claimed', recovery_reason = ?,
+                 recovery_run_id = ?, updated_at = MAX(updated_at, ?)
+             WHERE attempt_id = ? AND status = 'running' AND recovery_claim_id IS NULL`,
+          )
+          .run(requestedClaimId, candidate.reason_code, recoveryRunId, claimedAt, candidate.attempt_id);
+        if (updated.changes !== 1) {
+          throw new CrashRecoveryLedgerConflictError(`Candidate attempt ${candidate.attempt_id} lost its claim race`);
+        }
+      } else {
+        const updated = database
+          .prepare(
+            `UPDATE runtime_prompt_queue
+             SET recovery_claim_id = ?, recovery_status = 'claimed', recovery_reason = ?,
+                 recovery_run_id = ?, updated_at = MAX(updated_at, ?)
+             WHERE queue_item_id = ? AND recovery_claim_id IS NULL
+               AND status NOT IN ('complete','cancelled','superseded','failed')`,
+          )
+          .run(requestedClaimId, candidate.reason_code, recoveryRunId, claimedAt, candidate.queue_item_id);
+        if (updated.changes !== 1) {
+          throw new CrashRecoveryLedgerConflictError(
+            `Candidate queue item ${candidate.queue_item_id} lost its claim race`,
+          );
+        }
+      }
+
+      const candidateUpdate = database
+        .prepare(
+          `UPDATE runtime_recovery_candidates
+           SET action_status = 'claimed', claim_id = ?, updated_at = ?
+           WHERE recovery_run_id = ? AND candidate_key = ? AND action_status = 'pending' AND claim_id IS NULL`,
+        )
+        .run(requestedClaimId, claimedAt, recoveryRunId, candidateKey);
+      if (candidateUpdate.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery candidate ${candidateKey} lost its claim race`);
+      }
+      const claim = getRecoveryClaimByCandidateRow(database, candidateKey);
+      if (!claim) throw new CrashRecoveryLedgerNotFoundError(`Recovery claim missing after acquire: ${candidateKey}`);
+      return { status: "acquired", claim: rowToRecoveryClaim(claim) };
+    },
+    { label: "runtime-crash-recovery-acquire-claim" },
+  );
+}
+
+function getRecoveryClaimByIdRow(database: Database, claimId: string): RuntimeRecoveryClaimRow | null {
+  return (
+    (database.prepare("SELECT * FROM runtime_recovery_claims WHERE claim_id = ?").get(claimId) as
+      | RuntimeRecoveryClaimRow
+      | undefined) ?? null
+  );
+}
+
+export function getRuntimeRecoveryClaimByCandidate(candidateKey: string): RuntimeRecoveryClaimRecord | null {
+  const row = getRecoveryClaimByCandidateRow(getDb(), requiredText(candidateKey, "candidateKey"));
+  return row ? rowToRecoveryClaim(row) : null;
+}
+
+export function completeRuntimeRecoveryClaim(input: {
+  claimId: string;
+  status: Exclude<RuntimeRecoveryClaimStatus, "claimed">;
+  result: JsonRecord;
+  completedAt?: number;
+}): { claim: RuntimeRecoveryClaimRecord; candidate: RuntimeRecoveryCandidateRecord } {
+  const claimId = requiredText(input.claimId, "claimId");
+  const completedAt = assertTimestamp(input.completedAt ?? Date.now(), "completedAt");
+  const resultJson = stringifyRequiredJson(input.result, "claim result");
+
+  return executeWrite(
+    getDb(),
+    (database) => {
+      const current = getRecoveryClaimByIdRow(database, claimId);
+      if (!current) throw new CrashRecoveryLedgerNotFoundError(`Recovery claim not found: ${claimId}`);
+      rowToRecoveryClaim(current);
+      const candidate = getRecoveryCandidateRow(database, current.recovery_run_id, current.candidate_key);
+      if (!candidate) {
+        throw new CrashRecoveryLedgerNotFoundError(
+          `Winning recovery candidate ${current.candidate_key} is missing for claim ${claimId}`,
+        );
+      }
+      rowToRecoveryCandidate(candidate);
+      if (current.status === input.status) {
+        const sameCompletion = input.completedAt === undefined || completedAt === current.completed_at;
+        const sameResult = current.result_json === resultJson;
+        const candidateMatches =
+          candidate.action_status === input.status &&
+          candidate.claim_id === claimId &&
+          candidate.action_completed_at === current.completed_at &&
+          candidate.result_json === current.result_json;
+        const expectedRecoveryStatus = input.status === "applied" ? candidate.decision : "action_failed";
+        const source =
+          current.candidate_type === "turn_attempt"
+            ? current.attempt_id
+              ? getTurnAttemptRow(database, current.attempt_id)
+              : null
+            : current.queue_item_id
+              ? getPromptQueueRow(database, current.queue_item_id)
+              : null;
+        if (source) {
+          if (current.candidate_type === "turn_attempt") {
+            rowToTurnAttempt(source as RuntimeTurnAttemptRow);
+          } else {
+            rowToPromptQueue(source as RuntimePromptQueueRow);
+          }
+        }
+        const sourceMatches =
+          source?.recovery_claim_id === claimId &&
+          source.recovery_status === expectedRecoveryStatus &&
+          source.recovery_reason === candidate.reason_code &&
+          source.recovery_run_id === current.recovery_run_id &&
+          source.recovered_at === current.completed_at;
+        if (!sameCompletion || !sameResult || !candidateMatches || !sourceMatches) {
+          throw new CrashRecoveryLedgerConflictError(`Recovery claim ${claimId} already has different terminal data`);
+        }
+        return { claim: rowToRecoveryClaim(current), candidate: rowToRecoveryCandidate(candidate) };
+      }
+      if (current.status !== "claimed") {
+        throw new CrashRecoveryLedgerConflictError(
+          `Cannot transition recovery claim ${claimId} from ${current.status} to ${input.status}`,
+        );
+      }
+      if (candidate.action_status !== "claimed" || candidate.claim_id !== claimId) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery candidate projection diverged from claim ${claimId}`);
+      }
+      const run = getRecoveryRunRow(database, current.recovery_run_id);
+      if (!run || run.status !== "running" || run.mode !== "apply") {
+        throw new CrashRecoveryLedgerConflictError(`Recovery run is no longer open for claim ${claimId}`);
+      }
+      rowToRecoveryRun(run);
+      const boot = getBootEpochRow(database, current.claimed_by_boot_epoch);
+      if (!boot || boot.status !== "active" || boot.lease_expires_at <= completedAt) {
+        throw new CrashRecoveryLedgerConflictError(`Claiming boot is no longer live for claim ${claimId}`);
+      }
+      rowToBootEpoch(boot);
+      if (completedAt < current.claimed_at || completedAt < current.updated_at || completedAt < candidate.updated_at) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery claim ${claimId} completion time is regressive`);
+      }
+
+      const claimUpdate = database
+        .prepare(
+          `UPDATE runtime_recovery_claims
+           SET status = ?, completed_at = ?, result_json = ?, updated_at = ?
+           WHERE claim_id = ? AND status = 'claimed'`,
+        )
+        .run(input.status, completedAt, resultJson, completedAt, claimId);
+      if (claimUpdate.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery claim ${claimId} lost its terminal transition race`);
+      }
+      const candidateUpdate = database
+        .prepare(
+          `UPDATE runtime_recovery_candidates
+           SET action_status = ?, result_json = ?, action_completed_at = ?, updated_at = ?
+           WHERE recovery_run_id = ? AND candidate_key = ? AND claim_id = ? AND action_status = 'claimed'`,
+        )
+        .run(
+          input.status,
+          resultJson,
+          completedAt,
+          completedAt,
+          current.recovery_run_id,
+          current.candidate_key,
+          claimId,
+        );
+      if (candidateUpdate.changes !== 1) {
+        throw new CrashRecoveryLedgerConflictError(`Recovery candidate projection diverged for claim ${claimId}`);
+      }
+
+      const recoveryStatus = input.status === "applied" ? candidate.decision : "action_failed";
+      let sourceProjection: RuntimeTurnAttemptRow | RuntimePromptQueueRow | null;
+      if (current.candidate_type === "turn_attempt") {
+        const source = current.attempt_id ? getTurnAttemptRow(database, current.attempt_id) : null;
+        if (!source || completedAt < source.updated_at) {
+          throw new CrashRecoveryLedgerConflictError(`Attempt projection is missing or newer than claim ${claimId}`);
+        }
+        rowToTurnAttempt(source);
+        if (
+          source.recovery_claim_id !== claimId ||
+          source.recovery_status !== "claimed" ||
+          source.recovery_reason !== candidate.reason_code ||
+          source.recovery_run_id !== current.recovery_run_id ||
+          source.recovered_at !== null
+        ) {
+          throw new CrashRecoveryLedgerConflictError(`Attempt projection diverged for claim ${claimId}`);
+        }
+        const sourceUpdate = database
+          .prepare(
+            `UPDATE runtime_turn_attempts
+             SET recovery_status = ?, recovery_reason = ?, recovered_at = ?, updated_at = MAX(updated_at, ?)
+             WHERE attempt_id = ? AND recovery_claim_id = ? AND recovery_status = 'claimed'
+               AND recovery_reason = ? AND recovery_run_id = ? AND recovered_at IS NULL`,
+          )
+          .run(
+            recoveryStatus,
+            candidate.reason_code,
+            completedAt,
+            completedAt,
+            current.attempt_id,
+            claimId,
+            candidate.reason_code,
+            current.recovery_run_id,
+          );
+        if (sourceUpdate.changes !== 1) {
+          throw new CrashRecoveryLedgerConflictError(`Attempt projection diverged for claim ${claimId}`);
+        }
+        sourceProjection = current.attempt_id ? getTurnAttemptRow(database, current.attempt_id) : null;
+      } else {
+        const source = current.queue_item_id ? getPromptQueueRow(database, current.queue_item_id) : null;
+        if (!source || completedAt < source.updated_at) {
+          throw new CrashRecoveryLedgerConflictError(`Queue projection is missing or newer than claim ${claimId}`);
+        }
+        rowToPromptQueue(source);
+        if (
+          source.recovery_claim_id !== claimId ||
+          source.recovery_status !== "claimed" ||
+          source.recovery_reason !== candidate.reason_code ||
+          source.recovery_run_id !== current.recovery_run_id ||
+          source.recovered_at !== null
+        ) {
+          throw new CrashRecoveryLedgerConflictError(`Queue projection diverged for claim ${claimId}`);
+        }
+        const sourceUpdate = database
+          .prepare(
+            `UPDATE runtime_prompt_queue
+             SET recovery_status = ?, recovery_reason = ?, recovered_at = ?, updated_at = MAX(updated_at, ?)
+             WHERE queue_item_id = ? AND recovery_claim_id = ? AND recovery_status = 'claimed'
+               AND recovery_reason = ? AND recovery_run_id = ? AND recovered_at IS NULL`,
+          )
+          .run(
+            recoveryStatus,
+            candidate.reason_code,
+            completedAt,
+            completedAt,
+            current.queue_item_id,
+            claimId,
+            candidate.reason_code,
+            current.recovery_run_id,
+          );
+        if (sourceUpdate.changes !== 1) {
+          throw new CrashRecoveryLedgerConflictError(`Queue projection diverged for claim ${claimId}`);
+        }
+        sourceProjection = current.queue_item_id ? getPromptQueueRow(database, current.queue_item_id) : null;
+      }
+
+      const claimRow = getRecoveryClaimByIdRow(database, claimId);
+      const candidateRow = getRecoveryCandidateRow(database, current.recovery_run_id, current.candidate_key);
+      if (
+        !claimRow ||
+        !candidateRow ||
+        !sourceProjection ||
+        sourceProjection.recovery_claim_id !== claimId ||
+        sourceProjection.recovery_status !== recoveryStatus ||
+        sourceProjection.recovered_at !== completedAt
+      ) {
+        throw new CrashRecoveryLedgerNotFoundError(`Recovery claim projections missing after completion: ${claimId}`);
+      }
+      if (current.candidate_type === "turn_attempt") {
+        rowToTurnAttempt(sourceProjection as RuntimeTurnAttemptRow);
+      } else {
+        rowToPromptQueue(sourceProjection as RuntimePromptQueueRow);
+      }
+      return { claim: rowToRecoveryClaim(claimRow), candidate: rowToRecoveryCandidate(candidateRow) };
+    },
+    { label: "runtime-crash-recovery-complete-claim" },
+  );
+}
+
+export interface CrashRecoveryStore {
+  createBootEpoch: typeof createRuntimeBootEpoch;
+  getBootEpoch: typeof getRuntimeBootEpoch;
+  listBootEpochs: typeof listRuntimeBootEpochs;
+  heartbeatBootEpoch: typeof heartbeatRuntimeBootEpoch;
+  markBootEpochGracefulStopped: typeof markRuntimeBootEpochGracefulStopped;
+  markBootEpochAbandoned: typeof markRuntimeBootEpochAbandoned;
+  createTurnAttempt: typeof createRuntimeTurnAttempt;
+  getTurnAttempt: typeof getRuntimeTurnAttempt;
+  listTurnAttempts: typeof listRuntimeTurnAttempts;
+  heartbeatTurnAttempt: typeof heartbeatRuntimeTurnAttempt;
+  markTurnAttemptSafety: typeof markRuntimeTurnAttemptSafety;
+  terminalizeTurnAttempt: typeof terminalizeRuntimeTurnAttempt;
+  enqueuePrompt: typeof enqueueRuntimePrompt;
+  getPromptQueueItem: typeof getRuntimePromptQueueItem;
+  listPromptQueue: typeof listRuntimePromptQueue;
+  compareAndSetPromptQueueStatus: typeof compareAndSetRuntimePromptQueueStatus;
+  createRecoveryRun: typeof createRuntimeRecoveryRun;
+  getRecoveryRun: typeof getRuntimeRecoveryRun;
+  listRecoveryRuns: typeof listRuntimeRecoveryRuns;
+  completeRecoveryRun: typeof completeRuntimeRecoveryRun;
+  buildRecoveryCandidateKey: typeof buildRuntimeRecoveryCandidateKey;
+  recordRecoveryCandidate: typeof recordRuntimeRecoveryCandidate;
+  getRecoveryCandidate: typeof getRuntimeRecoveryCandidate;
+  listRecoveryCandidates: typeof listRuntimeRecoveryCandidates;
+  acquireRecoveryClaim: typeof acquireRuntimeRecoveryClaim;
+  getRecoveryClaimByCandidate: typeof getRuntimeRecoveryClaimByCandidate;
+  completeRecoveryClaim: typeof completeRuntimeRecoveryClaim;
+}
+
+export const sqliteCrashRecoveryStore: CrashRecoveryStore = {
+  createBootEpoch: createRuntimeBootEpoch,
+  getBootEpoch: getRuntimeBootEpoch,
+  listBootEpochs: listRuntimeBootEpochs,
+  heartbeatBootEpoch: heartbeatRuntimeBootEpoch,
+  markBootEpochGracefulStopped: markRuntimeBootEpochGracefulStopped,
+  markBootEpochAbandoned: markRuntimeBootEpochAbandoned,
+  createTurnAttempt: createRuntimeTurnAttempt,
+  getTurnAttempt: getRuntimeTurnAttempt,
+  listTurnAttempts: listRuntimeTurnAttempts,
+  heartbeatTurnAttempt: heartbeatRuntimeTurnAttempt,
+  markTurnAttemptSafety: markRuntimeTurnAttemptSafety,
+  terminalizeTurnAttempt: terminalizeRuntimeTurnAttempt,
+  enqueuePrompt: enqueueRuntimePrompt,
+  getPromptQueueItem: getRuntimePromptQueueItem,
+  listPromptQueue: listRuntimePromptQueue,
+  compareAndSetPromptQueueStatus: compareAndSetRuntimePromptQueueStatus,
+  createRecoveryRun: createRuntimeRecoveryRun,
+  getRecoveryRun: getRuntimeRecoveryRun,
+  listRecoveryRuns: listRuntimeRecoveryRuns,
+  completeRecoveryRun: completeRuntimeRecoveryRun,
+  buildRecoveryCandidateKey: buildRuntimeRecoveryCandidateKey,
+  recordRecoveryCandidate: recordRuntimeRecoveryCandidate,
+  getRecoveryCandidate: getRuntimeRecoveryCandidate,
+  listRecoveryCandidates: listRuntimeRecoveryCandidates,
+  acquireRecoveryClaim: acquireRuntimeRecoveryClaim,
+  getRecoveryClaimByCandidate: getRuntimeRecoveryClaimByCandidate,
+  completeRecoveryClaim: completeRuntimeRecoveryClaim,
+};


### PR DESCRIPTION
## Objective

Establish the storage-only foundation for native crash recovery: a normative contract plus an additive, typed, fail-closed ledger for boots, attempts, prompts, recovery runs, candidates, and claims.

## Problem

A stale `session_turns.status=running` row cannot prove that work was live when a daemon died, whether another boot still owns it, or whether replay is safe. Ravi needs durable identities and transactional invariants before any runtime instrumentation, classification, or resume path can make those decisions.

## Solution

- add the `daemon/restart/crash-recovery` spec, rationale, checks, and runbook
- add six additive SQLite ledgers for boot epochs, turn attempts, prompt atoms, recovery runs, candidates, and claims
- expose typed DAO operations for leases, heartbeats, immutable prompt fingerprints, FIFO queue transitions, candidates, claims, and terminal projections
- fence ownership and claim mutations transactionally, reject divergent retries/corrupt persisted state, and preserve historical trace data
- teach the quality gate to recognize the focused crash-recovery storage tests

## Practical impact

Later stacked children can persist live ownership and queue lifecycle against an explicit contract instead of inferring resumability from trace recency. This PR itself is inert storage infrastructure: it does not start a recovery sweep or replay work.

## What does NOT change

This is the first child only. It does not add provider/boot instrumentation, the durable live dispatcher integration, candidate classification, startup/reconnect sweeping, inspect/dry-run/apply CLI, automatic crash resume, or the crash/reboot E2E harness. Those remain separate sequential PRs. In particular, #392 contains instrumentation and the durable queue is a later stacked cut.

## Validation

- focused ledger suite: 23 pass, 0 fail, 135 assertions
- trace/dispatcher/delivery regressions: 88 pass, 0 fail, 362 assertions
- concurrent claim race across two processes produced one global winner and one idempotent existing claim
- `ravi specs sync` and full/checks reads for `daemon/restart/crash-recovery`
- `bunx biome check`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- GitHub Quality Gate and PR description checks are green

## Risks

The schema is additive, but its invariants intentionally fail closed on malformed identities, ownership ambiguity, illegal transitions, or divergent retry content. Runtime integrations must preserve those constraints rather than bypassing them.

## Rollback

Revert commits `7553f7c4` and `f73dcbd0`. No runtime path depends on these tables within this PR, so leaving the additive schema unused is also safe until an explicit cleanup migration.

Part of #388.
