### PR TITLE
Fix runtime steering backlog after tool barriers

### DIFF
--- a/.ravi/specs/runtime/delivery-queue/CHECKS.md
+++ b/.ravi/specs/runtime/delivery-queue/CHECKS.md
@@ -25,12 +25,16 @@
 - `after_response` / `followup` never calls provider interrupt during text generation.
 - `after_task` never calls provider interrupt during text generation or active task work.
 - `after_tool` / `steer` waits for startup, compaction, and tool barriers before interrupting.
+- Provider tool-result delivery immediately re-evaluates queued `after_tool` / `steer` atoms; no later inbound message is required.
+- A pending provider callback write blocks every interrupt lane, including `immediate_interrupt`.
 - `immediate_interrupt` still respects startup, compaction, and unsafe tool barriers.
 
 ## Queue Integrity
 
 - Pending prompt atoms keep source, context, pending id, barrier, queue time, task barrier metadata, and launch metadata.
 - Same-lane prompt atoms are delivered FIFO.
+- A leading compatible burst from the same human channel authority may be folded chronologically under the newest channel envelope.
+- Different actors, chats, threads, authority envelopes, commands, and replay attempts are never folded together; incompatible atoms in the same releasable lane retain FIFO order.
 - Bypassing a blocked prompt atom is traceable.
 - Batched prompt atoms keep their internal order.
 - Daemon restart resume preserves queued prompt atoms.
@@ -52,6 +56,8 @@
 - Immediate arrives while an unsafe tool is running and waits.
 - Operational event arrives during active task and waits for the task barrier.
 - Human channel input arrives during active text generation and can interrupt after safe barriers.
+- Multiple compatible human messages arrive during one tool call and are released together immediately after tool completion.
+- Different actors or threads queued during one tool call retain isolated FIFO turns.
 - Human channel input that interrupts a turn is delivered next without replaying the superseded turn first.
 - Unexpected provider interruption without a newer prompt retains the active prompt for recovery replay.
 - Intentional provider/model restart is not marked as ambiguous and retains normal batching behavior.

--- a/.ravi/specs/runtime/delivery-queue/SPEC.md
+++ b/.ravi/specs/runtime/delivery-queue/SPEC.md
@@ -106,6 +106,22 @@ Within the same barrier lane, delivery SHOULD be FIFO.
 
 `after_tool` and `immediate_interrupt` prompt atoms MAY request interruption only through the session dispatcher's interrupt path, with trace events that explain the source, barrier, and safety state.
 
+When a running tool's result has crossed its provider callback boundary, the
+dispatcher MUST immediately re-evaluate queued `after_tool` and
+`immediate_interrupt` atoms. The callback write is an atomic safety barrier:
+even the immediate lane MUST wait for its delivery acknowledgement. Releasing a
+tool barrier MUST NOT depend on another inbound message arriving.
+
+The runtime MAY fold the leading run of compatible human channel steer atoms
+into one physical successor turn. Compatibility requires the same channel
+backend session and target, reply surface and thread, human actor identity,
+runtime selection, approval route, and barrier. Replay attempts, Ravi Commands,
+task-gated atoms, and internal producer envelopes MUST remain isolated. Folded
+text MUST preserve chronological order, the newest atom MUST own the successor
+envelope, and the older channel bindings MUST reach a terminal interrupted
+state. An incompatible actor, channel, thread, authority, or barrier ends the
+run and retains FIFO ownership.
+
 When a later prompt atom intentionally interrupts an active provider turn, the
 atoms already yielded to that turn MUST be dequeued before the next provider
 turn. The interrupting atom MUST become the next eligible work according to its
@@ -210,6 +226,9 @@ Each queued, released, batched, bypassed, or interrupted prompt SHOULD include:
 - `sessions answer` enters the follow-up lane by default, unless the call explicitly opts into immediate or belongs to a traced synchronous unblock flow.
 - Operational execute/heartbeat/trigger prompts do not interrupt active task work by default.
 - Human channel messages can still interrupt after safe tool barriers.
+- Human channel messages queued during a tool are reconsidered as soon as its result is delivered to the provider, without requiring another inbound message.
+- A compatible burst from the same human, channel, and thread is delivered as one chronological steering input using the newest envelope.
+- Bursts are never folded across actors, channels, threads, authority envelopes, Ravi Commands, or replay ownership.
 - A human channel message that interrupts an active turn is the next provider input; the superseded turn is not replayed ahead of it.
 - A provider interruption without a newer prompt reconciles the active prompt atom when the provider advertises support; otherwise it retries the atom only when generic replay remains durably safe.
 - Ambiguous recovery reuses one logical delivery id; intentional restarts create a new delivery id and preserve normal batching.

--- a/src/runtime/delivery-queue.test.ts
+++ b/src/runtime/delivery-queue.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
+  canReleaseRuntimeDeliveryBarrier,
   createQueuedRuntimeUserMessage,
   createRuntimeMessageGenerator,
   getDeliverableRuntimeMessages,
+  prepareRuntimeInterruptSuccessor,
   shouldInterruptRuntimeForIncoming,
 } from "./delivery-queue.js";
 import {
@@ -249,6 +251,27 @@ describe("runtime delivery queue", () => {
     });
   });
 
+  it("keeps every interrupt lane closed while a provider tool callback is being delivered", () => {
+    const session = makeStreamingSession({
+      turnActive: true,
+      toolRunning: false,
+      currentToolSafety: "safe",
+      toolResultDeliveryPending: true,
+    });
+
+    for (const barrier of ["immediate_interrupt", "after_tool", "after_response", "after_task"] as const) {
+      expect(canReleaseRuntimeDeliveryBarrier("dev", session, barrier, undefined, false)).toBe(false);
+    }
+    expect(shouldInterruptRuntimeForIncoming("dev", session, "immediate_interrupt")).toEqual({
+      interrupt: false,
+      reason: "tool_result_delivery",
+    });
+    expect(shouldInterruptRuntimeForIncoming("dev", session, "after_tool")).toEqual({
+      interrupt: false,
+      reason: "tool_result_delivery",
+    });
+  });
+
   it("delivers the steering prompt next instead of replaying the superseded channel turn", async () => {
     const active = createQueuedRuntimeUserMessage(channelPrompt("implement the old plan", "turn-a"));
     const steering = createQueuedRuntimeUserMessage(channelPrompt("stop and use the new plan", "turn-b"));
@@ -281,6 +304,117 @@ describe("runtime delivery queue", () => {
     session.done = true;
     session.onTurnComplete?.();
     await generator.return(undefined);
+  });
+
+  it("coalesces a compatible channel backlog behind the latest interrupting prompt", async () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("old active work", "turn-a"));
+    const queued = createQueuedRuntimeUserMessage(channelPrompt("first steering detail", "turn-b"));
+    const latest = createQueuedRuntimeUserMessage(channelPrompt("latest steering direction", "turn-c"));
+    const session = makeStreamingSession({ pendingMessages: [active] });
+    const generator = createRuntimeMessageGenerator({
+      sessionName: "dev",
+      session,
+      stashedMessages: new Map(),
+    });
+
+    expect((await generator.next()).value).toMatchObject({
+      message: { content: "old active work" },
+    });
+    session.pendingMessages.push(queued, latest);
+
+    const prepared = prepareRuntimeInterruptSuccessor("dev", session);
+
+    expect(prepared?.coalescedMessages).toEqual([queued]);
+    expect(session.pendingMessages).toHaveLength(2);
+    expect(session.pendingMessages[0]).toBe(active);
+    expect(session.pendingMessages[1]).toMatchObject({
+      pendingId: latest.pendingId,
+      message: { content: "first steering detail\n\nlatest steering direction" },
+      launchPrompt: {
+        prompt: "first steering detail\n\nlatest steering direction",
+        _channelBackend: { binding: { turnId: "turn-c" } },
+      },
+    });
+
+    session.currentTurnSuperseded = true;
+    session.interrupted = true;
+    session.turnActive = false;
+    session.onTurnComplete?.();
+
+    expect((await generator.next()).value).toMatchObject({
+      message: { content: "first steering detail\n\nlatest steering direction" },
+    });
+
+    session.done = true;
+    session.onTurnComplete?.();
+    await generator.return(undefined);
+  });
+
+  it("preserves FIFO instead of combining or reordering different actors", () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("active", "turn-a"));
+    const otherActor = createQueuedRuntimeUserMessage(channelPrompt("other actor", "turn-b", "user-b"));
+    const latest = createQueuedRuntimeUserMessage(channelPrompt("latest", "turn-c", "user-a"));
+    const session = makeStreamingSession({
+      turnActive: true,
+      pendingMessages: [active, otherActor, latest],
+      currentTurnPendingIds: [active.pendingId!],
+    });
+
+    const prepared = prepareRuntimeInterruptSuccessor("dev", session);
+
+    expect(prepared?.coalescedMessages).toEqual([]);
+    expect(prepared?.message).toBe(otherActor);
+    expect(session.pendingMessages.map((message) => message.message.content)).toEqual([
+      "active",
+      "other actor",
+      "latest",
+    ]);
+  });
+
+  it("keeps steering prompts from different channel threads isolated", () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("active", "turn-a"));
+    const firstThread = createQueuedRuntimeUserMessage(channelPrompt("thread one", "turn-b", "user-a", "thread-1"));
+    const secondThread = createQueuedRuntimeUserMessage(channelPrompt("thread two", "turn-c", "user-a", "thread-2"));
+    const session = makeStreamingSession({
+      turnActive: true,
+      pendingMessages: [active, firstThread, secondThread],
+      currentTurnPendingIds: [active.pendingId!],
+    });
+
+    const prepared = prepareRuntimeInterruptSuccessor("dev", session);
+
+    expect(prepared?.coalescedMessages).toEqual([]);
+    expect(prepared?.message).toBe(firstThread);
+    expect(session.pendingMessages).toEqual([active, firstThread, secondThread]);
+  });
+
+  it("does not fold Ravi Commands into conversational steering", () => {
+    const active = createQueuedRuntimeUserMessage(channelPrompt("active", "turn-a"));
+    const command = createQueuedRuntimeUserMessage({
+      ...channelPrompt("#deploy", "turn-b"),
+      commands: [
+        {
+          id: "deploy",
+          scope: "agent",
+          sourcePath: "/commands/deploy.md",
+          originalText: "#deploy",
+          arguments: "",
+          renderedPromptSha256: "a".repeat(64),
+        },
+      ],
+    });
+    const steering = createQueuedRuntimeUserMessage(channelPrompt("after command", "turn-c"));
+    const session = makeStreamingSession({
+      turnActive: true,
+      pendingMessages: [active, command, steering],
+      currentTurnPendingIds: [active.pendingId!],
+    });
+
+    const prepared = prepareRuntimeInterruptSuccessor("dev", session);
+
+    expect(prepared?.coalescedMessages).toEqual([]);
+    expect(prepared?.message).toBe(command);
+    expect(session.pendingMessages).toEqual([active, command, steering]);
   });
 
   it("replays an active prompt marked for provider reconciliation", async () => {
@@ -495,9 +629,38 @@ describe("runtime delivery queue", () => {
   });
 });
 
-function channelPrompt(prompt: string, turnId: string) {
+function channelPrompt(prompt: string, turnId: string, senderId = "user-a", threadId?: string) {
   return {
     prompt,
+    deliveryBarrier: "after_tool" as const,
+    source: {
+      channel: "custom",
+      accountId: "connection-a",
+      instanceId: "channel-instance-a",
+      chatId: "conversation-a",
+      ...(threadId ? { threadId } : {}),
+      canonicalChatId: "chat-a",
+      actorType: "contact" as const,
+      contactId: senderId,
+      normalizedSenderId: senderId,
+      sourceMessageId: `message-${turnId}`,
+    },
+    context: {
+      channelId: "custom",
+      channelName: "Custom",
+      accountId: "connection-a",
+      instanceId: "channel-instance-a",
+      chatId: "conversation-a",
+      canonicalChatId: "chat-a",
+      messageId: `message-${turnId}`,
+      senderId,
+      isGroup: true,
+      timestamp: 1,
+      actorType: "contact" as const,
+      contactId: senderId,
+      normalizedSenderId: senderId,
+    },
+    _agentId: "agent-a",
     _channelBackend: {
       protocol: "ravi.channel.backend" as const,
       schemaVersion: 1 as const,

--- a/src/runtime/delivery-queue.ts
+++ b/src/runtime/delivery-queue.ts
@@ -8,7 +8,7 @@ import {
   type RuntimeHostStreamingSession,
   type RuntimeUserMessage,
 } from "./host-session.js";
-import type { RaviCommandPromptMetadata, RuntimeLaunchPrompt } from "./message-types.js";
+import type { MessageActorMetadata, RaviCommandPromptMetadata, RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimePromptMessage } from "./types.js";
 
 const log = logger.child("runtime:delivery-queue");
@@ -46,6 +46,71 @@ export function hasIsolatedRuntimeTurnEnvelope(
   return prompt?._channelBackend !== undefined || prompt?._turnOrigin !== undefined;
 }
 
+export interface RuntimeInterruptSuccessorPreparation {
+  message: RuntimeUserMessage;
+  coalescedMessages: RuntimeUserMessage[];
+}
+
+/**
+ * Prepare the first releasable successor for an intentional interrupt.
+ * Compatible human channel prompts at the front of that lane are folded into
+ * one input in their original order so they are neither lost nor replayed
+ * later as stale work.
+ */
+export function prepareRuntimeInterruptSuccessor(
+  sessionName: string,
+  session: RuntimeHostStreamingSession,
+): RuntimeInterruptSuccessorPreparation | null {
+  const activePendingIds = new Set(session.currentTurnPendingIds ?? []);
+  if (activePendingIds.size === 0) return null;
+
+  const successors = session.pendingMessages.filter(
+    (message) => !message.pendingId || !activePendingIds.has(message.pendingId),
+  );
+  const eligible = successors.filter(
+    (message) =>
+      shouldInterruptRuntimeForIncoming(
+        sessionName,
+        session,
+        message.deliveryBarrier ?? DEFAULT_DELIVERY_BARRIER,
+        message.taskBarrierTaskId,
+      ).interrupt,
+  );
+  if (eligible.length === 0) return null;
+
+  // Preserve FIFO across different actors and authority envelopes. A burst of
+  // compatible channel messages at the front of the releasable lane can share
+  // one physical provider turn, with the newest envelope owning that turn.
+  const firstEligible = eligible[0];
+  if (!firstEligible) return null;
+  const compatibilityKey = channelSteeringCompatibilityKey(firstEligible);
+  const cohort = [firstEligible];
+  if (compatibilityKey) {
+    for (const candidate of eligible.slice(1)) {
+      if (channelSteeringCompatibilityKey(candidate) !== compatibilityKey) break;
+      cohort.push(candidate);
+    }
+  }
+
+  const interrupting = cohort[cohort.length - 1];
+  if (!interrupting?.pendingId) return null;
+
+  const merged = mergeRuntimeSteeringCohort(cohort, interrupting);
+  const cohortSet = new Set(cohort);
+  const active = session.pendingMessages.filter(
+    (message) => message.pendingId !== undefined && activePendingIds.has(message.pendingId),
+  );
+  const remaining = session.pendingMessages.filter(
+    (message) => !cohortSet.has(message) && (!message.pendingId || !activePendingIds.has(message.pendingId)),
+  );
+  session.pendingMessages = [...active, merged, ...remaining];
+
+  return {
+    message: merged,
+    coalescedMessages: cohort.filter((message) => message !== interrupting),
+  };
+}
+
 function cloneRuntimeLaunchPrompt(prompt: RuntimePromptDeliveryMessage): RuntimeLaunchPrompt {
   return {
     ...prompt,
@@ -54,6 +119,139 @@ function cloneRuntimeLaunchPrompt(prompt: RuntimePromptDeliveryMessage): Runtime
     _approvalSource: prompt._approvalSource ? { ...prompt._approvalSource } : undefined,
     commands: prompt.commands ? prompt.commands.map((command) => ({ ...command })) : undefined,
   };
+}
+
+function mergeRuntimeSteeringCohort(
+  cohort: RuntimeUserMessage[],
+  interrupting: RuntimeUserMessage,
+): RuntimeUserMessage {
+  if (cohort.length <= 1) return interrupting;
+
+  const content = cohort.map((message) => message.message.content).join("\n\n");
+  return {
+    ...interrupting,
+    message: {
+      ...interrupting.message,
+      content,
+    },
+    launchPrompt: interrupting.launchPrompt
+      ? {
+          ...interrupting.launchPrompt,
+          prompt: content,
+        }
+      : undefined,
+  };
+}
+
+function steeringActorIdentity(metadata: MessageActorMetadata) {
+  return {
+    actorType: metadata.actorType ?? "",
+    contactId: metadata.contactId ?? "",
+    actorAgentId: metadata.actorAgentId ?? "",
+    automationId: metadata.automationId ?? "",
+    platformIdentityId: metadata.platformIdentityId ?? "",
+    normalizedSenderId: metadata.normalizedSenderId ?? "",
+    rawSenderId: metadata.rawSenderId ?? "",
+  };
+}
+
+function channelSteeringCompatibilityKey(message: RuntimeUserMessage): string | null {
+  const prompt = message.launchPrompt;
+  const backend = prompt?._channelBackend;
+  const source = prompt?.source;
+  const context = prompt?.context;
+  const barrier = message.deliveryBarrier ?? DEFAULT_DELIVERY_BARRIER;
+  if (
+    !backend ||
+    !source ||
+    !context ||
+    prompt._turnOrigin ||
+    message.replay === true ||
+    message.clientMessageId ||
+    (message.commands?.length ?? 0) > 0 ||
+    (prompt.commands?.length ?? 0) > 0 ||
+    context.isEditedMessage === true ||
+    Boolean(context.editedMessageId) ||
+    Boolean(context.editEventId) ||
+    (barrier !== "after_tool" && barrier !== "immediate_interrupt") ||
+    message.taskBarrierTaskId ||
+    prompt._observation ||
+    prompt._heartbeat ||
+    prompt._cron ||
+    prompt._trigger ||
+    prompt._sessionFollowup ||
+    prompt._thread ||
+    prompt._resumeStashedMessages ||
+    prompt._daemonRestartResume
+  ) {
+    return null;
+  }
+
+  const sourceActor = steeringActorIdentity(source);
+  const contextActor = steeringActorIdentity(context);
+  if (sourceActor.actorType && contextActor.actorType && sourceActor.actorType !== contextActor.actorType) return null;
+  const actorType = sourceActor.actorType || contextActor.actorType || "unknown";
+  if (actorType !== "contact" && actorType !== "unknown") return null;
+  const principal =
+    sourceActor.contactId ||
+    contextActor.contactId ||
+    sourceActor.platformIdentityId ||
+    contextActor.platformIdentityId ||
+    sourceActor.normalizedSenderId ||
+    contextActor.normalizedSenderId ||
+    sourceActor.rawSenderId ||
+    contextActor.rawSenderId ||
+    context.senderId;
+  if (!principal) return null;
+
+  return JSON.stringify({
+    barrier,
+    agentId: prompt._agentId ?? backend.binding.agentId,
+    runtimeProviderId: prompt._runtimeProviderId ?? "",
+    runtimeModel: prompt._runtimeModel ?? "",
+    backend: {
+      protocol: backend.protocol,
+      schemaVersion: backend.schemaVersion,
+      channelInstanceId: backend.binding.channelInstanceId,
+      agentId: backend.binding.agentId,
+      chatId: backend.binding.chatId,
+      sessionId: backend.binding.sessionId,
+      target: backend.target,
+    },
+    source: {
+      channel: source.channel,
+      accountId: source.accountId,
+      instanceId: source.instanceId ?? "",
+      chatId: source.chatId,
+      threadId: source.threadId ?? "",
+      canonicalChatId: source.canonicalChatId ?? "",
+      statusAnchorKind: source.statusAnchorKind ?? "",
+      suppressPresence: source.suppressPresence ?? false,
+      actor: sourceActor,
+    },
+    context: {
+      channelId: context.channelId,
+      accountId: context.accountId,
+      instanceId: context.instanceId ?? "",
+      chatId: context.chatId,
+      canonicalChatId: context.canonicalChatId ?? "",
+      senderId: context.senderId,
+      isGroup: context.isGroup,
+      groupId: context.groupId ?? "",
+      actor: contextActor,
+    },
+    principal,
+    approvalSource: prompt._approvalSource
+      ? {
+          channel: prompt._approvalSource.channel,
+          accountId: prompt._approvalSource.accountId,
+          instanceId: prompt._approvalSource.instanceId ?? "",
+          chatId: prompt._approvalSource.chatId,
+          threadId: prompt._approvalSource.threadId ?? "",
+          actor: steeringActorIdentity(prompt._approvalSource),
+        }
+      : null,
+  });
 }
 
 function isGeneratingText(session: RuntimeHostStreamingSession): boolean {
@@ -67,6 +265,8 @@ export function canReleaseRuntimeDeliveryBarrier(
   taskBarrierTaskId?: string,
   hasActiveTask = dbHasActiveTaskForSession(sessionName, taskBarrierTaskId),
 ): boolean {
+  if (session.toolResultDeliveryPending) return false;
+
   switch (barrier) {
     case "immediate_interrupt":
       if (session.starting || session.compacting) return false;
@@ -158,6 +358,9 @@ export function shouldInterruptRuntimeForIncoming(
   }
   if (barrier === "after_task" && dbHasActiveTaskForSession(sessionName, taskBarrierTaskId)) {
     return { interrupt: false, reason: "active_task" };
+  }
+  if (session.toolResultDeliveryPending) {
+    return { interrupt: false, reason: "tool_result_delivery" };
   }
   if (session.toolRunning) {
     if (barrier !== "immediate_interrupt") {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -562,6 +562,7 @@ export interface RunRuntimeEventLoopOptions {
   safeEmit: RuntimeSafeEmit;
   drainPendingStarts(): void;
   restartStashedSession?(input: { sessionName: string; reason: string }): void | Promise<void>;
+  onToolBarrierReleased?(sessionName: string): void | Promise<void>;
 }
 
 /** Process provider events from a streaming runtime session. */
@@ -582,6 +583,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     safeEmit,
     drainPendingStarts,
     restartStashedSession,
+    onToolBarrierReleased,
   } = options;
   prewarmPricingCatalog();
   const recordTraceEvent = (
@@ -928,11 +930,69 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       toolStuckTimer = undefined;
     }
     streaming.toolRunning = false;
+    streaming.toolResultDeliveryPending = false;
     streaming.currentToolId = undefined;
     streaming.currentToolName = undefined;
     streaming.currentToolInput = undefined;
     streaming.toolStartTime = undefined;
     streaming.currentToolSafety = null;
+  };
+  const finishActiveToolBarrier = async () => {
+    clearActiveToolState();
+
+    if (streaming.pendingAbort) {
+      if (streaming.pendingMessages.length > 0) {
+        log.info("Stashing aborted messages (deferred)", {
+          sessionName,
+          count: streaming.pendingMessages.length,
+        });
+        stashPendingRuntimeMessages(sessionName, streaming, stashedMessages, { crashRecovery });
+      }
+      log.info("Executing deferred abort after tool barrier released", {
+        sessionName,
+      });
+      streaming.internalAbortReason = streaming.internalAbortReason ?? "deferred_abort";
+      recordTraceEvent({
+        turnId: streaming.currentTraceTurnId,
+        provider: runtimeSession.provider,
+        model,
+        eventType: "session.abort",
+        eventGroup: "session",
+        status: "requested",
+        source: streaming.currentSource,
+        payloadJson: {
+          reason: streaming.internalAbortReason,
+          deferred: true,
+          toolCompleted: true,
+        },
+      });
+      recordTerminalTraceOnce({
+        status: "aborted",
+        eventType: "turn.interrupted",
+        abortReason: streaming.internalAbortReason,
+        payloadJson: {
+          reason: streaming.internalAbortReason,
+          deferred: true,
+        },
+      });
+      revokeAgentRuntimeContextsForSession(session.sessionKey, {
+        reason: streaming.internalAbortReason,
+      });
+      streaming.abortController.abort();
+      if (streamingSessions.delete(sessionName)) {
+        drainPendingStarts();
+      }
+      return;
+    }
+
+    try {
+      await onToolBarrierReleased?.(sessionName);
+    } catch (error) {
+      log.warn("Failed to release queued prompts after tool completion", {
+        sessionName,
+        error,
+      });
+    }
   };
   const signalTurnComplete = () => {
     clearProviderInactivityWatch();
@@ -1580,6 +1640,16 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       if (streaming.done) {
         break;
       }
+      const awaitsToolResultDelivery =
+        event.type === "tool.completed" &&
+        runtimeSession.provider === "codex" &&
+        event.metadata?.item?.type === "dynamic_tool_call";
+      if (awaitsToolResultDelivery) {
+        // Codex queues the synthetic completion before its JSON-RPC callback
+        // write resolves. Close every interrupt lane before asynchronous event
+        // projection gives another inbound dispatch a chance to run.
+        streaming.toolResultDeliveryPending = true;
+      }
       providerRawEventCount++;
       streaming.lastActivity = Date.now();
 
@@ -2052,6 +2122,10 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         // Arm provider inactivity watchdog: catches cases where the provider
         // (e.g. codex's API call to OpenAI) hangs silently with no further events.
         armProviderInactivityWatch();
+        if (streaming.toolResultDeliveryPending || streaming.toolRunning) {
+          await finishActiveToolBarrier();
+        }
+        continue;
       }
 
       if (event.type === "tool.completed") {
@@ -2172,51 +2246,9 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
               metadata: event.metadata,
             }
           : undefined;
-        clearActiveToolState();
-
-        // Execute deferred abort now that unsafe tool has completed
-        if (streaming.pendingAbort) {
-          if (streaming.pendingMessages.length > 0) {
-            log.info("Stashing aborted messages (deferred)", {
-              sessionName,
-              count: streaming.pendingMessages.length,
-            });
-            stashPendingRuntimeMessages(sessionName, streaming, stashedMessages, { crashRecovery });
-          }
-          log.info("Executing deferred abort after unsafe tool completed", {
-            sessionName,
-          });
-          streaming.internalAbortReason = streaming.internalAbortReason ?? "deferred_abort";
-          recordTraceEvent({
-            turnId: streaming.currentTraceTurnId,
-            provider: runtimeSession.provider,
-            model,
-            eventType: "session.abort",
-            eventGroup: "session",
-            status: "requested",
-            source: streaming.currentSource,
-            payloadJson: {
-              reason: streaming.internalAbortReason,
-              deferred: true,
-              toolCompleted: true,
-            },
-          });
-          recordTerminalTraceOnce({
-            status: "aborted",
-            eventType: "turn.interrupted",
-            abortReason: streaming.internalAbortReason,
-            payloadJson: {
-              reason: streaming.internalAbortReason,
-              deferred: true,
-            },
-          });
-          revokeAgentRuntimeContextsForSession(session.sessionKey, {
-            reason: streaming.internalAbortReason,
-          });
-          streaming.abortController.abort();
-          if (streamingSessions.delete(sessionName)) {
-            drainPendingStarts();
-          }
+        // Dynamic Codex callbacks finish on the later result-delivered marker.
+        if (!awaitsToolResultDelivery) {
+          await finishActiveToolBarrier();
         }
         continue;
       }

--- a/src/runtime/host-session.ts
+++ b/src/runtime/host-session.ts
@@ -106,6 +106,8 @@ export interface RuntimeHostStreamingSession {
   currentTaskBarrierTaskId?: string;
   /** Tool tracking */
   toolRunning: boolean;
+  /** A completed dynamic tool result is still being written to the provider callback. */
+  toolResultDeliveryPending?: boolean;
   currentToolId?: string;
   currentToolName?: string;
   currentToolInput?: unknown;

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -648,6 +648,21 @@ describe("RuntimeSessionDispatcher native runtime steer", () => {
       ),
     ).toBe(false);
   });
+
+  it("does not native steer past an already queued successor", () => {
+    const active = createQueuedRuntimeUserMessage({ prompt: "active", deliveryBarrier: "after_tool" });
+    const queued = createQueuedRuntimeUserMessage({ prompt: "queued", deliveryBarrier: "after_tool" });
+
+    expect(
+      canUseNativeRuntimeSteer(
+        createStreamingSession({
+          pendingMessages: [active, queued],
+          currentTurnPendingIds: [active.pendingId!],
+        }),
+        "after_tool",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("RuntimeSessionDispatcher abort resolution", () => {
@@ -678,6 +693,34 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
       ...overrides,
     };
   }
+
+  it("defers abort until a completed dynamic tool result reaches the provider", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-tool-delivery-abort-");
+    try {
+      getOrCreateSession("agent:main:test:tool-delivery-abort", "main", stateDir, {
+        name: "tool-delivery-abort",
+      });
+      const dispatcher = createDispatcher(2);
+      const activeSession = createActiveSession({
+        agentId: "main",
+        turnActive: true,
+        toolRunning: true,
+        toolResultDeliveryPending: true,
+        currentToolSafety: "safe",
+        currentToolName: "tools_invoke",
+      });
+      dispatcher.streamingSessions.set("tool-delivery-abort", activeSession);
+
+      expect(dispatcher.abortSession("tool-delivery-abort")).toBe(true);
+
+      expect(activeSession.pendingAbort).toBe(true);
+      expect(activeSession.internalAbortReason).toBe("explicit_abort_deferred");
+      expect(activeSession.abortController.signal.aborted).toBe(false);
+      expect(dispatcher.streamingSessions.get("tool-delivery-abort")).toBe(activeSession);
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
 
   it("continues closing every provider when one shutdown terminal fence fails", async () => {
     const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-shutdown-cleanup-");
@@ -1496,6 +1539,52 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
       expect(activeSession.pendingMessages[1]?.launchPrompt?.source).toEqual(slackSource);
       expect(activeSession.currentTurnSuperseded).toBe(true);
       expect(activeSession.interrupted).toBe(true);
+      expect(interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+
+  it("interrupts for a queued after_tool prompt as soon as the tool barrier releases", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-tool-release-");
+    try {
+      getOrCreateSession("agent:main:test:tool-release", "main", stateDir, { name: "tool-release" });
+      const interrupt = mock(async () => {});
+      const activeMessage = createQueuedRuntimeUserMessage({
+        prompt: "active tool work",
+        deliveryBarrier: "after_tool",
+      });
+      const successor = createQueuedRuntimeUserMessage({
+        prompt: "new direction after tool",
+        deliveryBarrier: "after_tool",
+      });
+      const dispatcher = createDispatcher(2);
+      const activeSession = createActiveSession({
+        agentId: "main",
+        turnActive: true,
+        toolRunning: false,
+        pendingMessages: [activeMessage, successor],
+        currentTurnPendingIds: [activeMessage.pendingId!],
+        queryHandle: {
+          provider: "codex",
+          events: (async function* () {})(),
+          interrupt,
+        },
+      });
+      dispatcher.streamingSessions.set("tool-release", activeSession);
+
+      await (
+        dispatcher as unknown as {
+          releaseQueuedPromptsAfterTool(sessionName: string): Promise<void>;
+        }
+      ).releaseQueuedPromptsAfterTool("tool-release");
+
+      expect(activeSession.currentTurnSuperseded).toBe(true);
+      expect(activeSession.interrupted).toBe(true);
+      expect(activeSession.pendingMessages.map((message) => message.message.content)).toEqual([
+        "active tool work",
+        "new direction after tool",
+      ]);
       expect(interrupt).toHaveBeenCalledTimes(1);
     } finally {
       await cleanupIsolatedRaviState(stateDir);

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -1,6 +1,8 @@
 import { configStore } from "../config-store.js";
+import { projectChannelRuntimeEvent } from "../channels/runtime-events.js";
 import { saveMessage } from "../db.js";
 import {
+  DEFAULT_DELIVERY_BARRIER,
   chooseMoreUrgentBarrier,
   describeDeliveryBarrier,
   type DeliveryBarrier,
@@ -20,7 +22,9 @@ import {
   getRuntimePromptDeliveryBarrier,
   hasIsolatedRuntimeTurnEnvelope,
   hasDeliverableRuntimeMessages,
+  prepareRuntimeInterruptSuccessor,
   shouldInterruptRuntimeForIncoming,
+  type RuntimeInterruptSuccessorPreparation,
   wakeRuntimeSessionIfDeliverable,
 } from "./delivery-queue.js";
 import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
@@ -435,10 +439,11 @@ export class RuntimeSessionDispatcher {
       getSessionByName(sessionName) ?? (identity.sessionKey ? getSession(identity.sessionKey) : null);
     const sessionKey = sessionEntry?.sessionKey ?? identity.sessionKey ?? sessionName;
 
-    if (session.toolRunning && session.currentToolSafety === "unsafe") {
-      log.info("Deferring abort - unsafe tool running", {
+    if (session.toolResultDeliveryPending || (session.toolRunning && session.currentToolSafety === "unsafe")) {
+      log.info("Deferring abort - tool barrier active", {
         sessionName,
         tool: session.currentToolName,
+        toolResultDeliveryPending: Boolean(session.toolResultDeliveryPending),
         provenance,
       });
       session.internalAbortReason = `${abortReason}_deferred`;
@@ -460,6 +465,7 @@ export class RuntimeSessionDispatcher {
           provenance,
           tool: session.currentToolName ?? null,
           toolSafety: session.currentToolSafety,
+          toolResultDeliveryPending: Boolean(session.toolResultDeliveryPending),
         },
       });
       return true;
@@ -946,10 +952,8 @@ export class RuntimeSessionDispatcher {
           return;
         }
 
-        appendUniqueRuntimeMessages(
-          existing.pendingMessages,
-          daemonRestartMessages ?? [createQueuedRuntimeUserMessage(prompt)],
-        );
+        const queuedMessages = daemonRestartMessages ?? [createQueuedRuntimeUserMessage(prompt)];
+        appendUniqueRuntimeMessages(existing.pendingMessages, queuedMessages);
         updateRuntimeLiveState(sessionName, {
           activity: "thinking",
           summary: existing.turnActive ? `queued ${existing.pendingMessages.length}` : "prompt queued",
@@ -1088,53 +1092,23 @@ export class RuntimeSessionDispatcher {
               this.scheduleIdleGapRecovery(sessionName, existing, sessionEntry?.sessionKey ?? sessionName);
             }
           } else {
-            existing.currentTurnSuperseded = true;
-            nats
-              .emit(`ravi.session.${sessionName}.runtime`, {
-                type: "turn.interrupt.requested",
+            const successor = prepareRuntimeInterruptSuccessor(sessionName, existing);
+            if (!successor) {
+              log.warn("Streaming: interrupt requested without a releasable successor", {
                 sessionName,
                 queueSize: existing.pendingMessages.length,
                 barrier: describeDeliveryBarrier(barrier),
-                barrierSource: prompt.deliveryBarrierSource ?? null,
-                reason: decision.reason,
-                source: prompt.source,
-                context: prompt.context,
-                taskBarrierTaskId: prompt.taskBarrierTaskId,
-                timestamp: new Date().toISOString(),
-              })
-              .catch((error) => {
-                log.warn("Failed to emit turn interrupt audit event", { sessionName, error });
               });
-            log.info("Streaming: interrupting turn", {
+              return;
+            }
+            await this.interruptForRuntimeSuccessor(
               sessionName,
-              queueSize: existing.pendingMessages.length,
-              barrier: describeDeliveryBarrier(barrier),
-              reason: decision.reason,
-            });
-            recordRuntimeTraceEvent({
-              sessionKey: sessionEntry?.sessionKey ?? sessionName,
-              sessionName,
-              agentId: existing.agentId,
-              runId: existing.traceRunId,
-              turnId: existing.currentTraceTurnId,
-              provider: existing.queryHandle.provider,
-              model: existing.currentModel,
-              eventType: "dispatch.interrupt_requested",
-              eventGroup: "dispatch",
-              status: "requested",
-              source: prompt.source ?? existing.currentSource,
-              messageId: prompt.context?.messageId,
-              payloadJson: {
-                queueSize: existing.pendingMessages.length,
-                barrier: describeDeliveryBarrier(barrier),
-                barrierSource: prompt.deliveryBarrierSource ?? null,
-                reason: decision.reason,
-                taskBarrierTaskId: prompt.taskBarrierTaskId ?? null,
-                currentTurnReplay: false,
-              },
-            });
-            existing.interrupted = true;
-            existing.queryHandle.interrupt().catch(() => {});
+              existing,
+              successor,
+              decision.reason,
+              prompt,
+              sessionEntry?.sessionKey ?? sessionName,
+            );
           }
         }
         return;
@@ -1378,6 +1352,7 @@ export class RuntimeSessionDispatcher {
         drainPendingStarts: () => this.drainPendingStarts(),
         restartStashedSession: ({ sessionName: stashedSessionName, reason }) =>
           this.restartStashedSession(stashedSessionName, reason),
+        onToolBarrierReleased: (releasedSessionName) => this.releaseQueuedPromptsAfterTool(releasedSessionName),
         crashRecovery: this.options.crashRecovery,
       });
     } finally {
@@ -1804,6 +1779,118 @@ export class RuntimeSessionDispatcher {
     await this.restartStashedSession(sessionName, "idle_gap_stuck");
   }
 
+  private async releaseQueuedPromptsAfterTool(sessionName: string): Promise<void> {
+    const existing = this.streamingSessions.get(sessionName);
+    if (
+      !existing ||
+      existing.done ||
+      existing.starting ||
+      existing.compacting ||
+      existing.toolRunning ||
+      !existing.turnActive ||
+      existing.currentTurnSuperseded ||
+      existing.interrupted
+    ) {
+      return;
+    }
+
+    const successor = prepareRuntimeInterruptSuccessor(sessionName, existing);
+    if (!successor) return;
+
+    const prompt = successor.message.launchPrompt;
+    const sessionEntry = getSessionByName(sessionName);
+    await this.interruptForRuntimeSuccessor(
+      sessionName,
+      existing,
+      successor,
+      "tool_barrier_released",
+      prompt,
+      sessionEntry?.sessionKey ?? sessionName,
+    );
+  }
+
+  private async interruptForRuntimeSuccessor(
+    sessionName: string,
+    existing: RuntimeHostStreamingSession,
+    successor: RuntimeInterruptSuccessorPreparation,
+    reason: string,
+    fallbackPrompt?: RuntimeLaunchPrompt,
+    sessionKey = sessionName,
+  ): Promise<void> {
+    const prompt = successor.message.launchPrompt ?? fallbackPrompt;
+    const source = prompt?.source ?? fallbackPrompt?.source ?? existing.currentSource;
+    const barrier = successor.message.deliveryBarrier ?? DEFAULT_DELIVERY_BARRIER;
+    existing.currentTurnSuperseded = true;
+    existing.interrupted = true;
+    nats
+      .emit(`ravi.session.${sessionName}.runtime`, {
+        type: "turn.interrupt.requested",
+        sessionName,
+        queueSize: existing.pendingMessages.length,
+        barrier: describeDeliveryBarrier(barrier),
+        barrierSource: successor.message.deliveryBarrierSource ?? prompt?.deliveryBarrierSource ?? null,
+        reason,
+        source,
+        context: prompt?.context ?? fallbackPrompt?.context,
+        taskBarrierTaskId: successor.message.taskBarrierTaskId ?? prompt?.taskBarrierTaskId,
+        timestamp: new Date().toISOString(),
+      })
+      .catch((error) => {
+        log.warn("Failed to emit turn interrupt audit event", { sessionName, error });
+      });
+    log.info("Streaming: interrupting turn", {
+      sessionName,
+      queueSize: existing.pendingMessages.length,
+      barrier: describeDeliveryBarrier(barrier),
+      reason,
+    });
+    recordRuntimeTraceEvent({
+      sessionKey,
+      sessionName,
+      agentId: existing.agentId,
+      runId: existing.traceRunId,
+      turnId: existing.currentTraceTurnId,
+      provider: existing.queryHandle.provider,
+      model: existing.currentModel,
+      eventType: "dispatch.interrupt_requested",
+      eventGroup: "dispatch",
+      status: "requested",
+      source,
+      messageId: prompt?.context?.messageId ?? fallbackPrompt?.context?.messageId,
+      payloadJson: {
+        queueSize: existing.pendingMessages.length,
+        barrier: describeDeliveryBarrier(barrier),
+        barrierSource: successor.message.deliveryBarrierSource ?? prompt?.deliveryBarrierSource ?? null,
+        reason,
+        taskBarrierTaskId: successor.message.taskBarrierTaskId ?? prompt?.taskBarrierTaskId ?? null,
+        currentTurnReplay: false,
+      },
+    });
+    if (successor.coalescedMessages.length > 0) {
+      recordRuntimeTraceEvent({
+        sessionKey,
+        sessionName,
+        agentId: existing.agentId,
+        runId: existing.traceRunId,
+        turnId: existing.currentTraceTurnId,
+        provider: existing.queryHandle.provider,
+        model: existing.currentModel,
+        eventType: "dispatch.coalesced_steering",
+        eventGroup: "dispatch",
+        status: "queued",
+        source,
+        messageId: prompt?.context?.messageId ?? fallbackPrompt?.context?.messageId,
+        payloadJson: {
+          coalescedMessages: successor.coalescedMessages.length,
+          queueSize: existing.pendingMessages.length,
+          reason: "compatible_channel_backlog",
+        },
+      });
+    }
+    existing.queryHandle.interrupt().catch(() => {});
+    await terminalizeCoalescedChannelMessages(sessionName, successor.coalescedMessages);
+  }
+
   private async tryNativeRuntimeSteer(
     sessionName: string,
     existing: RuntimeHostStreamingSession,
@@ -1923,7 +2010,8 @@ export function canUseNativeRuntimeSteer(session: RuntimeHostStreamingSession, b
     !session.done &&
     !session.starting &&
     !session.compacting &&
-    !session.toolRunning
+    !session.toolRunning &&
+    getPendingRuntimeTurnSuccessors(session).length === 0
   );
 }
 
@@ -2197,6 +2285,25 @@ function cloneRuntimeUserMessage(message: RuntimeUserMessage): RuntimeUserMessag
   return JSON.parse(JSON.stringify(message)) as RuntimeUserMessage;
 }
 
+async function terminalizeCoalescedChannelMessages(sessionName: string, messages: RuntimeUserMessage[]): Promise<void> {
+  for (const message of messages) {
+    const metadata = message.launchPrompt?._channelBackend;
+    if (!metadata) continue;
+    try {
+      await projectChannelRuntimeEvent({
+        metadata,
+        event: { type: "turn.interrupted" },
+      });
+    } catch (error) {
+      log.warn("Failed to terminalize coalesced channel turn", {
+        sessionName,
+        turnId: metadata.binding.turnId,
+        error,
+      });
+    }
+  }
+}
+
 function cloneRuntimeMessageTarget(target: RuntimeMessageTarget): RuntimeMessageTarget {
   return JSON.parse(JSON.stringify(target)) as RuntimeMessageTarget;
 }
@@ -2365,6 +2472,7 @@ function describeSessionState(session: RuntimeHostStreamingSession): Record<stri
     starting: session.starting,
     compacting: session.compacting,
     toolRunning: session.toolRunning,
+    toolResultDeliveryPending: Boolean(session.toolResultDeliveryPending),
     turnActive: session.turnActive,
     tool: session.currentToolName ?? null,
     idleMs: session.lastActivity ? Date.now() - session.lastActivity : null,

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -50,6 +50,7 @@ export interface StartRuntimeSessionOptions {
   safeEmit: RuntimeSafeEmit;
   drainPendingStarts(): void;
   restartStashedSession?(input: { sessionName: string; reason: string }): void | Promise<void>;
+  onToolBarrierReleased?(sessionName: string): void | Promise<void>;
   crashRecovery: RuntimeCrashRecoveryCoordinator;
 }
 
@@ -77,6 +78,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     safeEmit,
     drainPendingStarts,
     restartStashedSession,
+    onToolBarrierReleased,
     crashRecovery,
   } = options;
   const runId = createSessionTraceRunId();
@@ -183,6 +185,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     currentThinking: runtimeResolution.options.thinking,
     currentTaskBarrierTaskId: normalizePromptTaskBarrierTaskId(prompt.taskBarrierTaskId),
     toolRunning: false,
+    toolResultDeliveryPending: false,
     lastActivity: Date.now(),
     done: false,
     interrupted: false,
@@ -330,6 +333,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
         safeEmit,
         drainPendingStarts,
         restartStashedSession,
+        onToolBarrierReleased,
         crashRecovery,
       }),
     ).catch((err) => {

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -801,6 +801,86 @@ describe("runtime session trace instrumentation", () => {
     });
   });
 
+  it("releases queued delivery barriers after a tool completes without exposing callback failures", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-tool-barrier-release");
+    const releasedWithToolRunning: boolean[] = [];
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        {
+          type: "tool.started",
+          toolUse: { id: "tool-release", name: "Bash", input: { cmd: "true" } },
+        },
+        {
+          type: "tool.completed",
+          toolUseId: "tool-release",
+          toolName: "Bash",
+          content: "ok",
+        },
+        { type: "turn.interrupted" },
+      ]),
+      {
+        onToolBarrierReleased: () => {
+          releasedWithToolRunning.push(streaming.toolRunning);
+          streaming.currentTurnSuperseded = true;
+          streaming.interrupted = true;
+          throw new Error("synthetic barrier release failure");
+        },
+      },
+    );
+
+    expect(releasedWithToolRunning).toEqual([false]);
+  });
+
+  it("waits for a Codex dynamic tool result to cross JSON-RPC before releasing the barrier", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-tool-result-delivery");
+    const afterCompletion: Array<{ toolRunning: boolean; deliveryPending: boolean }> = [];
+    const released: Array<{ resultDelivered: boolean; toolRunning: boolean; deliveryPending: boolean }> = [];
+    let resultDelivered = false;
+    const runtimeSession: RuntimeSessionHandle = {
+      provider: "codex",
+      events: (async function* () {
+        yield {
+          type: "tool.started",
+          toolUse: { id: "tool-delivery", name: "tools_invoke", input: {} },
+        } satisfies RuntimeEvent;
+        yield {
+          type: "tool.completed",
+          toolUseId: "tool-delivery",
+          toolName: "tools_invoke",
+          content: "ok",
+          metadata: { item: { id: "tool-delivery", type: "dynamic_tool_call", status: "completed" } },
+        } satisfies RuntimeEvent;
+        afterCompletion.push({
+          toolRunning: streaming.toolRunning,
+          deliveryPending: Boolean(streaming.toolResultDeliveryPending),
+        });
+        resultDelivered = true;
+        yield { type: "tool.result_delivered", toolCallId: "tool-delivery" } satisfies RuntimeEvent;
+        yield { type: "turn.interrupted" } satisfies RuntimeEvent;
+      })(),
+      interrupt: async () => {},
+    };
+
+    await runTraceLoop(streaming, runtimeSession, {
+      onToolBarrierReleased: () => {
+        released.push({
+          resultDelivered,
+          toolRunning: streaming.toolRunning,
+          deliveryPending: Boolean(streaming.toolResultDeliveryPending),
+        });
+        streaming.currentTurnSuperseded = true;
+        streaming.interrupted = true;
+      },
+    });
+
+    expect(afterCompletion).toEqual([{ toolRunning: true, deliveryPending: true }]);
+    expect(released).toEqual([{ resultDelivered: true, toolRunning: false, deliveryPending: false }]);
+  });
+
   it("marks the active credential attempt succeeded on a successful terminal turn", async () => {
     const streaming = makeStreamingSession({
       currentRuntimeCredential: seedRuntimeCredentialAttempt("rcred_success"),


### PR DESCRIPTION
## Objective

Make interactive channel messages steer an active runtime at the first provider-safe boundary while preserving accepted queue order, authority, and delivery ownership.

## Problem

Messages received while a tool was running remained queued because tool completion cleared the tool state without re-evaluating the delivery queue. A later inbound message was needed to request interruption, allowing older queued prompts to run as isolated stale turns before the user's latest intent.

Codex dynamic tool completion is also emitted before the JSON-RPC result write finishes. Releasing interruption lanes on that early event can race the provider callback.

## Solution

- Re-evaluate queued `after_tool` and `immediate_interrupt` messages when the provider-safe tool barrier is released.
- Wait for Codex `tool.result_delivered` before opening interruption lanes for dynamic tool callbacks.
- Fold only a leading burst of compatible human channel messages into one chronological successor using the newest envelope.
- Preserve FIFO isolation across actors, chats, threads, commands, replay attempts, authority envelopes, runtime selection, and delivery barriers.
- Prevent native runtime steering from bypassing an already accepted successor.

## Practical impact

Intermediate messages across every channel backend are acted on at the first safe boundary. Compatible bursts reach the agent as one ordered steering input, while unrelated users or conversations remain isolated and cannot be reordered.

## What does NOT change

This does not change channel-specific ingress, routing, `after_response` or `after_task` semantics, command isolation, replay ownership, or provider session continuity. No schema or data migration is introduced.

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- Full pre-push gate, including generated SDK, OpenAPI, and Swift artifact checks
- Focused runtime suite: 135 tests passed

## Risks

The main risk is combining messages that should remain separate. The compatibility key therefore fails closed and requires the same actor, backend session, target, chat, thread, authority, runtime selection, approval route, and barrier. Callback delivery remains an explicit interrupt fence.

## Rollback

Revert commit `668fb30d` and redeploy the prior runtime. The change has no persistent migration, so rollback requires no data repair or compatibility procedure.
