### PR TITLE
feat(apps): close the app builder contract

### DIFF
--- a/.ravi/specs/apps/CHECKS.md
+++ b/.ravi/specs/apps/CHECKS.md
@@ -13,14 +13,22 @@ normative: false
 
 - `ravi apps scaffold <id> --dry-run --json` must return planned file paths
   and actions without creating files.
-- `ravi apps scaffold <id> --json` must create manifest, spec, and skill files.
+- `ravi apps scaffold <id> --json` must create a runnable CLI, manifest, spec,
+  and skill files.
 - Duplicate scaffold without `--force` must return typed `already_exists` error.
 
 ## Manifest Checks
 
 - Every scaffolded app must have `src/apps/<id>/ravi.app.json`.
-- Manifest must contain `id`, `name`, and valid permission declarations.
+- Default scaffolds must have `src/apps/<id>/cli.ts`, and
+  `ravi <id> list --json` must execute it through the App Router.
+- Manifest must contain `id`, `name`, `interfaces.cli`, `context.allow`, and
+  valid permission declarations.
 - `ravi apps show <id> --json` must return the parsed manifest.
+- App operations must use `interface: "cli"` except router-owned allowlisted
+  builtins.
+- SDK, tool, stream, UI, and automation clients must route through the generic
+  App Router instead of declaring independent operation executors.
 
 ## Lifecycle Checks
 
@@ -37,21 +45,29 @@ normative: false
 - App mutation requires `execute app:<app-id>`.
 - Apps not visible to the current principal must not appear in catalogs or
   SDK discovery.
+- Runtime dispatch must issue a fresh child context bounded by
+  `manifest.context.allow`.
+- The child process must receive the child key and must not receive the parent
+  `RAVI_CONTEXT_KEY` or synthesized Ravi identity env vars.
+- Failure to issue the requested child capabilities must fail before spawning
+  the app CLI.
 
-## SDK Checks
+## CLI Contract Checks
 
-- `bun run sdk:generate` and `bun run sdk:check` must pass after app changes.
-- `ravi sdk returns validate --json` must report zero issues.
+- App invocation must preserve argv, stdout, stderr, and exit status.
+- The launcher must spawn executable plus argv with `shell: false`; shell-like
+  input must remain literal data.
+- The child cwd must be bounded to the app/package root, and the environment
+  must exclude unrelated parent credentials and secrets.
+- `--json` must return structured output when declared, but must not be required
+  as an App-to-Ravi transport.
+- App calls to Ravi must use public `ravi ...` commands under the child context.
 
 ## Suggested Commands
 
 ```bash
 bun test src/cli/commands/apps.test.ts
 bun test src/apps/service.test.ts src/apps/router.test.ts src/apps/permissions.test.ts
-bun test src/sdk/gateway/dispatcher.test.ts
-bun run gen:commands
-bun run sdk:generate
-bun run sdk:check
 bun run typecheck
 bun run build
 ```

--- a/.ravi/specs/apps/RUNBOOK.md
+++ b/.ravi/specs/apps/RUNBOOK.md
@@ -12,9 +12,12 @@ normative: false
 ## Scaffold A New App
 
 ```bash
-ravi apps scaffold <app-id> --dry-run --json   # preview
-ravi apps scaffold <app-id> --json             # create
+ravi apps scaffold <app-id> --dry-run --json
+ravi apps scaffold <app-id> --json
 ```
+
+The default generates `bun cli.ts`. Pass `--command "<app-cli>"` when a real
+implementation CLI already exists.
 
 ## Inspect An App
 
@@ -23,6 +26,19 @@ ravi apps list --json
 ravi apps show <app-id> --json
 ravi apps check <app-id> --json
 ```
+
+## Run An App
+
+```bash
+ravi <app-id> <operation> [args...]
+ravi <app-id> <operation> [args...] --json
+```
+
+Use `--json` only when the caller needs structured output. The app process still
+uses the normal CLI contract.
+
+Use `ravi apps run <app-id> <operation>` only for router diagnostics or a static
+root-command collision.
 
 ## Delete A Scaffolded App
 
@@ -39,7 +55,7 @@ If `ravi apps scaffold <id>` returns `already_exists`:
 
 ```bash
 ravi apps show <id> --json        # inspect the existing app
-ravi apps scaffold <id> --force   # overwrite if intended
+ravi apps scaffold <id> --force   # refresh contracts; preserve existing cli.ts
 ```
 
 ## Handle Absent App
@@ -58,6 +74,17 @@ ravi agents permissions <agent> --json
 ravi permissions check agent:<agent> use app:<app-id>
 ravi permissions check agent:<agent> execute app:<app-id>
 ```
+
+Then inspect the app's child-context request:
+
+```bash
+ravi apps show <app-id> --json
+ravi context list --json
+ravi context info <context-id> --json
+```
+
+Confirm the launched CLI received a child `RAVI_CONTEXT_KEY`, not the parent
+key, and that its capabilities do not exceed `manifest.context.allow`.
 
 ## Validate App Specs
 

--- a/.ravi/specs/apps/SPEC.md
+++ b/.ravi/specs/apps/SPEC.md
@@ -4,6 +4,7 @@ title: "Ravi Apps"
 kind: domain
 domain: apps
 capabilities:
+  - builder
   - cli
   - lifecycle
   - manifest
@@ -39,18 +40,23 @@ normative: true
 
 Ravi Apps are the application layer of Ravi OS.
 
-An app is an operable capability unit that can be used by humans, agents, SDK
-clients, UIs, or automations through one or more stable interfaces. A CLI can
-be an app when it has a domain model, a machine-readable command surface,
-context-bound authorization, durable state when useful, and a skill that teaches
-agents when and how to operate it.
+An app is a CLI application with a declarative `ravi.app.json`. Humans and
+agents invoke it through `ravi <app-id> <operation>`. The App Router validates
+the manifest and caller authority, issues a least-privilege child context, then
+launches the app CLI.
+
+The app talks back to Ravi by invoking public `ravi ...` commands with the child
+`RAVI_CONTEXT_KEY`. There is no separate App JSON-RPC, host callback, SDK
+transport, or app-specific protocol. Arguments, stdout, stderr, and exit status
+are the process contract. `--json` is an optional machine-readable output mode,
+not the transport between the app and Ravi.
 
 This domain protects the distinction between:
 
-- app: the operational product/capability;
+- app: a CLI application plus its operational contract;
 - plugin: a packaging and discovery container;
 - skill: the agent teaching layer;
-- CLI: one possible control surface;
+- App Router: the Ravi launcher for app CLIs;
 - Ravi Command: a prompt template, not an app by itself.
 
 ## Invariants
@@ -58,10 +64,17 @@ This domain protects the distinction between:
 - A Ravi App MUST have a stable app id.
 - A Ravi App MUST define the operational problem it solves before defining its
   command surface.
-- A Ravi App MUST expose at least one machine-operable interface: CLI JSON,
-  SDK/gateway route, stream channel, or explicit runtime tool.
-- Ravi App CLI routing SHOULD be runtime-resolved through the app router instead
-  of requiring build-time command registration for each app.
+- A Ravi App MUST declare one canonical CLI implementation under
+  `interfaces.cli`.
+- App operations MUST dispatch to that CLI. Router-owned allowlisted builtins
+  MAY implement discovery, help, manifest inspection, and manifest validation.
+- Ravi App routing MUST be runtime-resolved through the App Router instead of
+  requiring build-time command registration for each app.
+- UI, SDK clients, runtime tools, and automations MUST invoke the same declared
+  operations through the generic App Router. They MUST NOT create independent
+  app executors or business implementations.
+- `--json` MAY be used when a caller needs structured output. It MUST NOT be
+  described or implemented as an App-to-Ravi protocol.
 - A Ravi App MUST declare the Ravi permissions or context capabilities needed
   to perform mutating or sensitive operations.
 - A Ravi App MAY declare an App Permission Provider for app-owned domain
@@ -82,15 +95,32 @@ This domain protects the distinction between:
   discovery, or root aliases.
 - Manifest permission declarations are requirements and audit metadata; they
   MUST NOT be treated as grants.
-- A Ravi App running inside Ravi runtime MUST use `RAVI_CONTEXT_KEY` as its
-  canonical identity and authorization bridge. It MUST NOT reconstruct identity
-  from `RAVI_AGENT_ID`, `RAVI_SESSION_KEY`, or ad-hoc environment variables.
+- Before launching an app CLI inside a Ravi runtime, the App Router MUST issue a
+  fresh least-privilege child context from the caller context.
+- The child context capability ceiling MUST be derived from the manifest's
+  explicit `context.allow` declaration and MUST NOT exceed the parent context.
+- The launcher MUST pass the child `RAVI_CONTEXT_KEY` as the only Ravi identity
+  credential. It MUST NOT forward the parent context key or synthesize identity
+  with `RAVI_AGENT_ID`, `RAVI_SESSION_KEY`, `RAVI_SESSION_NAME`, or ad-hoc
+  environment variables.
+- The launcher MUST parse declarative commands into executable plus argv and
+  spawn without a shell. User-supplied app arguments MUST remain literal argv.
+- The launcher MUST use a bounded app-root working directory and an allowlisted
+  environment that excludes unrelated parent credentials and secrets.
+- A Ravi App running inside Ravi MUST resolve identity and authority through
+  `ravi context whoami`, `ravi context check`, or
+  `ravi context authorize`, then use ordinary public `ravi ...` commands for
+  Ravi capabilities.
+- Child contexts MUST have a stable audit name, bounded TTL, lineage to the
+  parent context, and no raw key in logs or audit payloads.
+- `context.allow` is a requested child-context ceiling, not a grant. Failure to
+  issue the declared capability MUST fail before the app CLI starts.
 - A Ravi App SHOULD have a skill when agents are expected to use it. The skill
   MUST teach when to use the app, which commands to call, what outputs mean,
   and what failures require user input.
 - New first-party Ravi Apps SHOULD be created with `ravi apps scaffold` so the
-  manifest, spec, skill, operations, storage/events contract, and follow-up
-  commands start from the same app contract.
+  runnable thin CLI, manifest, spec, skill, operations, storage/events contract,
+  and follow-up commands start from the same app contract.
 - Existing CLIs that should become Ravi Apps SHOULD be imported or scaffolded
   from CLI metadata when available. Generated app contracts MUST be treated as
   drafts until product operations, permissions, storage, events, UI, and skills
@@ -106,17 +136,20 @@ This domain protects the distinction between:
 - Apps MUST NOT persist data merely because it is available. Persistence must
   add reuse, lineage, audit, cache value, or operational recovery.
 - Apps that emit events or artifacts SHOULD use Ravi-owned event/artifact
-  surfaces so other agents and UIs can observe them without scraping stdout.
+  commands so other agents and UIs can observe them without scraping human
+  stdout.
 
 ## App Contract
 
-Until a dedicated app manifest format exists, every app spec or implementation
-SHOULD document:
+Every `ravi.app.json` SHOULD document:
 
 - `id`: stable app slug;
 - `name`: human display name;
-- `interfaces`: CLI commands, SDK routes, stream channels, UIs, or tools;
+- `interfaces.cli`: the real CLI implementation entrypoint;
+- `interfaces.ui`: optional semantic UI descriptor;
+- `operations`: public app operations mapped to CLI commands or router builtins;
 - `permissions`: required Ravi capabilities/scopes;
+- `context.allow`: Ravi capabilities requested for the child CLI context;
 - `permission provider`: optional app-owned authorization decision hook;
 - `storage`: tables/files owned by the app;
 - `artifacts`: durable outputs the app creates;
@@ -132,9 +165,13 @@ SHOULD document:
 - Apps are not a replacement for `AGENTS.md`. Agents define identity and
   conversational behavior; apps define reusable capability surfaces.
 - Apps are not Ravi Commands. Ravi Commands are user-invoked prompt templates;
-  apps can include commands, CLIs, storage, events, and skills.
+  apps are executable CLIs with storage, events, and skills when useful.
 - Apps do not bypass the Permission Provider Runtime, context-key
   authorization, skill gates, or runtime provider boundaries.
+- Apps do not get a private Ravi SDK or a second transport contract. An app
+  calls the public Ravi CLI under its child context.
+- UI, SDK, tool, and automation surfaces are clients of the App Router, not
+  alternative app implementations.
 - Direct local CLI execution with no resolved principal MAY remain an operator
   break-glass path, but any execution carrying `agentId` or `RAVI_CONTEXT_KEY`
   MUST authorize through the Permission Provider Runtime. Runtime discovery
@@ -145,15 +182,45 @@ SHOULD document:
 
 - A new app spec SHOULD be retrievable with `ravi specs get apps/<capability>`.
 - A stateful app SHOULD expose a health/check command or documented check.
-- A CLI-backed app SHOULD satisfy `apps/cli` before agents rely on it.
+- Every app SHOULD satisfy `apps/cli` before agents rely on it.
 - A CLI-imported app SHOULD satisfy `apps/import-cli` before generated
   manifests are written or trusted.
+
+## Apps Command Inventory
+
+The public Apps management registry consists of:
+
+- `ravi apps list`
+- `ravi apps show`
+- `ravi apps check`
+- `ravi apps scaffold`
+- `ravi apps delete`
+- `ravi apps import-cli`
+- `ravi apps guide`
+- `ravi apps prompts`
+
+`ravi apps run` is an internal/debug router surface. Normal product invocation
+uses `ravi <app-id> <operation>`.
+
+This inventory MUST remain aligned with the decorated registry,
+`RAVI_APPS_COMMAND_GUIDANCE`, `ravi apps guide`, and `ravi-system-apps`.
+App construction MUST follow `apps/builder`; scaffold and import results MUST
+link the canonical `ravi-dev-app-creator` skill, the `apps/builder` spec, and
+the structured readiness checklist.
 
 ## Known Failure Modes
 
 - Script-only tools with no JSON output force agents to parse human prose.
 - Skills that compensate for a vague CLI create brittle agent behavior.
 - CLIs that use raw session env vars lose lineage and permission audit.
+- Launchers that forward the parent context key give apps the caller's full
+  authority.
+- Separate SDK, tool, or UI executors make the same app behave differently by
+  surface.
+- Treating `--json` as a host protocol adds a transport that the CLI does not
+  need.
+- Shell execution or full parent-environment inheritance turns the app launcher
+  into an injection and credential-leak boundary.
 - One generic database for unrelated apps creates unclear data ownership.
 - Plugins treated as permission grants cause unsafe capability assumptions.
 - Apps with no health/check surface fail silently inside automations.

--- a/.ravi/specs/apps/WHY.md
+++ b/.ravi/specs/apps/WHY.md
@@ -12,9 +12,8 @@ normative: false
 ## Rationale
 
 Ravi already has plugins, skills, CLIs, and tools. Apps fill a structural gap:
-a single concept that binds a domain model, machine-readable command surface,
-context-bound authorization, durable state, and an agent skill into one
-operable unit.
+a single concept that binds a real CLI, a manifest, context-bound
+authorization, durable state, and an agent skill into one operable unit.
 
 Without apps, each piece lives independently — a CLI has no permission model,
 a skill has no manifest, and a plugin has no domain contract. Agents cobble
@@ -28,13 +27,21 @@ lifecycle-manage a coherent capability unit.
 - Apps are not skills. Skills teach agents; apps define the surfaces agents
   operate on.
 - Apps are not Ravi Commands. Commands are prompt templates; apps can include
-  commands but also CLIs, storage, events, and skills.
+  storage, events, and skills around one CLI.
+- The CLI is the app implementation. `ravi <app-id>` is the launcher that
+  discovers, authorizes, and delegates to it.
+- The app uses ordinary `ravi ...` commands under a child context to use OS
+  capabilities. A separate App SDK or JSON protocol would duplicate the CLI.
+- JSON is an output format for machine callers. Process invocation remains
+  argv/stdout/stderr/exit status.
 - App ids are stable slugs used across manifests, specs, permissions, and
   context keys.
 - Scaffold provides the canonical creation path so manifests, specs, skills,
   and permissions start from the same contract.
 - The Permission Provider Runtime isolates apps at discovery and execution
   time. Manifest permission declarations are audit metadata, not grants.
+- UI, SDK, tools, and automations are adapters over the same App Router
+  operation, not parallel implementations.
 
 ## Rejected Alternatives
 
@@ -42,5 +49,9 @@ lifecycle-manage a coherent capability unit.
   containers, not operational contracts.
 - Making skills the app unit: rejected because skills are teaching artifacts,
   not executable surfaces.
+- Supporting CLI, SDK, tool, and stream as separate operation executors:
+  rejected because it multiplies contracts, authorization paths, and drift.
+- Adding an App-specific JSON-RPC protocol: rejected because a CLI already has
+  a stable process contract and can call Ravi's public CLI.
 - Auto-exposing every CLI command as an app operation: rejected because debug
   and rare commands should remain CLI-only.

--- a/.ravi/specs/apps/builder/CHECKS.md
+++ b/.ravi/specs/apps/builder/CHECKS.md
@@ -1,0 +1,26 @@
+# Ravi App Builder / CHECKS
+
+## Checks
+
+- The builder skill MUST validate with the canonical skill validator.
+- Claude, Codex, and Pi MUST advertise the app builder skill through their
+  declared skill-visibility mechanisms.
+- Pi MUST return an empty loaded-skill vector until it observes an explicit
+  skill load.
+- `ravi apps scaffold <app-id> --dry-run --json` MUST return the builder skill,
+  builder spec, and complete review checklist without writing files.
+- `ravi apps import-cli <command> --id <app-id> --dry-run --json` MUST label its
+  output as a draft requiring review.
+- Missing authentication MUST fail before provider network access.
+- The App Router MUST reject an undelegable child capability before spawning
+  the app CLI.
+- A public `ravi <app-id> <operation> --json` call MUST reach the real CLI and a
+  deterministic fake provider.
+- Google Search Console and Open-Meteo reference briefs MUST remain present and
+  MUST use the same generic builder workflow.
+- The Apps contract drift eval MUST fail when a registry command is absent from
+  guide guidance, the system skill, or the root Apps spec.
+- The Apps contract drift eval MUST fail when builder links or either reference
+  acceptance case are removed.
+- Typechecking, formatting, generated contract checks, focused tests, and the
+  full suite MUST pass before readiness is claimed.

--- a/.ravi/specs/apps/builder/RUNBOOK.md
+++ b/.ravi/specs/apps/builder/RUNBOOK.md
@@ -1,0 +1,60 @@
+# Ravi App Builder / RUNBOOK
+
+## Build From API Documentation
+
+1. Load `ravi-dev-app-creator`.
+2. Read `apps/builder`, `apps/manifest`, `apps/cli`, `apps/router`, and
+   `apps/permission-providers`.
+3. Capture the official source contract and operation matrix.
+4. Run scaffold in dry-run mode.
+5. Implement the provider client and real CLI with injected fake HTTP.
+6. Declare the smallest permissions and child-context ceiling.
+7. Review storage, events, artifacts, UI, and the domain skill explicitly.
+8. Validate the manifest and run the alias through the App Router.
+9. Exercise missing auth, provider failures, pagination, and mutations.
+10. Run the drift eval, generated-contract checks, and full suite.
+
+## Build From an Existing CLI
+
+1. Inspect machine metadata before human help.
+2. Run import in dry-run mode.
+3. Review public and debug candidates separately.
+4. Remove unsafe, interactive, streaming, or rare commands from the app
+   surface.
+5. Complete every remaining builder gate; do not stop at a valid manifest.
+
+## Inspect Builder Guidance
+
+```bash
+ravi skills show ravi-dev-app-creator --json
+ravi specs get apps/builder --mode full --json
+ravi apps guide --json
+ravi apps scaffold demo --dry-run --json
+```
+
+The scaffold result and import result include the canonical builder skill,
+spec, and review checklist.
+
+## Diagnose Runtime Skill Visibility
+
+```bash
+ravi skills inspect <agent-id> --json
+ravi skills show ravi-dev-app-creator --json
+```
+
+Claude uses plugin discovery, Codex uses managed skill synchronization, and Pi
+receives the allowlist-filtered catalog in its appended system prompt. An
+advertised Pi skill remains non-loaded until the instructions are explicitly
+read.
+
+## Diagnose Drift
+
+Run:
+
+```bash
+bun test src/cli/commands/apps.test.ts
+```
+
+The contract eval reports which command or builder reference is missing from
+the registry, guide, system skill, root spec, builder spec, or acceptance-case
+brief.

--- a/.ravi/specs/apps/builder/SPEC.md
+++ b/.ravi/specs/apps/builder/SPEC.md
@@ -1,0 +1,195 @@
+---
+id: apps/builder
+title: "Ravi App Builder"
+kind: capability
+domain: apps
+capability: builder
+capabilities:
+  - cli
+  - context
+  - import-cli
+  - manifest
+  - permissions
+  - scaffold
+  - skills
+  - testing
+tags:
+  - apps
+  - builder
+  - api
+  - cli
+  - skills
+applies_to:
+  - src/apps/builder.ts
+  - src/apps/guide.ts
+  - src/apps/import-cli.ts
+  - src/apps/scaffold.ts
+  - src/plugins/internal/ravi-dev/skills/app-creator
+  - src/plugins/internal/ravi-system/skills/apps/SKILL.md
+owners:
+  - ravi-dev
+status: active
+normative: true
+---
+
+# Ravi App Builder
+
+## Intent
+
+Define one domain-independent workflow for turning official API documentation,
+an existing CLI contract, or a new capability into a production-ready Ravi
+App.
+
+The builder produces a real CLI implementation plus `ravi.app.json`. The CLI
+communicates with Ravi through public `ravi ...` commands under the
+least-privilege child context issued by the App Router. There is no private
+App-to-host JSON protocol.
+
+## Builder Skill
+
+The canonical builder skill is `ravi-dev-app-creator`, sourced from
+`src/plugins/internal/ravi-dev/skills/app-creator/SKILL.md`.
+
+- Claude MUST discover the source skill through the `ravi-dev` plugin.
+- Codex MUST receive the managed `ravi-dev-app-creator` skill through plugin
+  skill synchronization.
+- Pi MUST receive an allowlist-filtered skill catalog in its appended system
+  prompt and MUST be able to load the complete skill with
+  `ravi skills show ravi-dev-app-creator --json`.
+- Pi catalog advertisement MUST NOT be reported as loaded-skill evidence.
+- `ravi apps guide`, scaffold results, and import results MUST link to this
+  skill and this spec.
+
+## Source Contract
+
+Before implementation, the builder MUST record:
+
+- official documentation URLs or the authoritative CLI metadata source;
+- resources and useful operator workflows;
+- authentication and credential lifecycle;
+- methods or subcommands;
+- pagination and limits;
+- provider error envelopes;
+- mutation, destructive action, retry, timeout, and idempotency behavior.
+
+An app surface MUST represent useful, safe workflows. It MUST NOT publish every
+endpoint or subcommand mechanically.
+
+## Build Flow
+
+### New API or CLI
+
+1. Define the operator, problem, and operation matrix.
+2. Run `ravi apps scaffold <app-id> --dry-run --json`.
+3. Implement the real CLI and stable `--json` output.
+4. Point `interfaces.cli.command` to the implementation, never to the public
+   `ravi <app-id>` alias.
+5. Declare operations, permissions, and the smallest `context.allow` ceiling.
+6. Add the domain skill and explicit decisions for storage, events, artifacts,
+   and semantic UI.
+7. Validate the manifest and exercise a public alias operation through the App
+   Router.
+
+### Existing CLI
+
+1. Prefer machine-readable manifest metadata, then decorated registry
+   metadata, then human help as the lowest-confidence source.
+2. Run `ravi apps import-cli <command> --id <app-id> --dry-run --json`.
+3. Treat every generated operation, permission, context capability, schema,
+   and product surface as a draft.
+4. Remove interactive, streaming, debug-only, and unsafe candidates from the
+   public app surface.
+5. Complete the same auth, permission, skill, functional, and release gates as
+   a new app.
+
+`import-cli` MUST NOT claim readiness merely because it generated a valid
+manifest.
+
+## Authentication and Authorization
+
+- Provider secrets MUST remain behind a Ravi credential broker or managed
+  connector boundary.
+- Tokens, refresh tokens, client secrets, secret references, and credential
+  paths MUST NOT appear in manifests, argv, stdout, specs, skills, or events.
+- Missing or disabled authentication MUST fail before network access.
+- `manifest.permissions` declares caller requirements; it is not a grant.
+- `manifest.context.allow` declares the child-process ceiling; it is not a
+  grant.
+- The router MUST fail before spawning when the parent cannot delegate the
+  declared child capabilities.
+- Restricted agents MUST receive only the app skill grants they need.
+
+## Functional Contract
+
+Every public operation MUST define:
+
+- explicit input bounds;
+- stable JSON output when machine use is supported;
+- typed and sanitized failure output;
+- non-zero exit status on failure;
+- pagination cursors or offsets where applicable;
+- bounded timeout and retry behavior;
+- idempotency semantics for mutation.
+
+Readiness requires a deterministic functional path through:
+
+```text
+ravi <app-id> <operation> -> App Router -> child context -> real CLI -> fake provider
+```
+
+Manifest validation alone is insufficient.
+
+## Reference Acceptance Cases
+
+The builder MUST remain independent of provider and domain. Its reference cases
+are:
+
+- Google Search Console: OAuth-backed sites, search analytics, sitemaps, health,
+  pagination, quotas, and sanitized provider failures.
+- Open-Meteo Forecast: unauthenticated forecast and health operations with a
+  different resource model and no child Ravi capabilities.
+
+The detailed briefs live in the builder skill reference
+`references/acceptance-cases.md`. A workflow passes the domain-independence
+gate only when the same builder checklist can create both apps without
+provider-specific logic in the builder itself.
+
+## Drift Contract
+
+A deterministic contract eval MUST compare:
+
+- decorated `ravi apps` registry commands;
+- `RAVI_APPS_COMMAND_GUIDANCE`;
+- prompt ids returned by `ravi apps guide`;
+- command inventory in `apps`;
+- commands documented by `ravi-system-apps`;
+- builder links and both reference acceptance cases.
+
+Adding or removing a command without updating every required surface MUST fail
+the eval.
+
+## Release Gate
+
+An app is ready only when:
+
+- the real CLI implements its public operations;
+- auth and secrets remain behind a Ravi boundary;
+- permissions and child context fail closed;
+- the app skill is indexed or explicitly granted;
+- `ravi apps check <app-id> --json` passes;
+- at least one public alias operation passes against a deterministic fake
+  provider;
+- missing auth, provider error, pagination, and mutation risks are tested where
+  relevant;
+- specs, skills, guide, registry, generated SDK/OpenAPI, formatting,
+  typechecking, and the full test suite have no drift.
+
+## Known Failure Modes
+
+- Treating a scaffold or imported draft as a finished application.
+- Pointing the implementation command back at the public app alias.
+- Adding a private host protocol instead of calling public Ravi commands.
+- Forwarding provider secrets through the manifest or child argv.
+- Treating permission declarations or skill visibility as grants.
+- Testing only manifest shape while the real CLI path is broken.
+- Embedding provider-specific assumptions in the generic builder.

--- a/.ravi/specs/apps/builder/WHY.md
+++ b/.ravi/specs/apps/builder/WHY.md
@@ -1,0 +1,33 @@
+# Ravi App Builder / WHY
+
+## Rationale
+
+App creation previously existed as separate pieces: manifest discovery,
+scaffold, CLI import, context isolation, skills, and router execution. That was
+enough to build an app manually, but not enough for an agent to turn unfamiliar
+API documentation into a complete, reviewed, functional app.
+
+A dedicated builder contract closes that gap without inventing another runtime
+abstraction. The implementation remains a normal CLI. The manifest describes
+how Ravi discovers and authorizes it. The skill teaches the workflow.
+
+## Why One Builder
+
+The workflow should be domain-independent. Google Search Console exercises
+OAuth, quotas, pagination, and multiple resources. Open-Meteo exercises an
+unrelated unauthenticated API with a simpler resource model. Supporting both
+with the same checklist is stronger evidence than hard-coding a single
+provider walkthrough.
+
+## Why Import Is a Draft
+
+CLI metadata can identify candidate commands, but it cannot decide product
+scope, prove auth safety, classify every mutation, choose storage, or establish
+functional readiness. Calling import output “ready” would turn inference into
+an unsafe production contract.
+
+## Why Drift Is Tested
+
+The registry is executable truth, while specs and skills are the truth agents
+read. A command added to only one side creates predictable failures. A
+deterministic contract eval makes that mismatch visible in CI.

--- a/.ravi/specs/apps/cli/CHECKS.md
+++ b/.ravi/specs/apps/cli/CHECKS.md
@@ -29,9 +29,10 @@ Expected:
 - the generated barrel includes the new command file;
 - no unrelated command exports changed.
 
-## SDK-Facing Command Drift
+## Static Command Compatibility Drift
 
-When a first-party CLI App command is exposed to SDK/gateway:
+When the underlying first-party static Ravi command is also exposed to
+SDK/gateway:
 
 ```bash
 bun run sdk:generate
@@ -43,22 +44,38 @@ Expected:
 - generated SDK files are current;
 - command return types are explicit when `@Returns(zod)` is present;
 - process/stream/interactive commands are excluded with `@CliOnly()`.
+- the app manifest still maps the operation to `cli`, and generic App callers
+  still use App Router authorization.
 
 ## Context-Key Launch Smoke
 
 For an external CLI App launched by Ravi:
 
 ```bash
-key="$(ravi context issue my-app --allow view:system:events --ttl 5m --json | jq -r '.context.key')"
-RAVI_CONTEXT_KEY="$key" ravi context whoami --json
-RAVI_CONTEXT_KEY="$key" ravi context check view system events --json
+ravi my-app inspect --json
+ravi context list --json
+ravi context info <child-context-id> --json
 ```
 
 Expected:
 
-- `whoami` resolves a context id;
-- check output is structured JSON;
-- raw context key is not printed by the app.
+- a fresh child context exists with `issuedFor` equivalent to `app:my-app`;
+- its capabilities are no broader than manifest `context.allow`;
+- lineage points to the caller context;
+- the app process received the child key, not the parent key;
+- legacy Ravi identity env vars were not synthesized;
+- unrelated parent credentials and secrets were not inherited;
+- the command ran with `shell: false` from a bounded app/package root;
+- raw context keys are absent from app output and audit.
+
+## Ravi Call Smoke
+
+For an app operation that calls a public Ravi command:
+
+- the app resolves identity through `ravi context whoami`;
+- `ravi context check` or `authorize` evaluates the child context;
+- the downstream `ravi ...` command succeeds only within the child ceiling;
+- an undeclared Ravi capability fails without executing the protected action.
 
 ## Agent-First Output Smoke
 
@@ -74,3 +91,6 @@ Expected:
 - includes stable semantic fields;
 - error cases return clear messages;
 - list commands include page/pagination metadata and are bounded by default.
+
+Also verify that omitting `--json` uses normal human CLI output and does not
+change routing, authorization, or child-context behavior.

--- a/.ravi/specs/apps/cli/RUNBOOK.md
+++ b/.ravi/specs/apps/cli/RUNBOOK.md
@@ -13,8 +13,9 @@ Use this when creating or reviewing a CLI App.
 4. Design command verbs and examples for humans and agents.
 5. Add `--json` to machine-consumed commands.
 6. Add bounded list behavior and pagination/page metadata.
-7. Define required Ravi capabilities.
-8. If the app runs inside Ravi, launch it with a child `RAVI_CONTEXT_KEY`.
+7. Declare caller permissions and child `context.allow` capabilities
+   separately.
+8. Make Ravi launch the app with a fresh child `RAVI_CONTEXT_KEY`.
 9. Write or update the app skill so agents know when to use it.
 10. Add checks/tests for the command surface and context behavior.
 
@@ -30,16 +31,24 @@ For code inside `src/cli/commands`:
 6. Run the focused command tests.
 7. If command metadata is SDK-facing, run `bun run sdk:generate` and
    `bun run sdk:check`.
+8. Keep manifest operations mapped to `cli`; do not add an SDK/tool/stream App
+   executor for the decorated command.
 
 ## External CLI App Launched By Ravi
 
-1. Parent issues a child key:
+1. The manifest declares the maximum child capabilities:
 
-   ```bash
-   ravi context issue <app-id> --allow <permission>:<object-type>:<object-id> --ttl 1h --json
+   ```json
+   {
+     "context": {
+       "allow": ["execute:group:artifacts"]
+     }
+   }
    ```
 
-2. Parent launches the app with only:
+2. The App Router authorizes the caller, issues a bounded child context with
+   `cliName: "app:<app-id>"`, builds an allowlisted environment, and launches
+   executable plus argv with `shell: false` from the bounded app root:
 
    ```bash
    RAVI_CONTEXT_KEY=<rctx_child> <app-command> ...
@@ -51,14 +60,21 @@ For code inside `src/cli/commands`:
    ravi context whoami --json
    ```
 
-4. App checks or requests capability:
+4. App checks or requests the narrow capability:
 
    ```bash
    ravi context check <permission> <object-type> <object-id> --json
    ravi context authorize <permission> <object-type> <object-id> --json
    ```
 
-5. App emits structured JSON output and never prints the raw context key.
+5. App calls the normal Ravi command it needs:
+
+   ```bash
+   ravi artifacts create ...
+   ```
+
+6. App returns normal CLI output and exit status. It emits JSON only when the
+   invoked command requested `--json`, and never prints the raw context key.
 
 ## Review A CLI App
 
@@ -68,8 +84,13 @@ Ask:
 - Is there a real domain model?
 - Is the command surface concrete?
 - Can an agent use `--json` without scraping?
+- Is JSON only an output format rather than a private protocol?
 - Are list commands bounded?
 - Are permissions least-privilege?
+- Does the router issue a fresh child context instead of forwarding the parent?
+- Does it launch without a shell, from a bounded cwd, and without unrelated
+  parent secrets?
+- Does the app call public `ravi ...` commands for Ravi capabilities?
 - Is state owned by the domain?
 - Does the skill teach operation instead of improvisation?
 - Are health/check commands present?

--- a/.ravi/specs/apps/cli/SPEC.md
+++ b/.ravi/specs/apps/cli/SPEC.md
@@ -32,13 +32,13 @@ normative: true
 
 ## Intent
 
-Define when a CLI should be treated as a Ravi App and how it connects to the
-Ravi OS application ecosystem.
+Define the executable contract for every Ravi App and how the app CLI connects
+to Ravi OS.
 
-A CLI App is not just an executable. It is a domain application whose primary
-interface is a CLI and whose behavior is safe for agents to operate through
-stable commands, machine-readable output, context-key authorization, and a
-teaching skill.
+A Ravi App is a domain CLI with stable commands, explicit machine output when
+needed, context-key authorization, and a teaching skill. The app can also run
+standalone when its domain permits, but Ravi-launched execution always uses a
+delegated child context.
 
 ## Invariants
 
@@ -59,25 +59,38 @@ teaching skill.
 - Commands MUST return or print enough structured information for an agent to
   decide the next step without scraping prose.
 - Errors MUST explain what failed, why it failed, and how to correct it.
-- A CLI App that runs inside Ravi runtime MUST receive `RAVI_CONTEXT_KEY` and
+- A CLI command's transport contract is argv, optional documented stdin,
+  stdout, stderr, and exit status.
+- Ravi MUST launch declared App CLI commands as executable plus argv with no
+  shell evaluation. User-provided arguments MUST remain separate literal argv
+  elements.
+- `--json` MUST mean machine-readable command output only. It MUST NOT define a
+  separate App host protocol, callback protocol, or JSON-RPC transport.
+- A CLI App launched by Ravi MUST receive a fresh child `RAVI_CONTEXT_KEY` and
   resolve identity through `ravi context whoami`, `ravi context check`, or
   `ravi context authorize`.
+- A CLI App MUST use ordinary public `ravi ...` commands when it needs Ravi
+  services. It MUST NOT depend on private runtime imports or reconstruct a Ravi
+  client protocol.
 - A CLI App MUST NOT print raw context keys, secrets, or bearer tokens.
 - A CLI App MUST declare least-privilege capabilities for sensitive actions.
-  It MUST NOT rely on broad inherited permission unless the launcher explicitly
-  needs `--inherit` and documents why.
+  The launcher MUST derive the child ceiling from manifest `context.allow`.
+- `--inherit` MUST NOT be the default launch mode. Any exception MUST be
+  explicit, reviewed, and documented outside the app manifest.
 - Stateful CLI Apps SHOULD use domain-specific SQLite storage when persistence
   adds reuse, lineage, audit, cache value, or durable asset tracking.
 - If a CLI App persists artifacts, it SHOULD store normalized input, output,
   metadata, hash, version, dependencies, source, and timestamps where useful.
 - The skill for a CLI App MUST be a teaching layer. It MUST NOT hide missing
   CLI behavior by asking the agent to improvise around weak commands.
-- First-party Ravi CLI Apps that live in `src/cli/commands` SHOULD use the
-  decorator registry so the same command surface can feed the CLI, SDK gateway,
-  OpenAPI, and generated clients.
+- A first-party App CLI MAY be implemented as a registered static Ravi command
+  under `src/cli/commands` and use the decorator registry for its command
+  contract. App-facing UI, SDK, tool, and automation callers MUST still enter
+  through the generic App Router; decorator metadata MUST NOT become a second
+  App operation executor.
 - CLI Apps with streaming or interactive operations MUST NOT expose those
-  operations through the single-shot SDK dispatcher. Use `@CliOnly()` or a
-  dedicated stream/control channel.
+  operations through a single-shot caller. They remain CLI operations and
+  SHOULD use `@CliOnly()` or a TTY/stream-capable launcher.
 - CLIs that are intended to be imported into Ravi Apps SHOULD expose a safe
   self-description command such as `manifest --json`, `app-manifest --json`, or
   `ravi manifest --json`.
@@ -111,7 +124,8 @@ CLI App commands SHOULD expose:
 - bounded defaults for reads;
 - clear next-step hints in human output.
 
-For first-party Ravi commands, decorators SHOULD carry the machine contract:
+For a first-party App CLI implemented as a static Ravi command, decorators
+SHOULD carry the CLI machine contract:
 
 - `@Group` for stable domain namespace;
 - `@Command` for operation name and description;
@@ -121,19 +135,47 @@ For first-party Ravi commands, decorators SHOULD carry the machine contract:
 - `@Returns.binary()` only for raw response bodies;
 - `@CliOnly()` for process, interactive, or streaming operations.
 
+Generated SDK/OpenAPI metadata for the underlying static command is a
+compatibility surface of Ravi CLI. It MUST NOT replace App Router authorization
+or be referenced as an independent App executor in `ravi.app.json`.
+
 ## Runtime Context
 
 For app launchers that call a CLI from inside Ravi:
 
-1. The parent SHOULD issue a child context with `ravi context issue`.
-2. The child process SHOULD receive only `RAVI_CONTEXT_KEY`.
-3. The app SHOULD resolve identity with `ravi context whoami`.
-4. The app SHOULD check or request specific capability with `ravi context check`
-   or `ravi context authorize`.
-5. Audit lineage SHOULD preserve `parentContextId`, `issuedFor`, source, and
-   the concrete command/action performed.
+1. The router MUST authorize the caller against `app:<app-id>`.
+2. The router MUST issue a fresh child context with stable
+   `cliName: "app:<app-id>"`, explicit capabilities from `context.allow`, and a
+   bounded TTL.
+3. The router MUST fail before process spawn if any required child capability
+   cannot be issued.
+4. The launcher MUST build an allowlisted child environment, removing the
+   parent `RAVI_CONTEXT_KEY`, legacy Ravi identity variables, and unrelated
+   credentials or secrets before setting the child `RAVI_CONTEXT_KEY`.
+5. The child process MUST receive the child key as its only Ravi identity
+   credential. Normal non-secret process environment such as `PATH` MAY remain.
+   The process MUST run from the bounded app/package root and without a shell.
+6. The app MUST resolve identity with `ravi context whoami`.
+7. The app MUST use `ravi context check` or `ravi context authorize` before a
+   Ravi action whose capability is not already known.
+8. The app performs the action through the ordinary Ravi CLI, for example
+   `ravi artifacts create`, `ravi sessions read`, or another public command.
+9. Audit lineage MUST preserve the child context id, `parentContextId`,
+   `issuedFor`, issuance mode, source app/operation, and result without storing
+   the raw key.
 
 Legacy env vars may exist for compatibility, but they are not the app contract.
+The router MUST NOT synthesize them for App execution.
+
+## Surface Adapters
+
+- The generic App Router MAY be called from CLI, UI, SDK, runtime tool, or
+  automation surfaces.
+- All adapters MUST resolve the same app operation and launch the same app CLI.
+- An adapter MAY request JSON output for its own consumption. That does not
+  change the App-to-Ravi integration model.
+- App manifests MUST NOT require separate SDK, tool, or stream executors for
+  the same operation.
 
 ## Validation
 
@@ -159,6 +201,13 @@ Legacy env vars may exist for compatibility, but they are not the app contract.
 - Missing `@Returns` turns SDK output into `unknown` and weakens app clients.
 - External CLIs that use session env vars instead of `RAVI_CONTEXT_KEY` lose
   least privilege and lineage.
+- Launchers that reuse the parent context key turn the app into a privilege
+  escalation surface.
+- Launchers that use a shell or inherit the full parent environment expose
+  command injection and credential leakage.
+- Separate SDK/tool implementations drift from the CLI and multiply auth paths.
+- Treating JSON output as a transport protocol adds a contract that process
+  execution already provides.
 - CLIs without self-description force `apps/import-cli` into low-confidence
   help parsing.
 - A skill that tells agents to "figure it out" instead of exposing a reliable

--- a/.ravi/specs/apps/cli/WHY.md
+++ b/.ravi/specs/apps/cli/WHY.md
@@ -2,9 +2,9 @@
 
 ## Rationale
 
-The CLI creator skill revealed a broader product pattern: a CLI can be an app
-inside Ravi OS when it has a domain model, stable machine interface, context
-bridge, storage ownership, and an agent teaching layer.
+The CLI creator work revealed the simplest durable App model: the CLI is the
+application. Ravi only needs to discover it, authorize its caller, delegate a
+child context, and launch it.
 
 This matters because agents are bad at operating vague scripts. They are good
 at operating tools with structured input, structured output, clear failure
@@ -12,14 +12,19 @@ modes, and permissions that the runtime can audit.
 
 ## Decisions
 
-- Treat CLI Apps as the first concrete Ravi App type.
+- Treat CLI as the canonical implementation type for every Ravi App.
 - Keep plugin and app concepts separate. A plugin packages assets; an app is
   the operational capability those assets expose.
 - Use `RAVI_CONTEXT_KEY` as the app-runtime bridge, not raw session env vars.
+- Issue a new least-privilege child context per launch instead of forwarding
+  the caller's context.
+- Let the app call ordinary `ravi ...` commands. Do not add a private App SDK
+  or App JSON-RPC transport.
+- Keep `--json` as an output option for machine callers.
 - Keep the skill as a teaching layer, not as a substitute for missing CLI UX.
-- Prefer first-party Ravi CLI Apps to use the decorated command registry so
-  one command surface can serve CLI, SDK, OpenAPI, gateway, and generated
-  clients.
+- Allow a first-party App CLI to use the decorated command registry when it is
+  implemented as a static Ravi command. Generated SDK/OpenAPI metadata remains
+  CLI compatibility metadata; App callers still use the App Router.
 - Persist only domain data that improves reuse, lineage, auditability,
   expensive-cache reuse, or recovery.
 
@@ -29,7 +34,8 @@ modes, and permissions that the runtime can audit.
 
 A runtime tool is good for one narrow action inside a provider session. A CLI
 App is better when the domain has entities, lifecycle, storage, health checks,
-or reuse outside one turn.
+or reuse outside one turn. A runtime tool may invoke the App Router, but it does
+not become a second implementation of the app.
 
 ### CLI App vs Ravi Command
 
@@ -46,6 +52,13 @@ or app metadata, but it is not the app by itself.
 
 - Let every app invent its own auth environment.
   This loses lineage and makes approvals impossible to reason about.
+- Forward the parent Ravi context into the app.
+  This gives the app more authority than its declared job requires.
+- Add a dedicated JSON host protocol.
+  The CLI process contract and public Ravi CLI already cover invocation and
+  integration.
+- Implement the same app again for SDK, tools, and UI.
+  This creates drift and inconsistent permission behavior.
 - Treat every plugin as an app.
   This blurs packaging with product behavior.
 - Make skills compensate for weak CLIs.

--- a/.ravi/specs/apps/import-cli/CHECKS.md
+++ b/.ravi/specs/apps/import-cli/CHECKS.md
@@ -72,3 +72,22 @@ Expected:
 - Generated operation MUST be marked review-required.
 - Permission suggestion SHOULD be present when possible.
 - Operation MUST NOT be silently treated as safe read-only.
+
+### Child Context Guard
+
+- Generated manifest MUST contain `context.allow`.
+- `context.allow` MUST default to empty when exact Ravi capabilities are not
+  explicitly self-described.
+- Importing operations that directly call `ravi <group>` SHOULD infer only
+  `execute:group:<group>`.
+- Suggested capabilities MUST be marked review-required.
+- Import MUST NOT generate implicit inheritance or a wildcard parent context.
+
+### Single Executor Guard
+
+- Imported domain operations MUST use `interface: "cli"`.
+- SDK, tool, stream, UI, and automation metadata MUST NOT become alternate
+  operation executors.
+- An imported `ravi <app-id> ...` implementation MUST fail when it resolves
+  through the dynamic App Router and MAY pass only when `<app-id>` is a
+  registered static command.

--- a/.ravi/specs/apps/import-cli/RUNBOOK.md
+++ b/.ravi/specs/apps/import-cli/RUNBOOK.md
@@ -21,6 +21,7 @@ ravi apps import-cli "<cli>" --id <app-id> --dry-run --json
 - commands missing `--json`;
 - mutating/destructive commands marked for review;
 - suggested permissions;
+- proposed child `context.allow` and why each capability is needed;
 - suggested storage/events/UI placeholders;
 - planned files.
 
@@ -42,6 +43,9 @@ ravi apps show <app-id> --json
 - collapse low-level commands into daily operations;
 - remove debug-only commands from top-level operations;
 - add or correct permissions;
+- keep `context.allow` empty or least-privilege; an inferred
+  `execute:group:<group>` is acceptable only while an imported operation
+  directly calls that public Ravi group; never accept inferred inheritance;
 - add events/storage/UI only where they have operational value;
 - update the generated skill so agents use declared operations only.
 
@@ -54,6 +58,8 @@ Ask:
 - Which operations mutate external state?
 - Which operations need confirmation, `--dry-run`, or stronger permission?
 - Which outputs are machine-readable JSON?
+- Which public `ravi ...` commands must the CLI call, and which exact child
+  capabilities do those commands require?
 - Which operation results should emit events?
 - Which state belongs in app storage versus upstream systems?
 - Which UI views would make the operation materially easier?
@@ -67,5 +73,6 @@ If import is weak, add a self-description command to the source CLI:
 ```
 
 The payload should describe command groups, args, options, JSON support,
-mutation risk, examples, schemas, and safe health checks. Re-run import after
-the CLI publishes that metadata.
+mutation risk, examples, schemas, safe health checks, and exact Ravi capability
+requirements when applicable. Re-run import after the CLI publishes that
+metadata.

--- a/.ravi/specs/apps/import-cli/SPEC.md
+++ b/.ravi/specs/apps/import-cli/SPEC.md
@@ -53,10 +53,13 @@ which permissions apply, and which events/UI/storage matter.
 - CLI import MAY use help parsing only as a low-confidence fallback, and MUST
   label help-derived fields as needing review.
 - Imported manifests MUST use `schema: "ravi.app/v1"`.
-- Imported operations MUST reference `interface: "cli"` unless the source CLI
-  explicitly declares SDK, tool, or stream surfaces.
-- Imported CLI operations MUST NOT point back to the app router dynamic alias
-  such as `ravi <app-id> ...`.
+- Imported domain operations MUST reference `interface: "cli"`.
+- SDK, tool, stream, UI, and automation metadata from the source MAY be
+  preserved as review notes, but MUST NOT become alternate operation executors.
+- Imported CLI operations MUST NOT resolve back through the app router dynamic
+  alias such as `ravi <app-id> ...`. The same text MAY be preserved only when
+  `<app-id>` is a registered static command and static resolution prevents
+  App Router re-entry.
 - Imported CLI operations SHOULD include `--json` when the source command
   supports machine output.
 - Commands without machine-readable output MUST be imported as warnings or
@@ -65,6 +68,12 @@ which permissions apply, and which events/UI/storage matter.
   require explicit review before they are treated as app operations.
 - Generated permission metadata MUST be conservative. The importer MAY suggest
   permission names, but MUST NOT treat suggestions as grants.
+- Generated `context.allow` MUST default to an empty array unless the source
+  explicitly self-describes the exact Ravi capabilities it needs or an
+  operation directly invokes a public `ravi <group>` command. In the latter
+  case the importer SHOULD infer only `execute:group:<group>`.
+- Any imported `context.allow` entry MUST be marked review-required and MUST
+  NOT request implicit inheritance.
 - Generated storage, events, UI, and skill text MUST be considered draft unless
   the source CLI self-describes those surfaces with schemas.
 - Imported command lists SHOULD be collapsed into domain operations. The
@@ -74,6 +83,9 @@ which permissions apply, and which events/UI/storage matter.
   from explicit metadata, what came from registry/decorators, and what came from
   heuristics.
 - Import output SHOULD include confidence, warnings, and review-required fields.
+- Import output MUST explicitly identify itself as a draft generator result and
+  MUST link `ravi-dev-app-creator`, `apps/builder`, and the complete structured
+  builder review checklist.
 - `ravi apps check <app-id> --json` MUST remain the validation gate after any
   import writes files.
 
@@ -99,6 +111,8 @@ The payload SHOULD include:
 - health/check commands that are safe and non-mutating;
 - suggested app operations and debug-only commands;
 - suggested permissions, storage, events, and skill hints when known.
+- exact Ravi capabilities the CLI needs to call through public `ravi ...`
+  commands, when known.
 
 The self-description command MUST be safe, deterministic, and side-effect free.
 It MUST NOT require domain credentials beyond what is needed to describe the
@@ -138,6 +152,8 @@ Generated manifest drafts SHOULD include:
 - operation candidates for daily app operations;
 - debug-only candidate commands as review notes, not necessarily operations;
 - conservative permission suggestions;
+- conservative child `context.allow` suggestions, empty by default except for
+  mechanically evident public `ravi <group>` dependencies;
 - placeholder storage/events/UI sections only when useful and clearly marked
   for review.
 
@@ -169,6 +185,11 @@ Dry-run output SHOULD include:
   "confidence": "high",
   "plannedFiles": [],
   "manifest": {},
+  "builder": {
+    "skill": "ravi-dev-app-creator",
+    "spec": "apps/builder",
+    "reviewChecklist": []
+  },
   "warnings": [],
   "reviewRequired": []
 }
@@ -181,8 +202,8 @@ Dry-run output SHOULD include:
 - CLI import is not permission grant. Suggested permissions remain
   requirements until configured permission providers grant them.
 - CLI import is not SDK codegen. Static SDK methods still come from the Ravi
-  decorated command registry; dynamic app operations are routed through
-  `apps.run` unless a separate static SDK surface is added.
+  decorated command registry; generic SDK/tool/UI clients route dynamic app
+  operations through the App Router.
 - CLI import is not UI implementation. It may draft semantic UI descriptors,
   but Web OS owns rendering.
 - CLI import does not replace domain modeling. It accelerates the first draft.
@@ -207,6 +228,8 @@ Dry-run output SHOULD include:
 - Parsing human help and pretending the result is a schema.
 - Generating operations without `--json` and forcing agents to scrape prose.
 - Inferring permissions as grants.
+- Inferring broad child-context capabilities or using `--inherit`.
+- Importing SDK/tool/stream surfaces as separate app implementations.
 - Running domain commands during import and causing side effects.
 - Creating recursive operations that dispatch back through the same dynamic app
   alias.

--- a/.ravi/specs/apps/import-cli/WHY.md
+++ b/.ravi/specs/apps/import-cli/WHY.md
@@ -23,6 +23,11 @@ explicit review for product, risk, storage, events, and UI decisions.
 - Generate conservative operation candidates and review notes.
 - Keep `ravi.app.json` as the app contract even when it is generated.
 - Keep dynamic apps out of static SDK method generation by default.
+- Import every executable operation through the source CLI; other caller
+  surfaces use the generic App Router.
+- Default child `context.allow` to empty because CLI metadata is not authority;
+  infer only an exact `execute:group:<group>` when the generated operation
+  directly calls `ravi <group>`, and keep that inference review-required.
 - Allow `scaffold --from-cli` as an alias, but make `apps/import-cli` the
   normative behavior.
 
@@ -38,3 +43,5 @@ explicit review for product, risk, storage, events, and UI decisions.
   This recreates the raw CLI instead of making an app.
 - Generate static Ravi command files for imported apps.
   That makes runtime app installation build-time again.
+- Generate SDK/tool/stream executors from source metadata.
+  That turns one imported CLI into multiple drifting implementations.

--- a/.ravi/specs/apps/lifecycle/CHECKS.md
+++ b/.ravi/specs/apps/lifecycle/CHECKS.md
@@ -10,7 +10,8 @@
 - Delete execution check
   - `ravi apps delete demo-app --json`
   - Must remove only scaffold-owned files.
-  - Must not remove implementation files, runtime storage, or credentials.
+  - Must not remove `cli.ts`, other implementation files, runtime storage, or
+    credentials.
   - Must report deleted file paths, kinds, and actions.
 
 - Delete absent app check
@@ -20,7 +21,8 @@
 - Scaffold collision check
   - `ravi apps scaffold demo-app --json` when files exist
   - Without `--force`: must return typed `already_exists` error with status 409.
-  - With `--force`: must overwrite and succeed.
+  - With `--force`: must overwrite scaffold-owned contracts, preserve an
+    existing `cli.ts`, report it as `preserved`, and succeed.
 
 - Show absent app check
   - `ravi apps show nonexistent --json`

--- a/.ravi/specs/apps/lifecycle/RUNBOOK.md
+++ b/.ravi/specs/apps/lifecycle/RUNBOOK.md
@@ -27,7 +27,7 @@ ravi apps check --json
 
 ```bash
 ravi apps show <id> --json        # inspect the existing app
-ravi apps scaffold <id> --force   # overwrite if intended
+ravi apps scaffold <id> --force   # refresh contracts; preserve existing cli.ts
 ```
 
 ## Handle Absent App

--- a/.ravi/specs/apps/lifecycle/SPEC.md
+++ b/.ravi/specs/apps/lifecycle/SPEC.md
@@ -50,6 +50,8 @@ gateway, and OpenAPI surfaces.
     scaffold-owned paths.
 - Delete MUST NOT remove runtime storage, artifacts, events, credentials,
   migrations, implementation files, or anything not clearly scaffold-owned.
+- The default generated `src/apps/<id>/cli.ts` becomes implementation-owned as
+  soon as scaffold returns and MUST be preserved by delete.
 - Delete MUST NOT execute app code, health checks, storage migrations, runtime
   commands, or credential access.
 - Delete MUST support `--dry-run` to report planned actions without writing.
@@ -60,6 +62,11 @@ gateway, and OpenAPI surfaces.
 
 - `ravi apps scaffold <app-id>` without `--force` MUST return a typed
   `already_exists` error when scaffold target files already exist.
+- The generated `cli.ts` participates in scaffold collision detection even
+  though delete preserves it as implementation-owned content.
+- With `--force`, scaffold MUST preserve an existing generated `cli.ts` and
+  report its action as `preserved`; it MAY overwrite the manifest, spec, and
+  generated skill contracts.
 - The `already_exists` error MUST include bounded evidence (paths that exist)
   and suggested next steps.
 

--- a/.ravi/specs/apps/lifecycle/WHY.md
+++ b/.ravi/specs/apps/lifecycle/WHY.md
@@ -15,8 +15,12 @@ that gateway consumers cannot reliably distinguish from transport failures.
 
 ## Decisions
 
-- Delete only touches files the scaffold itself would create. Implementation
-  files, runtime storage, and credentials are preserved.
+- Delete only touches generated contract artifacts explicitly listed by the
+  lifecycle contract. Implementation files, runtime storage, and credentials
+  are preserved.
+- The thin generated `cli.ts` is a starting implementation intended for
+  immediate editing, so delete preserves it rather than guessing whether its
+  contents are still boilerplate.
 - Delete supports dry-run so agents and operators can preview side effects.
 - Typed errors use a shared class with `code`, `message`, `status`, and
   `evidence` so all surfaces (CLI, JSON, gateway) can render them consistently.

--- a/.ravi/specs/apps/manifest/CHECKS.md
+++ b/.ravi/specs/apps/manifest/CHECKS.md
@@ -16,10 +16,15 @@
   - Fail on duplicate ids and report both paths.
 
 - Interface check
-  - Fail if no interface is declared.
+  - Fail if `interfaces.cli` is missing.
+  - Fail if `interfaces.cli.command` is missing or resolves through the
+    dynamic `ravi <app-id>` route.
+  - Accept `ravi <app-id>` only when `<app-id>` is a registered static command
+    and static resolution cannot re-enter the App Router.
   - Warn if a CLI interface is machine consumed but does not declare JSON
     support.
-  - Warn if an SDK interface has no namespace.
+  - Warn when new manifests declare SDK/tool/stream compatibility metadata
+    without a migration reason.
   - Fail if `interfaces.ui` has malformed routes, views, queries, actions, or
     forbidden raw UI code/style keys.
   - Fail if UI routes omit design-system icons.
@@ -28,21 +33,37 @@
 - Operation check
   - Fail if `operations` exists and is not an object.
   - Fail if operation ids are not fully qualified dot ids.
-  - Fail if operation `interface` is not `cli`, `sdk`, `tool`, or `stream`.
-  - Fail if an operation references an undeclared interface block.
-  - Fail if CLI operations omit `command`, SDK operations omit
-    `namespace`/`method`, tool operations omit `name`, or stream operations omit
-    `channel`.
+  - Fail if operation `interface` is not `builtin` or `cli`.
+  - Fail if builtin operations omit an allowlisted `handler`.
+  - Fail if CLI operations omit `command` or target a different undeclared CLI.
+  - Fail if a CLI operation resolves back through its own dynamic app alias.
+    Accept identical text only when it resolves to a registered static command.
+  - Fail if a command contains shell operators, substitutions, redirection, or
+    otherwise requires shell evaluation.
+  - Fail if `{args}` is repeated or embedded inside another token.
+  - Confirm shell-like user input is passed as literal argv with `shell: false`.
   - Fail if UI query/action operation references are undeclared.
   - Warn if operations omit `mutating`.
-  - Warn if mutating operations omit `permission` or `permissions`.
+  - Fail if mutating, sensitive, or identity-dependent operations omit
+    `permission` or `permissions`.
 
 - Permission check
-  - Fail if mutating/sensitive interfaces have no declared required or mutating
-    permission.
+  - Fail if `required`, `optional`, or `mutating` is missing or is not an array.
+  - Fail if an operation-level permission is absent from the appropriate
+    manifest permission array.
   - Fail if any permission declaration appears to contain a token, key, or raw
     credential.
   - Confirm manifest permissions are treated as requirements, not grants.
+
+- Child-context check
+  - Warn and default to an empty capability set when an installed v1 manifest
+    omits `context`; fail if `context.allow` is present but not an array.
+  - Require new and regenerated manifests to declare `context.allow`.
+  - Fail if an entry is not an explicit
+    `permission:objectType:objectId` capability.
+  - Fail if context metadata requests implicit inheritance.
+  - Fail if context metadata contains a raw key, token, credential, or secret.
+  - Confirm `context.allow` is treated as a requested ceiling, not a grant.
 
 - Storage check
   - Fail if `storage` exists and is not an object.
@@ -74,6 +95,8 @@
   - For CLI-backed health checks, prefer commands ending in `--json`.
 
 - App/CLI consistency check
-  - CLI-backed manifests should satisfy `apps/cli`.
-  - First-party SDK-facing CLI apps should keep registry, gateway, and SDK
-    codegen checks passing.
+  - Every manifest should satisfy `apps/cli`.
+  - UI, SDK, tool, and automation adapters should resolve the same App Router
+    operation.
+  - Running with and without `--json` should use the same authorization and
+    child-context path.

--- a/.ravi/specs/apps/manifest/RUNBOOK.md
+++ b/.ravi/specs/apps/manifest/RUNBOOK.md
@@ -9,13 +9,13 @@ Use this flow when adding or diagnosing a Ravi App manifest.
 1. Confirm the app solves a real operational problem, not just a command idea.
 2. Choose a stable app id and check for collisions.
 3. Declare `schema`, `id`, `name`, `version`, and `description`.
-4. Declare at least one interface: CLI, SDK, stream, tool, or UI.
-5. Declare top-level operations for UI snapshots, UI actions, SDK calls, agent
-   automations, or stream control when they exist.
-6. Declare required, optional, and mutating permissions.
-7. Declare storage, artifacts, events, and skills when they exist.
-8. Add safe health checks. For CLI-backed checks, prefer `--json`.
-9. Validate the manifest without executing app code.
+4. Declare the real app CLI under `interfaces.cli.command`.
+5. Declare top-level operations as `cli` or router-owned `builtin`.
+6. Declare required, optional, and mutating caller permissions.
+7. Declare the child-context ceiling under `context.allow`.
+8. Declare optional UI, storage, artifacts, events, and skills when useful.
+9. Add safe health checks. For machine checks, prefer `--json`.
+10. Validate the manifest without executing app code.
 
 ## Discovery Debugging
 
@@ -32,10 +32,12 @@ Use this flow when adding or diagnosing a Ravi App manifest.
 1. Read `permissions.required` and `permissions.mutating`.
 2. Confirm the caller has those capabilities through Ravi permission/context
    checks.
-3. For CLI-backed apps, confirm the launcher passes `RAVI_CONTEXT_KEY`.
-4. Confirm the app resolves identity through the context CLI, not ambient
+3. Confirm `context.allow` contains only the Ravi capabilities the CLI needs.
+4. Confirm the launcher issues and passes a fresh child `RAVI_CONTEXT_KEY`.
+5. Confirm the parent key and legacy Ravi identity env vars are absent.
+6. Confirm the app resolves identity through the context CLI, not ambient
    session env vars.
-5. Confirm the execution path still authorizes at runtime even if the manifest
+7. Confirm the execution path still authorizes at runtime even if the manifest
    preflight passed.
 
 ## Health Debugging

--- a/.ravi/specs/apps/manifest/SPEC.md
+++ b/.ravi/specs/apps/manifest/SPEC.md
@@ -39,13 +39,13 @@ normative: true
 Define the machine-readable contract that lets Ravi discover, reason about, and
 operate apps as first-class ecosystem units.
 
-The manifest is the bridge between an app implementation and Ravi OS. It
-declares the app id, interfaces, operations, permissions, storage, events,
-artifacts, skills, health checks, and versioning rules. It does not grant
-permissions and does not execute code by itself.
+The manifest binds one CLI implementation to Ravi OS. It declares the app id,
+CLI, operations, caller permissions, child-context ceiling, optional semantic
+UI, storage, events, artifacts, skills, health checks, and versioning rules. It
+does not grant permissions and does not execute code by itself.
 
 Canonical manifest file name: `ravi.app.json`.
-Canonical manifest protocol: `ravi.app/v1`.
+Canonical manifest schema: `ravi.app/v1`.
 
 ## Invariants
 
@@ -54,11 +54,30 @@ Canonical manifest protocol: `ravi.app/v1`.
 - A manifest MUST include a stable `id` that matches `^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)*$`.
 - A manifest MUST include `schema: "ravi.app/v1"`.
 - A manifest MUST include `name`, `version`, and `description`.
-- A manifest MUST declare at least one interface under `interfaces`: `cli`,
-  `sdk`, `stream`, `tool`, or `ui`.
-- A manifest MUST declare `permissions.required` for mutating, sensitive, or
-  identity-dependent operations. These declarations are requirements, not
-  grants.
+- A manifest MUST declare one canonical CLI implementation under
+  `interfaces.cli`.
+- `interfaces.cli.command` MUST identify the real app CLI entrypoint and MUST
+  NOT resolve through the public dynamic alias `ravi <app-id>`.
+- `interfaces.cli.command` MAY be a registered static Ravi command even when
+  its text is `ravi <app-id>`, but only when static command precedence
+  guarantees that invocation cannot re-enter the dynamic App Router.
+- A manifest MAY declare `interfaces.ui` as a semantic presentation descriptor.
+- `interfaces.sdk`, `interfaces.tool`, and `interfaces.stream` MAY describe
+  discovery metadata, but MUST NOT define operation executors. New manifests
+  SHOULD omit them unless another surface consumes that metadata.
+- A manifest MUST declare `context.allow` as an array of explicit Ravi
+  capabilities requested for the launched child context. An empty array is
+  valid for an app that does not call Ravi services.
+- A missing `context` block MUST fail validation. The runtime MUST NOT infer or
+  inherit capabilities.
+- `context.allow` MUST NOT contain `inherit`, wildcard-by-default behavior,
+  context keys, tokens, or credentials.
+- A manifest MUST declare `permissions.required`, `permissions.optional`, and
+  `permissions.mutating` arrays. Empty arrays are valid.
+- Mutating, sensitive, or identity-dependent operations MUST declare
+  operation-level `permission` or `permissions`, and each declared capability
+  MUST appear in the appropriate manifest permission array. These
+  declarations are requirements, not grants.
 - A manifest MAY declare `permissions.provider` for app-owned domain
   authorization. Provider declarations MUST satisfy `apps/permission-providers`
   and remain decision hooks, not grants.
@@ -74,8 +93,9 @@ Canonical manifest protocol: `ravi.app/v1`.
 - A manifest SHOULD name the skills that teach agents to operate the app.
 - A manifest SHOULD expose health checks for operational readiness. Health
   checks MUST be safe, non-destructive, and support `--json` when CLI-backed.
-- A manifest MAY declare top-level `operations` for UI, SDK, agent, or
-  automation use. UI queries and actions MUST reference declared operations.
+- A manifest SHOULD declare top-level `operations` for humans, agents, UI, SDK,
+  runtime tools, or automations. Every client surface resolves the same
+  operation through the App Router.
 - A manifest MAY declare operations with `interface: "builtin"` for
   router-owned allowlisted operations such as app help, manifest show, or
   manifest check.
@@ -94,6 +114,8 @@ Canonical manifest protocol: `ravi.app/v1`.
   of the current Ravi process. It MUST NOT resolve an older or different Ravi
   installation from `PATH`, because that creates version skew between app
   discovery and operation execution.
+- CLI command declarations MUST be tokenizable into executable plus argv and
+  MUST NOT require shell evaluation.
 
 ## Manifest Shape
 
@@ -108,18 +130,9 @@ The initial manifest contract is:
   "description": "Manage playback and playlists.",
   "interfaces": {
     "cli": {
-      "command": "ravi music",
+      "command": "musicctl",
       "json": true,
       "health": "musicctl check --json"
-    },
-    "sdk": {
-      "namespace": "music"
-    },
-    "stream": {
-      "channels": []
-    },
-    "tool": {
-      "names": []
     },
     "ui": {
       "routes": [
@@ -184,6 +197,12 @@ The initial manifest contract is:
       "permission": "music:write",
       "outputSchema": "schemas/music-library-sync.v1.json"
     }
+  },
+  "context": {
+    "allow": [
+      "execute:group:artifacts",
+      "execute:group:events"
+    ]
   },
   "permissions": {
     "required": ["music:read"],
@@ -262,19 +281,25 @@ merely because a manifest was generated.
 
 ## Interface Rules
 
-- `interfaces.cli.command` SHOULD reference the canonical user/operator
-  command. CLI-backed apps SHOULD satisfy `apps/cli`.
+- `interfaces.cli.command` MUST reference the real implementation CLI, such as
+  `musicctl` or a registered non-recursive static Ravi command.
+- The public operator command is derived from the app id:
+  `ravi <app-id> <operation>`. It MUST NOT be used as the implementation
+  command when it would resolve through the dynamic App Router.
+- A registered static command MAY be textually identical to the app route,
+  such as `ravi apps` for the `apps` manifest, only when static resolution
+  wins and the command cannot dispatch back into the same dynamic route.
 - `interfaces.cli.json` SHOULD be true for machine-consumed CLIs.
-- `interfaces.cli.health` MAY point at the router-owned safe check
-  `ravi <app-id> check --json`. It MUST NOT point at a mutating app operation
-  or arbitrary recursive app alias.
-- `interfaces.sdk.namespace` SHOULD match the generated SDK namespace when the
-  app is exposed through the SDK gateway.
-- `interfaces.stream.channels` SHOULD list stream/control channels for
-  long-running or interactive operations that do not belong in the single-shot
-  SDK dispatcher.
-- `interfaces.tool.names` SHOULD list explicit runtime tools when the app is
-  exposed as a tool surface.
+- `interfaces.cli.health` MAY point at a safe non-mutating health command under
+  the real CLI implementation, such as `musicctl health --json`. It MUST NOT
+  point at the public dynamic alias or at the router-owned
+  `ravi <app-id> check`.
+- SDK, tool, automation, and Web OS callers SHOULD use the generic App Router
+  API. They do not require a separate manifest executor.
+- Long-running and interactive behavior remains part of the app CLI and SHOULD
+  declare CLI launch/display hints rather than a separate stream executor.
+- Compatibility `interfaces.sdk`, `interfaces.tool`, or `interfaces.stream`
+  metadata MUST NOT be referenced by `operations.*.interface`.
 - `interfaces.ui` SHOULD satisfy `apps/ui` when the app has a visual surface.
   It SHOULD declare semantic routes and views that Ravi Web OS can render with
   the unified design system.
@@ -283,25 +308,32 @@ merely because a manifest was generated.
 
 ## Operation Rules
 
-- `operations` MAY declare named app operations used by UI, SDK, agents, or
-  automations.
+- `operations` MAY declare named app operations used by any caller surface.
 - Operation ids SHOULD be fully qualified dot ids such as `apps.list` or
   `music.library.sync`.
-- Each operation MUST declare `interface` as `builtin`, `cli`, `sdk`, `tool`,
-  or `stream`.
+- Each operation MUST declare `interface` as `builtin` or `cli`.
 - Builtin operations MUST declare an allowlisted router `handler`.
 - CLI operations MUST declare `command` and SHOULD support `--json`.
+- `{args}` MAY appear once in a CLI operation command, only as a complete argv
+  token. It expands to separate user-supplied argv elements and MUST NOT be
+  embedded in another token.
+- Named placeholders such as `{id}` MUST fail validation. `{args}` is the only
+  dynamic command token.
+- CLI operation commands MUST NOT contain shell operators, command
+  substitutions, redirections, or other constructs that require a shell.
+- CLI operation commands MUST resolve to `interfaces.cli.command` or to an
+  explicitly declared non-recursive static Ravi implementation command.
 - CLI operations generated from imported command metadata SHOULD be reviewed
   before agents or UIs rely on them, especially when mutation risk, permission
   metadata, input schema, or output schema came from heuristics.
 - CLI operations MUST NOT command back into their own public dynamic alias,
-  such as `ravi <app-id> <operation>`, because that recursively re-enters the
-  app router.
-- SDK operations MUST declare `namespace` and `method`.
-- Tool operations MUST declare `name`.
-- Stream operations MUST declare `channel`.
+  such as `ravi <app-id> <operation>`, when that prefix is dynamically routed,
+  because that recursively re-enters the app router.
+- CLI operations MAY use `ravi <app-id> ...` when `<app-id>` is a registered
+  static Ravi command and static resolution guarantees no App Router
+  re-entry.
 - Operations SHOULD declare `mutating` as a boolean.
-- Mutating operations SHOULD declare `permission` or `permissions`.
+- Mutating operations MUST declare `permission` or `permissions`.
 - Operations SHOULD declare input and output schema references when the
   operation is consumed by UI or automation.
 - Operations MAY declare `authorization.resource` to describe the app-domain
@@ -316,16 +348,42 @@ merely because a manifest was generated.
 
 ## Permission Rules
 
-- `permissions.required` are capabilities the caller must have before using
-  the app.
+- `permissions.required` are authorization requirements the caller must satisfy
+  before using the app.
 - `permissions.optional` are capabilities that unlock extra app behavior.
 - `permissions.mutating` are capabilities required for write, delete, send,
   publish, or externally visible operations.
 - The runtime MAY use manifest permissions to preflight, explain, or route an
   operation. It MUST still perform the actual authorization check at execution
   time.
-- CLI-backed apps running inside Ravi SHOULD receive `RAVI_CONTEXT_KEY` through
-  the launcher and resolve identity through the context CLI.
+- `permissions` and `context.allow` are different boundaries:
+  - `permissions` gates the caller and app-domain action;
+  - `context.allow` bounds what the launched CLI may ask Ravi to do.
+- Neither declaration is a grant.
+- The App Router MUST issue a fresh child context from `context.allow`, bounded
+  by parent authority and runtime policy, before launching the CLI.
+- The launcher MUST pass only the child `RAVI_CONTEXT_KEY` as Ravi identity.
+  It MUST NOT forward the parent key or synthesize session/agent identity env
+  vars.
+- Apps MUST use `ravi context ...` and public `ravi ...` commands to consume the
+  delegated capability.
+
+## CLI Process Rules
+
+- App input is argv plus any stdin explicitly documented by the app CLI.
+- App output is stdout, stderr, and exit status.
+- `--json` is a machine-readable output mode. It is not an App host protocol.
+- The manifest MUST NOT declare a private App callback URL, JSON-RPC endpoint,
+  or raw runtime socket as a requirement for ordinary operation.
+- If a CLI command begins with `ravi`, the router MUST execute the current Ravi
+  entrypoint rather than resolving another installation from `PATH`.
+- The router MUST execute the command without a shell. User input remains argv
+  data even when it contains quoting, substitutions, operators, or redirection
+  characters.
+- The process working directory MUST default to the app root. Any override
+  MUST normalize to a bounded allowed app/package root.
+- The launcher MUST build an allowlisted environment and MUST NOT inherit
+  unrelated parent credentials or secret environment variables.
 
 ## Storage Rules
 
@@ -373,7 +431,7 @@ merely because a manifest was generated.
 ## Validation Rules
 
 - Manifest validation MUST fail on invalid id, missing required fields, unknown
-  protocol, duplicate app id, malformed interface declarations, or executable
+  schema, duplicate app id, malformed interface declarations, or executable
   discovery behavior.
 - Manifest validation MUST fail when UI routes, views, queries, or actions
   reference undeclared operations or undeclared views.
@@ -381,18 +439,33 @@ merely because a manifest was generated.
   component, HTML, JavaScript, class, Tailwind, or bundle keys.
 - Manifest validation MUST fail when operations have malformed ids, undeclared
   interface targets, invalid target metadata, or invalid `mutating` shape.
+- Manifest validation MUST fail when CLI commands require shell evaluation,
+  contain an embedded placeholder, contain more than one dynamic placeholder,
+  or cannot be parsed into an executable plus argv.
+- Manifest validation MUST fail when an operation interface is not `builtin` or
+  `cli`.
+- Manifest validation MUST fail when `interfaces.cli` is missing or its command
+  resolves to the same dynamic app alias. It MUST accept a textually identical
+  registered static command only when static resolution prevents router
+  re-entry.
+- Manifest validation MUST fail when `context.allow` is present but malformed,
+  contains secrets/raw keys, or requests implicit inheritance. A missing block
+  in an already-installed v1 manifest MUST warn and resolve to an empty
+  capability set; authoring and generation checks MUST still require it.
 - Manifest validation MUST fail when router-executed CLI operations recursively
-  point at `ravi <app-id> ...` for the same app id.
-- Manifest validation MUST allow router-owned safe health commands such as
-  `ravi <app-id> check --json`, and MUST fail health commands that recurse into
-  mutating or non-health app operations.
+  resolve through `ravi <app-id> ...` for the same app id. It MUST accept that
+  text only for registered static commands that cannot enter the dynamic
+  route.
+- Manifest validation MUST fail when `interfaces.cli.health` resolves through
+  the public dynamic alias, targets `ravi <app-id> check`, or invokes a
+  mutating/non-health operation.
 - Manifest validation MUST fail when builtin operations use handlers outside
   the router allowlist.
 - Manifest validation SHOULD warn on missing health checks, missing skill for
   agent-operated apps, missing storage ownership for stateful apps, missing
   event declarations for eventful apps, and human-only CLI interfaces.
-- A first-party app with CLI and SDK surfaces SHOULD keep decorator registry,
-  SDK codegen, and gateway tests passing.
+- Generic SDK/UI/tool adapters SHOULD be tested against the same App Router
+  operation rather than against app-specific executors.
 
 ## Validation
 
@@ -401,7 +474,7 @@ merely because a manifest was generated.
 - App manifest indexes SHOULD be testable without executing any declared
   binary.
 - Duplicate manifest ids SHOULD be covered by a regression test.
-- CLI-backed manifests SHOULD be checked against `apps/cli`.
+- All manifests SHOULD be checked against `apps/cli`.
 - UI-backed manifests SHOULD be checked against `apps/ui`.
 
 ## Known Failure Modes
@@ -418,7 +491,12 @@ merely because a manifest was generated.
   Web OS design system.
 - Defining an app in prose only, with no manifest that UIs, agents, and SDKs can
   inspect.
+- Declaring SDK, tool, or stream as independent operation executors.
+- Forwarding a parent context key because the manifest omitted a child ceiling.
+- Treating `--json` as a private App-to-Ravi protocol.
 - Declaring router-owned operations as CLI commands that call the same dynamic
   alias and recurse forever.
 - Declaring health checks as the same dynamic app check command and causing
   check recursion.
+- Treating declarative CLI commands as shell programs and exposing app args to
+  command injection.

--- a/.ravi/specs/apps/manifest/WHY.md
+++ b/.ravi/specs/apps/manifest/WHY.md
@@ -10,7 +10,7 @@ The app manifest gives Ravi a stable indexable contract:
 - agents can understand what an app does and which skill teaches it;
 - UIs can list available apps without scraping plugin folders;
 - launchers can preflight permissions before spawning a CLI;
-- SDK/gateway surfaces can map an app to namespaces and commands;
+- SDK/gateway, tools, and automations can invoke the generic App Router;
 - operators can run health checks and diagnose missing capabilities;
 - future app stores or plugin registries can describe capability without
   granting access.
@@ -19,14 +19,18 @@ The app manifest gives Ravi a stable indexable contract:
 
 - The initial canonical file is `ravi.app.json`, separate from plugin manifests.
   A plugin packages apps; it is not itself the app.
-- The manifest protocol is `ravi.app/v1` so future schema changes can be
+- The manifest schema is `ravi.app/v1` so future schema changes can be
   explicit.
 - The manifest is declarative only. Discovery is metadata parsing, never code
   execution.
 - Permissions are declared as requirements, not grants. Runtime authorization
   remains the source of truth.
-- Interfaces are plural because an app may expose CLI, SDK, stream, tool, and
-  UI surfaces at the same time.
+- The CLI is the one executable App interface. Optional UI and compatibility
+  adapter metadata describe presentation/discovery, not alternate execution.
+- Caller permission requirements and child `context.allow` are separate
+  declarations because authorizing use of an app is different from delegating
+  Ravi capabilities into its process.
+- `--json` is command output, not a separate protocol.
 - Health checks belong in the manifest, but execution belongs to an explicit
   doctor/check command.
 - Router-owned app operations can use `interface: "builtin"` so new apps can
@@ -38,14 +42,22 @@ The app manifest gives Ravi a stable indexable contract:
   while apps are operational capability units.
 - Inferring apps from skills: rejected because skills teach agents but do not
   define machine contracts, storage, health, or permissions.
-- Inferring apps from CLI commands: rejected because not every app is CLI-first,
-  and command metadata alone cannot describe storage, events, artifacts, or UI.
+- Inferring the entire app from CLI commands: rejected because CLI metadata
+  alone cannot describe storage, events, artifacts, permissions, context
+  delegation, or UI.
+- Supporting independent CLI, SDK, tool, and stream executors: rejected because
+  it creates multiple implementations and inconsistent authorization.
+- Adding an App JSON-RPC protocol: rejected because the process contract and
+  public Ravi CLI already provide the necessary integration.
 - Letting discovery execute code to ask an app what it is: rejected because it
   creates side effects, security risk, and poor offline indexing.
 - Modeling router-owned operations as CLI-backed manifest commands like
   `ravi <app-id> check`: rejected because runtime app routing would recursively
   call itself.
+- Using a registered static Ravi command as the implementation: accepted even
+  when it is textually `ravi <app-id>`, because static command precedence keeps
+  execution out of the dynamic router. `ravi apps` is the canonical example.
 - Modeling executable health checks as arbitrary `ravi <app-id> ...` commands:
   rejected because non-health app operations can recursively call the same
-  router. The safe router check `ravi <app-id> check --json` is allowed for
-  `interfaces.cli.health`.
+  router. Router `check` validates health metadata without executing it;
+  executable health belongs under the real implementation CLI.

--- a/.ravi/specs/apps/permission-providers/CHECKS.md
+++ b/.ravi/specs/apps/permission-providers/CHECKS.md
@@ -17,6 +17,7 @@ ravi specs sync --json
 - A manifest with `permissions.provider` and missing `version` fails
   validation.
 - A manifest with unknown provider `interface` fails validation.
+- Provider interface other than `builtin` or `cli` fails validation.
 - A manifest with provider timeout above the runtime maximum fails validation
   or warns with a bounded clamp.
 - A manifest with provider operation pointing to a mutating/protected operation
@@ -62,6 +63,8 @@ ravi specs sync --json
 - Request does not include credentials or bearer tokens.
 - Provider subprocess env does not include raw context keys or credential-like
   variables.
+- An allowed domain operation receives a new bounded child key only after the
+  provider decision completes.
 - Request does not depend on display names, phone numbers, chat titles, session
   labels, or prompt annotations for authority.
 - Resource owner is canonical when ownership matters.
@@ -101,6 +104,15 @@ ravi specs sync --json
   denial.
 - Grant suggestion audit includes proposed subject/relation/object/TTL/reason
   without applying it.
+
+## Protocol Boundary Checks
+
+- Provider CLI reads one request from stdin and writes one decision to stdout.
+- Provider request/decision JSON is used only by the Permission Provider
+  Runtime.
+- Ordinary app operations are not required to implement the provider JSON ABI.
+- Ordinary app operations talk to Ravi through public CLI commands under their
+  child context.
 
 ## Migration Checks
 

--- a/.ravi/specs/apps/permission-providers/RUNBOOK.md
+++ b/.ravi/specs/apps/permission-providers/RUNBOOK.md
@@ -32,7 +32,11 @@
 
 5. Implement a provider operation that accepts
    `ravi.app.permission.request/v1` and returns
-   `ravi.app.permission.decision/v1`.
+   `ravi.app.permission.decision/v1`. For CLI providers, read one JSON request
+   from stdin and write one JSON decision to stdout.
+
+   The provider must not receive `RAVI_CONTEXT_KEY` and must not call the
+   protected app operation. This JSON ABI belongs only to authorization.
 
 6. Add tests before routing production operations through the provider:
 
@@ -46,6 +50,9 @@
 
 7. Add explain UX. A denied operation should tell the operator whether a
    required provider-runtime boundary denied or the app-domain provider denied.
+
+8. Verify an allowed operation returns to the App Router, which issues a fresh
+   child context and launches the domain CLI.
 
 ## Diagnose A Denial
 

--- a/.ravi/specs/apps/permission-providers/SPEC.md
+++ b/.ravi/specs/apps/permission-providers/SPEC.md
@@ -45,6 +45,10 @@ An app permission provider answers this question:
 It is an app-domain provider in the same provider runtime used by the rest of
 Ravi. It does not bypass other required providers.
 
+The provider request/decision JSON is a narrow internal authorization ABI. It
+is not the execution protocol for Ravi Apps. Ordinary app operations are CLIs
+launched with child context and call Ravi through public `ravi ...` commands.
+
 ## Invariants
 
 - Ravi core MUST NOT embed any grant graph as the outer guardrail. Ravi core owns only
@@ -84,6 +88,9 @@ Ravi. It does not bypass other required providers.
 - Provider decision payloads MUST NOT include secrets, raw context keys,
   credentials, bearer tokens, or arbitrary private app state.
 - Provider checks MUST be bounded by timeout and output-size limits.
+- A CLI permission provider MUST receive its request on stdin and return one
+  decision object on stdout. It MUST NOT receive `RAVI_CONTEXT_KEY` or call Ravi
+  as the protected app.
 - Provider decisions MAY be cached only when the provider declares a safe cache
   TTL and the cache key includes actor, surface, session authority mode, app id,
   operation id, resource id, action, provider version, and relevant policy
@@ -140,6 +147,9 @@ The normative pipeline is:
    - provider allow + required boundary providers allow => allow;
    - provider not_applicable on a provider-required operation => deny.
 7. Emit audit/explain metadata.
+8. After all required providers allow, return control to the App Router. The
+   router then issues the operation's child context and launches the app CLI.
+   The provider subprocess itself never receives that child key.
 
 ## Manifest Contract
 
@@ -173,9 +183,8 @@ Rules:
 - `permissions.provider.id` MUST be stable within the app.
 - `permissions.provider.version` MUST change when provider semantics change.
 - `interface` MUST be a bounded request/response app operation interface.
-  Current implementation supports `builtin` and `cli`. `sdk` and `tool` are
-  reserved until the runtime has bounded request/response executors for them.
-  Stream interfaces MUST NOT be used for permission provider decisions.
+  It MUST be `builtin` or `cli`. SDK, tool, stream, and UI interfaces MUST NOT
+  be used for permission provider decisions.
 - Provider operations MUST be safe to call for authorization. They MUST NOT
   perform the protected mutation as a side effect.
 - Provider operations MUST return JSON matching the declared decision schema.
@@ -248,7 +257,8 @@ Rules:
   authorization decision. Full user payloads SHOULD NOT be sent by default.
 - Provider subprocesses MUST NOT inherit raw context-key or credential
   environment variables. Normal app operations may receive runtime context env;
-  provider hooks are a stricter policy boundary.
+  provider hooks are a stricter policy boundary. A normal app operation
+  receives a newly issued child key, never the parent key.
 - The operation referenced by `permissions.provider.operation` is reserved for
   the runtime authorization path and MUST NOT be directly runnable as an ordinary
   app operation unless a future diagnostic spec defines that behavior.
@@ -343,6 +353,9 @@ Rules:
 - Providers MUST NOT depend on natural-language prompt annotations for identity.
 - Providers MUST NOT scrape chat history to infer authority when structured
   actor/resource metadata is available.
+- The provider JSON envelope is not reusable as a general App host protocol.
+- Provider CLIs are authorization hooks, not an alternate implementation of
+  the app's domain CLI.
 
 ## Validation
 
@@ -359,6 +372,8 @@ Rules:
 - App router tests SHOULD prove `needs_grant` returns a denial with grant
   suggestion and does not mutate provider-owned policy state.
 - Provider audit tests SHOULD prove context keys and secrets are not serialized.
+- Router tests SHOULD prove the provider subprocess receives no context key,
+  while the allowed domain operation receives a fresh bounded child key.
 
 ## Known Failure Modes
 

--- a/.ravi/specs/apps/permission-providers/WHY.md
+++ b/.ravi/specs/apps/permission-providers/WHY.md
@@ -48,6 +48,9 @@ That gives us a smaller core and a more pluggable app ecosystem.
   provider.
 - The implementation supports a provider-runtime facade before arbitrary
   external provider commands. Provider-owned config is not Ravi core.
+- The typed JSON envelope is limited to the authorization hook because a
+  provider must make a deterministic bounded decision. It does not define how
+  Apps talk to Ravi.
 
 ## Rejected Alternatives
 
@@ -65,6 +68,8 @@ That gives us a smaller core and a more pluggable app ecosystem.
   side-effect-free and fast.
 - **Let app provider allow bypass all other providers.** Rejected because it
   creates privilege escalation. Provider composition must be explicit.
+- **Reuse the provider JSON ABI as the general App protocol.** Rejected because
+  normal Apps are CLI processes and use child-context CLI composition.
 
 ## Migration Direction
 

--- a/.ravi/specs/apps/router/CHECKS.md
+++ b/.ravi/specs/apps/router/CHECKS.md
@@ -22,11 +22,31 @@ ravi specs sync --json
 - Duplicate app ids fail before dispatch and report both manifest sources.
 - Invalid manifests fail before dispatch.
 - Missing operation executors fail before dispatch.
-- CLI operations that call `ravi <app-id> ...` for the current app fail as
-  recursive aliases.
+- CLI operations that resolve through `ravi <app-id> ...` for the current app
+  fail as recursive aliases.
+- The same command text succeeds when `<app-id>` is a registered static
+  command and static precedence prevents dynamic-router re-entry.
 - `--json` returns structured success and failure output.
 - Mutating operations require declared permissions and runtime authorization.
-- Router audit includes `appId`, `operationId`, `interface`, `mutating`, status,
-  duration, and error class.
-- Child CLI/tool execution receives `RAVI_CONTEXT_KEY` when launched inside
-  Ravi runtime.
+- Operation interfaces are limited to `builtin` and `cli`.
+- UI, SDK, tool, and automation callers route to the same declared operation.
+- Declared commands are spawned with `shell: false`.
+- `{args}` expands only as complete argv elements; shell-like user input is
+  passed literally.
+- Named placeholders such as `{id}` fail validation; `{args}` is the only
+  dynamic command token.
+- Shell operators, substitutions, redirections, embedded placeholders, and
+  repeated dynamic placeholders fail manifest validation before spawn.
+- The child working directory resolves to the bounded app root.
+- Router audit includes `appId`, `operationId`, `interface`, `mutating`, caller
+  context id, child context id, status, duration, and error class.
+- Runtime CLI execution receives a fresh child `RAVI_CONTEXT_KEY`.
+- Child capabilities do not exceed manifest `context.allow`.
+- The child process does not receive the parent key or synthesized Ravi
+  identity env vars.
+- Child environment is allowlisted and contains no unrelated parent
+  credentials or secret variables.
+- Child-context issuance failure spawns no process.
+- Audit and process output contain no raw context key.
+- Running with and without `--json` uses the same routing, authorization, and
+  child-context path.

--- a/.ravi/specs/apps/router/RUNBOOK.md
+++ b/.ravi/specs/apps/router/RUNBOOK.md
@@ -44,18 +44,25 @@ required executor fields:
 
 - `builtin.handler`
 - `cli.command`
-- `sdk.namespace` and `sdk.method`
-- `tool.name`
-- `stream.channel`
 
-CLI operations must not point back to the same dynamic alias:
+Domain operations must use `cli`. UI, SDK, tool, and automation callers invoke
+the same operation through the App Router and do not define alternate
+executors.
+
+CLI operations must not resolve back through the same dynamic alias:
 
 ```text
 ravi <app-id> <operation>
 ```
 
 Use a router builtin for help/show/check placeholders or point the command at a
-real static/external executor.
+real static/external executor. A command may be textually `ravi <app-id> ...`
+only when `<app-id>` is a registered static command and static resolution
+cannot re-enter the App Router.
+
+Confirm the command is tokenized into executable plus argv and spawned without
+a shell. Pass an argument such as `$(whoami)` or `; false` and verify it reaches
+the CLI literally and executes nothing.
 
 For dot-separated operation ids, test the CLI-token form too:
 
@@ -77,6 +84,23 @@ For runtime execution, verify the caller context has the declared capability.
 Manifest permissions are only preflight metadata; the executor still needs real
 authorization.
 
+Then verify child delegation:
+
+```bash
+ravi context list --json
+ravi context info <child-context-id> --json
+```
+
+Confirm:
+
+- `issuedFor` identifies `app:<app-id>`;
+- capabilities do not exceed `manifest.context.allow`;
+- lineage points to the caller context;
+- the app did not receive the parent key;
+- unrelated parent credentials and secret environment variables are absent;
+- the process working directory is bounded to the declared app/package root;
+- failure to issue the child stopped dispatch.
+
 ## Diagnose JSON Contract
 
 Run both surfaces when root alias is expected:
@@ -88,3 +112,6 @@ ravi apps run <app-id> check --json
 
 Both should return structured JSON on success and failure. If the app has a
 static command collision, only the fallback `ravi apps run` form is expected.
+
+Repeat without `--json` and confirm the same routing and authorization path is
+used with human-readable output.

--- a/.ravi/specs/apps/router/SPEC.md
+++ b/.ravi/specs/apps/router/SPEC.md
@@ -36,9 +36,10 @@ normative: true
 
 Resolve Ravi App CLI routes at runtime from app manifests.
 
-The app router lets a newly discovered app become operable without generating a
-new TypeScript command file, rebuilding the CLI, regenerating the SDK, or adding
-a static Commander registration for every app.
+The App Router lets a newly discovered CLI become operable without generating a
+new TypeScript command file, rebuilding Ravi, or adding static Commander
+registration for every app. It is a launcher and authorization boundary, not a
+second app runtime.
 
 Operator command:
 
@@ -74,7 +75,8 @@ ravi apps run <app-id> [operation] [args...] --json
 - The router MUST resolve operations deterministically.
 - `ravi <app-id>` SHOULD show app help/summary.
 - `ravi <app-id> show` SHOULD show the app manifest summary.
-- `ravi <app-id> check` SHOULD run app manifest/health validation.
+- `ravi <app-id> check` SHOULD validate the manifest and the shape/safety of
+  declared health metadata without executing the app health command.
 - `ravi <app-id> <operation>` MUST map to a declared operation id, declared
   alias, or router-owned builtin.
 - Dot-separated local operation ids MAY be invoked as whitespace-separated CLI
@@ -83,8 +85,20 @@ ravi apps run <app-id> [operation] [args...] --json
 - Router-owned builtin operations MUST use an explicit allowlisted handler.
 - CLI-backed operations MUST NOT recursively invoke the same public dynamic
   alias, such as `ravi <app-id> <operation>`.
-- CLI-backed operations SHOULD be external commands or static internal Ravi
-  commands that do not re-enter the same dynamic route.
+- CLI-backed operations MUST invoke the app's declared CLI implementation or a
+  static internal Ravi command that does not re-enter the same dynamic route.
+- The router MUST parse the declared command into executable plus fixed argv
+  and spawn it without a shell.
+- `{args}` MUST be supported only as a complete argv placeholder. User-supplied
+  arguments MUST be inserted as separate argv elements and MUST NOT be
+  concatenated into a command string.
+- Named placeholders such as `{id}` MUST be rejected. `{args}` is the only
+  dynamic command token.
+- Shell operators, command substitution, redirection, and executable strings
+  that require shell evaluation MUST be rejected during manifest validation.
+- The app process working directory MUST default to the manifest's app root.
+  Any alternate working directory MUST be declarative, normalized, and bounded
+  to an allowed app/package root.
 - The router MUST perform manifest permission preflight before dispatch.
 - The router MUST still rely on the Permission Provider Runtime at execution
   time for mutating, sensitive, externally visible, or identity-dependent
@@ -97,22 +111,37 @@ ravi apps run <app-id> [operation] [args...] --json
   (`help`, `show`, `check`) MUST require `use app:<app-id>` before returning
   manifest details, validation errors, operation ids, or next commands.
 - Mutating operations MUST declare `permission` or `permissions`.
-- When a child process or tool execution is launched inside Ravi runtime, the
-  router SHOULD pass `RAVI_CONTEXT_KEY` when available and MUST NOT expose raw
-  secrets or bearer tokens.
+- When a runtime caller context exists, the router MUST issue a fresh child
+  context before launching the app CLI.
+- The child context MUST use stable `cliName: "app:<app-id>"`, a bounded TTL,
+  lineage to the caller, and explicit capabilities derived from manifest
+  `context.allow`.
+- The router MUST fail before spawning the CLI when the child context cannot be
+  issued with the declared capabilities.
+- The router MUST NOT forward the parent `RAVI_CONTEXT_KEY`.
+- The child process MUST receive the child `RAVI_CONTEXT_KEY` as its only Ravi
+  identity credential. The router MUST NOT synthesize `RAVI_AGENT_ID`,
+  `RAVI_SESSION_KEY`, or `RAVI_SESSION_NAME`.
+- The router MUST construct a bounded child environment from approved process
+  variables and explicit non-secret app metadata. It MUST NOT blindly spread
+  the parent environment.
+- The router MUST scrub raw credentials, bearer tokens, and unrelated secret
+  environment variables. App credentials MUST be resolved through Ravi's
+  credential boundary after authorization, not inherited from the launcher.
 - The router MUST emit audit metadata for app dispatch attempts, including
-  `appId`, `operationId`, `interface`, `mutating`, status, duration, and error
-  class when available.
+  `appId`, `operationId`, `interface`, `mutating`, caller context id, child
+  context id, status, duration, and error class when available. It MUST NOT log
+  either raw context key.
 - `--json` MUST produce machine-readable output for router success and failure
-  states.
-- Discovery and help/show/list operations MUST NOT execute app binaries, run
-  health checks, import arbitrary code, or mutate storage.
-- Stream operations MUST NOT be faked as single-shot CLI output. The router
-  SHOULD return the stream/control channel contract or hand off to a dedicated
-  streaming surface.
+  states when requested. It is an output format, not an App transport.
+- Discovery and help/show/check/list operations MUST NOT execute app binaries,
+  run health commands, import arbitrary code, or mutate storage.
+- Interactive or streaming app behavior MUST remain a CLI operation and use a
+  TTY/stream-capable launcher. It MUST NOT become a distinct operation executor.
+- UI, SDK, runtime tool, and automation callers MUST enter through the generic
+  App Router and resolve the same operation as the CLI alias.
 - Dynamic app routes MUST NOT be added to the static SDK decorator registry by
-  default. SDK clients MAY use the explicit app router API, but prompts and
-  agent-facing CLI guidance SHOULD prefer `ravi <app-id> <operation>`.
+  default. SDK clients MAY use the generic App Router API.
 
 ## Command Contract
 
@@ -129,7 +158,12 @@ Argument handling:
   tokens (`test a`) when the declared operation id matches.
 - Remaining args are operation-specific and MUST be passed only after the
   operation executor has been resolved and authorized.
+- Each remaining arg MUST remain one argv element. Quoting or shell-like text
+  in user input MUST be treated as data, not evaluated.
 - Global CLI flags such as `--json` MUST retain their normal behavior.
+- App process completion MUST preserve exit status, stdout, and stderr
+  semantics. Capturing output for a caller MUST NOT invent a second result
+  protocol.
 
 ## Resolution Order
 
@@ -145,26 +179,43 @@ use `ravi apps run <app-id> ...` only for that collision/debug case.
 
 ## Operation Executor Contract
 
-Operations MAY dispatch to one of these interfaces:
+Operations MAY dispatch to one of these executor types:
 
 - `builtin`: router-owned allowlisted handler.
-- `cli`: child process command that supports the declared machine contract.
-- `sdk`: SDK/gateway namespace and method.
-- `tool`: explicit runtime tool name and input mapping.
-- `stream`: stream/control channel declaration.
+- `cli`: the app's declared CLI implementation.
 
 Builtin operations MUST declare `handler`, such as `apps.manifest.show`,
 `apps.manifest.check`, `apps.help`, or another router-owned allowlisted
 handler.
 
-CLI operations MUST declare `command`. The command MUST NOT begin with the same
-dynamic alias being resolved, such as `ravi <app-id>` for the current app id.
+CLI operations MUST declare `command`. The command MUST NOT resolve through the
+same dynamic alias being handled, such as `ravi <app-id>` for the current app
+id. The same text MAY be used when `<app-id>` is a registered static command
+and static command precedence guarantees no dynamic-router re-entry. The
+command MUST resolve to the implementation declared by
+`interfaces.cli.command`, unless the manifest explicitly references another
+static internal Ravi command as the implementation.
 
-SDK operations MUST declare `namespace` and `method`.
+`{args}` MAY appear once as a full token in a CLI operation command. It expands
+to zero or more argv values. It MUST NOT be embedded inside another token.
+Command strings are declarative command lines, not shell programs.
 
-Tool operations MUST declare `name`.
+`sdk`, `tool`, and `stream` MUST NOT be operation executor values. Those
+surfaces are adapters that call this router.
 
-Stream operations MUST declare `channel`.
+## App-To-Ravi Contract
+
+The router does not host an App RPC protocol.
+
+1. Ravi launches the app CLI with a child context.
+2. The app resolves itself with `ravi context whoami`.
+3. The app checks or requests authority with `ravi context check` or
+   `ravi context authorize`.
+4. The app invokes the public `ravi ...` command it needs.
+5. The app returns normal CLI output and exit status.
+
+An app MAY use `--json` on a Ravi command when it needs structured output. That
+is ordinary CLI composition, not a distinct App protocol.
 
 ## Boundaries
 
@@ -178,6 +229,8 @@ Stream operations MUST declare `channel`.
 - The app router is not a replacement for first-party static CLI commands.
   Stable core commands may remain build-time registered when they need SDK
   codegen, decorators, or custom parser behavior.
+- The app router does not execute SDK, tool, UI, or stream implementations.
+  Those surfaces call the router.
 - The root-level alias is the user and agent-facing launcher. `ravi apps run`
   is the lower-level router entrypoint for diagnostics and collision fallback.
 
@@ -198,6 +251,9 @@ Stream operations MUST declare `channel`.
   without `use app:<app-id>`.
 - In agent/runtime context, a mutating operation MUST fail without
   `execute app:<app-id>` even when `use app:<app-id>` is present.
+- In agent/runtime context, a valid operation MUST launch with a new child
+  context no broader than manifest `context.allow`.
+- A child-context issuance failure MUST produce no app process.
 
 ## Known Failure Modes
 
@@ -209,6 +265,14 @@ Stream operations MUST declare `channel`.
   routing.
 - Treating manifest permissions as grants bypasses the Permission Provider
   Runtime and context-key authorization.
+- Forwarding the parent context key gives the app undeclared caller authority.
+- Implementing SDK/tool/stream as separate executors creates surface-dependent
+  behavior and authorization drift.
+- Treating JSON output as an App protocol duplicates the CLI process contract.
+- Executing manifest commands through a shell lets app arguments become command
+  injection.
+- Blindly inheriting the parent environment leaks credentials and unrelated
+  runtime authority.
 - Running health checks during discovery creates side effects and slow startup.
 - Hiding app route failures behind generic Commander help makes agents unable
   to diagnose missing manifests or invalid operations.

--- a/.ravi/specs/apps/router/WHY.md
+++ b/.ravi/specs/apps/router/WHY.md
@@ -29,11 +29,17 @@ audit events.
   commands by themselves.
 - Router-owned operations use `interface: "builtin"` so scaffolded apps can
   support help/show/check before domain implementation exists.
-- CLI operation commands are allowed, but they must not call the same public
-  dynamic alias. Recursion is a spec violation, not a runtime trick to support.
+- Domain operations use `interface: "cli"` and point to the app's real CLI.
+  They must not call the same public dynamic alias. A textually identical
+  registered static command is valid because static resolution does not
+  re-enter the router.
+- Every runtime launch gets a least-privilege child context. Passing the
+  caller's context would make the app inherit unrelated authority.
 - Dynamic app routes do not automatically enter the SDK decorator registry.
-  SDK clients can use a generic app router route unless the app explicitly
-  ships a typed SDK surface; CLI prompts should still teach `ravi <app-id>`.
+  SDK, UI, tools, and automations use the generic App Router route; CLI prompts
+  teach `ravi <app-id>`.
+- The process contract is enough. JSON remains an output mode, and the app uses
+  public `ravi ...` commands to talk to the OS.
 
 ## Rejected Alternatives
 
@@ -41,6 +47,15 @@ audit events.
   installation would require build-time work, codegen, and a CLI rebuild.
 - Making only `ravi apps run` available: rejected because humans expect a
   direct operator command once an app exists.
+- Supporting SDK, tool, and stream as independent executors: rejected because
+  one app would have multiple implementations and auth paths.
+- Adding an App-specific JSON protocol: rejected because CLI composition and a
+  child `RAVI_CONTEXT_KEY` already provide invocation, identity, and output.
+- Executing manifest command strings through a shell: rejected because
+  user-supplied argv would become code and quoting would become
+  platform-dependent.
+- Inheriting the full parent process environment: rejected because it leaks
+  unrelated credentials and authority outside the manifest contract.
 - Letting app ids override static commands: rejected because it would make app
   installation capable of changing core CLI behavior.
 - Using manifest `interface: "cli"` commands like `ravi <app-id> check`:

--- a/.ravi/specs/apps/scaffold/CHECKS.md
+++ b/.ravi/specs/apps/scaffold/CHECKS.md
@@ -5,23 +5,38 @@
 - Dry-run check
   - `ravi apps scaffold demo-app --dry-run --json`
   - Must not create files.
-  - Must return planned manifest/spec/skill paths.
+  - Must return planned CLI/manifest/spec/skill paths.
 
 - Write check
   - `ravi apps scaffold demo-app --json`
   - Must create a valid manifest.
+  - Must create a runnable `src/apps/demo-app/cli.ts` by default.
   - Must create spec and skill skeletons by default.
 
 - Validation check
   - `ravi apps check demo-app --json`
   - Must pass immediately after scaffold in a clean repo.
+  - Manifest must declare a real/draft CLI command, not `ravi demo-app`.
+  - Default manifest command must be `bun cli.ts`.
+  - Manifest must declare `context.allow: []` by default.
+  - Manifest must omit executable health unless a supplied CLI contract
+    declares a safe implementation health command.
 
 - Safety check
   - Re-running without `--force` must fail when target files exist.
-  - Re-running with `--force` may overwrite files and must report overwritten
-    actions.
+  - Re-running with `--force` may overwrite scaffold-owned contracts and must
+    report overwritten actions.
+  - An existing generated `cli.ts` must be preserved and reported as
+    `preserved`, because it is implementation-owned after the first scaffold.
 
 - Skill check
   - Scaffolded manifest must include the generated skill id.
   - Generated skill must teach agents to use `ravi apps show`, `ravi apps
     check`, and declared operations.
+
+- Executor check
+  - Generated domain operations must use `cli`.
+  - `ravi demo-app list --json` must execute the generated CLI through the
+    generic App Router.
+  - Generated discovery/help/check placeholders may use allowlisted `builtin`.
+  - Scaffold must not generate SDK, tool, or stream operation executors.

--- a/.ravi/specs/apps/scaffold/RUNBOOK.md
+++ b/.ravi/specs/apps/scaffold/RUNBOOK.md
@@ -22,10 +22,16 @@ ravi apps show <app-id> --json
 ravi apps guide <app-id> --json
 ```
 
-4. Implement the actual CLI/SDK/tool/stream operations declared by the
-   manifest.
+4. Run `ravi <app-id> list --json` to prove the generated CLI route, then
+   implement the actual domain operations declared by the manifest.
 
-5. Re-run checks and SDK/codegen tests when the command surface changes.
+5. Review `context.allow` and add only capabilities the CLI needs to call
+   public Ravi commands.
+
+6. Re-run manifest, router, and child-context checks.
+
+Use `--command "<app-cli>"` only when the implementation CLI already exists.
+In that mode scaffold does not generate `cli.ts`.
 
 ## Debug Scaffold Failure
 

--- a/.ravi/specs/apps/scaffold/SPEC.md
+++ b/.ravi/specs/apps/scaffold/SPEC.md
@@ -34,9 +34,10 @@ normative: true
 
 Define the generator that creates the initial files for a Ravi App.
 
-The scaffold creates an app contract, not a finished domain implementation. It
-SHOULD generate enough structure for agents, UIs, SDK clients, and operators to
-discover, inspect, validate, and continue implementing the app safely.
+The scaffold creates an app contract plus a runnable thin CLI, not a finished
+domain implementation. It SHOULD generate enough structure for agents, UI
+clients, generic App Router clients, and operators to discover, inspect,
+validate, invoke, and continue implementing the CLI safely.
 
 ## Invariants
 
@@ -44,30 +45,48 @@ discover, inspect, validate, and continue implementing the app safely.
 - Scaffolded manifests MUST use `schema: "ravi.app/v1"`.
 - Scaffolded app ids MUST satisfy the app id pattern from `apps/manifest`.
 - The scaffold MUST NOT overwrite existing files unless `--force` is passed.
+- Even with `--force`, the scaffold MUST preserve an existing generated
+  `cli.ts`: after the first scaffold it is implementation-owned, not a
+  regenerable contract file.
 - `--dry-run` MUST report the planned files without writing them.
 - The default scaffold SHOULD create:
   - `src/apps/<app-id>/ravi.app.json`;
+  - `src/apps/<app-id>/cli.ts`;
   - `.ravi/specs/apps/<app-id>/SPEC.md`;
   - `src/plugins/internal/ravi-system/skills/<app-id>/SKILL.md`.
-- Scaffolded manifests SHOULD include CLI, operations, UI descriptor, skills,
-  health, storage, events, and versioning sections.
+- Scaffolded manifests SHOULD include CLI, operations, `context.allow`, optional
+  UI descriptor, skills, health, storage, events, and versioning sections.
 - Scaffolded manifests SHOULD default `interfaces.cli.command` to
-  `ravi <app-id>` as the operator-facing alias once the app router exists.
+  `bun cli.ts` and generate that implementation entrypoint when no
+  `--command` is supplied.
+- When `--command` is supplied, the scaffold MUST use that real implementation
+  command and MUST NOT generate `cli.ts`.
+- Scaffolded manifests MUST NOT use `ravi <app-id>` as
+  `interfaces.cli.command`; that is the router alias, not the app CLI.
+- Scaffolded `context.allow` MUST default to an empty array and require explicit
+  review before capabilities are added.
 - Scaffolded UI MUST satisfy `apps/ui`.
 - Scaffolded operations MUST reference declared interfaces.
-- Scaffolded operations SHOULD use router-safe builtin operations for initial
-  help, show, check, and placeholder read operations until real domain
-  implementation exists.
+- Scaffolded discovery operations SHOULD use router-safe builtins for initial
+  help, show, and check. The default read operation MUST invoke the generated
+  CLI so scaffold-to-router execution is real on day one.
+- Scaffold MUST NOT generate SDK, tool, or stream operation executors. Those
+  caller surfaces use the generic App Router.
 - The scaffold MUST NOT generate operation commands that recursively invoke
   `ravi <app-id> <operation>` for the same app id.
-- The scaffold MAY generate `interfaces.cli.health` as
-  `ravi <app-id> check --json`, because that is a router-owned safe check.
-  It MUST NOT generate health commands that invoke arbitrary app operations.
+- The scaffold MUST omit `interfaces.cli.health` by default unless the supplied
+  CLI contract declares a safe non-mutating health command.
+- A generated health command MUST use the real implementation CLI. It MUST NOT
+  target the public `ravi <app-id>` alias or the router-owned `check` builtin.
 - Scaffolded skills MUST teach agents to start from `ravi apps show`, validate
   with `ravi apps check`, and operate declared operations through
   `ravi <app-id> <operation>`.
-- The scaffold MUST NOT execute generated commands, health checks, app code, or
-  storage migrations.
+- Scaffold output MUST link `ravi-dev-app-creator`, `apps/builder`, and the
+  complete structured builder review checklist. This guidance is part of the
+  generator contract even when `--skip-skill` or `--skip-spec` is selected.
+- The scaffold command MUST NOT execute generated commands, health checks, app
+  code, or storage migrations. Validation tests MAY invoke the generated CLI
+  after file creation.
 - Scaffold-from-CLI behavior, whether exposed as `ravi apps import-cli` or
   `ravi apps scaffold --from-cli`, MUST follow `apps/import-cli`.
 
@@ -77,7 +96,7 @@ discover, inspect, validate, and continue implementing the app safely.
 ravi apps scaffold <app-id> \
   --name "Display Name" \
   --description "What this app does" \
-  --command "ravi my-app" \
+  --command "my-app-cli" \
   --from-cli "external-cli" \
   --dry-run \
   --force \
@@ -90,21 +109,29 @@ ravi apps scaffold <app-id> \
 ## Validation
 
 - `ravi apps scaffold example --dry-run --json` SHOULD return planned files.
+- Scaffold JSON output MUST include `builder.skill`, `builder.command`,
+  `builder.spec`, and the complete `builder.reviewChecklist`.
 - `ravi apps scaffold example --json` SHOULD write files in an empty repo.
 - `ravi apps check example --json` SHOULD pass immediately after scaffold.
+- `ravi example list --json` SHOULD execute the generated `bun cli.ts` through
+  the App Router immediately after scaffold.
 - After app router support exists, scaffolded apps SHOULD be invokable through
   `ravi example check --json` when `example` has no static command collision.
 - Scaffolded apps SHOULD remain invokable through
   `ravi apps run example check --json` as a router fallback/debug path.
 - Re-running scaffold without `--force` SHOULD fail if target files exist.
-- Re-running scaffold with `--force` MAY overwrite scaffold files.
+- Re-running scaffold with `--force` MAY overwrite scaffold-owned contract
+  files but MUST preserve an existing implementation `cli.ts` and report it as
+  `preserved`.
 
 ## Known Failure Modes
 
-- Treating scaffold as finished implementation.
+- Treating the thin generated CLI as finished domain implementation.
 - Overwriting an existing app without explicit force.
 - Creating an app skill but not listing it in the manifest.
 - Generating UI buttons with no backing operations.
 - Generating CLI operations that do not support JSON.
 - Generating CLI operations that recursively call the app router alias.
 - Generating health checks that recursively call the app router alias.
+- Generating broad or inherited child capabilities.
+- Generating SDK/tool/stream executors that duplicate the CLI.

--- a/.ravi/specs/apps/scaffold/WHY.md
+++ b/.ravi/specs/apps/scaffold/WHY.md
@@ -21,27 +21,36 @@ The scaffold keeps app creation aligned with the ecosystem:
 - The generated skill lives under the internal `ravi-system` plugin for
   first-party system apps.
 - Dry-run exists so agents can preview side effects before writing files.
-- The scaffold creates contract files only. CLI/domain implementation happens
+- The default scaffold creates a thin runnable `cli.ts` so the public alias can
+  prove real process execution immediately. Domain implementation still happens
   after the contract is reviewed.
+- The generated CLI command identifies the real app executable. The root
+  `ravi <app-id>` surface is derived by the router.
+- Child capabilities start empty because generation cannot safely infer what
+  authority an app should receive.
 - The scaffold should prepare apps for runtime routing. The generated root
   command is an app-router alias, not a new static TypeScript command.
 - Initial scaffold operations should prefer router builtins for help/show/check
-  so a new app is inspectable before domain implementation exists.
+  and use the thin CLI for a read-only `list`, so a new app is both inspectable
+  and invokable before domain implementation exists.
 
 ## Rejected Alternatives
 
-- Generating full CLI implementation immediately: rejected because domain logic
+- Generating full domain logic immediately: rejected because product behavior
   needs app-specific modeling.
 - Putting scaffold instructions only in chat: rejected because agents need to
-  recover the protocol through `ravi apps`.
+  recover the contract through `ravi apps`.
 - Overwriting by default: rejected because app manifests and skills are durable
   product surfaces.
-- Generating static CLI stubs for every scaffolded app: rejected because app
-  routing should work at runtime without a CLI rebuild.
+- Generating a new static Ravi command for every app: rejected because the
+  dynamic root alias is derived from the manifest and App Router.
+- Generating SDK/tool/stream implementations: rejected because they would
+  duplicate the app CLI instead of calling the generic App Router.
 - Generating operations that call `ravi <app-id>` from inside the manifest:
   rejected because router-executed CLI operations would recursively dispatch
   themselves.
-- Generating health checks that call arbitrary `ravi <app-id> ...` operations:
-  rejected because non-health app operations can recursively dispatch
-  themselves. The router-owned safe check `ravi <app-id> check --json` is
-  allowed for `interfaces.cli.health`.
+- Generating health checks without a real CLI health contract: rejected because
+  the scaffold cannot prove that an invented command is safe or implemented.
+- Using `ravi <app-id> check` as `interfaces.cli.health`: rejected because
+  router `check` validates metadata and would recurse if executed as app
+  health.

--- a/.ravi/specs/apps/ui/CHECKS.md
+++ b/.ravi/specs/apps/ui/CHECKS.md
@@ -31,12 +31,17 @@
 - Operation check
   - Fail if `operations` exists and is not an object.
   - Fail if operation ids are not fully qualified dot ids.
-  - Fail if operation `interface` is not `cli`, `sdk`, `tool`, or `stream`.
-  - Fail if an operation references an undeclared interface block.
-  - Fail if CLI operations omit command, SDK operations omit namespace/method,
-    tool operations omit name, or stream operations omit channel.
+  - Fail if operation `interface` is not `cli` or `builtin`.
+  - Fail if CLI operations omit command.
+  - Fail if builtin operations omit an allowlisted handler.
   - Warn if operations omit `mutating`.
   - Warn if CLI operations do not indicate machine-readable JSON output.
+
+- Router boundary check
+  - Confirm UI queries and actions invoke the generic App Router.
+  - Confirm UI invocation and CLI alias invocation resolve the same operation.
+  - Confirm both paths enforce caller authorization and issue the same bounded
+    child-context class.
 
 - Design-system boundary check
   - Fail if UI declarations include raw CSS, HTML, JavaScript, component,

--- a/.ravi/specs/apps/ui/RUNBOOK.md
+++ b/.ravi/specs/apps/ui/RUNBOOK.md
@@ -18,9 +18,11 @@
    `view`.
 3. Confirm each route view exists in `interfaces.ui.views`.
 4. Confirm each view query/action references a declared top-level operation.
-5. Confirm each operation declares a real interface target.
+5. Confirm each operation declares `cli` or an allowlisted router `builtin`.
 6. Confirm event topics in `refreshOn` are dot-separated Ravi topics.
 7. Remove raw CSS, HTML, JS, bundle, component, class, or Tailwind keys.
+8. Confirm the UI invokes the generic App Router and does not spawn the CLI
+   directly.
 
 ## Debug A Stale UI
 

--- a/.ravi/specs/apps/ui/SPEC.md
+++ b/.ravi/specs/apps/ui/SPEC.md
@@ -68,7 +68,7 @@ permissions preflight, and event wiring.
 - App operations MUST be declared under top-level `operations`.
 - Operation ids MUST be fully qualified dot ids such as `apps.list` or
   `music.playlist.create`.
-- Operations MUST declare `interface` as `cli`, `sdk`, `tool`, or `stream`.
+- Operations MUST declare `interface` as `cli` or router-owned `builtin`.
 - CLI operations MUST declare a command that supports machine-readable output.
   For Ravi-owned CLI apps this SHOULD be `--json`.
 - Operations SHOULD declare whether they are `mutating`. Mutating operations
@@ -78,6 +78,10 @@ permissions preflight, and event wiring.
 - `refreshOn` event topics MUST be valid dot-separated Ravi event topics.
 - Manifest UI declarations do not grant permissions. Runtime execution MUST
   still authorize operations through Ravi permissions/context keys.
+- Web OS MUST invoke actions and queries through the generic App Router. It
+  MUST NOT execute an app CLI directly or define a UI-specific executor.
+- A routed UI operation MUST use the same caller authorization and
+  child-context launch path as `ravi <app-id> <operation>`.
 - Discovery MUST NOT execute operations, import UI code, run health checks, or
   mutate storage.
 
@@ -180,9 +184,10 @@ Web OS boot
   -> render launcher/sidebar from manifests
   -> open /apps/:appId/:route
   -> load interfaces.ui descriptor
-  -> execute query operation for snapshot
+  -> execute query operation through App Router
+  -> App Router authorizes caller and launches app CLI with child context
   -> render with Ravi design-system primitives
-  -> user action invokes declared operation
+  -> user action invokes the same declared operation through App Router
   -> app emits event
   -> UI refreshes, patches, or invalidates affected view
 ```
@@ -191,7 +196,9 @@ Web OS boot
 
 - App UI descriptors are not microfrontends.
 - App UI descriptors are not permission grants.
-- App UI descriptors are not a replacement for CLI, SDK, or event contracts.
+- App UI descriptors are not a replacement for the app CLI or event contracts.
+- Web OS is an adapter over App Router operations, not an alternate app
+  implementation.
 - App-specific frontend bundles MAY exist only behind a future sandboxed UI
   extension spec. They are not part of `ravi.app/v1`.
 - Ravi Web OS MUST remain the owner of the unified design system.
@@ -211,6 +218,7 @@ Web OS boot
 
 - Letting each app ship its own React/CSS surface fragments the OS.
 - Buttons that are not backed by operations create fake UI.
+- UI actions that bypass the App Router create a second authorization path.
 - Eventful apps without `refreshOn` make the UI stale.
 - UI code that scrapes stdout couples rendering to human prose.
 - Declarative permissions without runtime authorization create false safety.

--- a/.ravi/specs/apps/ui/WHY.md
+++ b/.ravi/specs/apps/ui/WHY.md
@@ -13,10 +13,12 @@ and permission preflight.
 ## Decisions
 
 - UI is semantic manifest data, not arbitrary app code.
-- Operations are top-level because they are useful to UI, agents, SDK clients,
-  and automations. A view action should not hide its execution contract inline.
-- CLI remains a valid harness. The UI talks to operations; operations may call
-  CLI, SDK, tool, or stream surfaces.
+- Operations are top-level because UI, agents, SDK clients, tools, and
+  automations must invoke the same App Router contract.
+- The CLI is the app implementation. The UI talks to the App Router; the router
+  launches that CLI with the normal caller authorization and child context.
+- JSON is useful for UI snapshots, but it remains CLI output rather than a
+  separate UI/App protocol.
 - Events are the live bridge. Snapshot comes from operations; freshness comes
   from event topics.
 - Raw CSS/HTML/JS/bundles are excluded from `ravi.app/v1` so the first Web OS
@@ -29,6 +31,8 @@ and permission preflight.
   the OS contract is clear.
 - Rendering CLI help as UI: rejected because help text is not state, schema, or
   interaction contract.
+- Letting UI call app binaries directly: rejected because it bypasses the
+  router's app boundary, child context, and audit.
 - Defining all UI centrally in Web OS: rejected because apps need to own their
   own domain-specific views and actions.
 - Using events only with no snapshot operation: rejected because cold boot and

--- a/.ravi/specs/apps/visibility/SPEC.md
+++ b/.ravi/specs/apps/visibility/SPEC.md
@@ -34,10 +34,10 @@ normative: true
 App visibility ensures a principal cannot discover or inspect apps it cannot
 use.
 
-Apps are operational capability boundaries. A manifest can reveal tool
-surfaces, executable paths, SDK routes, permission requirements, and installed
-product capabilities. Therefore app discovery is authorized disclosure, not a
-free catalog.
+Apps are operational capability boundaries. A manifest can reveal CLI
+entrypoints, operations, child-context capabilities, permission requirements,
+and installed product capabilities. Therefore app discovery is authorized
+disclosure, not a free catalog.
 
 ## Invariants
 

--- a/.ravi/specs/apps/visibility/WHY.md
+++ b/.ravi/specs/apps/visibility/WHY.md
@@ -1,7 +1,8 @@
 # App Visibility / WHY
 
-App manifests disclose operational capability: executable paths, SDK routes,
-permission requirements, installed product features, and possible actions.
+App manifests disclose operational capability: CLI entrypoints, operations,
+child-context capabilities, permission requirements, installed product
+features, and possible actions.
 Discovery is therefore an authorization decision, not a harmless catalog read.
 
 The visibility boundary keeps runtime agents from learning about apps they

--- a/.ravi/specs/apps/youtube/CHECKS.md
+++ b/.ravi/specs/apps/youtube/CHECKS.md
@@ -2,7 +2,23 @@
 
 ## Checks
 
-- Manifest validation MUST pass with exactly one `youtube` app and zero errors or warnings.
+- Manifest validation MUST pass with exactly one `youtube` app and zero errors
+  or warnings after it declares
+  `context.allow: ["execute:group:yt"]`.
+- The public `ravi youtube` route and explicit `ravi apps run youtube` fallback
+  MUST resolve the same declared operation and launch the same `ravi yt`
+  implementation command.
+- No CLI operation command may begin with the dynamic prefix `ravi youtube`.
+- UI, generic SDK, runtime tool, and automation adapters MUST call the App
+  Router rather than execute a separate YouTube implementation.
+- In runtime context, read operations MUST require `use app:youtube`; mutating
+  operations MUST require `execute app:youtube`.
+- Runtime dispatch MUST issue a fresh `app:youtube` child context whose
+  capabilities are no broader than `execute:group:yt`. Child issuance failure
+  MUST start no CLI process.
+- The launched CLI MUST receive only the child `RAVI_CONTEXT_KEY` as Ravi
+  identity and MUST NOT receive the parent key or synthetic agent/session
+  identity variables.
 - The focused client, app, and CLI suites MUST pass without network access or a real credential.
 - `yt health --json` MUST pass metadata-only with `authenticated=false` and `externalCheckPerformed=false`.
 - `yt info --json` with isolated empty state MUST fail before any Google request with an actionable missing-credential error.
@@ -15,6 +31,8 @@ Run from the repository/worktree root:
 bun run gen:commands
 bun test src/apps/youtube src/cli/commands/youtube.test.ts
 bun src/cli/index.ts apps check youtube --json
+bun src/cli/index.ts youtube health --json
+bun src/cli/index.ts apps run youtube health --json
 bun src/cli/index.ts yt --help
 bun src/cli/index.ts yt health --json
 bun run sdk:generate

--- a/.ravi/specs/apps/youtube/RUNBOOK.md
+++ b/.ravi/specs/apps/youtube/RUNBOOK.md
@@ -9,7 +9,18 @@
    bun src/cli/index.ts apps show youtube --json
    ```
 
-2. Inspect Phase 1 readiness without resolving a secret:
+2. Verify the public App Router route and its explicit fallback:
+
+   ```bash
+   bun src/cli/index.ts youtube health --json
+   bun src/cli/index.ts apps run youtube health --json
+   ```
+
+   Both commands must resolve operation `youtube.health` and launch the
+   manifest implementation `ravi yt health --json`. The public route must not
+   add a second YouTube implementation.
+
+3. Inspect the underlying Phase 1 CLI without resolving a secret:
 
    ```bash
    bun src/cli/index.ts yt health --json
@@ -17,12 +28,22 @@
 
    `authenticated: false` is expected. `ready: true` means only that an active `youtube:<connection>` metadata record exists.
 
-3. If a command fails with `YouTube credential unavailable`, do not read or import the SDE token. Credential onboarding belongs to a later approved phase.
+4. In a Ravi runtime context, inspect the dispatch audit/trace and confirm:
 
-4. If a fake-fetch unit test fails, inspect the exact official endpoint, method, query and body recorded by the test. The implementation constants are in `src/apps/youtube/client.ts`.
+   - caller authorization checked `use app:youtube` or
+     `execute app:youtube`;
+   - the launched CLI received a fresh child context named `app:youtube`;
+   - the child ceiling is exactly `execute:group:yt` and does not exceed the
+     parent;
+   - the parent context key and synthetic agent/session identity variables were
+     not forwarded.
 
-5. If the CLI is absent, run `bun run gen:commands` and verify `src/cli/commands/index.ts` exports `youtube.js`. Do not edit the barrel manually.
+5. If a command fails with `YouTube credential unavailable`, do not read or import the SDE token. Credential onboarding belongs to a later approved phase.
 
-6. If SDK checks fail after a CLI contract change, run `bun run sdk:generate`, inspect the generated TypeScript and Swift SDK diffs, then rerun `bun run sdk:check`.
+6. If a fake-fetch unit test fails, inspect the exact official endpoint, method, query and body recorded by the test. The implementation constants are in `src/apps/youtube/client.ts`.
 
-7. Never debug Phase 1 by running reply, update, delete, create, add or remove against Google. Those paths are validated only with fake `fetch` until separately approved.
+7. If the CLI is absent, run `bun run gen:commands` and verify `src/cli/commands/index.ts` exports `youtube.js`. Do not edit the barrel manually.
+
+8. If SDK checks fail after a CLI contract change, run `bun run sdk:generate`, inspect the generated TypeScript and Swift SDK diffs, then rerun `bun run sdk:check`. Generated SDK methods for `ravi yt` are compatibility metadata; app-facing integrations still use the generic App Router.
+
+9. Never debug Phase 1 by running reply, update, delete, create, add or remove against Google. Those paths are validated only with fake `fetch` until separately approved.

--- a/.ravi/specs/apps/youtube/SPEC.md
+++ b/.ravi/specs/apps/youtube/SPEC.md
@@ -22,11 +22,40 @@ normative: true
 
 ## Intent
 
-Define the native, parallel Phase 1 migration of the legacy `sde yt` surface to a Ravi App. The app exposes official YouTube Data API v3 and YouTube Analytics API v2 resources while preserving the SDE implementation as an untouched fallback. Real credential onboarding and authenticated live proof are deliberately outside Phase 1.
+Define the native, parallel Phase 1 migration of the legacy `sde yt` surface
+to a Ravi App. The public app route is `ravi youtube`; the implementation CLI
+bound by the manifest is the registered static command `ravi yt`. The app
+exposes official YouTube Data API v3 and YouTube Analytics API v2 resources
+while preserving the SDE implementation as an untouched fallback. Real
+credential onboarding and authenticated live proof are deliberately outside
+Phase 1.
 
 ## Invariants
 
-- The app MUST use the native app ID `youtube` and the decorated CLI group `ravi yt` (alias `ravi youtube`).
+- The app MUST use the native app ID `youtube`.
+- `interfaces.cli.command` MUST identify `ravi yt` as the real, registered
+  static implementation CLI.
+- `ravi youtube <operation>` MUST be the canonical App Router route.
+  `ravi apps run youtube <operation>` MUST remain the explicit router fallback.
+- Direct `ravi yt <command>` is an implementation/debug and local-operator
+  compatibility surface. It is not a second App executor, and runtime app
+  callers MUST use the App Router.
+- Every CLI-backed manifest operation MUST invoke `ravi yt ...`; it MUST NOT
+  invoke `ravi youtube ...` and recursively re-enter the App Router.
+- UI, SDK, runtime tools, and automations MUST invoke declared `youtube.*`
+  operations through the generic App Router. Generated decorator SDK metadata
+  for `ravi yt` MAY remain for compatibility but MUST NOT define a separate app
+  implementation.
+- The manifest MUST declare `context.allow` with the reviewed child-context
+  ceiling required by the implementation CLI. For the current static command
+  boundary this MUST be `execute:group:yt`; it MUST NOT use inheritance or a
+  wildcard.
+- Manifest `permissions` gate the caller and operation. `context.allow` only
+  bounds the child CLI and MUST NOT be treated as an app permission grant.
+- In runtime context the App Router MUST launch `ravi yt` with a fresh child
+  context named `app:youtube`, bounded by the parent and the manifest ceiling.
+  It MUST NOT forward the parent context key or synthesize agent/session
+  identity environment variables.
 - The native client MUST call only official Google endpoints under `https://www.googleapis.com/youtube/v3` and `https://youtubeanalytics.googleapis.com/v2`.
 - The native client MUST NOT execute `sde`, import SDE modules, read SDE credential/token files, or alter the legacy SDE code or runtime.
 - Phase 1 MUST NOT implement OAuth consent/callback/token refresh, use a real token, or perform an authenticated live request.
@@ -47,6 +76,8 @@ Define the native, parallel Phase 1 migration of the legacy `sde yt` surface to 
 
 - `bun test src/apps/youtube src/cli/commands/youtube.test.ts`
 - `bun src/cli/index.ts apps check youtube --json`
+- `bun src/cli/index.ts youtube health --json`
+- `bun src/cli/index.ts apps run youtube health --json`
 - `bun src/cli/index.ts yt health --json`
 - `bun src/cli/index.ts yt info --json` with an isolated empty `RAVI_STATE_DIR` MUST fail before network access.
 - `bun run gen:commands && bun run sdk:generate && bun run sdk:check`
@@ -60,3 +91,8 @@ Define the native, parallel Phase 1 migration of the legacy `sde yt` surface to 
 - Treating captions as generic read can understate the required `youtube.force-ssl`/`youtubepartner` authorization.
 - Adding revenue metrics would introduce a financial permission class and the `yt-analytics-monetary.readonly` scope, which Phase 1 explicitly excludes.
 - Running mutation commands for validation would create public or irreversible effects; only fake-fetch tests are valid in Phase 1.
+- Treating `ravi yt` and `ravi youtube` as interchangeable public app routes
+  bypasses the App Router on the static path and obscures which authorization
+  boundary ran.
+- Declaring `ravi youtube` as an operation command recursively re-enters the
+  dynamic alias instead of launching the implementation CLI.

--- a/.ravi/specs/apps/youtube/WHY.md
+++ b/.ravi/specs/apps/youtube/WHY.md
@@ -16,6 +16,30 @@ Official sources:
 
 The client is native rather than an SDE wrapper because the official REST contract is clear and bounded. It accepts an access-token envelope from the Ravi credential broker but does not implement token acquisition or refresh in Phase 1. This lets the structure, command contract, permissions and failure behavior be tested without a real credential.
 
+## App Integration Contract
+
+The manifest deliberately separates the public app name from its implementation
+command:
+
+- `ravi youtube ...` enters the generic App Router, applies app visibility and
+  caller authorization, issues the child context, and resolves a declared
+  operation;
+- `ravi yt ...` is the registered static CLI that implements those operations;
+- `ravi apps run youtube ...` is the explicit fallback and diagnostic entrypoint.
+
+This preserves the existing decorated CLI and its generated SDK metadata
+without making the SDK, UI, or tool surfaces independent executors. They are
+clients of the same App Router operation.
+
+The two permission declarations also have different jobs. Operation
+`permissions` decide whether the caller may use or execute the YouTube app.
+`context.allow` caps what the launched `ravi yt` process may do inside Ravi.
+For the current implementation, `execute:group:yt` is the complete child
+ceiling; expanding it requires an explicit manifest and security review.
+
+`--json` remains an output option on `ravi yt`. It is useful to the router,
+agents, and automation, but it is not a protocol between the app and Ravi.
+
 ## Legacy Gaps Corrected
 
 - `sde yt videos` uses `search.list` for the upload feed. The native app follows Google's implementation guidance and reads the channel uploads playlist, reducing quota cost and preserving pagination.
@@ -65,3 +89,8 @@ Financial operations: none. Revenue and ad-performance reports are intentionally
 - **Credential import from SDE:** rejected because Phase 1 forbids real token use and legacy secret access.
 - **Database/cache:** rejected because all outputs are provider-owned data or deterministic derivations; persistence adds no lineage needed for Phase 1.
 - **NATS events:** rejected because no new cross-system lifecycle is introduced.
+- **Publish `ravi yt` as a second app path:** rejected because it bypasses the
+  generic App Router and creates two authorization stories for one app.
+- **Use SDK or tool operations as executors:** rejected because those surfaces
+  can call the generic App Router and do not need another business
+  implementation.

--- a/.ravi/specs/runtime/providers/pi/SPEC.md
+++ b/.ravi/specs/runtime/providers/pi/SPEC.md
@@ -118,10 +118,16 @@ Important: Pi `turn_end` is an internal LLM/tool-cycle boundary, not always a Ra
 
 ## Skill Visibility
 
-- The Pi RPC MVP does not support Ravi plugins or Codex-style skill catalogs.
+- The Pi RPC MVP has no provider-native plugin or skill-loading API. Ravi
+  nevertheless discovers its plugin skills, filters them by the agent
+  allowlist, and appends a compact skill catalog plus
+  `ravi skills show <skill> --json` loading instructions to the Pi system
+  prompt.
 - Current Pi state and event payloads do not expose a skill list, skill request, skill load, or skill unload event.
 - Pi sessions MUST report an empty `loadedSkills` vector unless Ravi owns an explicit skill injection flow and observes completion.
-- If the visibility payload includes skill records for Pi, their state MUST be `unknown` or non-loaded. The adapter MUST NOT infer loaded skills from appended prompt text.
+- Allowlisted catalog records MUST be reported as `advertised` with declared
+  `system-prompt` evidence. The adapter MUST NOT infer loaded skills from that
+  appended prompt text.
 - A future Pi SDK-backed provider MAY expose richer skill/resource state. That state MUST be mapped into the canonical `runtime/skill-loading` record shape before it appears in `session-visibility`.
 
 ## Usage Mapping

--- a/.ravi/specs/runtime/session-visibility/CHECKS.md
+++ b/.ravi/specs/runtime/session-visibility/CHECKS.md
@@ -1,0 +1,32 @@
+# Runtime Session Visibility Checks
+
+## Automated Checks
+
+```bash
+bun test src/runtime/session-visibility.test.ts src/runtime/session-trace.test.ts
+bun test src/runtime/claude-provider.test.ts src/runtime/codex-provider.test.ts src/runtime/pi-provider.test.ts
+bun test src/runtime/provider-contract.test.ts
+```
+
+## Contract Assertions
+
+- Every provider returns the same visibility payload shape.
+- Unsupported token or compact fields remain explicit instead of disappearing.
+- A newer persisted skill snapshot wins over stale live state, while a newer
+  live snapshot wins over stale persistence.
+- `loadedSkills` includes only observed loaded records.
+- Provider discovery, synchronization, prompt advertisement, and approval do
+  not populate `loadedSkills`.
+- Pi exposes only allowlisted advertised records with declared system-prompt
+  evidence until explicit load evidence exists.
+- Compaction and session reset clear the conservative loaded projection.
+- A missing session returns a structured error rather than an empty payload.
+
+## Manual Smoke
+
+1. Start one session for each supported provider.
+2. Query `ravi sessions visibility <session> --json` before and after a turn.
+3. Read one skill through `ravi skills show <skill> --json` and inspect the next
+   visibility snapshot.
+4. Trigger a compact/reset in a disposable session and verify `loadedSkills`
+   returns empty afterward.

--- a/.ravi/specs/runtime/session-visibility/RUNBOOK.md
+++ b/.ravi/specs/runtime/session-visibility/RUNBOOK.md
@@ -1,0 +1,40 @@
+# Runtime Session Visibility Runbook
+
+## Inspect A Session
+
+1. Resolve the exact Ravi session name or key.
+2. Run `ravi sessions visibility <session> --json`.
+3. Check `lastUpdatedAt` before interpreting token, compact, or skill state.
+4. Read `skills[].state`, `confidence`, `source`, and `evidence` together.
+5. Treat `loadedSkills` as the conservative compatibility projection, not as a
+   catalog of everything available to the provider.
+
+## Debug Missing Or Stale Skill State
+
+1. Confirm the skill is visible to the agent with
+   `ravi skills inspect --agent <agent> --json`.
+2. Inspect the session trace around provider start, tool completion, compaction,
+   and reset events.
+3. Compare live state with persisted `runtimeSessionParams.skillVisibility`.
+4. If the provider only advertises the skill, expect `state=advertised` and an
+   empty `loadedSkills` vector.
+5. For Pi, verify that only allowlisted skills reached the system-prompt catalog
+   and that their evidence is declared `system-prompt` evidence.
+6. For an explicit Ravi skill read, verify the successful tool completion was
+   normalized to the canonical frontmatter name.
+
+## Debug A Compact Or Reset
+
+1. Find the compact/reset boundary in the runtime trace.
+2. Confirm the persisted and live `loadedSkills` projections reset together.
+3. Confirm previously loaded records are no longer used as current enforcement
+   evidence.
+4. Re-query visibility after the boundary rather than relying on a cached client
+   response.
+
+## Change Procedure
+
+1. Update the provider adapter and shared visibility model together.
+2. Preserve the provider-neutral response shape and conservative defaults.
+3. Add provider-specific evidence tests without weakening the shared invariant.
+4. Run the checks in `CHECKS.md` and then the repository quality gate.

--- a/.ravi/specs/runtime/session-visibility/SPEC.md
+++ b/.ravi/specs/runtime/session-visibility/SPEC.md
@@ -67,7 +67,10 @@ A session-visibility query MUST return a structured payload with at least:
 - **Provider does not expose tokens** — `tokens.used` and `tokens.limit` MUST be `null`. Consumers MUST handle this gracefully without assuming the session is unbounded.
 - **Compaction event mid-query** — the response MUST reflect the post-compact state, with `compact.lastCompactedAt` updated and `loadedSkills` reset per `runtime/skill-loading`.
 - **Session not found** — return a structured error, not an empty payload; consumers MUST distinguish "no session" from "session with zero tokens".
-- **Provider does not expose skill loading** — return the normal visibility shape with conservative skill state. For Codex this may include `synced` or `advertised`; for Pi this is currently `unknown` or empty. Do not synthesize `loaded`.
+- **Provider does not expose skill loading** — return the normal visibility
+  shape with conservative skill state. For Codex this may include `synced` or
+  `advertised`; for Pi this may include allowlist-filtered `advertised` catalog
+  entries with declared `system-prompt` evidence. Do not synthesize `loaded`.
 
 ## Acceptance Criteria
 
@@ -76,4 +79,6 @@ A session-visibility query MUST return a structured payload with at least:
 - Compact events update `compact.lastCompactedAt` and reset `loadedSkills` to empty in the next visibility query.
 - Visibility responses are sub-100ms p95 in steady state (no provider round-trip required for cached state).
 - A Codex session with synchronized Ravi skills exposes those skills in `skills` but does not include them in `loadedSkills` until observed load evidence exists.
-- A Pi session exposes the skill fields without pretending to support skill loading.
+- A Pi session exposes only allowlisted skills as `advertised`, keeps
+  `loadedSkills` empty until explicit load evidence exists, and does not
+  pretend prompt catalog text is loaded content.

--- a/.ravi/specs/runtime/session-visibility/WHY.md
+++ b/.ravi/specs/runtime/session-visibility/WHY.md
@@ -1,0 +1,41 @@
+# Runtime Session Visibility Rationale
+
+## Why One Provider-Neutral Payload
+
+Operators and tools need one answer for session state regardless of whether the
+turn runs in Claude Code, Codex, or Pi. Exposing provider-native payloads would
+move normalization into every consumer and make authorization, diagnostics,
+and user interfaces disagree about the same session.
+
+The Ravi payload therefore keeps a stable shape and represents unsupported
+values explicitly. A missing provider signal becomes `null`, `unknown`, or an
+empty conservative projection; it never becomes an optimistic guess.
+
+## Why Skill Records And `loadedSkills` Both Exist
+
+Discovery, synchronization, prompt advertisement, and loading are different
+states. The detailed `skills` records preserve that distinction and retain the
+evidence needed to explain it. `loadedSkills` remains a compatibility projection
+for consumers that only need the small, enforcement-safe set proven loaded.
+
+This split prevents a catalog entry from silently becoming authorization
+evidence. It also lets older consumers keep working while newer ones show the
+full state and its confidence.
+
+## Why Pi Advertises Without Claiming Load
+
+Pi can receive an allowlist-filtered skill catalog and instructions for reading
+a skill through the public Ravi CLI, but its RPC surface has no native
+skill-loaded event. Recording the catalog as `advertised` with declared
+`system-prompt` evidence is useful and truthful. Projecting those entries into
+`loadedSkills` would be false evidence, so that vector stays empty until Ravi
+observes an explicit load.
+
+## Alternatives Rejected
+
+- Scraping provider text was rejected because formatting is unstable and cannot
+  prove what remains in the current context window.
+- Treating local files or synchronized skills as loaded was rejected because
+  presence on disk does not prove provider ingestion.
+- Performing a provider round-trip on every query was rejected because
+  visibility must be fast, read-only, and available during degraded operation.

--- a/.ravi/specs/runtime/skill-loading/CHECKS.md
+++ b/.ravi/specs/runtime/skill-loading/CHECKS.md
@@ -1,0 +1,35 @@
+# Runtime Skill Loading Checks
+
+## Automated Checks
+
+```bash
+bun test src/runtime/session-visibility.test.ts src/runtime/session-trace.test.ts src/runtime/skill-gate.test.ts
+bun test src/runtime/claude-provider.test.ts src/runtime/codex-provider.test.ts src/runtime/pi-provider.test.ts
+bun test src/runtime/allowed-skills.test.ts src/runtime/provider-contract.test.ts
+```
+
+## State And Evidence Assertions
+
+- A new session MUST begin with an empty `loadedSkills` vector.
+- Canonical skill ids MUST come from frontmatter names rather than paths or
+  aliases.
+- Available, synchronized, advertised, requested, stale, and unknown records
+  MUST NOT enter `loadedSkills`.
+- Only observed load evidence MUST create a loaded projection.
+- A successful Ravi-owned `skills show` read MUST record canonical `tool-call`
+  evidence.
+- Provider metadata invalidation MUST refresh catalog state without fabricating
+  a loaded-state transition.
+- Compaction and explicit session reset MUST clear loaded state in live and
+  persisted snapshots.
+
+## Provider Assertions
+
+- Claude plugin discovery alone MUST NOT be a loaded signal.
+- Codex synchronization and `skills/list` MUST remain synchronized or
+  advertised until matched instruction-source or Ravi-owned read evidence
+  exists.
+- Pi MUST filter the catalog through the agent allowlist, advertise it in the
+  system prompt, and keep `loadedSkills` empty without explicit load evidence.
+- The provider contract MUST expose the same skill-visibility capability shape
+  for Claude Code, Codex, and Pi.

--- a/.ravi/specs/runtime/skill-loading/RUNBOOK.md
+++ b/.ravi/specs/runtime/skill-loading/RUNBOOK.md
@@ -1,0 +1,43 @@
+# Runtime Skill Loading Runbook
+
+## Inspect Skill State
+
+1. Confirm agent visibility with `ravi skills inspect --agent <agent> --json`.
+2. Query `ravi sessions visibility <session> --json`.
+3. Locate the canonical skill id in `skills` and inspect its state, confidence,
+   source, evidence, and timestamps.
+4. Inspect `loadedSkills` separately; absence is expected for available,
+   synchronized, advertised, requested, stale, and unknown records.
+
+## Verify An Explicit Ravi Skill Read
+
+1. Run `ravi skills show <skill> --json` inside the target runtime context.
+2. Confirm the command succeeds and resolves the canonical frontmatter name.
+3. Inspect the tool-completion event in the session trace.
+4. Query visibility again and verify Ravi recorded observed `tool-call` evidence
+   before projecting the skill into `loadedSkills`.
+
+## Add Or Change A Provider
+
+1. Document the provider's discovery, advertisement, request, load, invalidation,
+   compact, and reset signals.
+2. Map each signal to the shared state and confidence enums.
+3. Prefer `unknown` when no provider-native or Ravi-owned evidence exists.
+4. Keep catalog filtering aligned with the agent skill allowlist.
+5. Emit and persist the normalized snapshot at provider event boundaries.
+6. Add tests proving non-load signals never enter `loadedSkills`.
+
+## Pi Diagnostics
+
+1. Verify the agent allowlist before provider startup.
+2. Inspect the appended system prompt for canonical skill names and public
+   `ravi skills show` loading instructions.
+3. Expect the records to be `advertised` with declared `system-prompt` evidence.
+4. Expect `loadedSkills` to remain empty until a successful Ravi-owned read is
+   observed.
+
+## Compact Or Reset Diagnostics
+
+1. Find the compact/reset event in the runtime trace.
+2. Confirm live and persisted loaded projections reset atomically.
+3. Confirm subsequent gates require new observed evidence.

--- a/.ravi/specs/runtime/skill-loading/SPEC.md
+++ b/.ravi/specs/runtime/skill-loading/SPEC.md
@@ -66,7 +66,7 @@ The capability exists because today there is no canonical place that answers "is
 | --- | --- | --- | --- |
 | Claude Code | Ravi plugins are discovered during runtime bootstrap and passed to the provider when plugin support is enabled. | Provider-native Skill tool or equivalent tool-use event, normalized by the adapter after the event shape is verified. | Passing a plugin to Claude is `advertised` or `available`, not `loaded`. Claude may report `loaded` only from observed provider events or Ravi-owned injection completion. |
 | Codex | `syncCodexSkills` materializes Ravi plugin skills into the Codex skills directory; app-server `skills/list` reports skill metadata; `skills/changed` invalidates that metadata. | No stable dedicated loaded-skill notification is currently exposed. Thread start/resume `instructionSources` may prove instruction files loaded; it can be treated as `loaded` only if the path is matched to a canonical skill file. A successful `ravi skills show <skill>` tool call is Ravi-owned read evidence and may mark that skill `loaded`. `UserInput` items with `type=skill` are `requested` unless followed by load evidence. | Codex MUST report `synced`/`advertised` for Ravi-managed skills today. It MUST NOT mark a skill `loaded` just because it was synchronized or listed in the system prompt. |
-| Pi | No Ravi plugin or skill catalog support in the current RPC MVP. | No skill-loaded event or state exists in the current Pi RPC surface. | Pi MUST report `unknown` or an empty `loadedSkills` vector until the RPC or SDK provider exposes explicit skill state/events. |
+| Pi | Ravi discovers plugin skills, filters them by the agent allowlist, records them as `advertised`, and appends their names plus `ravi skills show <skill> --json` loading instructions to the Pi system prompt. | No provider-native skill-loaded event or state exists in the current Pi RPC surface. A successful Ravi-owned skill read remains the only explicit load evidence available to the host. | Pi MAY report allowlisted catalog entries as `advertised` with declared `system-prompt` evidence, but MUST keep `loadedSkills` empty until Ravi observes explicit load evidence. |
 
 ## Rules
 
@@ -103,4 +103,5 @@ The capability exists because today there is no canonical place that answers "is
 - A compact event resets the vector to empty in the next visibility query and emits a structured event documenting the reset.
 - Vector content is identical regardless of which adapter the session is running under, given the same loaded skills.
 - A synchronized Codex skill appears as `synced` or `advertised`, not `loaded`, until an observed loaded-skill signal is captured.
-- A Pi session returns an empty `loadedSkills` vector and does not imply skill support until Pi exposes explicit skill state.
+- A Pi session advertises only allowlisted catalog entries and returns an empty
+  `loadedSkills` vector until Ravi observes explicit skill-load evidence.

--- a/.ravi/specs/runtime/skill-loading/WHY.md
+++ b/.ravi/specs/runtime/skill-loading/WHY.md
@@ -1,0 +1,42 @@
+# Runtime Skill Loading Rationale
+
+## Why Loading Requires Evidence
+
+A skill can exist in a plugin, be copied into provider storage, appear in a
+prompt catalog, or be requested without its body being present in the active
+context. Authorization and skill gates cannot safely collapse those states.
+
+Ravi therefore records a state, confidence, source, and evidence trail for each
+skill. Only `state=loaded` with `confidence=observed` enters the compatibility
+`loadedSkills` vector.
+
+## Why The Model Is Provider-Neutral
+
+Claude Code, Codex, and Pi expose different discovery and runtime signals. The
+adapter translates those signals into one Ravi model so consumers never infer
+security state from a provider name. Ambiguous signals resolve conservatively
+to `requested`, `advertised`, or `unknown`.
+
+## Why Compaction Resets Loaded State
+
+Compaction changes the live context window. Even when a provider may preserve
+some text internally, Ravi cannot prove that the exact skill body survived in a
+form suitable for enforcement. Resetting the loaded projection forces the next
+protected action to establish fresh evidence.
+
+## Why Pi Gets A Catalog
+
+Pi benefits from knowing which allowlisted Ravi skills are available and how to
+read them, even though it cannot emit a native loaded-skill event. The catalog
+is therefore represented as `advertised` with declared `system-prompt`
+evidence. This improves discoverability without pretending the skill body is
+already loaded.
+
+## Alternatives Rejected
+
+- Trusting filesystem presence was rejected because synchronization is not
+  provider ingestion.
+- Treating a prompt mention as loaded was rejected because a name is not the
+  skill body.
+- Keeping loaded state across compaction was rejected because it would turn
+  stale evidence into an authorization bypass.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "23fd6506a1c613a1"
+    "version": "a87672a7b75e8605"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -2007,12 +2007,300 @@
                       ]
                     },
                     "agent": {
-                      "additionalProperties": {
-                        "$ref": "#/$defs/__schema0"
+                      "additionalProperties": false,
+                      "properties": {
+                        "allowedSessions": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "contactScope": {
+                          "type": "string"
+                        },
+                        "cwd": {
+                          "type": "string"
+                        },
+                        "debounceMs": {
+                          "type": "number"
+                        },
+                        "defaults": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": {
+                                "$ref": "#/$defs/__schema0"
+                              },
+                              "propertyNames": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "dmScope": {
+                          "enum": [
+                            "main",
+                            "per-peer",
+                            "per-channel-peer",
+                            "per-account-channel-peer"
+                          ],
+                          "type": "string"
+                        },
+                        "effectiveModel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "effectiveProvider": {
+                          "type": "string"
+                        },
+                        "effort": {
+                          "enum": [
+                            "none",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh",
+                            "max",
+                            "ultra"
+                          ],
+                          "type": "string"
+                        },
+                        "groupDebounceMs": {
+                          "type": "number"
+                        },
+                        "heartbeat": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "accountId": {
+                              "type": "string"
+                            },
+                            "activeEnd": {
+                              "type": "string"
+                            },
+                            "activeStart": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "intervalMs": {
+                              "type": "number"
+                            },
+                            "lastRunAt": {
+                              "type": "number"
+                            },
+                            "model": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled",
+                            "intervalMs"
+                          ],
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "isDefault": {
+                          "type": "boolean"
+                        },
+                        "matrixAccount": {
+                          "type": "string"
+                        },
+                        "memoryModel": {
+                          "type": "string"
+                        },
+                        "mode": {
+                          "enum": [
+                            "active",
+                            "sentinel"
+                          ],
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "modelPresetId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "modelPresetVersion": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "modelSource": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "agent_preset",
+                                "agent_default",
+                                "global_default"
+                              ],
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "provider": {
+                          "type": "string"
+                        },
+                        "remote": {
+                          "type": "string"
+                        },
+                        "remoteUser": {
+                          "type": "string"
+                        },
+                        "settingSources": {
+                          "items": {
+                            "enum": [
+                              "user",
+                              "project"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "specMode": {
+                          "type": "boolean"
+                        },
+                        "systemPromptAppend": {
+                          "type": "string"
+                        },
+                        "tags": {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "assetId": {
+                                "type": "string"
+                              },
+                              "assetType": {
+                                "enum": [
+                                  "agent",
+                                  "automation",
+                                  "app",
+                                  "session",
+                                  "task",
+                                  "project",
+                                  "profile",
+                                  "contact",
+                                  "chat",
+                                  "route",
+                                  "instance",
+                                  "artifact",
+                                  "insight",
+                                  "workflow_spec",
+                                  "workflow_run",
+                                  "workflow_node",
+                                  "cron_job",
+                                  "trigger",
+                                  "hook",
+                                  "task_automation",
+                                  "observer_rule",
+                                  "observer_binding",
+                                  "observer_profile",
+                                  "command",
+                                  "skill",
+                                  "skill_gate_rule",
+                                  "context",
+                                  "call_profile",
+                                  "call_request",
+                                  "call_voice_agent",
+                                  "call_tool",
+                                  "outbound_queue",
+                                  "outbound_entry",
+                                  "spec",
+                                  "devin_session"
+                                ],
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "number"
+                              },
+                              "createdBy": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "$ref": "#/$defs/__schema0"
+                                },
+                                "propertyNames": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "tagId": {
+                                "type": "string"
+                              },
+                              "tagSlug": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "number"
+                              },
+                              "updatedBy": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "tagId",
+                              "tagSlug",
+                              "assetType",
+                              "assetId",
+                              "source",
+                              "createdAt",
+                              "updatedAt"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
                       },
-                      "propertyNames": {
-                        "type": "string"
-                      },
+                      "required": [
+                        "id",
+                        "cwd",
+                        "modelPresetId",
+                        "isDefault",
+                        "effectiveProvider",
+                        "effectiveModel",
+                        "modelSource",
+                        "modelPresetVersion",
+                        "tags"
+                      ],
                       "type": "object"
                     },
                     "agentId": {
@@ -3511,9 +3799,7 @@
                                         "interface": {
                                           "enum": [
                                             "builtin",
-                                            "cli",
-                                            "sdk",
-                                            "tool"
+                                            "cli"
                                           ],
                                           "type": "string"
                                         },
@@ -3692,6 +3978,33 @@
                         }
                       ]
                     },
+                    "builder": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "string"
+                        },
+                        "reviewChecklist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "skill": {
+                          "type": "string"
+                        },
+                        "spec": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "skill",
+                        "command",
+                        "spec",
+                        "reviewChecklist"
+                      ],
+                      "type": "object"
+                    },
                     "nextCommands": {
                       "items": {
                         "type": "string"
@@ -3753,6 +4066,7 @@
                     "app",
                     "skill",
                     "skillGate",
+                    "builder",
                     "prompts",
                     "nextCommands"
                   ],
@@ -3875,6 +4189,43 @@
                   },
                   "additionalProperties": false,
                   "properties": {
+                    "builder": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "string"
+                        },
+                        "reviewChecklist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "skill": {
+                          "type": "string"
+                        },
+                        "spec": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "skill",
+                        "command",
+                        "spec",
+                        "reviewChecklist"
+                      ],
+                      "type": "object"
+                    },
+                    "cliPath": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "command": {
                       "type": "string"
                     },
@@ -3970,12 +4321,14 @@
                             "enum": [
                               "planned",
                               "created",
-                              "overwritten"
+                              "overwritten",
+                              "preserved"
                             ],
                             "type": "string"
                           },
                           "kind": {
                             "enum": [
+                              "cli",
                               "manifest",
                               "spec",
                               "skill"
@@ -4153,12 +4506,14 @@
                     "command",
                     "dryRun",
                     "force",
+                    "cliPath",
                     "manifestPath",
                     "specPath",
                     "skillPath",
                     "skill",
                     "files",
                     "manifest",
+                    "builder",
                     "nextCommands",
                     "sourceCommand",
                     "source",
@@ -4348,9 +4703,7 @@
                                       "interface": {
                                         "enum": [
                                           "builtin",
-                                          "cli",
-                                          "sdk",
-                                          "tool"
+                                          "cli"
                                         ],
                                         "type": "string"
                                       },
@@ -4640,9 +4993,7 @@
                                       "interface": {
                                         "enum": [
                                           "builtin",
-                                          "cli",
-                                          "sdk",
-                                          "tool"
+                                          "cli"
                                         ],
                                         "type": "string"
                                       },
@@ -5048,9 +5399,7 @@
                                         "interface": {
                                           "enum": [
                                             "builtin",
-                                            "cli",
-                                            "sdk",
-                                            "tool"
+                                            "cli"
                                           ],
                                           "type": "string"
                                         },
@@ -5229,6 +5578,33 @@
                         }
                       ]
                     },
+                    "builder": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "string"
+                        },
+                        "reviewChecklist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "skill": {
+                          "type": "string"
+                        },
+                        "spec": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "skill",
+                        "command",
+                        "spec",
+                        "reviewChecklist"
+                      ],
+                      "type": "object"
+                    },
                     "nextCommands": {
                       "items": {
                         "type": "string"
@@ -5290,6 +5666,7 @@
                     "app",
                     "skill",
                     "skillGate",
+                    "builder",
                     "prompts",
                     "nextCommands"
                   ],
@@ -5397,7 +5774,13 @@
                         }
                       ]
                     },
+                    "callerContextId": {
+                      "type": "string"
+                    },
                     "channel": {
+                      "type": "string"
+                    },
+                    "childContextId": {
                       "type": "string"
                     },
                     "command": {
@@ -5427,10 +5810,7 @@
                         {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool",
-                            "stream"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -5509,9 +5889,7 @@
                         "interface": {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -5609,7 +5987,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "command": {
-                    "description": "Canonical CLI command (default: ravi <id>)",
+                    "description": "Implementation CLI command (default: generated bun cli.ts)",
                     "type": "string"
                   },
                   "description": {
@@ -5621,7 +5999,7 @@
                     "type": "boolean"
                   },
                   "force": {
-                    "description": "Overwrite existing scaffold files",
+                    "description": "Overwrite scaffold contracts while preserving an existing implementation CLI",
                     "type": "boolean"
                   },
                   "id": {
@@ -5694,6 +6072,43 @@
                   },
                   "additionalProperties": false,
                   "properties": {
+                    "builder": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "string"
+                        },
+                        "reviewChecklist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "skill": {
+                          "type": "string"
+                        },
+                        "spec": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "skill",
+                        "command",
+                        "spec",
+                        "reviewChecklist"
+                      ],
+                      "type": "object"
+                    },
+                    "cliPath": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "command": {
                       "type": "string"
                     },
@@ -5711,12 +6126,14 @@
                             "enum": [
                               "planned",
                               "created",
-                              "overwritten"
+                              "overwritten",
+                              "preserved"
                             ],
                             "type": "string"
                           },
                           "kind": {
                             "enum": [
+                              "cli",
                               "manifest",
                               "spec",
                               "skill"
@@ -5801,12 +6218,14 @@
                     "command",
                     "dryRun",
                     "force",
+                    "cliPath",
                     "manifestPath",
                     "specPath",
                     "skillPath",
                     "skill",
                     "files",
                     "manifest",
+                    "builder",
                     "nextCommands"
                   ],
                   "type": "object"
@@ -5991,9 +6410,7 @@
                                     "interface": {
                                       "enum": [
                                         "builtin",
-                                        "cli",
-                                        "sdk",
-                                        "tool"
+                                        "cli"
                                       ],
                                       "type": "string"
                                     },
@@ -15533,6 +15950,671 @@
           }
         ],
         "summary": "Accept one idempotent external channel message into a local agent session",
+        "tags": [
+          "channels"
+        ]
+      }
+    },
+    "/api/v1/channels/backend/runtime/interrupt": {
+      "post": {
+        "operationId": "channels.backend.runtime.interrupt",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "agentId": {
+                    "description": "Concrete local agent id used for authorization",
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "request": {
+                    "additionalProperties": false,
+                    "description": "Channel runtime interrupt request object (JSON when invoked from the CLI)",
+                    "properties": {
+                      "binding": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "agentId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "channelInstanceId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "chatId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "messageId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "sessionId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "turnId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "channelInstanceId",
+                          "agentId",
+                          "chatId",
+                          "messageId",
+                          "sessionId",
+                          "turnId"
+                        ],
+                        "type": "object"
+                      },
+                      "idempotencyKey": {
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "const": "ravi.channel.runtime-events",
+                        "type": "string"
+                      },
+                      "requestId": {
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                        "type": "string"
+                      },
+                      "requestedAt": {
+                        "format": "date-time",
+                        "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                        "type": "string"
+                      },
+                      "schemaVersion": {
+                        "const": 1,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "protocol",
+                      "schemaVersion",
+                      "requestId",
+                      "idempotencyKey",
+                      "binding",
+                      "requestedAt"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "agentId",
+                  "request"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "acceptedAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                      "type": "string"
+                    },
+                    "disposition": {
+                      "enum": [
+                        "requested",
+                        "duplicate",
+                        "rejected"
+                      ],
+                      "type": "string"
+                    },
+                    "error": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "category": {
+                          "enum": [
+                            "validation",
+                            "authentication",
+                            "authorization",
+                            "capacity",
+                            "availability",
+                            "internal"
+                          ],
+                          "type": "string"
+                        },
+                        "code": {
+                          "enum": [
+                            "INVALID_REQUEST",
+                            "IDEMPOTENCY_CONFLICT",
+                            "UNAUTHENTICATED",
+                            "PERMISSION_DENIED",
+                            "LOCAL_PERMISSION_DENIED",
+                            "NOT_FOUND",
+                            "RATE_LIMITED",
+                            "OVERLOADED",
+                            "UNAVAILABLE",
+                            "INTERNAL"
+                          ],
+                          "type": "string"
+                        },
+                        "correlationId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "retryAfterMs": {
+                          "exclusiveMinimum": 0,
+                          "maximum": 86400000,
+                          "type": "integer"
+                        },
+                        "retryable": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "category",
+                        "retryable"
+                      ],
+                      "type": "object"
+                    },
+                    "protocol": {
+                      "const": "ravi.channel.runtime-events",
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "const": 1,
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "protocol",
+                    "schemaVersion",
+                    "requestId",
+                    "disposition",
+                    "acceptedAt"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Idempotently request interruption of an accepted channel turn",
+        "tags": [
+          "channels"
+        ]
+      }
+    },
+    "/api/v1/channels/backend/runtime/readback": {
+      "post": {
+        "operationId": "channels.backend.runtime.readback",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "agentId": {
+                    "description": "Concrete local agent id used for authorization",
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "request": {
+                    "additionalProperties": false,
+                    "description": "Channel runtime readback request object (JSON when invoked from the CLI)",
+                    "properties": {
+                      "binding": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "agentId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "channelInstanceId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "chatId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "messageId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "sessionId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          },
+                          "turnId": {
+                            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "channelInstanceId",
+                          "agentId",
+                          "chatId",
+                          "messageId",
+                          "sessionId",
+                          "turnId"
+                        ],
+                        "type": "object"
+                      },
+                      "protocol": {
+                        "const": "ravi.channel.runtime-events",
+                        "type": "string"
+                      },
+                      "requestId": {
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                        "type": "string"
+                      },
+                      "schemaVersion": {
+                        "const": 1,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "protocol",
+                      "schemaVersion",
+                      "requestId",
+                      "binding"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "agentId",
+                  "request"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "assistantMessageId": {
+                      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                      "type": "string"
+                    },
+                    "binding": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "agentId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "channelInstanceId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "chatId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "messageId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "sessionId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "turnId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "channelInstanceId",
+                        "agentId",
+                        "chatId",
+                        "messageId",
+                        "sessionId",
+                        "turnId"
+                      ],
+                      "type": "object"
+                    },
+                    "lastEventRuntimeGenerationId": {
+                      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                      "type": "string"
+                    },
+                    "lastSequence": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "observedAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "const": "ravi.channel.runtime-events",
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                      "type": "string"
+                    },
+                    "runtimeGenerationId": {
+                      "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "const": 1,
+                      "type": "number"
+                    },
+                    "state": {
+                      "enum": [
+                        "accepted",
+                        "running",
+                        "waiting_approval",
+                        "completed",
+                        "failed",
+                        "interrupted"
+                      ],
+                      "type": "string"
+                    },
+                    "terminalEvent": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "correlation": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "binding": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "agentId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "channelInstanceId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "chatId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "messageId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "sessionId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "turnId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "channelInstanceId",
+                                "agentId",
+                                "chatId",
+                                "messageId",
+                                "sessionId",
+                                "turnId"
+                              ],
+                              "type": "object"
+                            },
+                            "causationId": {
+                              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                              "type": "string"
+                            },
+                            "correlationId": {
+                              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                              "type": "string"
+                            },
+                            "ingressRequestId": {
+                              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "correlationId",
+                            "ingressRequestId",
+                            "binding"
+                          ],
+                          "type": "object"
+                        },
+                        "eventId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "const": "turn.terminal_output",
+                          "type": "string"
+                        },
+                        "occurredAt": {
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                          "type": "string"
+                        },
+                        "payload": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "assistantMessageId": {
+                              "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                              "type": "string"
+                            },
+                            "content": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "const": "text",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "text"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "artifactId": {
+                                        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                        "type": "string"
+                                      },
+                                      "mediaType": {
+                                        "pattern": "^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "sizeBytes": {
+                                        "maximum": 9007199254740991,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "type": {
+                                        "const": "artifact",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "artifactId"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ]
+                              },
+                              "maxItems": 256,
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "error": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "category": {
+                                  "enum": [
+                                    "validation",
+                                    "authentication",
+                                    "authorization",
+                                    "capacity",
+                                    "availability",
+                                    "internal"
+                                  ],
+                                  "type": "string"
+                                },
+                                "code": {
+                                  "enum": [
+                                    "INVALID_REQUEST",
+                                    "IDEMPOTENCY_CONFLICT",
+                                    "UNAUTHENTICATED",
+                                    "PERMISSION_DENIED",
+                                    "LOCAL_PERMISSION_DENIED",
+                                    "NOT_FOUND",
+                                    "RATE_LIMITED",
+                                    "OVERLOADED",
+                                    "UNAVAILABLE",
+                                    "INTERNAL"
+                                  ],
+                                  "type": "string"
+                                },
+                                "correlationId": {
+                                  "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                                  "type": "string"
+                                },
+                                "retryAfterMs": {
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 86400000,
+                                  "type": "integer"
+                                },
+                                "retryable": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "code",
+                                "category",
+                                "retryable"
+                              ],
+                              "type": "object"
+                            },
+                            "state": {
+                              "enum": [
+                                "completed",
+                                "failed",
+                                "interrupted"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "state"
+                          ],
+                          "type": "object"
+                        },
+                        "protocol": {
+                          "const": "ravi.channel.runtime-events",
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "const": 1,
+                          "type": "number"
+                        },
+                        "sequence": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "protocol",
+                        "schemaVersion",
+                        "eventId",
+                        "kind",
+                        "occurredAt",
+                        "sequence",
+                        "correlation",
+                        "payload"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "protocol",
+                    "schemaVersion",
+                    "requestId",
+                    "binding",
+                    "state",
+                    "lastSequence",
+                    "observedAt"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "401": {
+            "description": "Unauthorized — bearer token missing or invalid."
+          },
+          "403": {
+            "description": "Forbidden — caller lacks the required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Read the provider-neutral state of an accepted channel turn",
         "tags": [
           "channels"
         ]
@@ -67101,6 +68183,373 @@
         },
         "security": [],
         "summary": "Attach a chat as the session output target and input source",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/api/v1/sessions/close-thread": {
+      "post": {
+        "operationId": "sessions.close-thread",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "return": {
+                    "description": "Completion result to deliver once to the parent session",
+                    "type": "string"
+                  },
+                  "session": {
+                    "description": "Explicit Slack thread session (defaults to current session)",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actionId": {
+                      "const": "thread.close",
+                      "type": "string"
+                    },
+                    "changed": {
+                      "type": "boolean"
+                    },
+                    "childSession": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "sessionKey": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "sessionName"
+                      ],
+                      "type": "object"
+                    },
+                    "closeSequence": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "closed": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "parentReturn": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "delivered": {
+                          "type": "boolean"
+                        },
+                        "pending": {
+                          "type": "boolean"
+                        },
+                        "requested": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "requested",
+                        "delivered",
+                        "pending"
+                      ],
+                      "type": "object"
+                    },
+                    "parentSession": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "sessionKey": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "sessionName"
+                      ],
+                      "type": "object"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "slack": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "channelId": {
+                          "type": "string"
+                        },
+                        "threadTs": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "channelId",
+                        "threadTs"
+                      ],
+                      "type": "object"
+                    },
+                    "status": {
+                      "const": "closed",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "actionId",
+                    "closed",
+                    "changed",
+                    "requestId",
+                    "closeSequence",
+                    "parentReturn",
+                    "parentSession",
+                    "childSession",
+                    "slack"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Close the current Slack thread session, optionally returning a result to its parent",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/api/v1/sessions/create-thread": {
+      "post": {
+        "operationId": "sessions.create-thread",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "description": "Initial Slack message and first instruction for the child session",
+                    "type": "string"
+                  },
+                  "model": {
+                    "description": "Optional model override for the child session",
+                    "type": "string"
+                  },
+                  "session": {
+                    "description": "Explicit initiating session (defaults to current session)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "actionId": {
+                      "const": "thread.create",
+                      "type": "string"
+                    },
+                    "child": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "modelOverride": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "status": {
+                          "const": "pending_root_delivery",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "modelOverride"
+                      ],
+                      "type": "object"
+                    },
+                    "executionMode": {
+                      "const": "durable",
+                      "type": "string"
+                    },
+                    "idempotencyKey": {
+                      "type": "string"
+                    },
+                    "initiatorSession": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "sessionKey": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "sessionName"
+                      ],
+                      "type": "object"
+                    },
+                    "nextAttemptAt": {
+                      "type": "number"
+                    },
+                    "parentSession": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "sessionKey": {
+                          "type": "string"
+                        },
+                        "sessionName": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "sessionKey",
+                        "sessionName"
+                      ],
+                      "type": "object"
+                    },
+                    "publishPending": {
+                      "type": "boolean"
+                    },
+                    "publishedNow": {
+                      "type": "boolean"
+                    },
+                    "queued": {
+                      "const": true,
+                      "type": "boolean"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "slack": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "accountId": {
+                          "type": "string"
+                        },
+                        "canonicalChatId": {
+                          "type": "string"
+                        },
+                        "channelId": {
+                          "type": "string"
+                        },
+                        "instanceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "accountId",
+                        "instanceId",
+                        "channelId",
+                        "canonicalChatId"
+                      ],
+                      "type": "object"
+                    },
+                    "status": {
+                      "const": "queued",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "queued",
+                    "actionId",
+                    "executionMode",
+                    "requestId",
+                    "idempotencyKey",
+                    "publishedNow",
+                    "publishPending",
+                    "parentSession",
+                    "initiatorSession",
+                    "slack",
+                    "child"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success — body conforms to the `@Returns` schema."
+          },
+          "400": {
+            "description": "Bad request — body failed schema validation."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        },
+        "security": [],
+        "summary": "Create a native Slack thread and start a child session in it",
         "tags": [
           "sessions"
         ]

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -3194,9 +3194,7 @@ export const AppsGuideReturnSchema = {
                         "interface": {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -3375,6 +3373,33 @@ export const AppsGuideReturnSchema = {
         }
       ]
     },
+    "builder": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "reviewChecklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "spec": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill",
+        "command",
+        "spec",
+        "reviewChecklist"
+      ],
+      "type": "object"
+    },
     "nextCommands": {
       "items": {
         "type": "string"
@@ -3436,6 +3461,7 @@ export const AppsGuideReturnSchema = {
     "app",
     "skill",
     "skillGate",
+    "builder",
     "prompts",
     "nextCommands"
   ],
@@ -3530,6 +3556,43 @@ export const AppsImportCliReturnSchema = {
   },
   "additionalProperties": false,
   "properties": {
+    "builder": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "reviewChecklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "spec": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill",
+        "command",
+        "spec",
+        "reviewChecklist"
+      ],
+      "type": "object"
+    },
+    "cliPath": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "command": {
       "type": "string"
     },
@@ -3625,12 +3688,14 @@ export const AppsImportCliReturnSchema = {
             "enum": [
               "planned",
               "created",
-              "overwritten"
+              "overwritten",
+              "preserved"
             ],
             "type": "string"
           },
           "kind": {
             "enum": [
+              "cli",
               "manifest",
               "spec",
               "skill"
@@ -3808,12 +3873,14 @@ export const AppsImportCliReturnSchema = {
     "command",
     "dryRun",
     "force",
+    "cliPath",
     "manifestPath",
     "specPath",
     "skillPath",
     "skill",
     "files",
     "manifest",
+    "builder",
     "nextCommands",
     "sourceCommand",
     "source",
@@ -3975,9 +4042,7 @@ export const AppsListReturnSchema = {
                       "interface": {
                         "enum": [
                           "builtin",
-                          "cli",
-                          "sdk",
-                          "tool"
+                          "cli"
                         ],
                         "type": "string"
                       },
@@ -4267,9 +4332,7 @@ export const AppsListReturnSchema = {
                       "interface": {
                         "enum": [
                           "builtin",
-                          "cli",
-                          "sdk",
-                          "tool"
+                          "cli"
                         ],
                         "type": "string"
                       },
@@ -4647,9 +4710,7 @@ export const AppsPromptsReturnSchema = {
                         "interface": {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -4828,6 +4889,33 @@ export const AppsPromptsReturnSchema = {
         }
       ]
     },
+    "builder": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "reviewChecklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "spec": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill",
+        "command",
+        "spec",
+        "reviewChecklist"
+      ],
+      "type": "object"
+    },
     "nextCommands": {
       "items": {
         "type": "string"
@@ -4889,6 +4977,7 @@ export const AppsPromptsReturnSchema = {
     "app",
     "skill",
     "skillGate",
+    "builder",
     "prompts",
     "nextCommands"
   ],
@@ -4968,7 +5057,13 @@ export const AppsRunReturnSchema = {
         }
       ]
     },
+    "callerContextId": {
+      "type": "string"
+    },
     "channel": {
+      "type": "string"
+    },
+    "childContextId": {
       "type": "string"
     },
     "command": {
@@ -4998,10 +5093,7 @@ export const AppsRunReturnSchema = {
         {
           "enum": [
             "builtin",
-            "cli",
-            "sdk",
-            "tool",
-            "stream"
+            "cli"
           ],
           "type": "string"
         },
@@ -5080,9 +5172,7 @@ export const AppsRunReturnSchema = {
         "interface": {
           "enum": [
             "builtin",
-            "cli",
-            "sdk",
-            "tool"
+            "cli"
           ],
           "type": "string"
         },
@@ -5158,7 +5248,7 @@ export const AppsScaffoldInputSchema = {
   "additionalProperties": false,
   "properties": {
     "command": {
-      "description": "Canonical CLI command (default: ravi <id>)",
+      "description": "Implementation CLI command (default: generated bun cli.ts)",
       "type": "string"
     },
     "description": {
@@ -5170,7 +5260,7 @@ export const AppsScaffoldInputSchema = {
       "type": "boolean"
     },
     "force": {
-      "description": "Overwrite existing scaffold files",
+      "description": "Overwrite scaffold contracts while preserving an existing implementation CLI",
       "type": "boolean"
     },
     "id": {
@@ -5237,6 +5327,43 @@ export const AppsScaffoldReturnSchema = {
   },
   "additionalProperties": false,
   "properties": {
+    "builder": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "reviewChecklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "spec": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill",
+        "command",
+        "spec",
+        "reviewChecklist"
+      ],
+      "type": "object"
+    },
+    "cliPath": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "command": {
       "type": "string"
     },
@@ -5254,12 +5381,14 @@ export const AppsScaffoldReturnSchema = {
             "enum": [
               "planned",
               "created",
-              "overwritten"
+              "overwritten",
+              "preserved"
             ],
             "type": "string"
           },
           "kind": {
             "enum": [
+              "cli",
               "manifest",
               "spec",
               "skill"
@@ -5344,12 +5473,14 @@ export const AppsScaffoldReturnSchema = {
     "command",
     "dryRun",
     "force",
+    "cliPath",
     "manifestPath",
     "specPath",
     "skillPath",
     "skill",
     "files",
     "manifest",
+    "builder",
     "nextCommands"
   ],
   "type": "object"
@@ -5506,9 +5637,7 @@ export const AppsShowReturnSchema = {
                     "interface": {
                       "enum": [
                         "builtin",
-                        "cli",
-                        "sdk",
-                        "tool"
+                        "cli"
                       ],
                       "type": "string"
                     },

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -623,7 +623,7 @@ export type AppsGuideReturn = {
         };
         failClosed: true;
         id: string;
-        interface: "builtin" | "cli" | "sdk" | "tool";
+        interface: "builtin" | "cli";
         operation: string;
         requestSchema: {
           kind: "ref" | "inline" | "unknown";
@@ -646,6 +646,12 @@ export type AppsGuideReturn = {
     warnings: string[];
   }) | null;
   appId: string | null;
+  builder: {
+    command: string;
+    reviewChecklist: string[];
+    skill: string;
+    spec: string;
+  };
   nextCommands: string[];
   prompts: Array<{
     commands: string[];
@@ -676,6 +682,13 @@ export type AppsImportCliInput = {
 
 /** Return shape for `apps.import-cli`. */
 export type AppsImportCliReturn = {
+  builder: {
+    command: string;
+    reviewChecklist: string[];
+    skill: string;
+    spec: string;
+  };
+  cliPath: string | null;
   command: string;
   confidence: "high" | "medium" | "low";
   debugCandidates: Array<{
@@ -694,8 +707,8 @@ export type AppsImportCliReturn = {
   description: string;
   dryRun: boolean;
   files: Array<{
-    action: "planned" | "created" | "overwritten";
-    kind: "manifest" | "spec" | "skill";
+    action: "planned" | "created" | "overwritten" | "preserved";
+    kind: "cli" | "manifest" | "spec" | "skill";
     path: string;
   }>;
   force: boolean;
@@ -755,7 +768,7 @@ export type AppsListReturn = {
         };
         failClosed: true;
         id: string;
-        interface: "builtin" | "cli" | "sdk" | "tool";
+        interface: "builtin" | "cli";
         operation: string;
         requestSchema: {
           kind: "ref" | "inline" | "unknown";
@@ -797,7 +810,7 @@ export type AppsListReturn = {
         };
         failClosed: true;
         id: string;
-        interface: "builtin" | "cli" | "sdk" | "tool";
+        interface: "builtin" | "cli";
         operation: string;
         requestSchema: {
           kind: "ref" | "inline" | "unknown";
@@ -859,7 +872,7 @@ export type AppsPromptsReturn = {
         };
         failClosed: true;
         id: string;
-        interface: "builtin" | "cli" | "sdk" | "tool";
+        interface: "builtin" | "cli";
         operation: string;
         requestSchema: {
           kind: "ref" | "inline" | "unknown";
@@ -882,6 +895,12 @@ export type AppsPromptsReturn = {
     warnings: string[];
   }) | null;
   appId: string | null;
+  builder: {
+    command: string;
+    reviewChecklist: string[];
+    skill: string;
+    spec: string;
+  };
   nextCommands: string[];
   prompts: Array<{
     commands: string[];
@@ -906,13 +925,15 @@ export type AppsRunInput = {
 /** Return shape for `apps.run`. */
 export type AppsRunReturn = {
   appId: string | null;
+  callerContextId?: string;
   channel?: string;
+  childContextId?: string;
   command?: string;
   durationMs: number;
   error?: string;
   exitCode?: number | null;
   handler?: string;
-  interface: ("builtin" | "cli" | "sdk" | "tool" | "stream") | null;
+  interface: ("builtin" | "cli") | null;
   mutating: boolean;
   ok: boolean;
   operation: string | null;
@@ -927,7 +948,7 @@ export type AppsRunReturn = {
     durationMs: number;
     error?: string;
     grantSuggestion?: unknown;
-    interface: "builtin" | "cli" | "sdk" | "tool";
+    interface: "builtin" | "cli";
     providerId: string;
     providerOperationId: string;
     providerVersion: string;
@@ -956,12 +977,19 @@ export type AppsScaffoldInput = {
 
 /** Return shape for `apps.scaffold`. */
 export type AppsScaffoldReturn = {
+  builder: {
+    command: string;
+    reviewChecklist: string[];
+    skill: string;
+    spec: string;
+  };
+  cliPath: string | null;
   command: string;
   description: string;
   dryRun: boolean;
   files: Array<{
-    action: "planned" | "created" | "overwritten";
-    kind: "manifest" | "spec" | "skill";
+    action: "planned" | "created" | "overwritten" | "preserved";
+    kind: "cli" | "manifest" | "spec" | "skill";
     path: string;
   }>;
   force: boolean;
@@ -1003,7 +1031,7 @@ export type AppsShowReturn = {
         };
         failClosed: true;
         id: string;
-        interface: "builtin" | "cli" | "sdk" | "tool";
+        interface: "builtin" | "cli";
         operation: string;
         requestSchema: {
           kind: "ref" | "inline" | "unknown";

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:51ce560f8fcd9d638a23621971cffd0543294915a3093e40e747a6c544b3ce70";
+export const REGISTRY_HASH = "sha256:b4099daeebae02e7cf8fbe37407c4b234efa8a3962ed4d85b0ff31d1e3dfb77f";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "d8ae8c2983a1";
+export const GIT_SHA = "d51a072e42f3";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviClient.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviClient.generated.swift
@@ -831,11 +831,37 @@ public struct ChannelsBackendNamespace: Sendable {
     self.transport = transport
   }
 
+  public var runtime: ChannelsBackendRuntimeNamespace {
+    ChannelsBackendRuntimeNamespace(transport: transport)
+  }
+
   public func ingress(_ agentId: String, _ request: RaviJSON) async throws -> ChannelsBackendIngressReturn {
     var requestBody: [String: RaviJSON] = [:]
     requestBody["agentId"] = try RaviJSON.fromEncodable(agentId)
     requestBody["request"] = try RaviJSON.fromEncodable(request)
     return try await transport.call(groupSegments: ["channels","backend"], command: "ingress", body: requestBody, as: ChannelsBackendIngressReturn.self)
+  }
+}
+
+public struct ChannelsBackendRuntimeNamespace: Sendable {
+  private let transport: any RaviTransport
+
+  init(transport: any RaviTransport) {
+    self.transport = transport
+  }
+
+  public func interrupt(_ agentId: String, _ request: RaviJSON) async throws -> ChannelsBackendRuntimeInterruptReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["agentId"] = try RaviJSON.fromEncodable(agentId)
+    requestBody["request"] = try RaviJSON.fromEncodable(request)
+    return try await transport.call(groupSegments: ["channels","backend","runtime"], command: "interrupt", body: requestBody, as: ChannelsBackendRuntimeInterruptReturn.self)
+  }
+
+  public func readback(_ agentId: String, _ request: RaviJSON) async throws -> ChannelsBackendRuntimeReadbackReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["agentId"] = try RaviJSON.fromEncodable(agentId)
+    requestBody["request"] = try RaviJSON.fromEncodable(request)
+    return try await transport.call(groupSegments: ["channels","backend","runtime"], command: "readback", body: requestBody, as: ChannelsBackendRuntimeReadbackReturn.self)
   }
 }
 
@@ -4145,6 +4171,19 @@ public struct SessionsNamespace: Sendable {
     requestBody["nameOrKey"] = try RaviJSON.fromEncodable(nameOrKey)
     try options.encodeBody(into: &requestBody)
     return try await transport.call(groupSegments: ["sessions"], command: "attach", body: requestBody, as: SessionsAttachReturn.self)
+  }
+
+  public func closeThread(_ options: SessionsCloseThreadOptions = .init()) async throws -> SessionsCloseThreadReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["sessions"], command: "close-thread", body: requestBody, as: SessionsCloseThreadReturn.self)
+  }
+
+  public func createThread(_ message: String, _ options: SessionsCreateThreadOptions = .init()) async throws -> SessionsCreateThreadReturn {
+    var requestBody: [String: RaviJSON] = [:]
+    requestBody["message"] = try RaviJSON.fromEncodable(message)
+    try options.encodeBody(into: &requestBody)
+    return try await transport.call(groupSegments: ["sessions"], command: "create-thread", body: requestBody, as: SessionsCreateThreadReturn.self)
   }
 
   public func delete(_ nameOrKey: String) async throws -> SessionsDeleteReturn {

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -1734,12 +1734,300 @@ public enum RaviSchemas {
         ]
       },
       "agent": {
-        "additionalProperties": {
-          "$ref": "#/$defs/__schema0"
+        "additionalProperties": false,
+        "properties": {
+          "allowedSessions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "contactScope": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "debounceMs": {
+            "type": "number"
+          },
+          "defaults": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/__schema0"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "dmScope": {
+            "enum": [
+              "main",
+              "per-peer",
+              "per-channel-peer",
+              "per-account-channel-peer"
+            ],
+            "type": "string"
+          },
+          "effectiveModel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "effectiveProvider": {
+            "type": "string"
+          },
+          "effort": {
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max",
+              "ultra"
+            ],
+            "type": "string"
+          },
+          "groupDebounceMs": {
+            "type": "number"
+          },
+          "heartbeat": {
+            "additionalProperties": false,
+            "properties": {
+              "accountId": {
+                "type": "string"
+              },
+              "activeEnd": {
+                "type": "string"
+              },
+              "activeStart": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "intervalMs": {
+                "type": "number"
+              },
+              "lastRunAt": {
+                "type": "number"
+              },
+              "model": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "enabled",
+              "intervalMs"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "matrixAccount": {
+            "type": "string"
+          },
+          "memoryModel": {
+            "type": "string"
+          },
+          "mode": {
+            "enum": [
+              "active",
+              "sentinel"
+            ],
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "modelPresetId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelPresetVersion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelSource": {
+            "anyOf": [
+              {
+                "enum": [
+                  "agent_preset",
+                  "agent_default",
+                  "global_default"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "remote": {
+            "type": "string"
+          },
+          "remoteUser": {
+            "type": "string"
+          },
+          "settingSources": {
+            "items": {
+              "enum": [
+                "user",
+                "project"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "specMode": {
+            "type": "boolean"
+          },
+          "systemPromptAppend": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "assetId": {
+                  "type": "string"
+                },
+                "assetType": {
+                  "enum": [
+                    "agent",
+                    "automation",
+                    "app",
+                    "session",
+                    "task",
+                    "project",
+                    "profile",
+                    "contact",
+                    "chat",
+                    "route",
+                    "instance",
+                    "artifact",
+                    "insight",
+                    "workflow_spec",
+                    "workflow_run",
+                    "workflow_node",
+                    "cron_job",
+                    "trigger",
+                    "hook",
+                    "task_automation",
+                    "observer_rule",
+                    "observer_binding",
+                    "observer_profile",
+                    "command",
+                    "skill",
+                    "skill_gate_rule",
+                    "context",
+                    "call_profile",
+                    "call_request",
+                    "call_voice_agent",
+                    "call_tool",
+                    "outbound_queue",
+                    "outbound_entry",
+                    "spec",
+                    "devin_session"
+                  ],
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "number"
+                },
+                "createdBy": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "additionalProperties": {
+                    "$ref": "#/$defs/__schema0"
+                  },
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "tagId": {
+                  "type": "string"
+                },
+                "tagSlug": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "number"
+                },
+                "updatedBy": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "tagId",
+                "tagSlug",
+                "assetType",
+                "assetId",
+                "source",
+                "createdAt",
+                "updatedAt"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
         },
-        "propertyNames": {
-          "type": "string"
-        },
+        "required": [
+          "id",
+          "cwd",
+          "modelPresetId",
+          "isDefault",
+          "effectiveProvider",
+          "effectiveModel",
+          "modelSource",
+          "modelPresetVersion",
+          "tags"
+        ],
         "type": "object"
       },
       "agentId": {
@@ -2934,9 +3222,7 @@ public enum RaviSchemas {
                           "interface": {
                             "enum": [
                               "builtin",
-                              "cli",
-                              "sdk",
-                              "tool"
+                              "cli"
                             ],
                             "type": "string"
                           },
@@ -3115,6 +3401,33 @@ public enum RaviSchemas {
           }
         ]
       },
+      "builder": {
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "reviewChecklist": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "spec": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "skill",
+          "command",
+          "spec",
+          "reviewChecklist"
+        ],
+        "type": "object"
+      },
       "nextCommands": {
         "items": {
           "type": "string"
@@ -3176,6 +3489,7 @@ public enum RaviSchemas {
       "app",
       "skill",
       "skillGate",
+      "builder",
       "prompts",
       "nextCommands"
     ],
@@ -3272,6 +3586,43 @@ public enum RaviSchemas {
     },
     "additionalProperties": false,
     "properties": {
+      "builder": {
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "reviewChecklist": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "spec": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "skill",
+          "command",
+          "spec",
+          "reviewChecklist"
+        ],
+        "type": "object"
+      },
+      "cliPath": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "command": {
         "type": "string"
       },
@@ -3367,12 +3718,14 @@ public enum RaviSchemas {
               "enum": [
                 "planned",
                 "created",
-                "overwritten"
+                "overwritten",
+                "preserved"
               ],
               "type": "string"
             },
             "kind": {
               "enum": [
+                "cli",
                 "manifest",
                 "spec",
                 "skill"
@@ -3550,12 +3903,14 @@ public enum RaviSchemas {
       "command",
       "dryRun",
       "force",
+      "cliPath",
       "manifestPath",
       "specPath",
       "skillPath",
       "skill",
       "files",
       "manifest",
+      "builder",
       "nextCommands",
       "sourceCommand",
       "source",
@@ -3719,9 +4074,7 @@ public enum RaviSchemas {
                         "interface": {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -4011,9 +4364,7 @@ public enum RaviSchemas {
                         "interface": {
                           "enum": [
                             "builtin",
-                            "cli",
-                            "sdk",
-                            "tool"
+                            "cli"
                           ],
                           "type": "string"
                         },
@@ -4393,9 +4744,7 @@ public enum RaviSchemas {
                           "interface": {
                             "enum": [
                               "builtin",
-                              "cli",
-                              "sdk",
-                              "tool"
+                              "cli"
                             ],
                             "type": "string"
                           },
@@ -4574,6 +4923,33 @@ public enum RaviSchemas {
           }
         ]
       },
+      "builder": {
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "reviewChecklist": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "spec": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "skill",
+          "command",
+          "spec",
+          "reviewChecklist"
+        ],
+        "type": "object"
+      },
       "nextCommands": {
         "items": {
           "type": "string"
@@ -4635,6 +5011,7 @@ public enum RaviSchemas {
       "app",
       "skill",
       "skillGate",
+      "builder",
       "prompts",
       "nextCommands"
     ],
@@ -4716,7 +5093,13 @@ public enum RaviSchemas {
           }
         ]
       },
+      "callerContextId": {
+        "type": "string"
+      },
       "channel": {
+        "type": "string"
+      },
+      "childContextId": {
         "type": "string"
       },
       "command": {
@@ -4746,10 +5129,7 @@ public enum RaviSchemas {
           {
             "enum": [
               "builtin",
-              "cli",
-              "sdk",
-              "tool",
-              "stream"
+              "cli"
             ],
             "type": "string"
           },
@@ -4828,9 +5208,7 @@ public enum RaviSchemas {
           "interface": {
             "enum": [
               "builtin",
-              "cli",
-              "sdk",
-              "tool"
+              "cli"
             ],
             "type": "string"
           },
@@ -4907,7 +5285,7 @@ public enum RaviSchemas {
     "additionalProperties": false,
     "properties": {
       "command": {
-        "description": "Canonical CLI command (default: ravi <id>)",
+        "description": "Implementation CLI command (default: generated bun cli.ts)",
         "type": "string"
       },
       "description": {
@@ -4919,7 +5297,7 @@ public enum RaviSchemas {
         "type": "boolean"
       },
       "force": {
-        "description": "Overwrite existing scaffold files",
+        "description": "Overwrite scaffold contracts while preserving an existing implementation CLI",
         "type": "boolean"
       },
       "id": {
@@ -4987,6 +5365,43 @@ public enum RaviSchemas {
     },
     "additionalProperties": false,
     "properties": {
+      "builder": {
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "reviewChecklist": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "spec": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "skill",
+          "command",
+          "spec",
+          "reviewChecklist"
+        ],
+        "type": "object"
+      },
+      "cliPath": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "command": {
         "type": "string"
       },
@@ -5004,12 +5419,14 @@ public enum RaviSchemas {
               "enum": [
                 "planned",
                 "created",
-                "overwritten"
+                "overwritten",
+                "preserved"
               ],
               "type": "string"
             },
             "kind": {
               "enum": [
+                "cli",
                 "manifest",
                 "spec",
                 "skill"
@@ -5094,12 +5511,14 @@ public enum RaviSchemas {
       "command",
       "dryRun",
       "force",
+      "cliPath",
       "manifestPath",
       "specPath",
       "skillPath",
       "skill",
       "files",
       "manifest",
+      "builder",
       "nextCommands"
     ],
     "type": "object"
@@ -5258,9 +5677,7 @@ public enum RaviSchemas {
                       "interface": {
                         "enum": [
                           "builtin",
-                          "cli",
-                          "sdk",
-                          "tool"
+                          "cli"
                         ],
                         "type": "string"
                       },
@@ -13824,6 +14241,599 @@ public enum RaviSchemas {
       "requestId",
       "disposition",
       "acceptedAt"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsBackendRuntimeInterruptInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentId": {
+        "description": "Concrete local agent id used for authorization",
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "request": {
+        "additionalProperties": false,
+        "description": "Channel runtime interrupt request object (JSON when invoked from the CLI)",
+        "properties": {
+          "binding": {
+            "additionalProperties": false,
+            "properties": {
+              "agentId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "channelInstanceId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "chatId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "messageId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "sessionId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "turnId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "channelInstanceId",
+              "agentId",
+              "chatId",
+              "messageId",
+              "sessionId",
+              "turnId"
+            ],
+            "type": "object"
+          },
+          "idempotencyKey": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "protocol": {
+            "const": "ravi.channel.runtime-events",
+            "type": "string"
+          },
+          "requestId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "requestedAt": {
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+          },
+          "schemaVersion": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "protocol",
+          "schemaVersion",
+          "requestId",
+          "idempotencyKey",
+          "binding",
+          "requestedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "agentId",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsBackendRuntimeInterruptReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "acceptedAt": {
+        "format": "date-time",
+        "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+        "type": "string"
+      },
+      "disposition": {
+        "enum": [
+          "requested",
+          "duplicate",
+          "rejected"
+        ],
+        "type": "string"
+      },
+      "error": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "enum": [
+              "validation",
+              "authentication",
+              "authorization",
+              "capacity",
+              "availability",
+              "internal"
+            ],
+            "type": "string"
+          },
+          "code": {
+            "enum": [
+              "INVALID_REQUEST",
+              "IDEMPOTENCY_CONFLICT",
+              "UNAUTHENTICATED",
+              "PERMISSION_DENIED",
+              "LOCAL_PERMISSION_DENIED",
+              "NOT_FOUND",
+              "RATE_LIMITED",
+              "OVERLOADED",
+              "UNAVAILABLE",
+              "INTERNAL"
+            ],
+            "type": "string"
+          },
+          "correlationId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "retryAfterMs": {
+            "exclusiveMinimum": 0,
+            "maximum": 86400000,
+            "type": "integer"
+          },
+          "retryable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "code",
+          "category",
+          "retryable"
+        ],
+        "type": "object"
+      },
+      "protocol": {
+        "const": "ravi.channel.runtime-events",
+        "type": "string"
+      },
+      "requestId": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "schemaVersion": {
+        "const": 1,
+        "type": "number"
+      }
+    },
+    "required": [
+      "protocol",
+      "schemaVersion",
+      "requestId",
+      "disposition",
+      "acceptedAt"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsBackendRuntimeReadbackInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "agentId": {
+        "description": "Concrete local agent id used for authorization",
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "request": {
+        "additionalProperties": false,
+        "description": "Channel runtime readback request object (JSON when invoked from the CLI)",
+        "properties": {
+          "binding": {
+            "additionalProperties": false,
+            "properties": {
+              "agentId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "channelInstanceId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "chatId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "messageId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "sessionId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "turnId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "channelInstanceId",
+              "agentId",
+              "chatId",
+              "messageId",
+              "sessionId",
+              "turnId"
+            ],
+            "type": "object"
+          },
+          "protocol": {
+            "const": "ravi.channel.runtime-events",
+            "type": "string"
+          },
+          "requestId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "schemaVersion": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "protocol",
+          "schemaVersion",
+          "requestId",
+          "binding"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "agentId",
+      "request"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let ChannelsBackendRuntimeReadbackReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "assistantMessageId": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "binding": {
+        "additionalProperties": false,
+        "properties": {
+          "agentId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "channelInstanceId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "chatId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "messageId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "sessionId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "turnId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channelInstanceId",
+          "agentId",
+          "chatId",
+          "messageId",
+          "sessionId",
+          "turnId"
+        ],
+        "type": "object"
+      },
+      "lastEventRuntimeGenerationId": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "lastSequence": {
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "observedAt": {
+        "format": "date-time",
+        "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+        "type": "string"
+      },
+      "protocol": {
+        "const": "ravi.channel.runtime-events",
+        "type": "string"
+      },
+      "requestId": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "runtimeGenerationId": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+        "type": "string"
+      },
+      "schemaVersion": {
+        "const": 1,
+        "type": "number"
+      },
+      "state": {
+        "enum": [
+          "accepted",
+          "running",
+          "waiting_approval",
+          "completed",
+          "failed",
+          "interrupted"
+        ],
+        "type": "string"
+      },
+      "terminalEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "correlation": {
+            "additionalProperties": false,
+            "properties": {
+              "binding": {
+                "additionalProperties": false,
+                "properties": {
+                  "agentId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "channelInstanceId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "chatId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "messageId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "sessionId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "turnId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "channelInstanceId",
+                  "agentId",
+                  "chatId",
+                  "messageId",
+                  "sessionId",
+                  "turnId"
+                ],
+                "type": "object"
+              },
+              "causationId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "correlationId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "ingressRequestId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "correlationId",
+              "ingressRequestId",
+              "binding"
+            ],
+            "type": "object"
+          },
+          "eventId": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+            "type": "string"
+          },
+          "kind": {
+            "const": "turn.terminal_output",
+            "type": "string"
+          },
+          "occurredAt": {
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": false,
+            "properties": {
+              "assistantMessageId": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                "type": "string"
+              },
+              "content": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "text": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "const": "text",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "artifactId": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                          "type": "string"
+                        },
+                        "mediaType": {
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "sizeBytes": {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "type": {
+                          "const": "artifact",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "artifactId"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "maxItems": 256,
+                "minItems": 1,
+                "type": "array"
+              },
+              "error": {
+                "additionalProperties": false,
+                "properties": {
+                  "category": {
+                    "enum": [
+                      "validation",
+                      "authentication",
+                      "authorization",
+                      "capacity",
+                      "availability",
+                      "internal"
+                    ],
+                    "type": "string"
+                  },
+                  "code": {
+                    "enum": [
+                      "INVALID_REQUEST",
+                      "IDEMPOTENCY_CONFLICT",
+                      "UNAUTHENTICATED",
+                      "PERMISSION_DENIED",
+                      "LOCAL_PERMISSION_DENIED",
+                      "NOT_FOUND",
+                      "RATE_LIMITED",
+                      "OVERLOADED",
+                      "UNAVAILABLE",
+                      "INTERNAL"
+                    ],
+                    "type": "string"
+                  },
+                  "correlationId": {
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._~-]*$",
+                    "type": "string"
+                  },
+                  "retryAfterMs": {
+                    "exclusiveMinimum": 0,
+                    "maximum": 86400000,
+                    "type": "integer"
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "code",
+                  "category",
+                  "retryable"
+                ],
+                "type": "object"
+              },
+              "state": {
+                "enum": [
+                  "completed",
+                  "failed",
+                  "interrupted"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          "protocol": {
+            "const": "ravi.channel.runtime-events",
+            "type": "string"
+          },
+          "schemaVersion": {
+            "const": 1,
+            "type": "number"
+          },
+          "sequence": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "protocol",
+          "schemaVersion",
+          "eventId",
+          "kind",
+          "occurredAt",
+          "sequence",
+          "correlation",
+          "payload"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "protocol",
+      "schemaVersion",
+      "requestId",
+      "binding",
+      "state",
+      "lastSequence",
+      "observedAt"
     ],
     "type": "object"
   }
@@ -54457,6 +55467,321 @@ public enum RaviSchemas {
   {
     "additionalProperties": {},
     "properties": {},
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsCloseThreadInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "return": {
+        "description": "Completion result to deliver once to the parent session",
+        "type": "string"
+      },
+      "session": {
+        "description": "Explicit Slack thread session (defaults to current session)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsCloseThreadReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "actionId": {
+        "const": "thread.close",
+        "type": "string"
+      },
+      "changed": {
+        "type": "boolean"
+      },
+      "childSession": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionKey": {
+            "type": "string"
+          },
+          "sessionName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sessionKey",
+          "sessionName"
+        ],
+        "type": "object"
+      },
+      "closeSequence": {
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "closed": {
+        "const": true,
+        "type": "boolean"
+      },
+      "parentReturn": {
+        "additionalProperties": false,
+        "properties": {
+          "delivered": {
+            "type": "boolean"
+          },
+          "pending": {
+            "type": "boolean"
+          },
+          "requested": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "requested",
+          "delivered",
+          "pending"
+        ],
+        "type": "object"
+      },
+      "parentSession": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionKey": {
+            "type": "string"
+          },
+          "sessionName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionKey",
+          "sessionName"
+        ],
+        "type": "object"
+      },
+      "requestId": {
+        "type": "string"
+      },
+      "slack": {
+        "additionalProperties": false,
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "threadTs": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "channelId",
+          "threadTs"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "const": "closed",
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "actionId",
+      "closed",
+      "changed",
+      "requestId",
+      "closeSequence",
+      "parentReturn",
+      "parentSession",
+      "childSession",
+      "slack"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsCreateThreadInputSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "message": {
+        "description": "Initial Slack message and first instruction for the child session",
+        "type": "string"
+      },
+      "model": {
+        "description": "Optional model override for the child session",
+        "type": "string"
+      },
+      "session": {
+        "description": "Explicit initiating session (defaults to current session)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "message"
+    ],
+    "type": "object"
+  }
+  """#
+
+  public static let SessionsCreateThreadReturnSchema = #"""
+  {
+    "additionalProperties": false,
+    "properties": {
+      "actionId": {
+        "const": "thread.create",
+        "type": "string"
+      },
+      "child": {
+        "additionalProperties": false,
+        "properties": {
+          "modelOverride": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "const": "pending_root_delivery",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "modelOverride"
+        ],
+        "type": "object"
+      },
+      "executionMode": {
+        "const": "durable",
+        "type": "string"
+      },
+      "idempotencyKey": {
+        "type": "string"
+      },
+      "initiatorSession": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionKey": {
+            "type": "string"
+          },
+          "sessionName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sessionKey",
+          "sessionName"
+        ],
+        "type": "object"
+      },
+      "nextAttemptAt": {
+        "type": "number"
+      },
+      "parentSession": {
+        "additionalProperties": false,
+        "properties": {
+          "sessionKey": {
+            "type": "string"
+          },
+          "sessionName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sessionKey",
+          "sessionName"
+        ],
+        "type": "object"
+      },
+      "publishPending": {
+        "type": "boolean"
+      },
+      "publishedNow": {
+        "type": "boolean"
+      },
+      "queued": {
+        "const": true,
+        "type": "boolean"
+      },
+      "requestId": {
+        "type": "string"
+      },
+      "slack": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "canonicalChatId": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          },
+          "instanceId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountId",
+          "instanceId",
+          "channelId",
+          "canonicalChatId"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "const": "queued",
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "queued",
+      "actionId",
+      "executionMode",
+      "requestId",
+      "idempotencyKey",
+      "publishedNow",
+      "publishPending",
+      "parentSession",
+      "initiatorSession",
+      "slack",
+      "child"
+    ],
     "type": "object"
   }
   """#

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -321,7 +321,7 @@ public struct AgentsPermissionsOptions: Codable, Sendable {
 public struct AgentsPermissionsReturn: Codable, Sendable {
   public var action: String
   public var after: RaviJSON?
-  public var agent: [String: RaviJSON]?
+  public var agent: RaviJSON?
   public var agentId: String
   public var before: RaviJSON?
   public var changed: Bool
@@ -330,7 +330,7 @@ public struct AgentsPermissionsReturn: Codable, Sendable {
   public var profile: String?
   public var runtimePermissions: RaviJSON?
 
-  public init(action: String, after: RaviJSON? = nil, agent: [String: RaviJSON]? = nil, agentId: String, before: RaviJSON? = nil, changed: Bool, command: String? = nil, defaults: RaviJSON? = nil, profile: String? = nil, runtimePermissions: RaviJSON? = nil) {
+  public init(action: String, after: RaviJSON? = nil, agent: RaviJSON? = nil, agentId: String, before: RaviJSON? = nil, changed: Bool, command: String? = nil, defaults: RaviJSON? = nil, profile: String? = nil, runtimePermissions: RaviJSON? = nil) {
     self.action = action
     self.after = after
     self.agent = agent
@@ -597,14 +597,16 @@ public struct AppsDeleteReturn: Codable, Sendable {
 public struct AppsGuideReturn: Codable, Sendable {
   public var app: RaviJSON
   public var appId: RaviJSON
+  public var builder: RaviJSON
   public var nextCommands: [String]
   public var prompts: [RaviJSON]
   public var skill: String
   public var skillGate: RaviJSON
 
-  public init(app: RaviJSON, appId: RaviJSON, nextCommands: [String], prompts: [RaviJSON], skill: String, skillGate: RaviJSON) {
+  public init(app: RaviJSON, appId: RaviJSON, builder: RaviJSON, nextCommands: [String], prompts: [RaviJSON], skill: String, skillGate: RaviJSON) {
     self.app = app
     self.appId = appId
+    self.builder = builder
     self.nextCommands = nextCommands
     self.prompts = prompts
     self.skill = skill
@@ -614,6 +616,7 @@ public struct AppsGuideReturn: Codable, Sendable {
   enum CodingKeys: String, CodingKey {
     case app = "app"
     case appId = "appId"
+    case builder = "builder"
     case nextCommands = "nextCommands"
     case prompts = "prompts"
     case skill = "skill"
@@ -688,6 +691,8 @@ public struct AppsImportCliOptions: Codable, Sendable {
 }
 
 public struct AppsImportCliReturn: Codable, Sendable {
+  public var builder: RaviJSON
+  public var cliPath: RaviJSON
   public var command: String
   public var confidence: String
   public var debugCandidates: [RaviJSON]
@@ -709,7 +714,9 @@ public struct AppsImportCliReturn: Codable, Sendable {
   public var specPath: RaviJSON
   public var warnings: [String]
 
-  public init(command: String, confidence: String, debugCandidates: [RaviJSON], description: String, dryRun: Bool, files: [RaviJSON], force: Bool, id: String, manifest: [String: RaviJSON], manifestPath: String, name: String, nextCommands: [String], operationCandidates: [RaviJSON], reviewRequired: [String], skill: RaviJSON, skillPath: RaviJSON, source: String, sourceCommand: String, specPath: RaviJSON, warnings: [String]) {
+  public init(builder: RaviJSON, cliPath: RaviJSON, command: String, confidence: String, debugCandidates: [RaviJSON], description: String, dryRun: Bool, files: [RaviJSON], force: Bool, id: String, manifest: [String: RaviJSON], manifestPath: String, name: String, nextCommands: [String], operationCandidates: [RaviJSON], reviewRequired: [String], skill: RaviJSON, skillPath: RaviJSON, source: String, sourceCommand: String, specPath: RaviJSON, warnings: [String]) {
+    self.builder = builder
+    self.cliPath = cliPath
     self.command = command
     self.confidence = confidence
     self.debugCandidates = debugCandidates
@@ -733,6 +740,8 @@ public struct AppsImportCliReturn: Codable, Sendable {
   }
 
   enum CodingKeys: String, CodingKey {
+    case builder = "builder"
+    case cliPath = "cliPath"
     case command = "command"
     case confidence = "confidence"
     case debugCandidates = "debugCandidates"
@@ -810,14 +819,16 @@ public struct AppsListReturn: Codable, Sendable {
 public struct AppsPromptsReturn: Codable, Sendable {
   public var app: RaviJSON
   public var appId: RaviJSON
+  public var builder: RaviJSON
   public var nextCommands: [String]
   public var prompts: [RaviJSON]
   public var skill: String
   public var skillGate: RaviJSON
 
-  public init(app: RaviJSON, appId: RaviJSON, nextCommands: [String], prompts: [RaviJSON], skill: String, skillGate: RaviJSON) {
+  public init(app: RaviJSON, appId: RaviJSON, builder: RaviJSON, nextCommands: [String], prompts: [RaviJSON], skill: String, skillGate: RaviJSON) {
     self.app = app
     self.appId = appId
+    self.builder = builder
     self.nextCommands = nextCommands
     self.prompts = prompts
     self.skill = skill
@@ -827,6 +838,7 @@ public struct AppsPromptsReturn: Codable, Sendable {
   enum CodingKeys: String, CodingKey {
     case app = "app"
     case appId = "appId"
+    case builder = "builder"
     case nextCommands = "nextCommands"
     case prompts = "prompts"
     case skill = "skill"
@@ -836,7 +848,9 @@ public struct AppsPromptsReturn: Codable, Sendable {
 
 public struct AppsRunReturn: Codable, Sendable {
   public var appId: RaviJSON
+  public var callerContextId: String?
   public var channel: String?
+  public var childContextId: String?
   public var command: String?
   public var durationMs: Double
   public var error: String?
@@ -853,9 +867,11 @@ public struct AppsRunReturn: Codable, Sendable {
   public var stderr: String?
   public var stdout: String?
 
-  public init(appId: RaviJSON, channel: String? = nil, command: String? = nil, durationMs: Double, error: String? = nil, exitCode: RaviJSON? = nil, handler: String? = nil, interface: RaviJSON, mutating: Bool, ok: Bool, operation: RaviJSON, operationId: RaviJSON, permissionProvider: RaviJSON? = nil, result: RaviJSON? = nil, status: String, stderr: String? = nil, stdout: String? = nil) {
+  public init(appId: RaviJSON, callerContextId: String? = nil, channel: String? = nil, childContextId: String? = nil, command: String? = nil, durationMs: Double, error: String? = nil, exitCode: RaviJSON? = nil, handler: String? = nil, interface: RaviJSON, mutating: Bool, ok: Bool, operation: RaviJSON, operationId: RaviJSON, permissionProvider: RaviJSON? = nil, result: RaviJSON? = nil, status: String, stderr: String? = nil, stdout: String? = nil) {
     self.appId = appId
+    self.callerContextId = callerContextId
     self.channel = channel
+    self.childContextId = childContextId
     self.command = command
     self.durationMs = durationMs
     self.error = error
@@ -875,7 +891,9 @@ public struct AppsRunReturn: Codable, Sendable {
 
   enum CodingKeys: String, CodingKey {
     case appId = "appId"
+    case callerContextId = "callerContextId"
     case channel = "channel"
+    case childContextId = "childContextId"
     case command = "command"
     case durationMs = "durationMs"
     case error = "error"
@@ -955,6 +973,8 @@ public struct AppsScaffoldOptions: Codable, Sendable {
 }
 
 public struct AppsScaffoldReturn: Codable, Sendable {
+  public var builder: RaviJSON
+  public var cliPath: RaviJSON
   public var command: String
   public var description: String
   public var dryRun: Bool
@@ -969,7 +989,9 @@ public struct AppsScaffoldReturn: Codable, Sendable {
   public var skillPath: RaviJSON
   public var specPath: RaviJSON
 
-  public init(command: String, description: String, dryRun: Bool, files: [RaviJSON], force: Bool, id: String, manifest: [String: RaviJSON], manifestPath: String, name: String, nextCommands: [String], skill: RaviJSON, skillPath: RaviJSON, specPath: RaviJSON) {
+  public init(builder: RaviJSON, cliPath: RaviJSON, command: String, description: String, dryRun: Bool, files: [RaviJSON], force: Bool, id: String, manifest: [String: RaviJSON], manifestPath: String, name: String, nextCommands: [String], skill: RaviJSON, skillPath: RaviJSON, specPath: RaviJSON) {
+    self.builder = builder
+    self.cliPath = cliPath
     self.command = command
     self.description = description
     self.dryRun = dryRun
@@ -986,6 +1008,8 @@ public struct AppsScaffoldReturn: Codable, Sendable {
   }
 
   enum CodingKeys: String, CodingKey {
+    case builder = "builder"
+    case cliPath = "cliPath"
     case command = "command"
     case description = "description"
     case dryRun = "dryRun"
@@ -3171,6 +3195,75 @@ public struct ChannelsBackendIngressReturn: Codable, Sendable {
     case protocol_ = "protocol"
     case requestId = "requestId"
     case schemaVersion = "schemaVersion"
+  }
+}
+
+public struct ChannelsBackendRuntimeInterruptReturn: Codable, Sendable {
+  public var acceptedAt: String
+  public var disposition: String
+  public var error: RaviJSON?
+  public var protocol_: String
+  public var requestId: String
+  public var schemaVersion: Int
+
+  public init(acceptedAt: String, disposition: String, error: RaviJSON? = nil, protocol_: String, requestId: String, schemaVersion: Int) {
+    self.acceptedAt = acceptedAt
+    self.disposition = disposition
+    self.error = error
+    self.protocol_ = protocol_
+    self.requestId = requestId
+    self.schemaVersion = schemaVersion
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case acceptedAt = "acceptedAt"
+    case disposition = "disposition"
+    case error = "error"
+    case protocol_ = "protocol"
+    case requestId = "requestId"
+    case schemaVersion = "schemaVersion"
+  }
+}
+
+public struct ChannelsBackendRuntimeReadbackReturn: Codable, Sendable {
+  public var assistantMessageId: String?
+  public var binding: RaviJSON
+  public var lastEventRuntimeGenerationId: String?
+  public var lastSequence: Int
+  public var observedAt: String
+  public var protocol_: String
+  public var requestId: String
+  public var runtimeGenerationId: String?
+  public var schemaVersion: Int
+  public var state: String
+  public var terminalEvent: RaviJSON?
+
+  public init(assistantMessageId: String? = nil, binding: RaviJSON, lastEventRuntimeGenerationId: String? = nil, lastSequence: Int, observedAt: String, protocol_: String, requestId: String, runtimeGenerationId: String? = nil, schemaVersion: Int, state: String, terminalEvent: RaviJSON? = nil) {
+    self.assistantMessageId = assistantMessageId
+    self.binding = binding
+    self.lastEventRuntimeGenerationId = lastEventRuntimeGenerationId
+    self.lastSequence = lastSequence
+    self.observedAt = observedAt
+    self.protocol_ = protocol_
+    self.requestId = requestId
+    self.runtimeGenerationId = runtimeGenerationId
+    self.schemaVersion = schemaVersion
+    self.state = state
+    self.terminalEvent = terminalEvent
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case assistantMessageId = "assistantMessageId"
+    case binding = "binding"
+    case lastEventRuntimeGenerationId = "lastEventRuntimeGenerationId"
+    case lastSequence = "lastSequence"
+    case observedAt = "observedAt"
+    case protocol_ = "protocol"
+    case requestId = "requestId"
+    case runtimeGenerationId = "runtimeGenerationId"
+    case schemaVersion = "schemaVersion"
+    case state = "state"
+    case terminalEvent = "terminalEvent"
   }
 }
 
@@ -17365,6 +17458,141 @@ public struct SessionsAttachOptions: Codable, Sendable {
 }
 
 public typealias SessionsAttachReturn = [String: RaviJSON]
+
+public struct SessionsCloseThreadOptions: Codable, Sendable {
+  public var return_: String?
+  public var session: String?
+
+  public init(return_: String? = nil, session: String? = nil) {
+    self.return_ = return_
+    self.session = session
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case return_ = "return"
+    case session = "session"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.return_ {
+      body["return"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.session {
+      body["session"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SessionsCloseThreadReturn: Codable, Sendable {
+  public var actionId: String
+  public var changed: Bool
+  public var childSession: RaviJSON
+  public var closeSequence: Int
+  public var closed: Bool
+  public var parentReturn: RaviJSON
+  public var parentSession: RaviJSON
+  public var requestId: String
+  public var slack: RaviJSON
+  public var status: String
+
+  public init(actionId: String, changed: Bool, childSession: RaviJSON, closeSequence: Int, closed: Bool, parentReturn: RaviJSON, parentSession: RaviJSON, requestId: String, slack: RaviJSON, status: String) {
+    self.actionId = actionId
+    self.changed = changed
+    self.childSession = childSession
+    self.closeSequence = closeSequence
+    self.closed = closed
+    self.parentReturn = parentReturn
+    self.parentSession = parentSession
+    self.requestId = requestId
+    self.slack = slack
+    self.status = status
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case actionId = "actionId"
+    case changed = "changed"
+    case childSession = "childSession"
+    case closeSequence = "closeSequence"
+    case closed = "closed"
+    case parentReturn = "parentReturn"
+    case parentSession = "parentSession"
+    case requestId = "requestId"
+    case slack = "slack"
+    case status = "status"
+  }
+}
+
+public struct SessionsCreateThreadOptions: Codable, Sendable {
+  public var model: String?
+  public var session: String?
+
+  public init(model: String? = nil, session: String? = nil) {
+    self.model = model
+    self.session = session
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case model = "model"
+    case session = "session"
+  }
+
+  func encodeBody(into body: inout [String: RaviJSON]) throws {
+    if let value = self.model {
+      body["model"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.session {
+      body["session"] = try RaviJSON.fromEncodable(value)
+    }
+  }
+}
+
+public struct SessionsCreateThreadReturn: Codable, Sendable {
+  public var actionId: String
+  public var child: RaviJSON
+  public var executionMode: String
+  public var idempotencyKey: String
+  public var initiatorSession: RaviJSON
+  public var nextAttemptAt: Double?
+  public var parentSession: RaviJSON
+  public var publishPending: Bool
+  public var publishedNow: Bool
+  public var queued: Bool
+  public var requestId: String
+  public var slack: RaviJSON
+  public var status: String
+
+  public init(actionId: String, child: RaviJSON, executionMode: String, idempotencyKey: String, initiatorSession: RaviJSON, nextAttemptAt: Double? = nil, parentSession: RaviJSON, publishPending: Bool, publishedNow: Bool, queued: Bool, requestId: String, slack: RaviJSON, status: String) {
+    self.actionId = actionId
+    self.child = child
+    self.executionMode = executionMode
+    self.idempotencyKey = idempotencyKey
+    self.initiatorSession = initiatorSession
+    self.nextAttemptAt = nextAttemptAt
+    self.parentSession = parentSession
+    self.publishPending = publishPending
+    self.publishedNow = publishedNow
+    self.queued = queued
+    self.requestId = requestId
+    self.slack = slack
+    self.status = status
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case actionId = "actionId"
+    case child = "child"
+    case executionMode = "executionMode"
+    case idempotencyKey = "idempotencyKey"
+    case initiatorSession = "initiatorSession"
+    case nextAttemptAt = "nextAttemptAt"
+    case parentSession = "parentSession"
+    case publishPending = "publishPending"
+    case publishedNow = "publishedNow"
+    case queued = "queued"
+    case requestId = "requestId"
+    case slack = "slack"
+    case status = "status"
+  }
+}
 
 public typealias SessionsDeleteReturn = [String: RaviJSON]
 

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:df7dc0abc6645ed29bed74df9bb8b5b9d4f7804f85ac2a415aaf72eaefc82693"
-public let RAVI_GIT_SHA = "561d8ea6c0c0"
+public let RAVI_REGISTRY_HASH = "sha256:b4099daeebae02e7cf8fbe37407c4b234efa8a3962ed4d85b0ff31d1e3dfb77f"
+public let RAVI_GIT_SHA = "d51a072e42f3"

--- a/src/apps/apps/ravi.app.json
+++ b/src/apps/apps/ravi.app.json
@@ -61,34 +61,37 @@
       ]
     }
   },
+  "context": {
+    "allow": ["execute:group:apps"]
+  },
   "operations": {
     "apps.list": {
       "interface": "cli",
-      "command": "ravi apps list --json",
+      "command": "ravi apps list {args} --json",
       "mutating": false,
       "outputSchema": "schemas/apps-list.v1.json"
     },
     "apps.check": {
       "interface": "cli",
-      "command": "ravi apps check {id} --json",
+      "command": "ravi apps check {args} --json",
       "mutating": false,
       "outputSchema": "schemas/apps-check.v1.json"
     },
     "apps.guide": {
       "interface": "cli",
-      "command": "ravi apps guide {id} --json",
+      "command": "ravi apps guide {args} --json",
       "mutating": false,
       "outputSchema": "schemas/apps-guide.v1.json"
     },
     "apps.prompts": {
       "interface": "cli",
-      "command": "ravi apps prompts {id} --json",
+      "command": "ravi apps prompts {args} --json",
       "mutating": false,
       "outputSchema": "schemas/apps-guide.v1.json"
     },
     "apps.scaffold": {
       "interface": "cli",
-      "command": "ravi apps scaffold {id} --json",
+      "command": "ravi apps scaffold {args} --json",
       "mutating": true,
       "permission": "apps:write",
       "outputSchema": "schemas/apps-scaffold.v1.json"

--- a/src/apps/builder.ts
+++ b/src/apps/builder.ts
@@ -1,0 +1,26 @@
+import type { RaviAppBuilderGuidance } from "./types.js";
+
+export const RAVI_APP_BUILDER_SKILL = "ravi-dev-app-creator";
+export const RAVI_APP_BUILDER_SPEC = "apps/builder";
+
+export const RAVI_APP_BUILDER_REVIEW_CHECKLIST = [
+  "Source contract: record the official API or CLI documentation, resource model, operation matrix, pagination, quotas, and error envelope.",
+  "CLI boundary: choose one real implementation command; keep the public ravi <app-id> alias out of interfaces.cli.command to avoid router recursion.",
+  "Authentication: choose a Ravi credential-broker or managed connector boundary; never place tokens, refresh tokens, client secrets, or secret paths in manifests, argv, stdout, specs, or skills.",
+  "Permissions: classify read, sensitive read, write, and destructive operations; declare operation permissions and the smallest child-context ceiling in context.allow.",
+  "Skill visibility: create the app operating skill, verify it is indexed for the target runtime, and grant it to restricted agents when their allowlist requires an explicit grant.",
+  "Machine contract: define stable --json output, typed errors, exit status, pagination cursors, idempotency behavior, and bounded timeouts for every public operation.",
+  "Product surfaces: make an explicit yes/no decision for storage, events, artifacts, and semantic UI; add only the surfaces that create reuse, lineage, audit, recovery, or operator value.",
+  "Failure behavior: prove missing auth fails before network access, provider errors are sanitized, retries are bounded, and destructive actions require explicit authorization.",
+  "Functional validation: exercise the public ravi <app-id> <operation> route with fake credentials and fake HTTP or a deterministic fake CLI, not only manifest validation.",
+  "Release gate: run app, CLI, router, permission, skill, spec, type, formatting, generated-contract, and full-suite checks before claiming the app is ready.",
+] as const;
+
+export function buildRaviAppBuilderGuidance(): RaviAppBuilderGuidance {
+  return {
+    skill: RAVI_APP_BUILDER_SKILL,
+    command: `ravi skills show ${RAVI_APP_BUILDER_SKILL} --json`,
+    spec: RAVI_APP_BUILDER_SPEC,
+    reviewChecklist: [...RAVI_APP_BUILDER_REVIEW_CHECKLIST],
+  };
+}

--- a/src/apps/command.test.ts
+++ b/src/apps/command.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildRaviAppProcessEnv,
+  parseRaviAppCapability,
+  parseRaviAppCommand,
+  resolveRaviAppCommand,
+  tokenizeRaviAppCommand,
+} from "./command.js";
+
+describe("Ravi App CLI command contract", () => {
+  it("tokenizes quoted and escaped argv without invoking a shell", () => {
+    expect(tokenizeRaviAppCommand(`tool "two words" 'three words' escaped\\ value`)).toEqual([
+      "tool",
+      "two words",
+      "three words",
+      "escaped value",
+    ]);
+  });
+
+  it("inserts dynamic args only at the complete {args} token", () => {
+    expect(resolveRaviAppCommand("tool before {args} after", ["one", "two words"])).toMatchObject({
+      executable: "tool",
+      argv: ["before", "one", "two words", "after"],
+    });
+    expect(resolveRaviAppCommand("tool fixed", ["one"])).toMatchObject({
+      executable: "tool",
+      argv: ["fixed", "one"],
+    });
+  });
+
+  it("rejects named placeholders instead of maintaining a second interpolation contract", () => {
+    expect(() => resolveRaviAppCommand("tool get {id} --json", ["record-1", "--verbose"])).toThrow(
+      'Unsupported CLI command placeholder in token "{id}"; only a complete {args} token is allowed',
+    );
+  });
+
+  it("rewrites the ravi executable to the current runtime entrypoint", () => {
+    expect(
+      resolveRaviAppCommand("ravi contacts list {args} --json", ["--limit", "2"], {
+        execPath: "/runtime/bun",
+        entrypoint: "/repo/src/cli/index.ts",
+      }),
+    ).toMatchObject({
+      executable: "/runtime/bun",
+      argv: ["/repo/src/cli/index.ts", "contacts", "list", "--limit", "2", "--json"],
+    });
+  });
+
+  it("rejects shell syntax, substitution, malformed quoting, and unsafe placeholders", () => {
+    const unsafe = [
+      "tool a | other",
+      "tool a && other",
+      "tool a; other",
+      "tool > output",
+      "tool $(other)",
+      "tool `other`",
+      "tool\nother",
+      "tool {}",
+      "tool prefix-{args}",
+      "tool {args} {id}",
+      "tool 'unterminated",
+      "tool dangling\\",
+    ];
+
+    for (const command of unsafe) {
+      expect(() => parseRaviAppCommand(command)).toThrow();
+    }
+  });
+
+  it("builds a strict process environment and injects only the child context key", () => {
+    const env = buildRaviAppProcessEnv(
+      {
+        PATH: "/bin",
+        HOME: "/home/test",
+        RAVI_STATE_DIR: "/state",
+        RAVI_CONTEXT_KEY: "parent-secret",
+        RAVI_SESSION_KEY: "legacy-session",
+        RAVI_AGENT_ID: "legacy-agent",
+        API_TOKEN: "provider-secret",
+      },
+      {
+        appId: "probe",
+        operationId: "probe.inspect",
+        appRoot: "/apps/probe",
+        contextKey: "child-secret",
+      },
+    );
+
+    expect(env).toEqual({
+      PATH: "/bin",
+      HOME: "/home/test",
+      RAVI_STATE_DIR: "/state",
+      RAVI_APP_ID: "probe",
+      RAVI_APP_OPERATION_ID: "probe.inspect",
+      RAVI_APP_ROOT: "/apps/probe",
+      RAVI_CONTEXT_KEY: "child-secret",
+    });
+    expect(env.RAVI_SESSION_KEY).toBeUndefined();
+    expect(env.RAVI_AGENT_ID).toBeUndefined();
+    expect(env.API_TOKEN).toBeUndefined();
+  });
+
+  it("parses explicit manifest capabilities", () => {
+    expect(parseRaviAppCapability("execute:group:contacts")).toEqual({
+      permission: "execute",
+      objectType: "group",
+      objectId: "contacts",
+      source: "app-manifest",
+    });
+    expect(parseRaviAppCapability("read:resource:org:123")).toMatchObject({
+      permission: "read",
+      objectType: "resource",
+      objectId: "org:123",
+    });
+    expect(() => parseRaviAppCapability("execute:group")).toThrow(/expected permission:objectType:objectId/);
+  });
+});

--- a/src/apps/command.ts
+++ b/src/apps/command.ts
@@ -1,0 +1,220 @@
+import { basename, resolve } from "node:path";
+import type { ContextCapability } from "../router/router-db.js";
+
+export interface RaviAppCommandTemplate {
+  executable: string;
+  argv: string[];
+  argsPlaceholderIndex: number | null;
+}
+
+export interface RaviAppCommandInvocation {
+  executable: string;
+  argv: string[];
+  displayCommand: string;
+}
+
+export interface RaviAppCommandRuntime {
+  execPath?: string;
+  entrypoint?: string;
+}
+
+const SAFE_APP_ENV_KEYS = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "COLORTERM",
+  "NO_COLOR",
+  "FORCE_COLOR",
+  "CI",
+  "BUN_INSTALL",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "RAVI_HOME",
+  "RAVI_STATE_DIR",
+] as const;
+
+export function parseRaviAppCommand(command: string): RaviAppCommandTemplate {
+  const tokens = tokenizeRaviAppCommand(command);
+  const executable = tokens[0];
+  if (!executable) throw new Error("CLI command must declare an executable.");
+
+  let argsPlaceholderIndex: number | null = null;
+  const argv = tokens.slice(1);
+  for (let index = 0; index < argv.length; index++) {
+    const token = argv[index]!;
+    if (token === "{args}") {
+      if (argsPlaceholderIndex !== null) {
+        throw new Error("CLI command may contain a dynamic argv placeholder at most once.");
+      }
+      argsPlaceholderIndex = index;
+      continue;
+    }
+    if (token.includes("{") || token.includes("}")) {
+      throw new Error(
+        `Unsupported CLI command placeholder in token "${token}"; only a complete {args} token is allowed in new manifests.`,
+      );
+    }
+  }
+  if (executable.includes("{") || executable.includes("}")) {
+    throw new Error("CLI command executable must be static; placeholders are not allowed.");
+  }
+
+  return { executable, argv, argsPlaceholderIndex };
+}
+
+export function tokenizeRaviAppCommand(command: string): string[] {
+  if (!command.trim()) throw new Error("CLI command must be a non-empty string.");
+  if (/[\r\n\0]/.test(command)) throw new Error("CLI command must be a single line.");
+  if (command.includes("`") || command.includes("$(")) {
+    throw new Error("CLI command must not contain command substitution.");
+  }
+
+  const tokens: string[] = [];
+  let token = "";
+  let tokenStarted = false;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of command) {
+    if (escaped) {
+      token += char;
+      tokenStarted = true;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      tokenStarted = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        token += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      tokenStarted = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (tokenStarted) {
+        tokens.push(token);
+        token = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+    if ("|&;<>".includes(char)) {
+      throw new Error(`CLI command must not contain shell operator "${char}".`);
+    }
+    token += char;
+    tokenStarted = true;
+  }
+
+  if (escaped) throw new Error("CLI command must not end with a dangling escape.");
+  if (quote) throw new Error("CLI command contains an unterminated quote.");
+  if (tokenStarted) tokens.push(token);
+  if (tokens.length === 0) throw new Error("CLI command must declare an executable.");
+  return tokens;
+}
+
+export function resolveRaviAppCommand(
+  command: string,
+  args: string[] = [],
+  runtime: RaviAppCommandRuntime = {},
+): RaviAppCommandInvocation {
+  const parsed = parseRaviAppCommand(command);
+  const argv = [...parsed.argv];
+  if (parsed.argsPlaceholderIndex === null) {
+    argv.push(...args);
+  } else {
+    argv.splice(parsed.argsPlaceholderIndex, 1, ...args);
+  }
+
+  let executable = parsed.executable;
+  if (isRaviExecutable(executable)) {
+    const execPath = runtime.execPath ?? process.execPath;
+    const entrypoint = runtime.entrypoint ?? process.argv[1];
+    if (!execPath?.trim() || !entrypoint?.trim()) {
+      throw new Error("Cannot resolve the current Ravi CLI entrypoint for an app command.");
+    }
+    executable = execPath;
+    argv.unshift(resolve(entrypoint));
+  }
+
+  return {
+    executable,
+    argv,
+    displayCommand: [parsed.executable, ...renderTemplateArgs(parsed, args)].map(quoteDisplayArg).join(" "),
+  };
+}
+
+export function buildRaviAppProcessEnv(
+  source: NodeJS.ProcessEnv,
+  input: {
+    appId?: string;
+    operationId?: string;
+    appRoot?: string;
+    contextKey?: string;
+  } = {},
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of SAFE_APP_ENV_KEYS) {
+    const value = source[key];
+    if (typeof value === "string") env[key] = value;
+  }
+  if (input.appId) env.RAVI_APP_ID = input.appId;
+  if (input.operationId) env.RAVI_APP_OPERATION_ID = input.operationId;
+  if (input.appRoot) env.RAVI_APP_ROOT = input.appRoot;
+  if (input.contextKey) env.RAVI_CONTEXT_KEY = input.contextKey;
+  return env;
+}
+
+export function parseRaviAppCapability(value: string): ContextCapability {
+  const match = /^([^:\s]+):([^:\s]+):(.+)$/.exec(value.trim());
+  if (!match || !match[3]?.trim()) {
+    throw new Error(`Invalid context capability "${value}"; expected permission:objectType:objectId.`);
+  }
+  return {
+    permission: match[1]!,
+    objectType: match[2]!,
+    objectId: match[3]!.trim(),
+    source: "app-manifest",
+  };
+}
+
+function renderTemplateArgs(parsed: RaviAppCommandTemplate, args: string[]): string[] {
+  const argv = [...parsed.argv];
+  if (parsed.argsPlaceholderIndex === null) {
+    argv.push(...args);
+  } else {
+    argv.splice(parsed.argsPlaceholderIndex, 1, ...args);
+  }
+  return argv;
+}
+
+function isRaviExecutable(value: string): boolean {
+  return value === "ravi" || basename(value) === "ravi";
+}
+
+function quoteDisplayArg(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+,-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}

--- a/src/apps/contract-eval.ts
+++ b/src/apps/contract-eval.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { RAVI_APP_BUILDER_SKILL, RAVI_APP_BUILDER_SPEC } from "./builder.js";
+import { buildAppsGuide, RAVI_APPS_COMMAND_GUIDANCE } from "./guide.js";
+
+export type RaviAppsContractSurface =
+  | "registry"
+  | "guide"
+  | "system-skill"
+  | "builder-skill"
+  | "apps-spec"
+  | "builder-spec"
+  | "acceptance-cases";
+
+export interface RaviAppsContractDrift {
+  surface: RaviAppsContractSurface;
+  code: string;
+  detail: string;
+}
+
+export interface RaviAppsContractEvalResult {
+  ok: boolean;
+  registryCommands: string[];
+  documentedCommands: string[];
+  drift: RaviAppsContractDrift[];
+}
+
+export interface RaviAppsContractEvalOptions {
+  cwd?: string;
+  guidance?: readonly {
+    command: string;
+    promptId: string;
+    audience: "public" | "debug";
+  }[];
+}
+
+const CONTRACT_PATHS = {
+  systemSkill: "src/plugins/internal/ravi-system/skills/apps/SKILL.md",
+  builderSkill: "src/plugins/internal/ravi-dev/skills/app-creator/SKILL.md",
+  appsSpec: ".ravi/specs/apps/SPEC.md",
+  builderSpec: ".ravi/specs/apps/builder/SPEC.md",
+  acceptanceCases: "src/plugins/internal/ravi-dev/skills/app-creator/references/acceptance-cases.md",
+} as const;
+
+export function evaluateRaviAppsContract(
+  registryCommands: readonly string[],
+  options: RaviAppsContractEvalOptions = {},
+): RaviAppsContractEvalResult {
+  const cwd = options.cwd ?? process.cwd();
+  const guidance = options.guidance ?? RAVI_APPS_COMMAND_GUIDANCE;
+  const registry = sortedUnique(registryCommands);
+  const documented = sortedUnique(guidance.map((entry) => entry.command));
+  const drift: RaviAppsContractDrift[] = [];
+  const guidePromptIds = new Set(buildAppsGuide().prompts.map((prompt) => prompt.id));
+  const contents = {
+    systemSkill: readContractFile(cwd, CONTRACT_PATHS.systemSkill, "system-skill", drift),
+    builderSkill: readContractFile(cwd, CONTRACT_PATHS.builderSkill, "builder-skill", drift),
+    appsSpec: readContractFile(cwd, CONTRACT_PATHS.appsSpec, "apps-spec", drift),
+    builderSpec: readContractFile(cwd, CONTRACT_PATHS.builderSpec, "builder-spec", drift),
+    acceptanceCases: readContractFile(cwd, CONTRACT_PATHS.acceptanceCases, "acceptance-cases", drift),
+  };
+
+  for (const command of registry) {
+    const entry = guidance.find((candidate) => candidate.command === command);
+    if (!entry) {
+      drift.push({
+        surface: "guide",
+        code: "registry_command_missing_guidance",
+        detail: `ravi apps ${command} is registered but absent from RAVI_APPS_COMMAND_GUIDANCE`,
+      });
+      continue;
+    }
+    if (!guidePromptIds.has(entry.promptId)) {
+      drift.push({
+        surface: "guide",
+        code: "guidance_prompt_missing",
+        detail: `ravi apps ${command} points to missing guide prompt ${entry.promptId}`,
+      });
+    }
+    requireText(contents.systemSkill, `ravi apps ${command}`, "system-skill", "command_missing", drift);
+    requireText(contents.appsSpec, `ravi apps ${command}`, "apps-spec", "command_missing", drift);
+  }
+
+  for (const command of documented) {
+    if (!registry.includes(command)) {
+      drift.push({
+        surface: "registry",
+        code: "guidance_command_not_registered",
+        detail: `RAVI_APPS_COMMAND_GUIDANCE documents ravi apps ${command}, but the command is not registered`,
+      });
+    }
+  }
+
+  const runGuidance = guidance.find((entry) => entry.command === "run");
+  if (runGuidance?.audience !== "debug") {
+    drift.push({
+      surface: "guide",
+      code: "run_audience_drift",
+      detail: "ravi apps run must remain explicitly classified as internal/debug",
+    });
+  }
+
+  for (const command of registry.filter((entry) => entry !== "run")) {
+    const entry = guidance.find((candidate) => candidate.command === command);
+    if (entry && entry.audience !== "public") {
+      drift.push({
+        surface: "guide",
+        code: "public_audience_drift",
+        detail: `ravi apps ${command} must remain classified as public`,
+      });
+    }
+  }
+
+  for (const [surface, content] of [
+    ["system-skill", contents.systemSkill],
+    ["builder-spec", contents.builderSpec],
+  ] as const) {
+    requireText(content, RAVI_APP_BUILDER_SKILL, surface, "builder_skill_link_missing", drift);
+    requireText(content, RAVI_APP_BUILDER_SPEC, surface, "builder_spec_link_missing", drift);
+  }
+  requireText(contents.builderSkill, "name: app-creator", "builder-skill", "builder_frontmatter_missing", drift);
+  requireText(contents.builderSkill, "## Gate De Prontidão", "builder-skill", "readiness_gate_missing", drift);
+  requireText(
+    contents.acceptanceCases,
+    "Google Search Console",
+    "acceptance-cases",
+    "google_reference_case_missing",
+    drift,
+  );
+  requireText(
+    contents.acceptanceCases,
+    "Open-Meteo Forecast",
+    "acceptance-cases",
+    "second_reference_case_missing",
+    drift,
+  );
+
+  return {
+    ok: drift.length === 0,
+    registryCommands: registry,
+    documentedCommands: documented,
+    drift,
+  };
+}
+
+function readContractFile(
+  cwd: string,
+  path: string,
+  surface: RaviAppsContractSurface,
+  drift: RaviAppsContractDrift[],
+): string {
+  try {
+    return readFileSync(join(cwd, path), "utf8");
+  } catch (error) {
+    drift.push({
+      surface,
+      code: "contract_file_missing",
+      detail: `${path}: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return "";
+  }
+}
+
+function requireText(
+  content: string,
+  needle: string,
+  surface: RaviAppsContractSurface,
+  code: string,
+  drift: RaviAppsContractDrift[],
+): void {
+  if (content.includes(needle)) {
+    return;
+  }
+  drift.push({
+    surface,
+    code,
+    detail: `missing ${JSON.stringify(needle)}`,
+  });
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/src/apps/guide.ts
+++ b/src/apps/guide.ts
@@ -1,7 +1,20 @@
+import { buildRaviAppBuilderGuidance, RAVI_APP_BUILDER_SKILL } from "./builder.js";
 import { getAppManifest } from "./service.js";
 import type { RaviAppManifestRecord, RaviAppsGuidePrompt, RaviAppsGuideResult } from "./types.js";
 
 export const RAVI_APPS_SKILL = "ravi-system-apps";
+
+export const RAVI_APPS_COMMAND_GUIDANCE = [
+  { command: "list", promptId: "discover", audience: "public" },
+  { command: "show", promptId: "inspect", audience: "public" },
+  { command: "check", promptId: "validate", audience: "public" },
+  { command: "run", promptId: "operate", audience: "debug" },
+  { command: "scaffold", promptId: "build", audience: "public" },
+  { command: "delete", promptId: "lifecycle", audience: "public" },
+  { command: "import-cli", promptId: "import-cli", audience: "public" },
+  { command: "guide", promptId: "guidance", audience: "public" },
+  { command: "prompts", promptId: "guidance", audience: "public" },
+] as const;
 
 export function buildAppsGuide(id?: string): RaviAppsGuideResult {
   const app = id?.trim() ? getAppManifest(id) : null;
@@ -15,6 +28,7 @@ export function buildAppsGuide(id?: string): RaviAppsGuideResult {
       group: "apps",
       skill: RAVI_APPS_SKILL,
     },
+    builder: buildRaviAppBuilderGuidance(),
     prompts: [...basePrompts(), ...appPrompts],
     nextCommands: buildNextCommands(app),
   };
@@ -26,60 +40,101 @@ function basePrompts(): RaviAppsGuidePrompt[] {
       id: "discover",
       title: "Discover Ravi apps",
       prompt:
-        "List apps before assuming an app exists. Use JSON output and inspect id, source, interfaces, permissions, validity, errors, and warnings.",
+        "List apps before assuming one exists. Inspect source, interfaces, permissions, validity, errors, and warnings.",
       commands: ["ravi apps list --json"],
     },
     {
       id: "inspect",
       title: "Inspect one app",
       prompt:
-        "Use show to read the manifest. Treat the manifest as metadata only: it declares interfaces, operations, UI, permissions, storage, events, skills, health, and versioning.",
+        "Use show to read the declarative contract. The manifest describes operations and requirements; it is neither executable code nor a permission grant.",
       commands: ["ravi apps show <app-id> --json"],
     },
     {
       id: "validate",
       title: "Validate manifests",
       prompt:
-        "Run check before operating or editing an app. Manifest checks must not execute app code, health commands, or mutating operations.",
+        "Run check before operating or editing an app. Manifest validation must not execute app code, external health calls, or mutations.",
       commands: ["ravi apps check [app-id] --json"],
     },
     {
-      id: "scaffold",
-      title: "Scaffold a new app",
-      prompt:
-        "Create a conservative app skeleton with manifest, spec, skill, operations, and optional UI descriptor. Review the generated files before implementing domain logic.",
+      id: "build",
+      title: "Build a new app",
+      prompt: `Load ${RAVI_APP_BUILDER_SKILL} before turning API documentation into an app. Start with a dry-run scaffold, then follow its auth, permissions, skill-grant, functional-test, and release checklist.`,
       commands: [
-        'ravi apps scaffold <app-id> --name "App Name" --description "What this app does" --json',
+        `ravi skills show ${RAVI_APP_BUILDER_SKILL} --json`,
+        "ravi specs get apps/builder --mode full --json",
         "ravi apps scaffold <app-id> --dry-run --json",
+        'ravi apps scaffold <app-id> --name "App Name" --description "What this app does" --json',
+      ],
+    },
+    {
+      id: "import-cli",
+      title: "Import an existing CLI as a draft",
+      prompt:
+        "import-cli is a draft generator. Review every candidate, remove debug/interactive commands, verify JSON and error contracts, then complete auth, permissions, context, storage, events, UI, skill, and functional tests before calling the app ready.",
+      commands: [
+        "ravi apps import-cli <cli-command> --id <app-id> --dry-run --json",
+        "ravi apps import-cli <cli-command> --id <app-id> --json",
       ],
     },
     {
       id: "operate",
       title: "Operate through the app alias",
       prompt:
-        "Never guess app commands. Read manifest.operations and use only declared operations. For normal app use, call ravi <app-id> <operation> --json. Keep ravi apps run for router debugging or static command collisions only.",
-      commands: ["ravi apps show <app-id> --json", "ravi <app-id> <operation> --json"],
+        "For normal use, read manifest.operations and call ravi <app-id> <operation> --json. ravi apps run is an internal/debug router surface for diagnostics or static command collisions, not the normal product path.",
+      commands: [
+        "ravi <app-id> <operation> --json",
+        "ravi apps run <app-id> <operation> --json  # internal/debug only",
+      ],
     },
     {
-      id: "ui",
-      title: "Understand app UI",
+      id: "lifecycle",
+      title: "Delete only scaffold-owned contracts",
       prompt:
-        "Read interfaces.ui for routes, views, queries, actions, refreshOn, and design-system hints. The app declares semantic UI only; Web OS owns rendering and styling.",
-      commands: ["ravi apps show <app-id> --json", "ravi specs get apps/ui --mode rules --json"],
+        "Preview deletion first. The delete command owns generated manifest/spec/skill artifacts; it must preserve authored implementation code, app state, credentials, and unrelated files.",
+      commands: ["ravi apps delete <app-id> --dry-run --json", "ravi apps delete <app-id> --json"],
     },
     {
-      id: "storage-events",
-      title: "Understand storage and events",
+      id: "guidance",
+      title: "Read embedded guidance",
       prompt:
-        "Read manifest.storage and manifest.events before assuming persistence or subscriptions. App domain data belongs to app-owned storage; events belong to the shared Ravi event plane.",
-      commands: ["ravi apps show <app-id> --json", "ravi specs get apps/manifest --mode rules --json"],
+        "guide returns the full operational result and prompts is its compatibility alias. Both must stay aligned with the Apps registry and the dedicated builder skill.",
+      commands: ["ravi apps guide [app-id] --json", "ravi apps prompts [app-id] --json"],
+    },
+    {
+      id: "auth-readiness",
+      title: "Prove auth and functional readiness",
+      prompt:
+        "Keep provider secrets behind the Ravi credential broker or a managed connector. A ready app proves missing auth fails before fetch, permissions fail closed, provider errors are sanitized, the app skill is visible or granted, and at least one public alias operation succeeds against a deterministic fake provider.",
+      commands: [
+        "ravi apps show <app-id> --json",
+        "ravi permissions status --json",
+        "ravi skills inspect <agent-id> --json",
+        "ravi <app-id> <health-or-read-operation> --json",
+      ],
+    },
+    {
+      id: "ui-storage-events",
+      title: "Decide optional product surfaces",
+      prompt:
+        "Make explicit yes/no decisions for semantic UI, app-owned storage, events, and artifacts. Add them only when they create operator value, reuse, lineage, audit, recovery, or durable outputs.",
+      commands: [
+        "ravi apps show <app-id> --json",
+        "ravi specs get apps/manifest --mode rules --json",
+        "ravi specs get apps/ui --mode rules --json",
+      ],
     },
     {
       id: "skill-gate",
-      title: "Skill gate",
+      title: "Load the operational skill",
       prompt:
-        "The apps command group is gated by ravi-system-apps. If a tool call asks for that skill, load it and retry the registry/manifest command. App operation should still prefer ravi <app-id> <operation>.",
-      commands: ["ravi skill-gates show apps --json", "ravi skills show ravi-system-apps --json"],
+        "The apps command group is gated by ravi-system-apps. Load it when the gate asks. Use the separate app creator skill for implementation work and the generated app skill for domain operation.",
+      commands: [
+        "ravi skill-gates show apps --json",
+        "ravi skills show ravi-system-apps --json",
+        `ravi skills show ${RAVI_APP_BUILDER_SKILL} --json`,
+      ],
     },
   ];
 }
@@ -101,7 +156,7 @@ function buildAppSpecificPrompts(app: RaviAppManifestRecord): RaviAppsGuidePromp
         `Interfaces: ${app.interfaceNames.join(", ") || "none"}.`,
         `Operations: ${operations.join(", ") || "none"}.`,
         `Skills: ${skills.join(", ") || "none"}.`,
-        `Check validity and warnings before using any operation. Operate through ${appCommand} <operation>.`,
+        `Check validity and warnings before use. Operate through ${appCommand} <operation>.`,
       ].join(" "),
       commands: [`ravi apps show ${app.id} --json`, `ravi apps check ${app.id} --json`, `${appCommand} check --json`],
     },
@@ -110,10 +165,19 @@ function buildAppSpecificPrompts(app: RaviAppManifestRecord): RaviAppsGuidePromp
 
 function buildNextCommands(app: RaviAppManifestRecord | null): string[] {
   if (!app) {
-    return ["ravi apps list --json", "ravi apps scaffold <app-id> --dry-run --json"];
+    return [
+      `ravi skills show ${RAVI_APP_BUILDER_SKILL} --json`,
+      "ravi apps list --json",
+      "ravi apps scaffold <app-id> --dry-run --json",
+    ];
   }
   const appCommand = `ravi ${app.id.split("/").join(" ")}`;
-  return [`ravi apps show ${app.id} --json`, `ravi apps check ${app.id} --json`, `${appCommand} check --json`];
+  return [
+    `ravi skills show ${RAVI_APP_BUILDER_SKILL} --json`,
+    `ravi apps show ${app.id} --json`,
+    `ravi apps check ${app.id} --json`,
+    `${appCommand} check --json`,
+  ];
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/src/apps/import-cli.ts
+++ b/src/apps/import-cli.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { basename } from "node:path";
 import { getRegistry, type CommandRegistryEntry } from "../cli/registry-snapshot.js";
+import { buildRaviAppProcessEnv, resolveRaviAppCommand, tokenizeRaviAppCommand } from "./command.js";
 import { normalizeAppId, RAVI_APP_MANIFEST_SCHEMA } from "./service.js";
 import { scaffoldApp } from "./scaffold.js";
 import type {
@@ -98,18 +99,22 @@ export function importCliApp(options: RaviAppImportCliOptions): RaviAppImportCli
   });
   const appSlug = id.replace(/\//g, "-");
   const operationPrefix = id.replace(/\//g, ".");
-  const appCommand = `ravi ${id.split("/").join(" ")}`;
   const name = options.name?.trim() || metadata.name || titleFromAppId(id);
   const description = options.description?.trim() || metadata.description || `Operate ${sourceCommand} as a Ravi App.`;
   const skill = options.includeSkill === false ? null : `ravi-system-${appSlug}`;
+  const contextAllow = inferRaviGroupCapabilities([
+    metadata.command,
+    ...metadata.candidates.map((candidate) => candidate.command),
+  ]);
   const manifest = buildImportedManifest({
     id,
     appSlug,
     operationPrefix,
     name,
     description,
-    command: appCommand,
+    command: metadata.command,
     candidates: metadata.candidates,
+    contextAllow,
     skill,
     includeUi: options.includeUi !== false,
   });
@@ -119,7 +124,7 @@ export function importCliApp(options: RaviAppImportCliOptions): RaviAppImportCli
     id,
     name,
     description,
-    command: appCommand,
+    command: metadata.command,
     manifest,
   });
 
@@ -131,7 +136,14 @@ export function importCliApp(options: RaviAppImportCliOptions): RaviAppImportCli
     operationCandidates: metadata.candidates,
     debugCandidates: metadata.debugCandidates,
     warnings: metadata.warnings,
-    reviewRequired: metadata.reviewRequired,
+    reviewRequired: [
+      "Treat this import as a draft generator, not proof that the app is ready or that every CLI command should be public.",
+      ...metadata.reviewRequired,
+      ...contextAllow.map(
+        (capability) =>
+          `Review inferred child capability ${capability}; keep it only while imported operations call that Ravi group.`,
+      ),
+    ],
   };
 }
 
@@ -155,7 +167,7 @@ function resolveCliMetadata(input: {
 }
 
 function metadataFromRegistry(command: string): ImportedCliMetadata {
-  const tokens = splitShellWords(command);
+  const tokens = tokenizeRaviAppCommand(command);
   if (!isRaviExecutable(tokens[0])) {
     throw new Error(`Registry import only supports Ravi CLI commands, got: ${command}`);
   }
@@ -197,11 +209,12 @@ function metadataFromSelfDescription(
   command: string,
   input: { cwd?: string; env?: NodeJS.ProcessEnv },
 ): ImportedCliMetadata {
-  const probe = `${command} manifest --json`;
-  const run = spawnSync(probe, {
+  const invocation = resolveRaviAppCommand(command, ["manifest", "--json"]);
+  const probe = invocation.displayCommand;
+  const run = spawnSync(invocation.executable, invocation.argv, {
     cwd: input.cwd ?? process.cwd(),
-    env: { ...process.env, ...(input.env ?? {}) },
-    shell: true,
+    env: buildRaviAppProcessEnv(input.env ?? process.env),
+    shell: false,
     encoding: "utf8",
     timeout: 5_000,
     maxBuffer: 1024 * 1024,
@@ -312,7 +325,9 @@ function candidateFromSelfDescription(
   if (mutating) reviewRequired.push("Confirm mutation risk and permission before enabling as an app operation.");
   if (destructive) reviewRequired.push("Confirm destructive behavior and require strong permission.");
   if (streaming || interactive)
-    reviewRequired.push("Streaming or interactive operations need a stream/tool surface, not CLI single-shot.");
+    reviewRequired.push(
+      "Keep this as a CLI operation and add explicit TTY/streaming launch behavior before exposing it.",
+    );
   return {
     id: name,
     name,
@@ -336,6 +351,7 @@ function buildImportedManifest(input: {
   description: string;
   command: string;
   candidates: RaviAppImportCliOperationCandidate[];
+  contextAllow: string[];
   skill: string | null;
   includeUi: boolean;
 }): RaviAppManifest {
@@ -380,7 +396,6 @@ function buildImportedManifest(input: {
     cli: {
       command: input.command,
       json: input.candidates.some((candidate) => candidate.json),
-      health: `${input.command} check --json`,
     },
   };
   if (input.includeUi) {
@@ -423,6 +438,9 @@ function buildImportedManifest(input: {
     version: "0.1.0",
     description: input.description,
     interfaces,
+    context: {
+      allow: input.contextAllow,
+    },
     operations,
     permissions: {
       required: [],
@@ -453,40 +471,29 @@ function buildImportedManifest(input: {
   };
 }
 
+function inferRaviGroupCapabilities(commands: string[]): string[] {
+  const capabilities = new Set<string>();
+  for (const command of commands) {
+    let tokens: string[];
+    try {
+      tokens = tokenizeRaviAppCommand(command);
+    } catch {
+      continue;
+    }
+    if (!isRaviExecutable(tokens[0])) continue;
+    const group = tokens[1];
+    if (!group || group.startsWith("-") || !/^[a-z][a-z0-9-]*$/.test(group)) continue;
+    capabilities.add(`execute:group:${group}`);
+  }
+  return Array.from(capabilities).sort();
+}
+
 function tryResolve<T>(fn: () => T): T | null {
   try {
     return fn();
   } catch {
     return null;
   }
-}
-
-function splitShellWords(input: string): string[] {
-  const out: string[] = [];
-  let current = "";
-  let quote: "'" | '"' | null = null;
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i]!;
-    if (quote) {
-      if (char === quote) quote = null;
-      else current += char;
-      continue;
-    }
-    if (char === "'" || char === '"') {
-      quote = char;
-      continue;
-    }
-    if (/\s/.test(char)) {
-      if (current) {
-        out.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += char;
-  }
-  if (current) out.push(current);
-  return out;
 }
 
 function isRaviExecutable(token?: string): boolean {

--- a/src/apps/index.ts
+++ b/src/apps/index.ts
@@ -1,4 +1,6 @@
 export * from "./types.js";
+export * from "./builder.js";
+export * from "./contract-eval.js";
 export * from "./service.js";
 export * from "./scaffold.js";
 export * from "./import-cli.js";

--- a/src/apps/router.test.ts
+++ b/src/apps/router.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { runWithContext } from "../cli/context.js";
 import type { ContextCapability, ContextRecord } from "../router/router-db.js";
+import { createRuntimeContext, getContextLineage } from "../runtime/context-registry.js";
 import { cleanupIsolatedRaviState } from "../test/ravi-state.js";
-import { maybeRunAppAliasRoute, resolveAppAliasInvocation, resolveRaviCliCommand, runAppOperation } from "./router.js";
+import { maybeRunAppAliasRoute, resolveAppAliasInvocation, runAppOperation } from "./router.js";
 
 const tempRoots: string[] = [];
 const tempStateDirs: string[] = [];
@@ -56,6 +58,9 @@ function manifest(id: string): Record<string, unknown> {
         health: `ravi ${id.split("/").join(" ")} check --json`,
       },
     },
+    context: {
+      allow: [],
+    },
     operations: {
       [`${prefix}.list`]: {
         interface: "builtin",
@@ -82,7 +87,7 @@ function manifest(id: string): Record<string, unknown> {
     permissions: {
       required: [],
       optional: [],
-      mutating: [],
+      mutating: [`${id}:write`],
     },
     health: {
       checks: [{ type: "builtin", handler: "apps.manifest.check" }],
@@ -161,6 +166,80 @@ console.log(JSON.stringify({
     "utf8",
   );
   return path;
+}
+
+function writeContextProbeApp(root: string): { appDir: string; scriptPath: string } {
+  const appDir = join(root, "src", "apps", "probe-app");
+  const scriptPath = join(appDir, "app-cli.mjs");
+  const cliEntrypoint = resolve(originalCwd, "src", "cli", "index.ts");
+  mkdirSync(appDir, { recursive: true });
+  writeFileSync(
+    scriptPath,
+    `
+const whoami = Bun.spawnSync({
+  cmd: [process.execPath, ${JSON.stringify(cliEntrypoint)}, "context", "whoami", "--json"],
+  cwd: process.cwd(),
+  env: process.env,
+  stdout: "pipe",
+  stderr: "pipe"
+});
+const stdout = new TextDecoder().decode(whoami.stdout).trim();
+const stderr = new TextDecoder().decode(whoami.stderr).trim();
+if (whoami.exitCode !== 0) {
+  console.error(stderr || "context whoami failed");
+  process.exit(whoami.exitCode || 1);
+}
+console.log(JSON.stringify({
+  argv: process.argv.slice(2),
+  cwd: process.cwd(),
+  env: {
+    childContextPresent: Boolean(process.env.RAVI_CONTEXT_KEY),
+    RAVI_SESSION_KEY: process.env.RAVI_SESSION_KEY ?? null,
+    RAVI_SESSION_NAME: process.env.RAVI_SESSION_NAME ?? null,
+    RAVI_AGENT_ID: process.env.RAVI_AGENT_ID ?? null,
+    APP_SECRET: process.env.APP_SECRET ?? null,
+    RAVI_APP_ID: process.env.RAVI_APP_ID ?? null,
+    RAVI_APP_OPERATION_ID: process.env.RAVI_APP_OPERATION_ID ?? null,
+    RAVI_APP_ROOT: process.env.RAVI_APP_ROOT ?? null
+  },
+  whoami: JSON.parse(stdout)
+}));
+`,
+    "utf8",
+  );
+  writeManifest(root, "probe-app", {
+    schema: "ravi.app/v1",
+    id: "probe-app",
+    name: "Context Probe App",
+    version: "0.1.0",
+    description: "Prove bounded Ravi App child-context execution.",
+    interfaces: {
+      cli: {
+        command: "bun app-cli.mjs",
+        json: true,
+      },
+    },
+    context: {
+      allow: ["execute:group:context"],
+    },
+    operations: {
+      "probe-app.inspect": {
+        interface: "cli",
+        command: "bun app-cli.mjs inspect {args}",
+        json: true,
+        mutating: false,
+      },
+    },
+    permissions: {
+      required: [],
+      optional: [],
+      mutating: [],
+    },
+    health: {
+      checks: [{ type: "builtin", handler: "apps.manifest.check" }],
+    },
+  });
+  return { appDir, scriptPath };
 }
 
 function providerManifest(root: string, id: string, options: { timeoutMs?: number } = {}): Record<string, unknown> {
@@ -370,25 +449,134 @@ describe("Ravi app router", () => {
     expect(realpathSync((result.result as { cwd: string }).cwd)).toBe(realpathSync(appDir));
   });
 
-  it("runs Ravi CLI app operations through the current installation", () => {
-    expect(
-      resolveRaviCliCommand("ravi yt health --json", {
-        execPath: "/opt/bun/bin/bun",
-        entrypoint: "/opt/ravi current/dist/bundle/index.js",
+  it("runs an external CLI through the public alias with a least-privilege child context", () => {
+    const root = makeRepo();
+    const { appDir } = writeContextProbeApp(root);
+    const cliEntrypoint = resolve(originalCwd, "src", "cli", "index.ts");
+    const markerPath = join(root, "shell-injection-marker");
+    const injectionArg = `$(touch ${markerPath})`;
+    const parent = createRuntimeContext({
+      kind: "agent-runtime",
+      agentId: "main",
+      capabilities: [
+        { permission: "use", objectType: "app", objectId: "probe-app" },
+        { permission: "execute", objectType: "group", objectId: "context" },
+      ],
+    });
+
+    const run = spawnSync(
+      process.execPath,
+      [cliEntrypoint, "probe-app", "inspect", injectionArg, ";", "literal value", "--json"],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          RAVI_CONTEXT_KEY: parent.contextKey,
+          RAVI_SESSION_KEY: "legacy-session",
+          RAVI_SESSION_NAME: "legacy-name",
+          RAVI_AGENT_ID: "legacy-agent",
+          APP_SECRET: "must-not-leak",
+          RAVI_LOG_LEVEL: "error",
+          RAVI_CLI_LOG_LEVEL: "error",
+          RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+        },
+        encoding: "utf8",
+        timeout: 30_000,
+      },
+    );
+
+    expect(run.status).toBe(0);
+    expect(run.stderr).not.toContain("must-not-leak");
+    const payload = JSON.parse(run.stdout) as {
+      ok: boolean;
+      callerContextId: string;
+      childContextId: string;
+      result: {
+        argv: string[];
+        cwd: string;
+        env: Record<string, unknown>;
+        whoami: {
+          contextId: string;
+          kind: string;
+          capabilities: ContextCapability[];
+          metadata: Record<string, unknown>;
+          lineage: Record<string, unknown>;
+        };
+      };
+    };
+
+    expect(payload).toMatchObject({
+      ok: true,
+      callerContextId: parent.contextId,
+      result: {
+        argv: ["inspect", injectionArg, ";", "literal value"],
+        env: {
+          childContextPresent: true,
+          RAVI_SESSION_KEY: null,
+          RAVI_SESSION_NAME: null,
+          RAVI_AGENT_ID: null,
+          APP_SECRET: null,
+          RAVI_APP_ID: "probe-app",
+          RAVI_APP_OPERATION_ID: "probe-app.inspect",
+          RAVI_APP_ROOT: realpathSync(appDir),
+        },
+        whoami: {
+          kind: "app-runtime",
+          capabilities: [{ permission: "execute", objectType: "group", objectId: "context" }],
+          metadata: {
+            appId: "probe-app",
+            operationId: "probe-app.inspect",
+            source: "app-router",
+            parentContextId: parent.contextId,
+            issuedFor: "app:probe-app",
+            issuanceMode: "explicit",
+          },
+          lineage: {
+            parentContextId: parent.contextId,
+            issuedFor: "app:probe-app",
+            issuanceMode: "explicit",
+          },
+        },
+      },
+    });
+    expect(payload.childContextId).not.toBe(parent.contextId);
+    expect(payload.result.whoami.contextId).toBe(payload.childContextId);
+    expect(realpathSync(payload.result.cwd)).toBe(realpathSync(appDir));
+    expect(existsSync(markerPath)).toBe(false);
+    expect(run.stdout).not.toContain(parent.contextKey);
+
+    const lineage = getContextLineage(parent.contextId);
+    expect(lineage?.descendants.map((context) => context.contextId)).toContain(payload.childContextId);
+  }, 30_000);
+
+  it("fails before spawning when context.allow exceeds the caller context", async () => {
+    const root = makeRepo();
+    const { scriptPath } = writeContextProbeApp(root);
+    const markerPath = join(root, "should-not-spawn");
+    writeFileSync(
+      scriptPath,
+      `await Bun.write(${JSON.stringify(markerPath)}, "spawned"); console.log(JSON.stringify({ ok: true }));\n`,
+      "utf8",
+    );
+    const parent = createRuntimeContext({
+      kind: "agent-runtime",
+      agentId: "main",
+      capabilities: [{ permission: "use", objectType: "app", objectId: "probe-app" }],
+    });
+
+    const result = await runWithContext({ agentId: "main", context: parent }, () =>
+      runAppOperation({
+        appId: "probe-app",
+        operation: "inspect",
+        args: ["literal"],
+        json: true,
       }),
-    ).toBe("/opt/bun/bin/bun '/opt/ravi current/dist/bundle/index.js' yt health --json");
-    expect(
-      resolveRaviCliCommand("bun local-app.mjs --json", {
-        execPath: "/opt/bun/bin/bun",
-        entrypoint: "/opt/ravi/dist/bundle/index.js",
-      }),
-    ).toBe("bun local-app.mjs --json");
-    expect(
-      resolveRaviCliCommand("ravi yt info --json", {
-        execPath: "/opt/bun/bin/bun",
-        entrypoint: "dist/bundle/index.js",
-      }),
-    ).toBe(`/opt/bun/bin/bun ${join(process.cwd(), "dist/bundle/index.js")} yt info --json`);
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Capability not granted by parent context: execute:group:context");
+    expect(result.childContextId).toBeUndefined();
+    expect(existsSync(markerPath)).toBe(false);
   });
 
   it("resolves dotted operation ids from whitespace-separated CLI tokens", async () => {

--- a/src/apps/router.ts
+++ b/src/apps/router.ts
@@ -1,6 +1,12 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import { discoverAppManifests, getAppManifest, RAVI_APP_BUILTIN_OPERATION_HANDLERS } from "./service.js";
+import {
+  buildRaviAppProcessEnv,
+  parseRaviAppCapability,
+  resolveRaviAppCommand,
+  tokenizeRaviAppCommand,
+} from "./command.js";
 import type {
   RaviAppAliasInvocation,
   RaviAppManifestRecord,
@@ -10,7 +16,14 @@ import type {
   RaviAppRunResult,
 } from "./types.js";
 import { emitCliAuditEvent } from "../cli/audit.js";
+import { getContext } from "../cli/context.js";
 import { AppPermissionProviderDeniedError, evaluateAppPermissionProvider } from "../permissions/provider-runtime.js";
+import {
+  getRuntimeContextFromEnv,
+  issueRuntimeContext,
+  type IssueRuntimeContextInput,
+} from "../runtime/context-registry.js";
+import type { ContextRecord } from "../router/router-db.js";
 import { assertCanRunAppOperation, assertCanUseApp, filterVisibleAppManifests } from "./permissions.js";
 
 interface ResolvedOperation {
@@ -28,6 +41,7 @@ const DEFAULT_STATIC_ROOT_COMMANDS = new Set(["apps"]);
 export async function runAppOperation(options: RaviAppRunOptions): Promise<RaviAppRunResult> {
   const startedAt = Date.now();
   const operationName = options.operation?.trim() || null;
+  const callerContext = resolveCallerContext(options.env);
   let result: RaviAppRunResult;
 
   try {
@@ -47,6 +61,8 @@ export async function runAppOperation(options: RaviAppRunOptions): Promise<RaviA
       cwd: options.cwd,
       env: options.env,
       staticRootCommands: mergeStaticRootCommands(options.staticRootCommands),
+      runtime: options.runtime,
+      callerContext,
       startedAt,
     });
   } catch (error) {
@@ -60,6 +76,7 @@ export async function runAppOperation(options: RaviAppRunOptions): Promise<RaviA
       status: "failed",
       durationMs: Date.now() - startedAt,
       error: error instanceof Error ? error.message : String(error),
+      ...(callerContext ? { callerContextId: callerContext.contextId } : {}),
       ...(error instanceof AppPermissionProviderDeniedError ? { permissionProvider: error.audit } : {}),
     };
   }
@@ -74,6 +91,8 @@ export async function runAppOperation(options: RaviAppRunOptions): Promise<RaviA
       operationId: result.operationId,
       interface: result.interface,
       mutating: result.mutating,
+      callerContextId: result.callerContextId,
+      childContextId: result.childContextId,
       permissionProvider: result.permissionProvider
         ? {
             providerId: result.permissionProvider.providerId,
@@ -273,6 +292,8 @@ async function dispatchResolvedOperation(
     cwd?: string;
     env?: NodeJS.ProcessEnv;
     staticRootCommands: Set<string>;
+    runtime?: RaviAppRunOptions["runtime"];
+    callerContext?: ContextRecord;
     startedAt: number;
   },
 ): Promise<RaviAppRunResult> {
@@ -311,6 +332,7 @@ async function dispatchResolvedOperation(
         mutating,
         status: "completed",
         durationMs: Date.now() - options.startedAt,
+        ...(options.callerContext ? { callerContextId: options.callerContext.contextId } : {}),
         handler,
         result: runBuiltinHandler(handler, app),
       },
@@ -328,28 +350,7 @@ async function dispatchResolvedOperation(
     return withPermissionProvider(await runCliOperation(app, resolved, options), permissionProvider);
   }
 
-  if (interfaceName === "stream") {
-    return withPermissionProvider(
-      {
-        ok: true,
-        appId,
-        operation: localOperationName(appId, resolved.id),
-        operationId: resolved.id,
-        interface: "stream",
-        mutating,
-        status: "completed",
-        durationMs: Date.now() - options.startedAt,
-        channel: operation.channel,
-        result: {
-          channel: operation.channel,
-          message: "Stream operations must be handled by a dedicated stream/control surface.",
-        },
-      },
-      permissionProvider,
-    );
-  }
-
-  throw new Error(`App operation interface is not supported by the CLI router yet: ${interfaceName}`);
+  throw new Error(`App operation interface is not supported by the router: ${interfaceName}`);
 }
 
 function withPermissionProvider(
@@ -368,25 +369,23 @@ async function runCliOperation(
     json: boolean;
     cwd?: string;
     env?: NodeJS.ProcessEnv;
+    runtime?: RaviAppRunOptions["runtime"];
+    callerContext?: ContextRecord;
     startedAt: number;
   },
 ): Promise<RaviAppRunResult> {
   const appId = app.manifest?.id ?? app.id;
-  const command = renderCliCommand(resolved.operation.command ?? "", {
-    appId,
-    operationId: resolved.id,
-    args: options.args,
-  });
-  const runtimeCommand = resolveRaviCliCommand(command);
+  const invocation = resolveRaviAppCommand(resolved.operation.command ?? "", options.args, options.runtime);
   const appRoot = dirname(app.path);
-  const run = await spawnShellCommand(runtimeCommand, {
+  const childContext = issueAppChildContext(app, resolved.id, options.callerContext);
+  const run = await spawnExecutable(invocation.executable, invocation.argv, {
     cwd: appRoot,
-    env: {
-      ...options.env,
-      RAVI_APP_ID: appId,
-      RAVI_APP_OPERATION_ID: resolved.id,
-      RAVI_APP_ROOT: appRoot,
-    },
+    env: buildRaviAppProcessEnv(options.env ?? process.env, {
+      appId,
+      operationId: resolved.id,
+      appRoot,
+      contextKey: childContext?.contextKey,
+    }),
     capture: options.json,
   });
   const parsed = options.json ? parseJsonOutput(run.stdout) : undefined;
@@ -400,8 +399,10 @@ async function runCliOperation(
     mutating: resolved.operation.mutating === true,
     status: run.exitCode === 0 ? "completed" : "failed",
     durationMs: Date.now() - options.startedAt,
-    command,
+    command: invocation.displayCommand,
     exitCode: run.exitCode,
+    ...(options.callerContext ? { callerContextId: options.callerContext.contextId } : {}),
+    ...(childContext ? { childContextId: childContext.contextId } : {}),
     ...(options.json
       ? {
           stdout: run.stdout,
@@ -552,39 +553,12 @@ function stripRouterFlags(argv: string[]): {
   return { json, help, args };
 }
 
-function renderCliCommand(template: string, input: { appId: string; operationId: string; args: string[] }): string {
-  let usedArgsPlaceholder = false;
-  const rendered = template.replace(/\{([a-zA-Z][a-zA-Z0-9_]*)\}/g, (match, name: string) => {
-    if (name === "id" || name === "appId") return quoteShellArg(input.appId);
-    if (name === "operation" || name === "operationId") return quoteShellArg(input.operationId);
-    if (name === "args") {
-      usedArgsPlaceholder = true;
-      return input.args.map(quoteShellArg).join(" ");
-    }
-    return match;
-  });
-  if (usedArgsPlaceholder || input.args.length === 0) return rendered;
-  return `${rendered} ${input.args.map(quoteShellArg).join(" ")}`;
-}
-
-export function resolveRaviCliCommand(
-  command: string,
-  runtime: { execPath?: string; entrypoint?: string } = {},
-): string {
-  if (!/^\s*ravi(?=\s|$)/.test(command)) return command;
-  const execPath = runtime.execPath ?? process.execPath;
-  const entrypoint = runtime.entrypoint ?? process.argv[1];
-  if (!execPath?.trim() || !entrypoint?.trim()) return command;
-  const selfInvocation = `${quoteShellArg(execPath)} ${quoteShellArg(resolve(entrypoint))}`;
-  return command.replace(/^\s*ravi(?=\s|$)/, selfInvocation);
-}
-
-function spawnShellCommand(
-  command: string,
+function spawnExecutable(
+  executable: string,
+  argv: string[],
   options: {
     cwd?: string;
     env?: NodeJS.ProcessEnv;
-    mergeProcessEnv?: boolean;
     capture: boolean;
     stdin?: string;
     timeoutMs?: number;
@@ -597,11 +571,11 @@ function spawnShellCommand(
   timedOut: boolean;
   truncated: boolean;
 }> {
-  return new Promise((resolve) => {
-    const child = spawn(command, {
+  return new Promise((resolveRun) => {
+    const child = spawn(executable, argv, {
       cwd: options.cwd ?? process.cwd(),
-      env: options.mergeProcessEnv === false ? options.env : { ...process.env, ...(options.env ?? {}) },
-      shell: true,
+      env: options.env,
+      shell: false,
       stdio: options.capture ? ["pipe", "pipe", "pipe"] : "inherit",
     });
     let stdout = "";
@@ -640,9 +614,19 @@ function spawnShellCommand(
       child.stdin?.on("error", () => {});
       child.stdin?.end(options.stdin ?? "");
     }
+    let spawnError: Error | null = null;
+    child.on("error", (error) => {
+      spawnError = error;
+    });
     child.on("close", (exitCode) => {
       if (timeout) clearTimeout(timeout);
-      resolve({ exitCode, stdout, stderr, timedOut, truncated });
+      resolveRun({
+        exitCode,
+        stdout,
+        stderr: spawnError ? `${stderr}${stderr ? "\n" : ""}${spawnError.message}` : stderr,
+        timedOut,
+        truncated,
+      });
     });
   });
 }
@@ -679,7 +663,7 @@ function mergeStaticRootCommands(staticRootCommands?: Set<string>): Set<string> 
 }
 
 function isRecursiveCliCommand(appId: string, command: string, staticRootCommands: Set<string>): boolean {
-  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  const tokens = resolveCommandTokens(command);
   if (tokens[0] !== "ravi") return false;
   const first = tokens[1];
   if (!first || staticRootCommands.has(first)) return false;
@@ -689,7 +673,38 @@ function isRecursiveCliCommand(appId: string, command: string, staticRootCommand
   return appSegments.every((segment, index) => tokens[index + 1] === segment);
 }
 
-function quoteShellArg(value: string): string {
-  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) return value;
-  return `'${value.replace(/'/g, "'\\''")}'`;
+function resolveCallerContext(env?: NodeJS.ProcessEnv): ContextRecord | undefined {
+  return getRuntimeContextFromEnv(env ?? process.env) ?? getContext()?.context;
+}
+
+function issueAppChildContext(
+  app: RaviAppManifestRecord,
+  operationId: string,
+  parent: ContextRecord | undefined,
+): ContextRecord | undefined {
+  if (!parent) return undefined;
+  const appId = app.manifest?.id ?? app.id;
+  const allow = app.manifest?.context?.allow ?? [];
+  const capabilities = allow.map(parseRaviAppCapability);
+  const input: IssueRuntimeContextInput = {
+    parent,
+    cliName: `app:${appId}`,
+    kind: "app-runtime",
+    capabilities,
+    inheritCapabilities: false,
+    metadata: {
+      appId,
+      operationId,
+      source: "app-router",
+    },
+  };
+  return issueRuntimeContext(input);
+}
+
+function resolveCommandTokens(command: string): string[] {
+  try {
+    return tokenizeRaviAppCommand(command);
+  } catch {
+    return [];
+  }
 }

--- a/src/apps/scaffold.ts
+++ b/src/apps/scaffold.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { buildRaviAppBuilderGuidance } from "./builder.js";
 import { normalizeAppId, RAVI_APP_MANIFEST_FILE, RAVI_APP_MANIFEST_SCHEMA } from "./service.js";
 import {
   RaviAppError,
@@ -26,7 +27,8 @@ export function scaffoldApp(options: RaviAppScaffoldOptions): RaviAppScaffoldRes
   const operationPrefix = operationPrefixForAppId(id);
   const name = options.name?.trim() || titleFromAppId(id);
   const description = options.description?.trim() || `Operate the ${name} Ravi app.`;
-  const command = options.command?.trim() || `ravi ${id.split("/").join(" ")}`;
+  const generateCli = options.manifest === undefined && !options.command?.trim();
+  const command = options.command?.trim() || "bun cli.ts";
   const includeUi = options.includeUi !== false;
   const includeSkill = options.includeSkill !== false;
   const includeSpec = options.includeSpec !== false;
@@ -35,6 +37,7 @@ export function scaffoldApp(options: RaviAppScaffoldOptions): RaviAppScaffoldRes
   const skill = includeSkill ? `ravi-system-${appSlug}` : null;
 
   const appDir = join(repoRoot, "src", "apps", ...id.split("/"));
+  const cliPath = generateCli ? join(appDir, "cli.ts") : null;
   const manifestPath = join(appDir, RAVI_APP_MANIFEST_FILE);
   const specPath = includeSpec ? join(repoRoot, ".ravi", "specs", "apps", ...id.split("/"), "SPEC.md") : null;
   const skillSourcePath = join(repoRoot, "src", "plugins", "internal", "ravi-system");
@@ -59,6 +62,13 @@ export function scaffoldApp(options: RaviAppScaffoldOptions): RaviAppScaffoldRes
       content: `${JSON.stringify(manifest, null, 2)}\n`,
     },
   ];
+  if (cliPath) {
+    targets.push({
+      kind: "cli",
+      path: cliPath,
+      content: buildCliSkeleton({ id, name, description, command }),
+    });
+  }
   if (specPath) {
     targets.push({
       kind: "spec",
@@ -85,14 +95,17 @@ export function scaffoldApp(options: RaviAppScaffoldOptions): RaviAppScaffoldRes
 
   const files = targets.map((target): RaviAppScaffoldFileResult => {
     const existed = existsSync(target.path);
+    const preserveImplementation = target.kind === "cli" && existed;
     if (!dryRun) {
       mkdirSync(dirname(target.path), { recursive: true });
-      writeFileSync(target.path, target.content, "utf8");
+      if (!preserveImplementation) {
+        writeFileSync(target.path, target.content, "utf8");
+      }
     }
     return {
       kind: target.kind,
       path: target.path,
-      action: dryRun ? "planned" : existed ? "overwritten" : "created",
+      action: dryRun ? "planned" : preserveImplementation ? "preserved" : existed ? "overwritten" : "created",
     };
   });
 
@@ -103,12 +116,14 @@ export function scaffoldApp(options: RaviAppScaffoldOptions): RaviAppScaffoldRes
     command,
     dryRun,
     force,
+    cliPath,
     manifestPath,
     specPath,
     skillPath,
     skill,
     files,
     manifest,
+    builder: buildRaviAppBuilderGuidance(),
     nextCommands: buildNextCommands({
       id,
       appSlug,
@@ -135,7 +150,6 @@ function buildScaffoldManifest(input: {
     cli: {
       command: input.command,
       json: true,
-      health: `${input.command} check --json`,
     },
   };
 
@@ -181,6 +195,9 @@ function buildScaffoldManifest(input: {
     version: "0.1.0",
     description: input.description,
     interfaces,
+    context: {
+      allow: [],
+    },
     operations: {
       [`${input.operationPrefix}.help`]: {
         interface: "builtin",
@@ -193,8 +210,8 @@ function buildScaffoldManifest(input: {
         mutating: false,
       },
       [`${input.operationPrefix}.list`]: {
-        interface: "builtin",
-        handler: "apps.stub.list",
+        interface: "cli",
+        command: `${input.command} list {args} --json`,
         mutating: false,
         outputSchema: `schemas/${input.appSlug}-list.v1.json`,
       },
@@ -242,6 +259,77 @@ function buildScaffoldManifest(input: {
   };
 }
 
+function buildCliSkeleton(input: { id: string; name: string; description: string; command: string }): string {
+  return `#!/usr/bin/env bun
+
+const APP = {
+  id: ${JSON.stringify(input.id)},
+  name: ${JSON.stringify(input.name)},
+  version: "0.1.0",
+  description: ${JSON.stringify(input.description)},
+  command: ${JSON.stringify(input.command)},
+};
+
+const rawArgs = process.argv.slice(2);
+const wantsJson = rawArgs.includes("--json");
+const args = rawArgs.filter((arg) => arg !== "--json");
+const operation = args.shift() ?? "help";
+
+function printJson(value: unknown): void {
+  process.stdout.write(\`\${JSON.stringify(value)}\\n\`);
+}
+
+function print(value: unknown): void {
+  if (wantsJson) {
+    printJson(value);
+    return;
+  }
+  if (typeof value === "string") {
+    process.stdout.write(\`\${value}\\n\`);
+    return;
+  }
+  process.stdout.write(\`\${JSON.stringify(value, null, 2)}\\n\`);
+}
+
+switch (operation) {
+  case "manifest":
+    printJson({
+      ...APP,
+      commands: [
+        {
+          id: "list",
+          name: "List",
+          description: "List app-owned records.",
+          command: \`\${APP.command} list {args} --json\`,
+          json: true,
+          mutating: false,
+        },
+      ],
+    });
+    break;
+  case "list":
+    print({ items: [], total: 0, args });
+    break;
+  case "help":
+    print({
+      app: APP.id,
+      usage: \`\${APP.command} <operation> [args] [--json]\`,
+      operations: ["list"],
+    });
+    break;
+  default:
+    printJson({ ok: false, error: \`Unknown operation: \${operation}\` });
+    process.exitCode = 1;
+}
+
+/*
+ * When Ravi launches this CLI, RAVI_CONTEXT_KEY identifies a least-privilege
+ * child context. To call Ravi, spawn ["ravi", "<group>", ..., "--json"] with
+ * process.env unchanged and declare execute:group:<group> in context.allow.
+ */
+`;
+}
+
 function buildSpecSkeleton(input: {
   id: string;
   appSlug: string;
@@ -280,22 +368,25 @@ ${input.description}
 ## Invariants
 
 - This app MUST keep a valid \`ravi.app.json\`.
+- \`interfaces.cli.command\` MUST name the real implementation CLI, never the public \`ravi ${input.id.split("/").join(" ")}\` alias.
+- \`context.allow\` MUST list only the Ravi capabilities delegated to that CLI process; an empty list is valid.
 - CLI operations SHOULD support \`--json\`.
 - UI actions MUST reference declared operations.
-- Mutating operations SHOULD declare required permissions.
+- Mutating operations MUST declare permissions in \`permissions.mutating\`.
 - App state SHOULD use app-owned storage when persistence adds reuse, lineage, audit, or recovery.
-- Router-owned scaffold operations MUST use builtin handlers until real domain implementation exists.
+- Router-owned discovery/check operations MAY use builtin handlers; domain operations MUST execute the implementation CLI.
 
 ## Interfaces
 
-- CLI: \`${input.command}\`
+- Public CLI: \`ravi ${input.id.split("/").join(" ")} <operation>\`
+- Implementation CLI: \`${input.command}\`
 - Manifest: \`src/apps/${input.id}/ravi.app.json\`
 
 ## Validation
 
 - \`ravi apps check ${input.id} --json\`
 - \`ravi apps show ${input.id} --json\`
-- \`${input.command} check --json\`
+- \`ravi ${input.id.split("/").join(" ")} check --json\`
 `;
 }
 
@@ -312,8 +403,8 @@ description: |
   Opera o Ravi App ${input.name}. Use quando precisar:
   - Entender o manifesto e as interfaces do app ${input.id}
   - Validar se o app esta descoberto pelo Ravi
-  - Operar os comandos CLI declarados em ${input.command}
-  - Revisar UI, operations, storage, events e permissoes do app
+  - Operar o app pelo alias ravi ${input.id.split("/").join(" ")}
+  - Revisar CLI, context.allow, UI, operations, storage, events e permissoes do app
 ---
 
 # ${input.name}
@@ -332,23 +423,27 @@ ravi apps show ${input.id} --json
 
 \`\`\`bash
 ravi apps check ${input.id} --json
-${input.command} check --json
+ravi ${input.id.split("/").join(" ")} check --json
 \`\`\`
 
-3. Leia \`manifest.interfaces\`, \`manifest.operations\`, \`manifest.permissions\`, \`manifest.storage\` e \`manifest.events\`.
+3. Leia \`manifest.interfaces.cli\`, \`manifest.context.allow\`, \`manifest.operations\`, \`manifest.permissions\`, \`manifest.storage\` e \`manifest.events\`.
 
-4. Use apenas operations declaradas. Para operar o app, use o alias \`${input.command} <operation>\`. Para CLI, prefira comandos com \`--json\`.
+4. Use apenas operations declaradas. Para operar o app, use o alias \`ravi ${input.id.split("/").join(" ")} <operation>\`. \`${input.command}\` e o CLI de implementacao e nao deve chamar o alias de volta.
+
+5. Dentro do CLI, chame outras superficies com o comando publico \`ravi <group> ... --json\`, preservando \`process.env\`. Declare antes \`execute:group:<group>\` em \`context.allow\`; o router fornece somente o \`RAVI_CONTEXT_KEY\` do contexto-filho.
 
 ## Comandos Iniciais
 
 \`\`\`bash
-${input.command} list --json
-${input.command} check --json
+ravi ${input.id.split("/").join(" ")} list --json
+ravi ${input.id.split("/").join(" ")} check --json
 \`\`\`
 
 ## Regras
 
 - Nao execute comandos mutating sem checar permissoes.
+- Nao adicione capacidades implicitas: o processo recebe apenas o contexto-filho derivado de \`context.allow\`.
+- Nao use shell, pipes, redirecionamento ou substituicao de comando nas declarations de CLI.
 - Nao raspe stdout se houver JSON ou eventos declarados.
 - Nao invente rotas UI fora de \`interfaces.ui\`.
 - Se o manifesto estiver incompleto, corrija o app/manifest antes de compensar no agente.
@@ -363,12 +458,14 @@ function buildNextCommands(input: {
   skill: string | null;
   skillSourcePath: string;
 }): string[] {
-  const { id, appSlug, command, includeSpec, skill, skillSourcePath } = input;
+  const { id, appSlug, includeSpec, skill, skillSourcePath } = input;
+  const publicCommand = `ravi ${id.split("/").join(" ")}`;
   const commands = [
+    "ravi skills show ravi-dev-app-creator --json",
     `ravi apps show ${id} --json`,
     `ravi apps check ${id} --json`,
-    `${command} check --json`,
-    `${command} list --json`,
+    `${publicCommand} check --json`,
+    `${publicCommand} list --json`,
     `ravi apps guide ${id} --json`,
   ];
   if (includeSpec) commands.push(`ravi specs get apps/${id} --mode rules --json`);

--- a/src/apps/service.test.ts
+++ b/src/apps/service.test.ts
@@ -39,6 +39,9 @@ function validManifest(overrides: Record<string, unknown> = {}): Record<string, 
         json: true,
       },
     },
+    context: {
+      allow: [],
+    },
     permissions: {
       required: [],
       optional: [],
@@ -261,7 +264,7 @@ describe("Ravi app manifest service", () => {
           },
           "apps.check": {
             interface: "cli",
-            command: "ravi apps check {id} --json",
+            command: "ravi apps check {args} --json",
             mutating: false,
           },
         },
@@ -274,9 +277,111 @@ describe("Ravi app manifest service", () => {
     expect(app.errors).toEqual([]);
   });
 
+  it("rejects unsafe executors, malformed context ceilings, and undeclared permissions", () => {
+    const root = makeRepo();
+    writeManifest(
+      root,
+      "unsafe-app",
+      validManifest({
+        id: "unsafe-app",
+        name: "Unsafe App",
+        interfaces: {
+          cli: {
+            command: "bun cli.ts",
+            json: true,
+          },
+          sdk: {
+            namespace: "unsafeApp",
+          },
+        },
+        context: {
+          allow: ["execute:group:context", "execute:group:context", "execute:group:*", "malformed"],
+        },
+        operations: {
+          "unsafe-app.sdk": {
+            interface: "sdk",
+            mutating: false,
+          },
+          "unsafe-app.shell": {
+            interface: "cli",
+            command: "bun cli.ts list | cat --json",
+            mutating: false,
+          },
+          "unsafe-app.read": {
+            interface: "cli",
+            command: "bun cli.ts list --json",
+            mutating: false,
+            permission: "unsafe-app:read",
+          },
+          "unsafe-app.write": {
+            interface: "cli",
+            command: "bun cli.ts write --json",
+            mutating: true,
+            permission: "unsafe-app:write",
+          },
+        },
+      }),
+    );
+
+    const app = getAppManifest("unsafe-app");
+    const errors = app.errors.join("\n");
+    expect(app.valid).toBe(false);
+    expect(errors).toContain("context.allow[1] duplicates another delegated capability");
+    expect(errors).toContain("context.allow[2] must be explicit and must not contain wildcards");
+    expect(errors).toContain('Invalid context capability "malformed"');
+    expect(errors).toContain("operations.unsafe-app.sdk.interface must be one of builtin|cli");
+    expect(errors).toContain('operations.unsafe-app.shell.command: CLI command must not contain shell operator "|"');
+    expect(errors).toContain(
+      'operations.unsafe-app.read permission "unsafe-app:read" must be declared in permissions.required|optional',
+    );
+    expect(errors).toContain(
+      'operations.unsafe-app.write permission "unsafe-app:write" must be declared in permissions.mutating',
+    );
+
+    writeManifest(
+      root,
+      "missing-context",
+      validManifest({
+        id: "missing-context",
+        name: "Missing Context",
+        context: undefined,
+      }),
+    );
+    const missingContextApp = getAppManifest("missing-context");
+    expect(missingContextApp.valid).toBe(false);
+    expect(missingContextApp.errors).toContain("context is required and must declare context.allow.");
+  });
+
+  it("rejects named argv placeholders", () => {
+    const root = makeRepo();
+    writeManifest(
+      root,
+      "legacy-placeholder",
+      validManifest({
+        id: "legacy-placeholder",
+        name: "Legacy Placeholder",
+        operations: {
+          "legacy-placeholder.get": {
+            interface: "cli",
+            command: "bun cli.ts get {id} --json",
+            mutating: false,
+          },
+        },
+      }),
+    );
+
+    const app = getAppManifest("legacy-placeholder");
+    expect(app.valid).toBe(false);
+    expect(app.errors.join("\n")).toContain(
+      'Unsupported CLI command placeholder in token "{id}"; only a complete {args} token is allowed',
+    );
+  });
+
   it("accepts app permission provider metadata without executing the provider", () => {
     const root = makeRepo();
     const marker = join(root, "provider-ran");
+    const providerScript = join(root, "permission-provider.mjs");
+    writeFileSync(providerScript, `await Bun.write(${JSON.stringify(marker)}, "ran");\n`);
     writeManifest(
       root,
       "apps",
@@ -284,7 +389,7 @@ describe("Ravi app manifest service", () => {
         operations: {
           "apps.permissions.decide": {
             interface: "cli",
-            command: `touch ${marker} && echo '{"decision":"allow"}' --json`,
+            command: `bun ${providerScript} {args}`,
             mutating: false,
             inputSchema: "schemas/permission-request.v1.json",
             outputSchema: "schemas/permission-decision.v1.json",
@@ -532,6 +637,10 @@ describe("Ravi app manifest service", () => {
         id: "ui-artifacts-valid",
         name: "UI Artifacts Valid",
         interfaces: {
+          cli: {
+            command: "ui-artifacts-valid",
+            json: true,
+          },
           ui: {
             views: [
               {
@@ -558,6 +667,10 @@ describe("Ravi app manifest service", () => {
         id: "ui-artifacts-invalid",
         name: "UI Artifacts Invalid",
         interfaces: {
+          cli: {
+            command: "ui-artifacts-invalid",
+            json: true,
+          },
           ui: {
             views: [
               {

--- a/src/apps/service.ts
+++ b/src/apps/service.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import { loadInternalPlugins } from "../plugins/internal-loader.js";
 import { discoverPlugins } from "../plugins/index.js";
 import { getRaviStateDir } from "../utils/paths.js";
+import { parseRaviAppCapability, parseRaviAppCommand, tokenizeRaviAppCommand } from "./command.js";
 import {
   RaviAppError,
   type RaviAppCheckResult,
@@ -35,7 +36,7 @@ export const RAVI_APP_BUILTIN_OPERATION_HANDLERS = new Set([
   "apps.stub.list",
 ]);
 
-const VALID_OPERATION_INTERFACES = new Set(["builtin", "cli", "sdk", "tool", "stream"]);
+const VALID_OPERATION_INTERFACES = new Set(["builtin", "cli"]);
 const VALID_PERMISSION_PROVIDER_INTERFACES = new Set(["builtin", "cli"]);
 const VALID_STORAGE_KINDS = new Set(["state", "cache", "artifact-index", "config", "ledger"]);
 const VALID_EVENT_DURABILITY = new Set(["ephemeral", "logged", "replayable"]);
@@ -314,23 +315,23 @@ function validateManifest(
   requireString(manifest, "description", errors);
 
   if (!isObject(manifest.interfaces)) {
-    errors.push("interfaces must be an object with at least one of cli|sdk|stream|tool|ui.");
+    errors.push("interfaces must be an object with a required cli interface.");
   } else {
     const declared = Object.keys(manifest.interfaces);
     const known = declared.filter((name) => VALID_INTERFACES.has(name));
-    if (known.length === 0) {
-      errors.push("interfaces must declare at least one of cli|sdk|stream|tool|ui.");
-    }
+    if (known.length === 0) errors.push("interfaces must declare at least one known interface.");
+    if (!isObject(manifest.interfaces.cli)) errors.push("interfaces.cli is required and must be an object.");
     for (const name of declared.filter((entry) => !VALID_INTERFACES.has(entry))) {
       warnings.push(`Unknown interface "${name}" will be ignored by v1 discovery.`);
     }
     validateInterfaceBlocks(manifest, operationIds, errors, warnings);
   }
 
+  validateContext(manifest.context, errors);
   validateOperations(manifest.operations, manifest.interfaces, manifest.id, errors, warnings);
 
-  if (manifest.permissions !== undefined && !isObject(manifest.permissions)) {
-    errors.push("permissions must be an object when present.");
+  if (!isObject(manifest.permissions)) {
+    errors.push("permissions is required and must be an object.");
   } else {
     validatePermissions(manifest.permissions, manifest.operations, errors);
   }
@@ -360,6 +361,40 @@ function validateManifest(
   return { errors, warnings };
 }
 
+function validateContext(value: unknown, errors: string[]): void {
+  if (value === undefined) {
+    errors.push("context is required and must declare context.allow.");
+    return;
+  }
+  if (!isObject(value)) {
+    errors.push("context must be an object when present.");
+    return;
+  }
+  if (!isStringArray(value.allow)) {
+    errors.push("context.allow is required and must be an array of capability strings.");
+    return;
+  }
+  const seen = new Set<string>();
+  value.allow.forEach((entry, index) => {
+    const path = `context.allow[${index}]`;
+    if (!entry.trim()) {
+      errors.push(`${path} must be a non-empty capability string.`);
+      return;
+    }
+    if (entry.includes("*")) {
+      errors.push(`${path} must be explicit and must not contain wildcards.`);
+      return;
+    }
+    try {
+      parseRaviAppCapability(entry);
+    } catch (error) {
+      errors.push(`${path}: ${formatError(error)}`);
+    }
+    if (seen.has(entry)) errors.push(`${path} duplicates another delegated capability.`);
+    seen.add(entry);
+  });
+}
+
 function validateInterfaceBlocks(
   manifest: RaviAppManifest,
   operationIds: Set<string>,
@@ -375,7 +410,9 @@ function validateInterfaceBlocks(
     }
     if (name === "cli") {
       if (typeof value.command !== "string" || !value.command.trim()) {
-        warnings.push("interfaces.cli.command should declare the canonical CLI command.");
+        errors.push("interfaces.cli.command must declare the implementation CLI command.");
+      } else {
+        validateCliCommand(value.command, "interfaces.cli.command", errors);
       }
       if (value.json !== true) {
         warnings.push("interfaces.cli.json should be true for machine-consumed CLI apps.");
@@ -387,6 +424,11 @@ function validateInterfaceBlocks(
       ) {
         errors.push(`interfaces.cli.health must not recursively invoke ravi ${manifest.id.split("/").join(" ")}.`);
       }
+      if (typeof value.health === "string") {
+        validateCliCommand(value.health, "interfaces.cli.health", errors);
+      } else if (value.health !== undefined) {
+        errors.push("interfaces.cli.health must be a command string when present.");
+      }
     }
     if (name === "sdk" && (typeof value.namespace !== "string" || !value.namespace.trim())) {
       warnings.push("interfaces.sdk.namespace should declare the generated SDK namespace.");
@@ -397,6 +439,16 @@ function validateInterfaceBlocks(
         warnings.push("interfaces.ui should be paired with top-level operations for snapshots and actions.");
       }
     }
+  }
+}
+
+function validateCliCommand(command: string, path: string, errors: string[]): boolean {
+  try {
+    parseRaviAppCommand(command);
+    return true;
+  } catch (error) {
+    errors.push(`${path}: ${formatError(error)}`);
+    return false;
   }
 }
 
@@ -449,7 +501,7 @@ function validateOperations(
       errors.push(`${path}.permissions must be an array of strings when present.`);
     }
     if (operation.mutating === true && operation.permission === undefined && operation.permissions === undefined) {
-      warnings.push(`${path} is mutating and should declare permission or permissions.`);
+      errors.push(`${path} is mutating and must declare permission or permissions.`);
     }
 
     validateOperationTarget(operation, path, typeof appId === "string" ? appId.trim() : "", errors, warnings);
@@ -532,6 +584,7 @@ function validateOperationTarget(
       errors.push(`${path}.command is required for cli operations.`);
       return;
     }
+    if (!validateCliCommand(operation.command, `${path}.command`, errors)) return;
     if (isRecursiveDynamicAppCommand(appId, operation.command)) {
       errors.push(`${path}.command must not recursively invoke ravi ${appId.split("/").join(" ")}.`);
     }
@@ -539,27 +592,6 @@ function validateOperationTarget(
       warnings.push(`${path}.command should support --json for Web OS snapshots and actions.`);
     }
     return;
-  }
-
-  if (interfaceName === "sdk") {
-    if (typeof operation.namespace !== "string" || !operation.namespace.trim()) {
-      errors.push(`${path}.namespace is required for sdk operations.`);
-    }
-    if (typeof operation.method !== "string" || !operation.method.trim()) {
-      errors.push(`${path}.method is required for sdk operations.`);
-    }
-    return;
-  }
-
-  if (interfaceName === "tool") {
-    if (typeof operation.name !== "string" || !operation.name.trim()) {
-      errors.push(`${path}.name is required for tool operations.`);
-    }
-    return;
-  }
-
-  if (interfaceName === "stream") {
-    validateEventTopic(operation.channel, `${path}.channel`, errors);
   }
 }
 
@@ -577,6 +609,7 @@ function validateHealth(value: Record<string, unknown>, appId: unknown, errors: 
     }
     if (check.type === "cli" && typeof check.command === "string") {
       const id = typeof appId === "string" ? appId.trim() : "";
+      validateCliCommand(check.command, `health.checks[${index}].command`, errors);
       if (isRecursiveDynamicAppCommand(id, check.command) && !isRouterHealthCommand(id, check.command)) {
         errors.push(`health.checks[${index}].command must not recursively invoke ravi ${id.split("/").join(" ")}.`);
       }
@@ -867,12 +900,30 @@ function collectUiViewIds(value: unknown): Set<string> {
 }
 
 function validatePermissions(value: unknown, operations: unknown, errors: string[]): void {
-  if (value === undefined) return;
   if (!isObject(value)) return;
   for (const key of ["required", "optional", "mutating"]) {
     const raw = value[key];
-    if (raw !== undefined && !isStringArray(raw)) {
+    if (!isStringArray(raw)) {
       errors.push(`permissions.${key} must be an array of strings.`);
+    }
+  }
+  const required = isStringArray(value.required) ? value.required : [];
+  const optional = isStringArray(value.optional) ? value.optional : [];
+  const mutating = isStringArray(value.mutating) ? value.mutating : [];
+  if (isObject(operations)) {
+    for (const [id, operation] of Object.entries(operations)) {
+      if (!isObject(operation)) continue;
+      const declared = [
+        ...(typeof operation.permission === "string" ? [operation.permission] : []),
+        ...(isStringArray(operation.permissions) ? operation.permissions : []),
+      ];
+      const allowed = operation.mutating === true ? mutating : [...required, ...optional];
+      for (const permission of declared) {
+        if (!allowed.includes(permission)) {
+          const bucket = operation.mutating === true ? "permissions.mutating" : "permissions.required|optional";
+          errors.push(`operations.${id} permission "${permission}" must be declared in ${bucket}.`);
+        }
+      }
     }
   }
   validatePermissionProvider(value.provider, operations, errors);
@@ -1407,7 +1458,12 @@ function formatError(error: unknown): string {
 
 function isRecursiveDynamicAppCommand(appId: string, command: string): boolean {
   if (!appId || STATIC_APP_ROOT_EXCEPTIONS.has(appId)) return false;
-  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  let tokens: string[];
+  try {
+    tokens = tokenizeRaviAppCommand(command);
+  } catch {
+    return false;
+  }
   if (tokens[0] !== "ravi") return false;
 
   const slashForm = tokens[1] === appId;
@@ -1419,7 +1475,12 @@ function isRecursiveDynamicAppCommand(appId: string, command: string): boolean {
 
 function isRouterHealthCommand(appId: string, command: string): boolean {
   if (!appId) return false;
-  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  let tokens: string[];
+  try {
+    tokens = tokenizeRaviAppCommand(command);
+  } catch {
+    return false;
+  }
   if (tokens[0] !== "ravi") return false;
 
   const appSegments = appId.split("/");

--- a/src/apps/types.ts
+++ b/src/apps/types.ts
@@ -48,6 +48,10 @@ export interface RaviAppPermissions {
   provider: RaviAppPermissionProviderDeclaration | null;
 }
 
+export interface RaviAppContext {
+  allow: string[];
+}
+
 export interface RaviAppManifest {
   schema: string;
   id: string;
@@ -55,8 +59,9 @@ export interface RaviAppManifest {
   version: string;
   description: string;
   interfaces: Record<string, unknown>;
+  context: RaviAppContext;
   operations?: unknown;
-  permissions?: Partial<RaviAppPermissions>;
+  permissions: Partial<RaviAppPermissions>;
   storage?: unknown;
   artifacts?: unknown;
   events?: unknown;
@@ -66,7 +71,7 @@ export interface RaviAppManifest {
   [key: string]: unknown;
 }
 
-export type RaviAppOperationInterface = "builtin" | "cli" | "sdk" | "tool" | "stream";
+export type RaviAppOperationInterface = "builtin" | "cli";
 
 export type RaviAppOperationAuthorizationOwner = "actor" | "surface" | "executorAgent";
 
@@ -144,8 +149,8 @@ export interface RaviAppCheckResult {
   warnings: string[];
 }
 
-export type RaviAppScaffoldFileKind = "manifest" | "spec" | "skill";
-export type RaviAppScaffoldFileAction = "planned" | "created" | "overwritten";
+export type RaviAppScaffoldFileKind = "cli" | "manifest" | "spec" | "skill";
+export type RaviAppScaffoldFileAction = "planned" | "created" | "overwritten" | "preserved";
 
 export interface RaviAppScaffoldOptions {
   id: string;
@@ -167,6 +172,13 @@ export interface RaviAppScaffoldFileResult {
   action: RaviAppScaffoldFileAction;
 }
 
+export interface RaviAppBuilderGuidance {
+  skill: string;
+  command: string;
+  spec: string;
+  reviewChecklist: string[];
+}
+
 export interface RaviAppScaffoldResult {
   id: string;
   name: string;
@@ -174,12 +186,14 @@ export interface RaviAppScaffoldResult {
   command: string;
   dryRun: boolean;
   force: boolean;
+  cliPath: string | null;
   manifestPath: string;
   specPath: string | null;
   skillPath: string | null;
   skill: string | null;
   files: RaviAppScaffoldFileResult[];
   manifest: RaviAppManifest;
+  builder: RaviAppBuilderGuidance;
   nextCommands: string[];
 }
 
@@ -253,6 +267,7 @@ export interface RaviAppsGuideResult {
     group: string;
     skill: string;
   };
+  builder: RaviAppBuilderGuidance;
   prompts: RaviAppsGuidePrompt[];
   nextCommands: string[];
 }
@@ -263,6 +278,10 @@ export interface RaviAppRunOptions extends RaviAppDiscoveryOptions {
   args?: string[];
   json?: boolean;
   staticRootCommands?: Set<string>;
+  runtime?: {
+    execPath?: string;
+    entrypoint?: string;
+  };
 }
 
 export interface RaviAppRunResult {
@@ -282,6 +301,8 @@ export interface RaviAppRunResult {
   exitCode?: number | null;
   stdout?: string;
   stderr?: string;
+  callerContextId?: string;
+  childContextId?: string;
   permissionProvider?: RaviAppPermissionProviderAudit;
 }
 

--- a/src/apps/youtube/ravi.app.json
+++ b/src/apps/youtube/ravi.app.json
@@ -56,6 +56,9 @@
       ]
     }
   },
+  "context": {
+    "allow": ["execute:group:yt"]
+  },
   "operations": {
     "youtube.check": {
       "interface": "builtin",

--- a/src/cli/commands/apps.test.ts
+++ b/src/cli/commands/apps.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { runWithContext } from "../context.js";
+import { getCommandsMetadata } from "../decorators.js";
 import { cleanupIsolatedRaviState } from "../../test/ravi-state.js";
+import { evaluateRaviAppsContract } from "../../apps/contract-eval.js";
+import { RAVI_APPS_COMMAND_GUIDANCE } from "../../apps/guide.js";
 import { AppsCommands } from "./apps.js";
 import type { ContextCapability, ContextRecord } from "../../router/router-db.js";
 
@@ -16,6 +19,35 @@ const contextEnvKeys = ["RAVI_CONTEXT_KEY", "RAVI_SESSION_KEY", "RAVI_SESSION_NA
 const originalContextEnv = new Map<(typeof contextEnvKeys)[number], string | undefined>(
   contextEnvKeys.map((key) => [key, process.env[key]]),
 );
+const appsContractFiles = [
+  "src/plugins/internal/ravi-system/skills/apps/SKILL.md",
+  "src/plugins/internal/ravi-dev/skills/app-creator/SKILL.md",
+  "src/plugins/internal/ravi-dev/skills/app-creator/references/acceptance-cases.md",
+  ".ravi/specs/apps/SPEC.md",
+  ".ravi/specs/apps/builder/SPEC.md",
+] as const;
+
+function makeAppsContractFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "ravi-apps-contract-"));
+  tempRoots.push(root);
+  restoreAppsContractFixture(root);
+  return root;
+}
+
+function restoreAppsContractFixture(root: string): void {
+  for (const relativePath of appsContractFiles) {
+    const target = join(root, relativePath);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, readFileSync(join(originalCwd, relativePath), "utf8"));
+  }
+}
+
+function removeContractText(root: string, relativePath: (typeof appsContractFiles)[number], text: string): void {
+  const path = join(root, relativePath);
+  const content = readFileSync(path, "utf8");
+  expect(content).toContain(text);
+  writeFileSync(path, content.replaceAll(text, "removed-by-contract-drift-test"));
+}
 
 function makeRepo(): string {
   const root = mkdtempSync(join(tmpdir(), "ravi-apps-cli-"));
@@ -45,6 +77,9 @@ function makeRepo(): string {
           sdk: {
             namespace: "apps",
           },
+        },
+        context: {
+          allow: [],
         },
         permissions: {
           required: [],
@@ -121,6 +156,67 @@ afterEach(async () => {
 });
 
 describe("AppsCommands", () => {
+  it("evaluates registry, guide, specs, and skills as one drift-sensitive contract", () => {
+    const registryCommands = getCommandsMetadata(AppsCommands).map((command) => command.name);
+    const result = evaluateRaviAppsContract(registryCommands, { cwd: originalCwd });
+
+    expect(result.ok).toBe(true);
+    expect(result.drift).toEqual([]);
+    expect(result.registryCommands).toEqual(result.documentedCommands);
+
+    const driftedGuidance = RAVI_APPS_COMMAND_GUIDANCE.filter((entry) => entry.command !== "show");
+    const drifted = evaluateRaviAppsContract(registryCommands, {
+      cwd: originalCwd,
+      guidance: driftedGuidance,
+    });
+
+    expect(drifted.ok).toBe(false);
+    expect(drifted.drift).toContainEqual(
+      expect.objectContaining({
+        surface: "guide",
+        code: "registry_command_missing_guidance",
+      }),
+    );
+  });
+
+  it("detects command, builder-link, and acceptance-case drift outside the guide", () => {
+    const registryCommands = getCommandsMetadata(AppsCommands).map((command) => command.name);
+    const fixture = makeAppsContractFixture();
+
+    removeContractText(fixture, "src/plugins/internal/ravi-system/skills/apps/SKILL.md", "ravi apps show");
+    expect(evaluateRaviAppsContract(registryCommands, { cwd: fixture }).drift).toContainEqual(
+      expect.objectContaining({ surface: "system-skill", code: "command_missing" }),
+    );
+
+    restoreAppsContractFixture(fixture);
+    removeContractText(fixture, ".ravi/specs/apps/SPEC.md", "ravi apps show");
+    expect(evaluateRaviAppsContract(registryCommands, { cwd: fixture }).drift).toContainEqual(
+      expect.objectContaining({ surface: "apps-spec", code: "command_missing" }),
+    );
+
+    restoreAppsContractFixture(fixture);
+    removeContractText(fixture, ".ravi/specs/apps/builder/SPEC.md", "ravi-dev-app-creator");
+    expect(evaluateRaviAppsContract(registryCommands, { cwd: fixture }).drift).toContainEqual(
+      expect.objectContaining({
+        surface: "builder-spec",
+        code: "builder_skill_link_missing",
+      }),
+    );
+
+    restoreAppsContractFixture(fixture);
+    removeContractText(
+      fixture,
+      "src/plugins/internal/ravi-dev/skills/app-creator/references/acceptance-cases.md",
+      "Open-Meteo Forecast",
+    );
+    expect(evaluateRaviAppsContract(registryCommands, { cwd: fixture }).drift).toContainEqual(
+      expect.objectContaining({
+        surface: "acceptance-cases",
+        code: "second_reference_case_missing",
+      }),
+    );
+  });
+
   it("lists, shows, and checks app manifests as JSON", () => {
     makeRepo();
     const commands = new AppsCommands();
@@ -194,12 +290,18 @@ describe("AppsCommands", () => {
     const guide = captureJson(() => commands.guide(undefined, true)) as {
       skill: string;
       skillGate: { group: string; skill: string };
+      builder: { skill: string; spec: string; reviewChecklist: string[] };
       prompts: Array<{ id: string; commands: string[] }>;
     };
 
     expect(guide.skill).toBe("ravi-system-apps");
     expect(guide.skillGate).toEqual({ group: "apps", skill: "ravi-system-apps" });
-    expect(guide.prompts.map((prompt) => prompt.id)).toContain("scaffold");
+    expect(guide.builder).toMatchObject({
+      skill: "ravi-dev-app-creator",
+      spec: "apps/builder",
+    });
+    expect(guide.builder.reviewChecklist.length).toBeGreaterThan(5);
+    expect(guide.prompts.map((prompt) => prompt.id)).toContain("build");
     expect(guide.prompts.find((prompt) => prompt.id === "operate")?.commands).toContain(
       "ravi <app-id> <operation> --json",
     );
@@ -260,34 +362,51 @@ describe("AppsCommands", () => {
       ),
     ) as {
       id: string;
+      cliPath: string;
       manifestPath: string;
       specPath: string;
       skillPath: string;
       skill: string;
       files: Array<{ kind: string; action: string }>;
-      manifest: { operations: Record<string, unknown>; interfaces: Record<string, unknown> };
+      manifest: {
+        context: { allow: string[] };
+        operations: Record<string, unknown>;
+        interfaces: Record<string, { command?: string }>;
+      };
+      builder: { skill: string; spec: string; reviewChecklist: string[] };
       nextCommands: string[];
     };
 
     expect(created.id).toBe("music");
     expect(created.skill).toBe("ravi-system-music");
-    expect(created.files.map((file) => file.action)).toEqual(["created", "created", "created"]);
+    expect(created.files.map((file) => file.action)).toEqual(["created", "created", "created", "created"]);
     expect(Object.hasOwn(created.manifest.operations, "music.list")).toBe(true);
     expect(created.manifest.operations["music.list"]).toMatchObject({
-      interface: "builtin",
-      handler: "apps.stub.list",
+      interface: "cli",
+      command: "bun cli.ts list {args} --json",
     });
     expect(created.manifest.operations["music.check"]).toMatchObject({
       interface: "builtin",
       handler: "apps.manifest.check",
     });
+    expect(created.manifest.interfaces.cli).toMatchObject({ command: "bun cli.ts", json: true });
+    expect(created.manifest.context.allow).toEqual([]);
+    expect(created.builder).toMatchObject({
+      skill: "ravi-dev-app-creator",
+      spec: "apps/builder",
+    });
+    expect(created.builder.reviewChecklist.length).toBeGreaterThan(5);
     expect(created.manifest.interfaces).toHaveProperty("ui");
+    expect(existsSync(created.cliPath)).toBe(true);
+    expect(readFileSync(created.cliPath, "utf8")).toContain("RAVI_CONTEXT_KEY");
+    expect(readFileSync(created.cliPath, "utf8")).toContain("execute:group:<group>");
     expect(existsSync(created.manifestPath)).toBe(true);
     expect(existsSync(created.specPath)).toBe(true);
     expect(existsSync(created.skillPath)).toBe(true);
     expect(readFileSync(created.skillPath, "utf8")).toContain("ravi apps show music --json");
     expect(readFileSync(created.skillPath, "utf8")).toContain("ravi music check --json");
     expect(created.nextCommands).toContain("ravi apps guide music --json");
+    expect(created.nextCommands).toContain("ravi skills show ravi-dev-app-creator --json");
     expect(created.nextCommands).toContain("ravi music check --json");
     expect(created.nextCommands).toContain("ravi music list --json");
     expect(created.nextCommands.some((command) => command.includes("ravi skills show music --source "))).toBe(true);
@@ -305,6 +424,32 @@ describe("AppsCommands", () => {
     };
     expect(check.ok).toBe(true);
     expect(check.results[0]).toMatchObject({ id: "music", ok: true, errors: [] });
+
+    const authoredCli = "// Authored implementation: scaffold must preserve this file.\n";
+    writeFileSync(created.cliPath, authoredCli, "utf8");
+    const forced = captureJson(() =>
+      commands.scaffold(
+        "music",
+        "Music",
+        "Manage music.",
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+        undefined,
+        true,
+      ),
+    ) as {
+      files: Array<{ kind: string; action: string }>;
+    };
+    expect(forced.files).toEqual([
+      expect.objectContaining({ kind: "manifest", action: "overwritten" }),
+      expect.objectContaining({ kind: "cli", action: "preserved" }),
+      expect.objectContaining({ kind: "spec", action: "overwritten" }),
+      expect.objectContaining({ kind: "skill", action: "overwritten" }),
+    ]);
+    expect(readFileSync(created.cliPath, "utf8")).toBe(authoredCli);
 
     const nested = captureJson(() =>
       commands.scaffold(
@@ -428,21 +573,28 @@ exit 1
       operationCandidates: Array<{ id: string; mutating: boolean; destructive: boolean }>;
       debugCandidates: Array<{ id: string }>;
       manifest: {
-        interfaces: Record<string, { command?: string; health?: string }>;
+        context: { allow: string[] };
+        interfaces: Record<string, { command?: string }>;
         operations: Record<string, { interface: string; command?: string; permission?: string }>;
       };
       reviewRequired: string[];
       sourceCommand: string;
       command: string;
+      builder: {
+        skill: string;
+        command: string;
+        spec: string;
+        reviewChecklist: string[];
+      };
     };
 
     expect(dryRun).toMatchObject({ id: "fake-app", source: "manifest", confidence: "high" });
     expect(dryRun.sourceCommand).toBe(fakeCli);
-    expect(dryRun.command).toBe("ravi fake-app");
+    expect(dryRun.command).toBe(fakeCli);
     expect(dryRun.manifest.interfaces.cli).toMatchObject({
-      command: "ravi fake-app",
-      health: "ravi fake-app check --json",
+      command: fakeCli,
     });
+    expect(dryRun.manifest.context.allow).toEqual([]);
     expect(dryRun.operationCandidates.map((candidate) => candidate.id)).toEqual(["list", "delete"]);
     expect(dryRun.debugCandidates.map((candidate) => candidate.id)).toEqual(["watch"]);
     expect(dryRun.manifest.operations["fake-app.list"]).toMatchObject({
@@ -454,6 +606,13 @@ exit 1
       permission: "fake-app:write",
     });
     expect(dryRun.reviewRequired.join("\n")).toContain("Confirm mutation risk");
+    expect(dryRun.reviewRequired[0]).toContain("draft generator");
+    expect(dryRun.builder).toMatchObject({
+      skill: "ravi-dev-app-creator",
+      command: "ravi skills show ravi-dev-app-creator --json",
+      spec: "apps/builder",
+    });
+    expect(dryRun.builder.reviewChecklist.length).toBeGreaterThan(5);
     expect(existsSync(dryRun.manifestPath)).toBe(false);
 
     const created = captureJson(() =>
@@ -473,9 +632,15 @@ exit 1
     ) as {
       manifestPath: string;
       files: Array<{ action: string }>;
+      builder: { skill: string; spec: string; reviewChecklist: string[] };
     };
 
     expect(created.files.map((file) => file.action)).toEqual(["created", "created", "created"]);
+    expect(created.builder).toMatchObject({
+      skill: "ravi-dev-app-creator",
+      spec: "apps/builder",
+    });
+    expect(created.builder.reviewChecklist.length).toBeGreaterThan(5);
     expect(existsSync(created.manifestPath)).toBe(true);
 
     const check = captureJson(() => commands.check("fake-app", true)) as {
@@ -508,8 +673,12 @@ exit 1
       source: string;
       confidence: string;
       operationCandidates: Array<{ id: string; command: string }>;
-      manifest: { operations: Record<string, { command?: string }> };
+      manifest: {
+        context: { allow: string[] };
+        operations: Record<string, { command?: string }>;
+      };
       files: Array<{ kind: string; path: string; action: string }>;
+      reviewRequired: string[];
       warnings: string[];
     };
 
@@ -519,6 +688,8 @@ exit 1
     expect(imported.manifest.operations["imported-apps.list"]).toMatchObject({
       command: "ravi apps list {args} --json",
     });
+    expect(imported.manifest.context.allow).toEqual(["execute:group:apps"]);
+    expect(imported.reviewRequired.join("\n")).toContain("Review inferred child capability execute:group:apps");
     expect(imported.warnings.join("\n")).toContain("assumes generated operations should use --json");
   });
 
@@ -552,6 +723,22 @@ exit 1
       appId: "music",
       operationId: "music.check",
       result: { ok: true, checked: 1 },
+    });
+
+    const list = (await captureJsonAsync(() => commands.run("music", "list", ["alpha", "beta"], true))) as {
+      ok: boolean;
+      appId: string;
+      operationId: string;
+      interface: string;
+      result: { items: unknown[]; total: number; args: string[] };
+    };
+
+    expect(list).toMatchObject({
+      ok: true,
+      appId: "music",
+      operationId: "music.list",
+      interface: "cli",
+      result: { items: [], total: 0, args: ["alpha", "beta"] },
     });
   });
 });

--- a/src/cli/commands/apps.ts
+++ b/src/cli/commands/apps.ts
@@ -46,7 +46,7 @@ const appPermissionProviderSchemaSummarySchema = z.object({
 const appPermissionProviderSchema = z.object({
   id: z.string(),
   version: z.string(),
-  interface: z.enum(["builtin", "cli", "sdk", "tool"]),
+  interface: z.enum(["builtin", "cli"]),
   operation: z.string(),
   decisionSchema: appPermissionProviderSchemaSummarySchema,
   requestSchema: appPermissionProviderSchemaSummarySchema,
@@ -121,9 +121,16 @@ const appsCheckReturnSchema = z.object({
 });
 
 const appScaffoldFileSchema = z.object({
-  kind: z.enum(["manifest", "spec", "skill"]),
+  kind: z.enum(["cli", "manifest", "spec", "skill"]),
   path: z.string(),
-  action: z.enum(["planned", "created", "overwritten"]),
+  action: z.enum(["planned", "created", "overwritten", "preserved"]),
+});
+
+const appBuilderGuidanceSchema = z.object({
+  skill: z.string(),
+  command: z.string(),
+  spec: z.string(),
+  reviewChecklist: z.array(z.string()),
 });
 
 const appsScaffoldReturnSchema = z.object({
@@ -133,12 +140,14 @@ const appsScaffoldReturnSchema = z.object({
   command: z.string(),
   dryRun: z.boolean(),
   force: z.boolean(),
+  cliPath: z.string().nullable(),
   manifestPath: z.string(),
   specPath: z.string().nullable(),
   skillPath: z.string().nullable(),
   skill: z.string().nullable(),
   files: z.array(appScaffoldFileSchema),
   manifest: z.record(z.string(), jsonValueSchema),
+  builder: appBuilderGuidanceSchema,
   nextCommands: z.array(z.string()),
 });
 
@@ -195,6 +204,7 @@ const appsGuideReturnSchema = z.object({
     group: z.string(),
     skill: z.string(),
   }),
+  builder: appBuilderGuidanceSchema,
   prompts: z.array(appGuidePromptSchema),
   nextCommands: z.array(z.string()),
 });
@@ -204,7 +214,7 @@ const appsRunReturnSchema = z.object({
   appId: z.string().nullable(),
   operation: z.string().nullable(),
   operationId: z.string().nullable(),
-  interface: z.enum(["builtin", "cli", "sdk", "tool", "stream"]).nullable(),
+  interface: z.enum(["builtin", "cli"]).nullable(),
   mutating: z.boolean(),
   status: z.enum(["completed", "failed"]),
   durationMs: z.number(),
@@ -216,12 +226,14 @@ const appsRunReturnSchema = z.object({
   exitCode: z.number().nullable().optional(),
   stdout: z.string().optional(),
   stderr: z.string().optional(),
+  callerContextId: z.string().optional(),
+  childContextId: z.string().optional(),
   permissionProvider: z
     .object({
       providerId: z.string(),
       providerVersion: z.string(),
       providerOperationId: z.string(),
-      interface: z.enum(["builtin", "cli", "sdk", "tool"]),
+      interface: z.enum(["builtin", "cli"]),
       requestId: z.string(),
       decision: z.enum(["allow", "deny", "needs_grant", "not_applicable", "error", "invalid"]),
       reasonCode: z.string().nullable(),
@@ -474,10 +486,14 @@ export class AppsCommands {
     @Arg("id", { description: "Stable app id, e.g. music or music/player" }) id: string,
     @Option({ flags: "--name <name>", description: "Human display name" }) name?: string,
     @Option({ flags: "--description <text>", description: "Short app description" }) description?: string,
-    @Option({ flags: "--command <command>", description: "Canonical CLI command (default: ravi <id>)" })
+    @Option({ flags: "--command <command>", description: "Implementation CLI command (default: generated bun cli.ts)" })
     command?: string,
     @Option({ flags: "--dry-run", description: "Print planned files without writing" }) dryRun?: boolean,
-    @Option({ flags: "--force", description: "Overwrite existing scaffold files" }) force?: boolean,
+    @Option({
+      flags: "--force",
+      description: "Overwrite scaffold contracts while preserving an existing implementation CLI",
+    })
+    force?: boolean,
     @Option({ flags: "--skip-ui", description: "Do not include interfaces.ui in the manifest" }) skipUi?: boolean,
     @Option({ flags: "--skip-skill", description: "Do not create a skill skeleton" }) skipSkill?: boolean,
     @Option({ flags: "--skip-spec", description: "Do not create an app spec skeleton" }) skipSpec?: boolean,
@@ -505,6 +521,9 @@ export class AppsCommands {
       for (const file of payload.files) {
         console.log(`- ${file.action} ${file.kind}: ${file.path}`);
       }
+      console.log(`\nBuilder: ${payload.builder.command}`);
+      console.log("Review checklist:");
+      for (const item of payload.builder.reviewChecklist) console.log(`- ${item}`);
       console.log("\nNext commands:");
       for (const nextCommand of payload.nextCommands) console.log(`  ${nextCommand}`);
       return payload;
@@ -602,6 +621,9 @@ export class AppsCommands {
       for (const warning of payload.warnings) console.log(`warning: ${warning}`);
       for (const item of payload.reviewRequired) console.log(`review: ${item}`);
       for (const file of payload.files) console.log(`- ${file.action} ${file.kind}: ${file.path}`);
+      console.log(`\nBuilder: ${payload.builder.command}`);
+      console.log("Review checklist:");
+      for (const item of payload.builder.reviewChecklist) console.log(`- ${item}`);
       console.log("\nNext commands:");
       for (const nextCommand of payload.nextCommands) console.log(`  ${nextCommand}`);
       return payload;
@@ -646,6 +668,7 @@ export class AppsCommands {
       console.log("Ravi Apps guide");
       console.log(`skill: ${payload.skill}`);
       console.log(`skill gate: ${payload.skillGate.group} -> ${payload.skillGate.skill}`);
+      console.log(`builder: ${payload.builder.command}`);
       if (payload.app) {
         console.log(`app: ${payload.app.id} (${payload.app.interfaceNames.join(", ") || "no interfaces"})`);
       }

--- a/src/permissions/app-permission-provider-runtime.ts
+++ b/src/permissions/app-permission-provider-runtime.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+import { resolveRaviAppCommand } from "../apps/command.js";
 import { getContext } from "../cli/context.js";
 import {
   RAVI_APP_BUILTIN_OPERATION_HANDLERS,
@@ -119,15 +121,10 @@ export async function evaluateAppPermissionProvider(
       );
     }
 
-    const renderedCommand = renderCliCommand(command, {
-      appId: app.manifest?.id ?? app.id,
-      operationId: provider.operation,
-      args: [],
-    });
-    const run = await spawnShellCommand(renderedCommand, {
-      cwd: options.cwd,
+    const invocation = resolveRaviAppCommand(command);
+    const run = await spawnExecutable(invocation.executable, invocation.argv, {
+      cwd: dirname(app.path),
       env: buildPermissionProviderEnv(options.env),
-      mergeProcessEnv: false,
       capture: true,
       stdin: `${JSON.stringify(request)}\n`,
       timeoutMs: provider.timeoutMs ?? RAVI_APP_PERMISSION_PROVIDER_MAX_TIMEOUT_MS,
@@ -700,27 +697,12 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function renderCliCommand(template: string, input: { appId: string; operationId: string; args: string[] }): string {
-  let usedArgsPlaceholder = false;
-  const rendered = template.replace(/\{([a-zA-Z][a-zA-Z0-9_]*)\}/g, (match, name: string) => {
-    if (name === "id" || name === "appId") return quoteShellArg(input.appId);
-    if (name === "operation" || name === "operationId") return quoteShellArg(input.operationId);
-    if (name === "args") {
-      usedArgsPlaceholder = true;
-      return input.args.map(quoteShellArg).join(" ");
-    }
-    return match;
-  });
-  if (usedArgsPlaceholder || input.args.length === 0) return rendered;
-  return `${rendered} ${input.args.map(quoteShellArg).join(" ")}`;
-}
-
-function spawnShellCommand(
-  command: string,
+function spawnExecutable(
+  executable: string,
+  argv: string[],
   options: {
     cwd?: string;
     env?: NodeJS.ProcessEnv;
-    mergeProcessEnv?: boolean;
     capture: boolean;
     stdin?: string;
     timeoutMs?: number;
@@ -734,10 +716,10 @@ function spawnShellCommand(
   truncated: boolean;
 }> {
   return new Promise((resolve) => {
-    const child = spawn(command, {
+    const child = spawn(executable, argv, {
       cwd: options.cwd ?? process.cwd(),
-      env: options.mergeProcessEnv === false ? options.env : { ...process.env, ...(options.env ?? {}) },
-      shell: true,
+      env: options.env,
+      shell: false,
       stdio: options.capture ? ["pipe", "pipe", "pipe"] : "inherit",
     });
     let stdout = "";
@@ -776,6 +758,11 @@ function spawnShellCommand(
       child.stdin?.on("error", () => {});
       child.stdin?.end(options.stdin ?? "");
     }
+    child.on("error", (error) => {
+      const next = appendOutputChunk(stderr, error.message, maxOutputBytes);
+      stderr = next.value;
+      truncated ||= next.truncated;
+    });
     child.on("close", (exitCode) => {
       if (timeout) clearTimeout(timeout);
       resolve({ exitCode, stdout, stderr, timedOut, truncated });
@@ -808,11 +795,6 @@ function parseJsonOutput(stdout: string): unknown {
 function localOperationName(appId: string, operationId: string): string {
   const prefix = `${appId.replace(/\//g, ".")}.`;
   return operationId.startsWith(prefix) ? operationId.slice(prefix.length) : operationId;
-}
-
-function quoteShellArg(value: string): string {
-  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) return value;
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function toSummary(record: RaviAppManifestRecord): Record<string, unknown> {

--- a/src/plugins/codex-skills.test.ts
+++ b/src/plugins/codex-skills.test.ts
@@ -60,6 +60,22 @@ describe("syncCodexSkills", () => {
     expect(existsSync(firstTargetDir)).toBe(false);
     expect(listCodexSkillDirs({ codexSkillsDir })).toEqual([]);
   });
+
+  it("materializes the canonical app builder skill and its references for Codex", () => {
+    const { codexSkillsDir, manifestPath } = createTestLayout();
+    const pluginPath = join(import.meta.dir, "internal", "ravi-dev");
+
+    const synced = syncCodexSkills([{ type: "local", path: pluginPath }], {
+      codexSkillsDir,
+      manifestPath,
+    });
+    const targetDir = join(codexSkillsDir, "ravi-dev-app-creator");
+
+    expect(synced).toContain("ravi-dev-app-creator");
+    expect(readFileSync(join(targetDir, "SKILL.md"), "utf8")).toContain("name: ravi-dev-app-creator");
+    expect(existsSync(join(targetDir, "references", "review-checklist.md"))).toBe(true);
+    expect(existsSync(join(targetDir, "references", "acceptance-cases.md"))).toBe(true);
+  });
 });
 
 function createTestLayout(): {

--- a/src/plugins/internal-loader.test.ts
+++ b/src/plugins/internal-loader.test.ts
@@ -22,8 +22,13 @@ describe("internal plugin packaging", () => {
     };
     const system = artifact.plugins.find((plugin) => plugin.name === "ravi-system");
     const paths = system?.files.map((file) => file.path) ?? [];
+    const developer = artifact.plugins.find((plugin) => plugin.name === "ravi-dev");
+    const developerPaths = developer?.files.map((file) => file.path) ?? [];
 
     expect(paths).toContain("apps/apps/ravi.app.json");
     expect(paths).toContain("apps/youtube/ravi.app.json");
+    expect(developerPaths).toContain("skills/app-creator/SKILL.md");
+    expect(developerPaths).toContain("skills/app-creator/references/review-checklist.md");
+    expect(developerPaths).toContain("skills/app-creator/references/acceptance-cases.md");
   });
 });

--- a/src/plugins/internal/ravi-dev/skills/app-creator/SKILL.md
+++ b/src/plugins/internal/ravi-dev/skills/app-creator/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: app-creator
+description: >-
+  Constrói Ravi Apps ponta a ponta a partir de documentação de API pública,
+  um CLI existente ou uma nova capacidade de domínio. Use quando precisar
+  pesquisar o contrato-fonte, desenhar o CLI real, criar ou importar o
+  ravi.app.json, integrar credenciais e contexto-filho, classificar permissões,
+  decidir storage/eventos/artifacts/UI, criar a skill operacional e provar a
+  aplicação com testes funcionais. Não use para apenas listar, inspecionar ou
+  operar um app existente; nesse caso use ravi-system-apps.
+---
+
+# Ravi App Creator
+
+Um Ravi App é um CLI real mais um `ravi.app.json`. O App Router autoriza a
+operação, emite um contexto-filho mínimo e lança o CLI sem shell. O app fala com
+o restante do Ravi chamando comandos públicos `ravi ...` sob esse contexto.
+Não existe protocolo JSON privado entre app e host; `--json` é o contrato de
+saída legível por agentes, UI e automações.
+
+## Comece Pelo Contrato
+
+Antes de alterar código:
+
+```bash
+ravi specs get apps/builder --mode full --json
+ravi apps guide --json
+ravi skills show ravi-dev-cli-creator --json
+ravi skills show ravi-dev-context-cli --json
+```
+
+Leia também [references/review-checklist.md](references/review-checklist.md).
+Para testar se o método é independente de domínio, use os dois briefs de
+[references/acceptance-cases.md](references/acceptance-cases.md).
+
+## Entradas Aceitas
+
+- documentação oficial de uma API;
+- um CLI que já possui contrato estável;
+- uma capacidade nova cujo CLI ainda será criado.
+
+Se a fonte for API, registre URLs oficiais, autenticação, recursos, métodos,
+paginação, limites e envelope de erro antes de escrever operações. Se a fonte
+for CLI, capture `manifest --json`, o registry decorado ou, como último recurso,
+o help humano.
+
+## Fluxo Canônico
+
+### 1. Defina o produto
+
+Escreva em uma frase o problema do operador e o usuário-alvo. Monte uma matriz
+de operações com:
+
+- nome público;
+- recurso/endpoint ou comando-fonte;
+- read, sensitive-read, write ou destructive;
+- entrada e saída estáveis;
+- paginação;
+- idempotência;
+- falhas esperadas;
+- prova funcional.
+
+Não publique cada endpoint ou subcomando automaticamente. Um app expõe o fluxo
+útil e seguro; comandos raros, interativos, streaming ou de diagnóstico podem
+continuar CLI-only.
+
+### 2. Escolha o CLI real
+
+Para um CLI novo:
+
+```bash
+ravi apps scaffold <app-id> --dry-run --json
+ravi apps scaffold <app-id> --name "Nome" --description "Resultado" --json
+```
+
+O default cria `src/apps/<app-id>/cli.ts` e usa `bun cli.ts` como
+`interfaces.cli.command`.
+
+Para um CLI existente:
+
+```bash
+ravi apps import-cli "<cli-real>" --id <app-id> --dry-run --json
+```
+
+`import-cli` é somente um gerador de rascunho. Ele não prova auth, segurança,
+qualidade dos schemas nem prontidão funcional. Revise todos os candidatos antes
+de escrever:
+
+```bash
+ravi apps import-cli "<cli-real>" --id <app-id> --json
+```
+
+`interfaces.cli.command` aponta para a implementação real. Nunca aponte para o
+alias público `ravi <app-id>`, pois o CLI reentraria no App Router.
+
+### 3. Implemente o contrato agent-first
+
+Cada operação pública deve ter:
+
+- argumentos explícitos e limites;
+- `--json` com forma estável;
+- stdout reservado ao dado e stderr a diagnóstico;
+- exit `0` para sucesso e não zero para falha;
+- erro tipado e sanitizado;
+- cursor/offset preservado quando a fonte pagina;
+- timeout e retry limitados;
+- comportamento de idempotência documentado.
+
+Não execute declarations por shell. Use executable + argv e trate argumentos do
+usuário como dados literais.
+
+### 4. Modele autenticação sem expor segredos
+
+Escolha uma destas fronteiras:
+
+- provider client first-party resolve a conexão dentro do broker Ravi;
+- connector gerenciado executa OAuth e entrega apenas a ação autorizada;
+- adapter de credential broker específico do provider executa a chamada.
+
+Nunca coloque token, refresh token, client secret, secret ref/path ou credencial
+serializada no manifesto, argv, stdout, evento, spec ou skill. Health local pode
+inspecionar metadata da conexão, mas não deve afirmar autenticação externa sem
+uma prova externa separada.
+
+O teste mínimo de auth deve provar que credencial ausente ou desabilitada falha
+antes de `fetch`, sem vazar a causa interna do backend.
+
+### 5. Separe permissão do app e capacidade do processo
+
+- `manifest.permissions` descreve requisitos do caller e mutações.
+- `manifest.context.allow` limita quais superfícies Ravi o CLI filho pode
+  chamar.
+- nenhum dos dois é grant.
+
+Use o menor teto possível em `context.allow`; lista vazia é válida. Quando o app
+chamar outra superfície, preserve `process.env` e use o CLI público:
+
+```ts
+const child = Bun.spawn(["ravi", "artifacts", "create", "--json"], {
+  env: process.env,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+```
+
+Declare a capacidade necessária e prove que o router falha antes do spawn
+quando o pai não pode delegá-la. Para um denial recorrente, prefira
+`ravi permissions resolve <denial-id>` ou um profile estreito; não use
+`full-access` como solução normal.
+
+### 6. Decida as superfícies opcionais
+
+Responda sim ou não, com justificativa:
+
+- storage: cria reuse, lineage, audit, cache caro ou recovery?
+- events: outro agente/UI precisa reagir sem scraping?
+- artifacts: existe saída durável com provenance?
+- UI semântica: há fluxo recorrente que merece route/view/action?
+
+Ausência explícita é melhor que infraestrutura sem necessidade. UI, SDK,
+tools e automações continuam clientes das mesmas operações do App Router.
+
+### 7. Crie a skill operacional
+
+O scaffold gera uma skill de domínio. Ajuste-a para ensinar:
+
+- quando usar o app;
+- como inspecionar e validar;
+- operações públicas e outputs;
+- riscos de mutação;
+- falhas que exigem intervenção;
+- health/readiness.
+
+Depois confirme a visibilidade do agent:
+
+```bash
+ravi skills show <app-skill> --json
+ravi skills inspect <agent-id> --json
+```
+
+Se o agent tiver allowlist e a skill não estiver visível, conceda somente a
+skill necessária com `ravi skills grant <agent-id> <app-skill>`.
+
+### 8. Prove o comportamento
+
+Teste em camadas:
+
+1. client com credencial injetada e HTTP fake;
+2. CLI real com JSON, erro, paginação e mutações simuladas;
+3. manifesto com `ravi apps check`;
+4. operação pelo alias público `ravi <app-id> <operation> --json`;
+5. router com contexto-filho e capability negada/permitida;
+6. skill/specs e contratos gerados;
+7. suíte completa.
+
+Um teste de manifesto não torna o app funcional. Pelo menos uma operação real
+deve atravessar o alias público até o client fake. Mutações e chamadas externas
+reais só acontecem quando o usuário as autorizar explicitamente.
+
+## Gate De Prontidão
+
+Só chame o app de pronto quando:
+
+- o CLI implementa as operações públicas;
+- auth e secrets estão atrás de uma fronteira Ravi;
+- permission e `context.allow` falham fechado;
+- a skill está indexada ou explicitamente concedida;
+- `ravi apps check <app-id> --json` passa;
+- uma operação pelo alias público passa funcionalmente;
+- erros e ausência de credencial foram exercitados;
+- specs, schemas, SDK/OpenAPI e testes não apresentam drift.
+
+Use o checklist estruturado retornado por `ravi apps scaffold ... --json` ou
+`ravi apps import-cli ... --json`; ele é parte do contrato de geração.
+
+## Comandos Finais
+
+```bash
+ravi apps show <app-id> --json
+ravi apps check <app-id> --json
+ravi <app-id> <operation> --json
+ravi apps guide <app-id> --json
+ravi specs get apps/<app-id> --mode full --json
+```
+
+`ravi apps run <app-id> <operation>` é diagnóstico interno do router. O caminho
+normal do produto é `ravi <app-id> <operation>`.

--- a/src/plugins/internal/ravi-dev/skills/app-creator/references/acceptance-cases.md
+++ b/src/plugins/internal/ravi-dev/skills/app-creator/references/acceptance-cases.md
@@ -1,0 +1,74 @@
+# Acceptance Cases
+
+Estes briefs testam o método da skill. Eles não pedem credenciais reais nem
+autorizam chamadas externas. A implementação de referência deve usar fake HTTP.
+
+## Caso A — Google Search Console
+
+### Fontes oficiais
+
+- Visão geral: <https://developers.google.com/webmaster-tools>
+- Pré-requisitos e OAuth: <https://developers.google.com/webmaster-tools/v1/prereqs>
+- Search Analytics query:
+  <https://developers.google.com/webmaster-tools/v1/searchanalytics/query>
+- Sitemaps list:
+  <https://developers.google.com/webmaster-tools/v1/sitemaps/list>
+- Limites: <https://developers.google.com/webmaster-tools/limits>
+
+### Brief
+
+Crie um app `search-console` cujo CLI real exponha inicialmente:
+
+- `sites`: lista propriedades acessíveis;
+- `analytics`: consulta um property URL por intervalo, dimensões e offset;
+- `sitemaps`: lista sitemaps de uma propriedade;
+- `health`: inspeciona somente metadata local da conexão.
+
+O client usa `https://www.googleapis.com/webmasters/v3`, OAuth 2 por uma
+conexão brokered e scopes read-only na primeira fase. `siteUrl` deve ser
+codificado como path data. A consulta de analytics preserva `rowLimit` e
+`startRow`; a saída não pode prometer cobertura completa porque a API retorna
+linhas principais sob limites internos.
+
+### Evidência esperada
+
+- operação matrix e schemas para sites/analytics/sitemaps/health;
+- ausência de tokens e fluxo OAuth ad hoc;
+- permission separada para read e eventual write futuro;
+- credencial ausente falha antes do fetch;
+- fake HTTP confirma método, path encoding, body, offset e erro sanitizado;
+- `ravi search-console analytics --json` atravessa o App Router;
+- storage/events/artifacts/UI têm decisão explícita, mesmo quando `não`.
+
+## Caso B — Open-Meteo Forecast
+
+### Fonte oficial
+
+- Forecast API: <https://open-meteo.com/en/docs>
+
+### Brief
+
+Crie um app `weather` cujo CLI real exponha inicialmente:
+
+- `forecast`: recebe latitude, longitude, timezone e uma allowlist curta de
+  variáveis horárias;
+- `health`: valida configuração local sem chamar rede.
+
+O client usa `https://api.open-meteo.com/v1/forecast`. A fase inicial não
+precisa de OAuth nem de secret. Isso deve permanecer uma decisão explícita:
+não crie broker ou permission sensível quando a fonte pública não exige.
+
+### Evidência esperada
+
+- validação de coordenadas e allowlist de variáveis;
+- JSON estável independentemente de ordem de query;
+- fake HTTP confirma query encoding, timezone e erro do provider;
+- `context.allow` vazio quando o CLI não chama outra superfície Ravi;
+- `ravi weather forecast --json` atravessa o App Router;
+- nenhuma regra específica de Google está embutida no builder.
+
+## Critério de independência
+
+O mesmo fluxo, checklist e gates devem servir aos dois casos. Diferenças de
+OAuth, quotas, recursos e risco pertencem aos apps e aos seus clients, não ao
+framework do builder.

--- a/src/plugins/internal/ravi-dev/skills/app-creator/references/review-checklist.md
+++ b/src/plugins/internal/ravi-dev/skills/app-creator/references/review-checklist.md
@@ -1,0 +1,64 @@
+# App Builder Review Checklist
+
+Use todos os gates. Marque `N/A` somente com justificativa escrita.
+
+## SOURCE_CONTRACT
+
+- [ ] Problema, usuário-alvo e resultado foram definidos.
+- [ ] Documentação oficial e versão/data de consulta estão registradas.
+- [ ] Recursos, operações, paginação, limites e erros foram mapeados.
+- [ ] Operações públicas foram selecionadas por valor e segurança, não por
+      espelhamento automático da fonte.
+
+## CLI_BOUNDARY
+
+- [ ] Existe um único CLI de implementação real.
+- [ ] `interfaces.cli.command` não aponta para `ravi <app-id>`.
+- [ ] Cada operação pública tem JSON estável, exit status e erro tipado.
+- [ ] stdout contém dados; stderr contém diagnóstico.
+- [ ] Argumentos são argv literal; não há shell, pipes ou redirecionamento.
+
+## AUTHENTICATION
+
+- [ ] Foi escolhida uma fronteira de broker/connector/provider client.
+- [ ] Nenhum secret ou secret path aparece em manifesto, argv, output ou docs.
+- [ ] Credencial ausente/desabilitada falha antes de rede.
+- [ ] Health local não afirma autenticação externa sem prova.
+- [ ] Erros do provider são sanitizados.
+
+## PERMISSIONS_CONTEXT
+
+- [ ] Reads sensíveis, writes e destructive têm classes distintas.
+- [ ] Mutações possuem permission metadata e confirmação adequada.
+- [ ] `context.allow` contém o menor teto necessário ou `[]`.
+- [ ] Falha de delegação acontece antes do CLI iniciar.
+- [ ] O processo recebe contexto-filho, nunca a chave pai.
+
+## SKILL_VISIBILITY
+
+- [ ] A skill operacional ensina comandos, outputs, riscos e recovery.
+- [ ] A skill está indexada no runtime-alvo.
+- [ ] Agents com allowlist receberam apenas o grant necessário.
+
+## OPTIONAL_SURFACES
+
+- [ ] Storage tem decisão explícita e ownership quando usado.
+- [ ] Events têm decisão explícita e schema quando usados.
+- [ ] Artifacts têm decisão explícita e provenance quando usados.
+- [ ] UI tem decisão explícita e referencia operations declaradas quando usada.
+
+## FUNCTIONAL_VALIDATION
+
+- [ ] Client usa fake HTTP e credencial injetada nos testes.
+- [ ] CLI exerce sucesso, input inválido, erro do provider e paginação.
+- [ ] `ravi apps check <app-id> --json` passa.
+- [ ] `ravi <app-id> <operation> --json` atravessa o router até o fake.
+- [ ] Contexto negado e permitido foram exercitados.
+- [ ] Não há chamada real, mutation real ou secret real em teste.
+
+## RELEASE
+
+- [ ] Specs e skill refletem o contrato final.
+- [ ] Schemas públicos e SDK/OpenAPI foram regenerados e checados.
+- [ ] Typecheck, lint/format, testes focados e suíte completa passam.
+- [ ] O resultado do scaffold/import e este checklist não apresentam drift.

--- a/src/plugins/internal/ravi-system/skills/apps/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/apps/SKILL.md
@@ -4,7 +4,9 @@ description: |
   Gerencia Ravi Apps. Use quando precisar:
   - Listar, mostrar ou validar manifests de apps
   - Criar scaffold de um novo Ravi App
-  - Entender interfaces CLI, SDK, UI, tool e stream de um app
+  - Importar um CLI existente como Ravi App
+  - Encaminhar construção ponta a ponta para ravi-dev-app-creator
+  - Entender o CLI real, o contexto delegado e as superficies consumidoras de um app
   - Usar operations, storage, events, artifacts, skills e health checks declarados em ravi.app.json
   - Ensinar agentes a operar apps via `ravi <app-id> <operation>`
 ---
@@ -13,9 +15,15 @@ description: |
 
 Ravi Apps sao a camada de aplicacoes do Ravi OS.
 
-Um app e uma unidade operacional com manifesto, interfaces, operations, permissoes,
-storage, events, skills e health checks. O manifesto e metadata declarativa; ele
-nao concede permissao e discovery/check nao executam codigo do app.
+Um app e um CLI real acompanhado de `ravi.app.json`. O App Router recebe uma
+operation, aplica autorizacao, emite um contexto-filho minimo e executa o CLI
+diretamente, sem shell.
+
+SDK, UI, tools e automacoes nao sao executores paralelos. Eles sao consumidores
+do mesmo App Router e das mesmas operations.
+
+O manifesto e metadata declarativa: nao concede permissao e discovery/check nao
+executam codigo do app.
 
 ## Comandos De Registry
 
@@ -25,6 +33,8 @@ ravi apps show <app-id> --json
 ravi apps check [app-id] --json
 ravi apps scaffold <app-id> --name "Nome" --description "Descricao" --json
 ravi apps scaffold <app-id> --dry-run --json
+ravi apps import-cli <cli-real> --id <app-id> --dry-run --json
+ravi apps delete <app-id> --dry-run --json
 ravi apps guide [app-id] --json
 ravi apps prompts [app-id] --json
 ```
@@ -36,8 +46,9 @@ prefira sempre:
 ravi <app-id> <operation> --json
 ```
 
-Use `ravi apps run <app-id> <operation> --json` apenas como fallback/debug
-quando houver colisao com comando estatico ou quando estiver testando o router.
+Use `ravi apps run <app-id> <operation> --json` apenas como superfície
+interna/debug quando houver colisao com comando estatico ou quando estiver
+testando o router.
 
 ## Fluxo Para Operar Um App
 
@@ -61,9 +72,10 @@ ravi apps check <app-id> --json
 
 4. Leia estes campos antes de operar:
 
-- `manifest.interfaces`: superficies CLI, SDK, UI, stream e tool.
+- `manifest.interfaces.cli`: comando do CLI real que implementa o app.
+- `manifest.context.allow`: capacidades Ravi delegadas ao processo filho.
 - `manifest.operations`: acoes e snapshots que agentes/UI podem chamar.
-- `manifest.permissions`: capacidades requeridas; requisitos, nao grants.
+- `manifest.permissions`: permissoes do dominio do app; requisitos, nao grants.
 - `manifest.storage`: storage que o app possui.
 - `manifest.events`: eventos emitidos/consumidos.
 - `manifest.skills`: skills que ensinam agentes a operar o app.
@@ -77,20 +89,56 @@ ravi <app-id> <operation> --json
 
 ## Fluxo Para Criar Um App
 
+Carregue primeiro a skill de construção:
+
+```bash
+ravi skills show ravi-dev-app-creator --json
+ravi specs get apps/builder --mode full --json
+```
+
+Ela governa pesquisa do contrato-fonte, desenho do CLI, auth/credentials,
+permissions/context, skill grants, decisões de storage/events/artifacts/UI,
+testes funcionais e o gate de release. Esta skill de sistema continua sendo a
+camada operacional de Apps.
+
 1. Gere um plano sem escrever arquivos:
 
 ```bash
 ravi apps scaffold <app-id> --dry-run --json
 ```
 
-2. Gere o scaffold:
+2. Para um CLI novo, gere o scaffold:
 
 ```bash
 ravi apps scaffold <app-id> --name "Nome" --description "O que o app faz" --json
 ```
 
+Sem `--command`, o scaffold gera um `src/apps/<app-id>/cli.ts` executavel por
+`bun cli.ts` e conecta a operation inicial `list` a ele. O resultado ja deve
+funcionar por `ravi <app-id> list --json`.
+
+Depois da primeira geracao, esse `cli.ts` e implementacao autoral. Um novo
+scaffold com `--force` atualiza os contratos, mas preserva o CLI existente e o
+reporta como `preserved`.
+
+Use `--command "<cli-real>"` somente quando o CLI de implementacao ja existir;
+nesse modo o scaffold nao gera `cli.ts`.
+
+Para um CLI existente, importe primeiro em dry-run:
+
+```bash
+ravi apps import-cli <cli-real> --id <app-id> --dry-run --json
+ravi apps import-cli <cli-real> --id <app-id> --json
+```
+
+`import-cli` e um gerador de rascunho. Nao prova auth, schemas, segurança,
+prontidão funcional nem que todos os subcomandos pertencem à superfície
+pública. O resultado retorna a skill de builder e um review checklist
+estruturado; complete os dois antes de chamar o app de pronto.
+
 3. Revise os arquivos criados:
 
+- `src/apps/<app-id>/cli.ts` (quando o scaffold criou um CLI novo)
 - `src/apps/<app-id>/ravi.app.json`
 - `.ravi/specs/apps/<app-id>/SPEC.md`
 - `src/plugins/internal/ravi-system/skills/<app-id>/SKILL.md`
@@ -99,15 +147,97 @@ ravi apps scaffold <app-id> --name "Nome" --description "O que o app faz" --json
 
 ```bash
 ravi apps check <app-id> --json
+ravi <app-id> list --json
 ravi apps guide <app-id> --json
 ```
 
-5. Implemente a logica real do CLI/SDK/tool/stream depois do manifesto estar coerente.
+5. Implemente ou ajuste o CLI real a partir do entrypoint executavel. Cada
+operation de dominio deve usar `interface: "cli"` e um comando tokenizavel;
+operations internas do registry podem usar `interface: "builtin"`.
+
+6. Declare `context.allow` com a menor lista possivel. Uma lista vazia e valida
+quando o CLI nao precisa chamar outras superficies Ravi.
+
+7. Prove funcionalmente pelo alias público com HTTP/CLI fake. `apps check`
+valida o manifesto, mas não prova que a operação de domínio funciona:
+
+```bash
+ravi <app-id> <operation> --json
+ravi skills inspect <agent-id> --json
+```
+
+Se o agent usar allowlist e a skill do app não estiver visível, conceda apenas
+essa skill com `ravi skills grant`.
+
+## Lifecycle De Scaffold
+
+Delete somente os artefatos de contrato que o scaffold possui:
+
+```bash
+ravi apps delete <app-id> --dry-run --json
+ravi apps delete <app-id> --json
+```
+
+O delete deve preservar CLI autoral, storage, credenciais e arquivos não
+gerados. Sempre faça dry-run primeiro.
+
+## Contrato Do Processo
+
+- O launcher usa `executable + argv` com `shell: false`.
+- Novos manifests usam somente `{args}`, no maximo uma vez e como token inteiro.
+- O leitor v1 aceita um placeholder nomeado legado, como `{id}`, somente como
+  token inteiro, trata-o como `{args}` e emite aviso de migracao.
+- Pipes, `;`, `&&`, redirecionamentos, backticks e substituicao de comando sao proibidos.
+- O processo roda no diretorio raiz do app.
+- O ambiente e allowlisted.
+- Quando existe contexto de caller, o processo recebe somente
+  `RAVI_CONTEXT_KEY` do contexto-filho, mais metadata `RAVI_APP_*`.
+- O processo nao recebe a chave do contexto pai nem identidade legada como
+  `RAVI_AGENT_ID` ou `RAVI_SESSION_*`.
+- `context.allow` e um pedido de delegacao, nao um grant. Se o pai nao possui a
+  capacidade, o router falha antes de iniciar o CLI.
+- Manifests v1 ja instalados sem `context` sao lidos com aviso e recebem
+  capacidade vazia. Nunca ha heranca implicita; novos manifests devem declarar
+  `context.allow`.
+
+Dentro do CLI, use:
+
+```bash
+ravi context whoami --json
+ravi context check <permission> <object-type> <object-id> --json
+ravi context authorize <permission> <object-type> <object-id> --json
+```
+
+Para chamar outra superficie do Ravi, o app apenas executa o CLI publico
+normal, preservando `process.env`; nao existe um protocolo JSON privado entre o
+app e o host. JSON e somente o formato de saida da operacao:
+
+```ts
+const child = Bun.spawn(["ravi", "contacts", "list", "--json"], {
+  env: process.env,
+  stdout: "pipe",
+  stderr: "pipe",
+});
+```
+
+Antes disso, o manifesto deve declarar
+`context.allow: ["execute:group:contacts"]`. O app nunca cria, copia ou recebe a
+chave pai: o App Router emite `RAVI_CONTEXT_KEY` do contexto-filho. Se o caller
+nao puder delegar essa capability, o CLI do app nem chega a iniciar.
+
+Ao importar um grupo `ravi <group>`, o importer pode inferir
+`execute:group:<group>`, mas essa lista continua sendo um teto solicitado e
+deve ser revisada.
 
 ## Regras
 
 - Nao invente comandos. Use apenas operations declaradas.
+- Nao trate `import-cli` como app pronto; ele produz um draft para review.
 - Nao ensine agentes a usar `ravi apps run` como caminho normal do app; use `ravi <app-id> <operation>`.
+- `interfaces.cli.command` deve apontar para o CLI real. Ele nunca deve chamar o
+  proprio alias dinamico `ravi <app-id>`, pois isso cria recursao.
+- Operations so podem executar `builtin` ou `cli`. Streaming e interatividade
+  continuam sendo comportamento do CLI/launcher, nao tipos de executor.
 - Operations com caminho pontuado podem ser chamadas em CLI como tokens separados quando declaradas. Exemplo: `app.test.a` pode ser invocado como `ravi app test a`.
 - Nao raspe stdout quando houver JSON.
 - Nao execute health checks durante discovery.
@@ -124,7 +254,10 @@ ravi apps guide <app-id> --json
 
 ```bash
 ravi specs get apps/manifest --mode rules --json
+ravi specs get apps/router --mode rules --json
 ravi specs get apps/cli --mode rules --json
 ravi specs get apps/ui --mode rules --json
 ravi specs get apps/scaffold --mode rules --json
+ravi specs get apps/import-cli --mode rules --json
+ravi specs get apps/builder --mode full --json
 ```

--- a/src/runtime/claude-provider.test.ts
+++ b/src/runtime/claude-provider.test.ts
@@ -130,6 +130,38 @@ describe("createClaudeRuntimeProvider", () => {
     expect(settings.PermissionRequest[0].matcher).toBe("*");
   });
 
+  it("advertises the allowlisted canonical app builder through the Claude plugin", () => {
+    const provider = createClaudeRuntimeProvider();
+    const pluginPath = join(import.meta.dir, "..", "plugins", "internal", "ravi-dev");
+    const session = provider.startSession(
+      makeStartRequest(
+        (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "build an app" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+        })(),
+        {
+          plugins: [{ type: "local", path: pluginPath }],
+          allowedSkills: ["ravi-dev-app-creator"],
+        },
+      ),
+    );
+
+    expect(session.skillVisibility?.loadedSkills).toEqual([]);
+    expect(session.skillVisibility?.skills).toEqual([
+      expect.objectContaining({
+        id: "app-creator",
+        provider: "claude",
+        state: "advertised",
+        confidence: "declared",
+        source: "plugin:ravi-dev/app-creator",
+      }),
+    ]);
+  });
+
   it("closes the active Claude SDK query idempotently", async () => {
     nextMessages = [{ type: "result", subtype: "success", session_id: "claude-session-close" }];
     queryGate = new Promise<void>((resolve) => {

--- a/src/runtime/pi-provider.test.ts
+++ b/src/runtime/pi-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -78,6 +78,52 @@ describe("Pi runtime provider", () => {
         guarantee: "adapter",
       },
     });
+  });
+
+  it("indexes allowed Ravi plugin skills in the Pi system prompt without claiming they were loaded", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ravi-pi-skills-"));
+    const pluginPath = join(root, "ravi-dev");
+    const skillPath = join(pluginPath, "skills", "app-creator");
+    mkdirSync(skillPath, { recursive: true });
+    writeFileSync(
+      join(skillPath, "SKILL.md"),
+      [
+        "---",
+        "name: app-creator",
+        "description: Build Ravi Apps from API or CLI contracts.",
+        "---",
+        "",
+        "# App Creator",
+      ].join("\n"),
+    );
+
+    const transport = new FakePiRpcTransport();
+    transport.pushEvent({ type: "agent_end", messages: [assistantMessage("fim")] });
+    const handle = createPiRuntimeProvider({ transport }).startSession(
+      createStartRequest("crie um app", {
+        plugins: [{ type: "local", path: pluginPath }],
+        allowedSkills: ["ravi-dev-app-creator"],
+      }),
+    );
+
+    expect(handle.skillVisibility).toMatchObject({
+      loadedSkills: [],
+      skills: [
+        {
+          id: "app-creator",
+          provider: "pi",
+          state: "advertised",
+          confidence: "declared",
+          source: "plugin:ravi-dev/app-creator",
+        },
+      ],
+    });
+
+    await collectRuntimeEvents(handle.events);
+
+    expect(transport.starts[0]?.systemPromptAppend).toContain("ravi-dev-app-creator");
+    expect(transport.starts[0]?.systemPromptAppend).toContain("ravi skills show <skill-name> --json");
+    expect(transport.starts[0]?.systemPromptAppend).toContain("availability only");
   });
 
   it("closes the Pi RPC transport idempotently", async () => {

--- a/src/runtime/pi-provider.ts
+++ b/src/runtime/pi-provider.ts
@@ -20,7 +20,7 @@ import type {
   SessionRuntimeProvider,
 } from "./types.js";
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
-import { emptySkillVisibilitySnapshot } from "./skill-visibility.js";
+import { buildPluginSkillVisibilitySnapshot } from "./skill-visibility.js";
 
 const DEFAULT_PI_COMMAND = "pi";
 const DEFAULT_PI_RESPONSE_TIMEOUT_MS = 30_000;
@@ -193,7 +193,7 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
           guarantee: "adapter",
         },
         skillVisibility: {
-          availability: "none",
+          availability: "provider",
           loadedState: "none",
         },
         supportsSessionResume: true,
@@ -223,7 +223,18 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
               }));
       const canRestartTransport = Boolean(options.transportFactory) || !options.transport;
       const initialTransport = createTransport();
-      const skillVisibility = emptySkillVisibilitySnapshot();
+      const skillVisibility = buildPluginSkillVisibilitySnapshot({
+        provider: "pi",
+        plugins: input.plugins,
+        state: "advertised",
+        confidence: "declared",
+        evidenceKind: "system-prompt",
+        ...(input.allowedSkills && input.allowedSkills.length > 0 ? { allowedSkills: input.allowedSkills } : {}),
+      });
+      const request: RuntimeStartRequest = {
+        ...input,
+        systemPromptAppend: buildPiSkillCatalogSystemPrompt(input.systemPromptAppend, skillVisibility),
+      };
       const state: PiSessionRuntimeState = {
         activeTurn: false,
         interrupted: false,
@@ -243,7 +254,7 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
         provider: "pi",
         skillVisibility,
         concurrentInputStrategy: "native_steer",
-        events: runPiTurns(input, createTransport, state, { canRestartTransport, skillVisibility }),
+        events: runPiTurns(request, createTransport, state, { canRestartTransport, skillVisibility }),
         interrupt: async () => {
           state.interrupted = true;
           const transport = state.transport;
@@ -268,6 +279,52 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
       };
     },
   };
+}
+
+export function buildPiSkillCatalogSystemPrompt(
+  basePrompt: string,
+  skillVisibility: RuntimeSkillVisibilitySnapshot,
+): string {
+  if (skillVisibility.skills.length === 0) {
+    return basePrompt;
+  }
+
+  const catalog = skillVisibility.skills.map((skill) => {
+    const alias = piManagedSkillAlias(skill);
+    return alias === skill.id ? `- ${alias}` : `- ${alias} (skill: ${skill.id})`;
+  });
+
+  return [
+    basePrompt.trim(),
+    "",
+    "## Ravi Skills Available to Pi",
+    "",
+    "The following skills are indexed for this session. When a task matches one, load its complete instructions before acting with:",
+    "",
+    "`ravi skills show <skill-name> --json`",
+    "",
+    ...catalog,
+    "",
+    "Treat this catalog as availability only. A skill is loaded only after its complete instructions are read.",
+  ]
+    .filter((line, index) => line || index > 0)
+    .join("\n");
+}
+
+function piManagedSkillAlias(skill: RuntimeSkillVisibilitySnapshot["skills"][number]): string {
+  const sourceMatch = /^plugin:([^/]+)\/([^/]+)$/.exec(skill.source ?? "");
+  if (!sourceMatch) {
+    return skill.id;
+  }
+  return `${piSkillSlug(sourceMatch[1] ?? "")}-${piSkillSlug(sourceMatch[2] ?? skill.id)}`;
+}
+
+function piSkillSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 function createPiRpcSubprocessTransport(options: CreatePiRpcSubprocessTransportOptions = {}): PiRpcTransport {

--- a/src/runtime/provider-contract.test.ts
+++ b/src/runtime/provider-contract.test.ts
@@ -243,7 +243,7 @@ describe("runtime provider contract", () => {
         guarantee: "adapter",
       },
       skillVisibility: {
-        availability: "none",
+        availability: "provider",
         loadedState: "none",
       },
       supportsSessionResume: true,

--- a/src/runtime/runtime-provider-bootstrap.ts
+++ b/src/runtime/runtime-provider-bootstrap.ts
@@ -53,7 +53,11 @@ export async function prepareRuntimeProviderBootstrap(
     ...(discoveredPlugins.length > 0 ? { plugins: discoveredPlugins } : {}),
     hostServices,
   });
-  const runtimePlugins = options.runtimeCapabilities.supportsPlugins ? discoveredPlugins : [];
+  const runtimePlugins =
+    options.runtimeCapabilities.supportsPlugins ||
+    options.runtimeCapabilities.skillVisibility.availability === "provider"
+      ? discoveredPlugins
+      : [];
 
   return {
     hostServices,

--- a/src/runtime/skill-gate.test.ts
+++ b/src/runtime/skill-gate.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import { createRuntimeContext } from "./context-registry.js";
 import { dbUpsertSkillGateRule, dbUpsertSkillGrant, getOrCreateSession, getSession } from "../router/index.js";
+import { dbUpdateAgent } from "../router/router-db.js";
 import { evaluateSkillGate, runtimeSkillGateForCommand, runtimeSkillGateForTool } from "./skill-gate.js";
 import { createRuntimeHostServices } from "./host-services.js";
 import type { RuntimeSkillVisibilitySnapshot } from "./types.js";
@@ -163,6 +164,12 @@ describe("evaluateSkillGate", () => {
 describe("runtime host skill-gate enforcement", () => {
   it("delivers and marks a required skill loaded when a dynamic tool is attempted", async () => {
     writeCodexSkill("ravi-system-image");
+    // System skills are visible through provider-owned group capabilities. The
+    // tool-local context permission below authorizes execution but must not
+    // accidentally become the agent's persisted skill allowlist.
+    dbUpdateAgent("main", {
+      defaults: { runtimePermissions: { capabilities: ["execute:group:image_generate"] } },
+    });
     getOrCreateSession("agent:main:main", "main", stateDir!, {
       name: "skill-gate-test",
       runtimeProvider: "codex",

--- a/src/skills/manager.test.ts
+++ b/src/skills/manager.test.ts
@@ -41,7 +41,7 @@ describe("skills manager", () => {
     const root = createTempRoot();
     writeText(
       join(root, "skills", "planner", "SKILL.md"),
-      "---\nname: planner\ndescription: |\n  Planeja execução\n---\n\n# Planner\n",
+      "---\nname: planner\ndescription: >-\n  Planeja execução\n  em etapas\n---\n\n# Planner\n",
     );
     writeText(
       join(root, ".codex", "skills", "reviewer", "SKILL.md"),
@@ -52,7 +52,7 @@ describe("skills manager", () => {
     const skills = discoverSkills(resolved);
 
     expect(skills.map((skill) => skill.name)).toEqual(["planner", "reviewer"]);
-    expect(skills.find((skill) => skill.name === "planner")?.description).toBe("Planeja execução");
+    expect(skills.find((skill) => skill.name === "planner")?.description).toBe("Planeja execução\nem etapas");
   });
 
   it("requires explicit selection when source has multiple skills", () => {

--- a/src/skills/manager.ts
+++ b/src/skills/manager.ts
@@ -460,10 +460,10 @@ function frontmatterValue(frontmatter: string | null, key: string): string | nul
 function frontmatterDescription(frontmatter: string | null): string | undefined {
   if (!frontmatter) return undefined;
   const simple = frontmatterValue(frontmatter, "description");
-  if (simple && simple !== "|" && simple !== ">") return simple;
+  if (simple && !/^[>|][+-]?$/.test(simple)) return simple;
 
   const lines = frontmatter.split(/\r?\n/);
-  const start = lines.findIndex((line) => /^description:\s*[>|]\s*$/.test(line));
+  const start = lines.findIndex((line) => /^description:\s*[>|][+-]?\s*$/.test(line));
   if (start === -1) return undefined;
 
   const collected: string[] = [];


### PR DESCRIPTION
## Objective

Close the Ravi Apps builder contract around one simple model: every app is a real CLI with a `ravi.app.json` manifest and communicates with Ravi through the public `ravi` CLI.

## Problem

Apps had working pieces but no single end-to-end builder contract. Manifest validation, router execution, scaffolding, specs, provider visibility, and builder guidance could drift independently. JSON could also be mistaken for a private app protocol instead of stable CLI input and output.

## Solution

- require `manifest.context.allow` as the explicit capability declaration
- authorize the manifest, issue a least-privilege child context, and execute shell-free argv
- make `{args}` the only dynamic command placeholder
- establish `ravi <app-id> <operation>` as the product path and retain `ravi apps run ...` as the router diagnostic path
- add the dedicated `app-creator` skill, inherited builder specs, review checklist, acceptance cases, and drift evaluation
- update scaffold/import drafts, packaged apps, provider skill visibility, public schemas, OpenAPI, and generated SDKs

## Practical impact

An app author can scaffold or import a CLI, declare exactly which Ravi capabilities it needs, implement ordinary commands, and invoke Ravi from inside the app without learning a private protocol. Reviewers get one checklist and executable checks covering the same contract.

## What does NOT change

Ravi remains the authorization and context authority. Apps do not receive raw parent credentials, do not bypass permission providers, and do not gain a second transport. The diagnostic `ravi apps run` surface remains available for router debugging.

## Validation

- full `bun run test` suite
- `bun run typecheck`, `bun run lint`, and `bun run build`
- focused Apps/provider/skill suite: 119 passed, 0 failed
- runtime visibility/skill-gate regression batch: 130 passed, 0 failed
- local specs and coverage quality gate
- TypeScript SDK, Swift SDK, and OpenAPI drift checks
- packaged `apps` and `youtube` manifest checks plus builder spec checks
- fresh-agent Search Console acceptance: 9 passed, 0 failed; manifest and public alias validated with fake auth
- fresh-agent Open-Meteo acceptance: 11 passed, 0 failed; manifest and public alias validated through a fixture/no-network flow

The isolated eval runner reached its orchestration timeout before emitting its final marker. Both agents completed afterward, and their artifacts, tests, manifests, and public alias executions were verified independently.

## Risks

This intentionally removes implicit compatibility behavior: manifests without `context.allow` and command templates using dynamic placeholders other than `{args}` now fail validation. The generated public contracts are larger because Apps commands are now fully typed.

## Rollback

Revert this PR (commits `9b2561d1` and `b6cc460f`) to restore the previous manifest, router, scaffolding, specs, skill visibility, and generated contract surfaces. No data migration or external state cleanup is required.

Closes #381
