### PR TITLE
fix(daemon): prevent recursive restart handoffs

### DIFF
--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -125,7 +125,7 @@ describe("daemon runtime target", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Ravi Daemon Status");
     expect(result.stderr).not.toContain("require() async module");
-  });
+  }, 20_000);
 
   it("restarts the installed runtime from any operator cwd without requiring a source project root", () => {
     const tempRoot = makeTempDir("ravi-daemon-runtime-");
@@ -245,7 +245,7 @@ describe("daemon runtime target", () => {
     expect(result.stdout).not.toContain('"mode": "handoff"');
     expect(readFileSync(pm2LogPath, "utf8")).toContain(`start ${realpathSync(fakeBundlePath)}`);
     expect(existsSync(childMarkerPath)).toBe(false);
-  });
+  }, 20_000);
 });
 
 describe("DaemonCommands --json", () => {

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -13,7 +13,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
+import {
+  cleanupIsolatedRaviState,
+  createIsolatedRaviState,
+  withoutRaviRuntimeContextEnv,
+} from "../../test/ravi-state.js";
 import { ContractError } from "../agent-contract.js";
 import { runWithContext } from "../context.js";
 import { DaemonCommands, findSourceProjectRoot, resolveDaemonRuntimeTarget } from "./daemon.js";
@@ -111,7 +115,7 @@ describe("daemon runtime target", () => {
       cwd: tempRoot,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...withoutRaviRuntimeContextEnv(process.env),
         PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
         RAVI_STATE_DIR: join(tempRoot, "state"),
         RAVI_TEST_BUNDLE: bundlePath,
@@ -186,6 +190,61 @@ describe("daemon runtime target", () => {
       cwd: realpathSync(sourceRoot),
       sourceProjectRoot: realpathSync(sourceRoot),
     });
+  });
+
+  it("executes a direct CLI restart once instead of handing off recursively", async () => {
+    const tempRoot = makeTempDir("ravi-daemon-restart-once-");
+    const fakeBinDir = join(tempRoot, "bin");
+    const fakePm2Path = join(fakeBinDir, "pm2");
+    const fakeBundlePath = join(tempRoot, "runtime", "index.js");
+    const pm2LogPath = join(tempRoot, "pm2.log");
+    const childMarkerPath = join(tempRoot, "handoff-child.log");
+
+    mkdirSync(fakeBinDir, { recursive: true });
+    mkdirSync(join(fakeBundlePath, ".."), { recursive: true });
+    writeFileSync(
+      fakePm2Path,
+      [
+        "#!/bin/sh",
+        'printf "%s\\n" "$*" >> "$DAEMON_TEST_PM2_LOG"',
+        'if [ "$1" = "jlist" ]; then printf "[]\\n"; fi',
+        "exit 0",
+      ].join("\n"),
+      "utf8",
+    );
+    chmodSync(fakePm2Path, 0o755);
+    writeFileSync(
+      fakeBundlePath,
+      [
+        'import { appendFileSync } from "node:fs";',
+        'appendFileSync(process.env.DAEMON_TEST_CHILD_MARKER, process.argv.slice(2).join(" "));',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = spawnSync("bun", ["src/cli/index.ts", "daemon", "restart", "-m", "restart once", "--json"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...withoutRaviRuntimeContextEnv(process.env),
+        HOME: join(tempRoot, "home"),
+        PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ""}`,
+        RAVI_STATE_DIR: join(tempRoot, "state"),
+        RAVI_CREDENTIALS_PATH: join(tempRoot, "missing-credentials.json"),
+        RAVI_BUNDLE: fakeBundlePath,
+        RAVI_DAEMON_CWD: tempRoot,
+        RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+        DAEMON_TEST_PM2_LOG: pm2LogPath,
+        DAEMON_TEST_CHILD_MARKER: childMarkerPath,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain('"mode": "handoff"');
+    expect(readFileSync(pm2LogPath, "utf8")).toContain(`start ${realpathSync(fakeBundlePath)}`);
+    expect(existsSync(childMarkerPath)).toBe(false);
   });
 });
 

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -9,7 +9,7 @@ import { existsSync, writeFileSync, readFileSync, mkdirSync, realpathSync, statS
 import { homedir, hostname } from "node:os";
 import { dirname, join } from "node:path";
 import { Group, Command, CommandAccess, CliOnly, Option, Returns } from "../decorators.js";
-import { getContext, hasContext, fail } from "../context.js";
+import { getContext, hasRuntimeInvocationContext, fail } from "../context.js";
 import { CONTRACT_EXIT_POLICY, CONTRACT_EXIT_USAGE, contractDryRun, contractFail } from "../agent-contract.js";
 import {
   daemonEnvReturnSchema,
@@ -428,8 +428,8 @@ export class DaemonCommands {
       fail('Flag -m é obrigatória. Use: ravi daemon restart -m "motivo"');
     }
 
-    // When called inside daemon, spawn detached restart and return immediately
-    if (hasContext()) {
+    // Runtime callers hand off so the daemon can stop after the current command returns.
+    if (hasRuntimeInvocationContext()) {
       const target = this.requireRuntimeTarget({ build });
 
       // Save restart reason with session context

--- a/src/cli/context.test.ts
+++ b/src/cli/context.test.ts
@@ -25,7 +25,7 @@ mock.module("../runtime/context-registry.js", () => ({
   getRuntimeContextFromEnv: () => resolvedContext,
 }));
 
-const { getContext } = await import("./context.js");
+const { getContext, hasContext, hasRuntimeInvocationContext, runWithContext } = await import("./context.js");
 
 describe("cli context resolution", () => {
   const originalEnv = {
@@ -114,6 +114,30 @@ describe("cli context resolution", () => {
         canonicalChatId: "chat-main",
       },
     });
+  });
+
+  it("does not mistake the generic CLI handler boundary for a runtime invocation", () => {
+    for (const context of [{}, { agentId: "operator", sessionName: "default" }]) {
+      expect(
+        runWithContext(context, () => ({
+          hasHandlerContext: hasContext(),
+          hasRuntimeInvocationContext: hasRuntimeInvocationContext(),
+        })),
+      ).toEqual({
+        hasHandlerContext: true,
+        hasRuntimeInvocationContext: false,
+      });
+    }
+  });
+
+  it.each(["tool", "gateway"] as const)("recognizes the %s transport as a runtime invocation", (transport) => {
+    expect(runWithContext({ transport }, () => hasRuntimeInvocationContext())).toBe(true);
+  });
+
+  it("recognizes explicit runtime env outside an in-process tool transport", () => {
+    process.env.RAVI_SESSION_NAME = "runtime-session";
+
+    expect(hasRuntimeInvocationContext()).toBe(true);
   });
 });
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -156,11 +156,27 @@ export function getContextValue<K extends keyof ToolContext>(key: K): ToolContex
 }
 
 /**
- * Check if running within a tool context (in-process or via env vars).
+ * Check whether any in-process CLI context or explicit runtime env is active.
  */
 export function hasContext(): boolean {
+  return contextStorage.getStore() !== undefined || hasRuntimeContextEnv();
+}
+
+/**
+ * Check whether the current command came from an explicit runtime invocation.
+ *
+ * A generic CLI handler also runs inside AsyncLocalStorage so expected command
+ * failures can be normalized at the registry boundary. That handler context is
+ * not enough to prove the command is running inside the daemon. Runtime tools,
+ * gateway calls, and child CLIs carrying explicit runtime env are.
+ */
+export function hasRuntimeInvocationContext(): boolean {
+  const transport = contextStorage.getStore()?.transport;
+  return transport === "tool" || transport === "gateway" || hasRuntimeContextEnv();
+}
+
+function hasRuntimeContextEnv(): boolean {
   return (
-    contextStorage.getStore() !== undefined ||
     !!process.env[RAVI_CONTEXT_KEY_ENV] ||
     !!process.env.RAVI_SESSION_KEY ||
     !!process.env.RAVI_SESSION_NAME ||


### PR DESCRIPTION
## Objective

Ensure daemon restart commands reach the process supervisor exactly once while retaining a safe handoff for calls issued from the running Ravi runtime.

## Problem

The CLI registry opens an async context around every command handler so expected failures can be normalized at the process boundary. The daemon restart command treated any async context as proof that it was executing inside the runtime.

After the command spawned a detached child with runtime context removed, the registry opened the same generic handler context in that child. The child handed off again, so the actual PM2 restart was never reached.

## Solution

Introduce an explicit runtime-invocation predicate that recognizes tool and gateway transports plus child CLIs carrying runtime identity through the environment. Use that predicate only for daemon restart handoff decisions, while preserving the broader generic context behavior used by CLI error normalization.

Add unit coverage for generic, tool, gateway, and environment contexts, plus a process-level regression test proving a direct restart reaches PM2 without spawning another handoff.

## Practical impact

Direct `ravi daemon restart` calls now execute the restart exactly once. Runtime-issued calls still hand off once, allowing the current command to return before the daemon stops. The previous silent no-op caused by recursive detached children is eliminated.

## What does NOT change

No CLI flags, configuration variables, daemon target resolution, process names, or public APIs change. Tool and gateway callers retain the existing detached restart behavior.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `bun test src/cli/context.test.ts src/cli/commands/daemon.test.ts`
- repository pre-push gate, including generated SDK drift checks

## Risks

An unofficial in-process caller that supplies a generic context but neither an official runtime transport nor runtime identity environment would restart inline. Supported tool, gateway, and child CLI paths are covered explicitly by the new predicate and tests.

## Rollback

Revert the single fix commit to restore the previous context predicate and remove the accompanying regression coverage. No data migration or configuration rollback is required.
