### PR TITLE
feat(update): support exact verified Ravi releases

### DIFF
--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -45,7 +45,11 @@ describe("update command helpers", () => {
 
   it("returns one machine-readable usage error for an invalid exact version", () => {
     const stateDir = join(tmpdir(), `ravi-update-contract-${process.pid}`);
-    const env: NodeJS.ProcessEnv = { ...process.env, RAVI_STATE_DIR: stateDir };
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      RAVI_STATE_DIR: stateDir,
+      RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+    };
     delete env.RAVI_CONTEXT_KEY;
     delete env.RAVI_SESSION_KEY;
     const result = spawnSync("bun", ["src/cli/index.ts", "update", "--version", "latest", "--json"], {

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   detectFromBinaryPath,
   findPackageRoot,
   managedRuntimeMatchesSnapshot,
   packageTagForChannel,
+  packageTagForVersion,
   planManagedRuntimeRestart,
   resolveUpdateChannel,
+  validateExpectedIntegrity,
 } from "./update.js";
 
 describe("update command helpers", () => {
@@ -24,6 +28,40 @@ describe("update command helpers", () => {
   it("formats package tags for npm channels", () => {
     expect(packageTagForChannel("next")).toBe("ravi.bot@next");
     expect(packageTagForChannel("latest")).toBe("ravi.bot@latest");
+  });
+
+  it("normalizes and pins exact package versions", () => {
+    expect(packageTagForVersion("v3.260811.2")).toBe("ravi.bot@3.260811.2");
+    expect(() => packageTagForVersion("next")).toThrow("exact version");
+    expect(() => packageTagForVersion("3.260811.2 || latest")).toThrow("exact version");
+  });
+
+  it("accepts only sha512 SRI values for release verification", () => {
+    const integrity = `sha512-${"A".repeat(86)}==`;
+    expect(validateExpectedIntegrity(integrity)).toBe(integrity);
+    expect(() => validateExpectedIntegrity("sha256-not-enough")).toThrow("sha512");
+    expect(() => validateExpectedIntegrity("sha512-A")).toThrow("sha512");
+  });
+
+  it("returns one machine-readable usage error for an invalid exact version", () => {
+    const stateDir = join(tmpdir(), `ravi-update-contract-${process.pid}`);
+    const env: NodeJS.ProcessEnv = { ...process.env, RAVI_STATE_DIR: stateDir };
+    delete env.RAVI_CONTEXT_KEY;
+    delete env.RAVI_SESSION_KEY;
+    const result = spawnSync("bun", ["src/cli/index.ts", "update", "--version", "latest", "--json"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+    rmSync(stateDir, { recursive: true, force: true });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      op: "ravi update",
+      error: { code: "USAGE_ERROR", retryable: false },
+    });
   });
 
   it("detects common global install paths", () => {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -5,9 +5,31 @@ import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { buildPm2Env, CHANNELS_PM2_PROCESS_NAME, getPm2Processes, PM2_PROCESS_NAME } from "../../pm2.js";
 import { getRaviStateDir } from "../../utils/paths.js";
+import { CONTRACT_EXIT_USAGE, contractFail } from "../agent-contract.js";
 
 export type UpdateChannel = "latest" | "next";
 export type InstallationType = "source" | "bun" | "npm" | "unknown";
+
+export interface RaviUpdateOptions {
+  next?: boolean;
+  stable?: boolean;
+  version?: string;
+  expectedIntegrity?: string;
+  restart?: boolean;
+  json?: boolean;
+}
+
+export interface RaviUpdateResult {
+  success: true;
+  package: typeof PACKAGE_NAME;
+  requested: string;
+  channel: UpdateChannel | null;
+  previousVersion: string | null;
+  currentVersion: string | null;
+  installMethod: Exclude<InstallationType, "unknown">;
+  restarted: boolean;
+  integrityVerified: boolean;
+}
 
 type RaviUpdateConfig = {
   updateChannel?: UpdateChannel;
@@ -19,6 +41,20 @@ type RunResult = {
   output: string;
 };
 
+interface CommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stream?: boolean;
+}
+
+interface UpdateReporter {
+  readonly json: boolean;
+  line(message?: string): void;
+  log(message: string): void;
+  ok(message: string): void;
+  warn(message: string): void;
+}
+
 export type ManagedRuntimeRestartStep = {
   action: "stop" | "restart";
   processName: typeof PM2_PROCESS_NAME | typeof CHANNELS_PM2_PROCESS_NAME;
@@ -26,18 +62,40 @@ export type ManagedRuntimeRestartStep = {
 
 const PACKAGE_NAME = "ravi.bot";
 const LOCAL_BIN = join(homedir(), ".local", "bin");
+const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const SRI_PATTERN = /^sha512-[A-Za-z0-9+/]+={0,2}$/;
 
-function log(message: string): void {
-  console.log(`> ${message}`);
+class UpdateFailure extends Error {
+  constructor(
+    message: string,
+    readonly code = "UPDATE_FAILED",
+    readonly exitCode = 1,
+  ) {
+    super(message);
+    this.name = "UpdateFailure";
+  }
 }
 
-function ok(message: string): void {
-  console.log(`✓ ${message}`);
+function createReporter(json: boolean): UpdateReporter {
+  return {
+    json,
+    line(message = "") {
+      if (!json) console.log(message);
+    },
+    log(message) {
+      if (!json) console.log(`> ${message}`);
+    },
+    ok(message) {
+      if (!json) console.log(`✓ ${message}`);
+    },
+    warn(message) {
+      if (!json) console.warn(message);
+    },
+  };
 }
 
-function fail(message: string): never {
-  console.error(`Error: ${message}`);
-  process.exit(1);
+function fail(message: string, code = "UPDATE_FAILED", exitCode = 1): never {
+  throw new UpdateFailure(message, code, exitCode);
 }
 
 function updateConfigPath(): string {
@@ -67,30 +125,25 @@ function safeRealpath(path: string): string {
   }
 }
 
-function runCommand(
-  command: string,
-  args: string[],
-  cwd?: string,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<RunResult> {
+function runCommand(command: string, args: string[], options: CommandOptions = {}): Promise<RunResult> {
   return new Promise((resolve) => {
     const output: string[] = [];
     const child = spawn(command, args, {
-      cwd,
-      stdio: ["inherit", "pipe", "pipe"],
-      env: { ...env, FORCE_COLOR: "1" },
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...(options.env ?? process.env), FORCE_COLOR: options.stream === false ? "0" : "1" },
     });
 
     child.stdout?.on("data", (data) => {
       const text = data.toString();
       output.push(text);
-      process.stdout.write(text);
+      if (options.stream !== false) process.stdout.write(text);
     });
 
     child.stderr?.on("data", (data) => {
       const text = data.toString();
       output.push(text);
-      process.stderr.write(text);
+      if (options.stream !== false) process.stderr.write(text);
     });
 
     child.on("close", (code) => {
@@ -207,6 +260,69 @@ export function packageTagForChannel(channel: UpdateChannel): string {
   return `${PACKAGE_NAME}@${channel}`;
 }
 
+export function normalizeExactVersion(value: string): string {
+  const version = value.trim().replace(/^v/, "");
+  if (!EXACT_VERSION_PATTERN.test(version)) {
+    fail("Use an exact version such as 3.260811.2.", "USAGE_ERROR", CONTRACT_EXIT_USAGE);
+  }
+  return version;
+}
+
+export function packageTagForVersion(version: string): string {
+  return `${PACKAGE_NAME}@${normalizeExactVersion(version)}`;
+}
+
+export function validateExpectedIntegrity(value: string): string {
+  const integrity = value.trim();
+  const digest = integrity.slice("sha512-".length);
+  if (!SRI_PATTERN.test(integrity) || Buffer.from(digest, "base64").byteLength !== 64) {
+    fail("Expected integrity must be a valid sha512 SRI.", "USAGE_ERROR", CONTRACT_EXIT_USAGE);
+  }
+  return integrity;
+}
+
+function packageVersionAt(packageRoot: string | null): string | null {
+  if (!packageRoot) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export function detectInstalledVersion(): string | null {
+  const which = runCommandSilent("which", ["ravi"]);
+  if (which.success) {
+    const fromPath = packageVersionAt(findPackageRoot(which.output.trim()));
+    if (fromPath) return fromPath;
+  }
+  return packageVersionAt(findPackageRoot(process.argv[1]));
+}
+
+async function verifyRegistryIntegrity(version: string, expectedIntegrity: string): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/${encodeURIComponent(version)}`, {
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    fail("The requested version could not be verified with the npm registry.", "REGISTRY_UNAVAILABLE");
+  }
+  if (!response.ok) {
+    fail(
+      response.status === 404
+        ? `Version ${version} does not exist in the npm registry.`
+        : "The requested version could not be verified with the npm registry.",
+      response.status === 404 ? "VERSION_NOT_FOUND" : "REGISTRY_UNAVAILABLE",
+    );
+  }
+  const metadata = (await response.json()) as { dist?: { integrity?: unknown } };
+  if (metadata.dist?.integrity !== expectedIntegrity) {
+    fail("Published integrity does not match the authorized release.", "INTEGRITY_MISMATCH");
+  }
+}
+
 export function planManagedRuntimeRestart(
   processes: Array<{ name: string; status: string }>,
 ): ManagedRuntimeRestartStep[] {
@@ -259,14 +375,20 @@ async function waitForManagedRuntime(
   return managedRuntimeMatchesSnapshot(previousProcesses, getPm2Processes());
 }
 
-async function restartManagedRuntimeProcesses(processes: Array<{ name: string; status: string }>): Promise<boolean> {
+async function restartManagedRuntimeProcesses(
+  processes: Array<{ name: string; status: string }>,
+  reporter: UpdateReporter,
+): Promise<boolean> {
   const plan = planManagedRuntimeRestart(processes);
   if (plan.length === 0) return true;
 
-  log("Restarting managed Ravi runtime with the updated bundle");
+  reporter.log("Restarting managed Ravi runtime with the updated bundle");
   let channelsStopped = false;
   for (const step of plan) {
-    const result = await runCommand("pm2", [step.action, step.processName], undefined, buildPm2Env());
+    const result = await runCommand("pm2", [step.action, step.processName], {
+      env: buildPm2Env(),
+      stream: !reporter.json,
+    });
     if (result.success) {
       if (step.action === "stop" && step.processName === CHANNELS_PM2_PROCESS_NAME) {
         channelsStopped = true;
@@ -279,60 +401,67 @@ async function restartManagedRuntimeProcesses(processes: Array<{ name: string; s
 
     // Do not leave channel intake stopped if a later daemon transition fails.
     if (channelsStopped && step.processName !== CHANNELS_PM2_PROCESS_NAME) {
-      await runCommand("pm2", ["restart", CHANNELS_PM2_PROCESS_NAME], undefined, buildPm2Env());
+      await runCommand("pm2", ["restart", CHANNELS_PM2_PROCESS_NAME], {
+        env: buildPm2Env(),
+        stream: !reporter.json,
+      });
     }
     return false;
   }
 
   if (!(await waitForManagedRuntime(processes))) return false;
-  ok("Managed Ravi runtime restarted");
+  reporter.ok("Managed Ravi runtime restarted");
   return true;
 }
 
 async function finishUpdate(
   restart: boolean,
   previousProcesses: Array<{ name: string; status: string }>,
-): Promise<void> {
-  console.log();
-  ok("Ravi CLI updated");
+  reporter: UpdateReporter,
+): Promise<boolean> {
+  reporter.line();
+  reporter.ok("Ravi CLI updated");
 
   if (!restart) {
-    console.log("Managed runtime restart skipped by request.");
-    console.log("Before handling new channel traffic, run:");
+    reporter.line("Managed runtime restart skipped by request.");
+    reporter.line("Before handling new channel traffic, run:");
     const online = new Set(
       previousProcesses.filter((process) => process.status === "online").map((process) => process.name),
     );
-    if (online.has(CHANNELS_PM2_PROCESS_NAME)) console.log("  ravi channels stop");
-    if (online.has(PM2_PROCESS_NAME)) console.log('  ravi daemon restart -m "load Ravi update"');
-    if (online.has(CHANNELS_PM2_PROCESS_NAME)) console.log("  ravi channels start");
-    return;
+    if (online.has(CHANNELS_PM2_PROCESS_NAME)) reporter.line("  ravi channels stop");
+    if (online.has(PM2_PROCESS_NAME)) reporter.line('  ravi daemon restart -m "load Ravi update"');
+    if (online.has(CHANNELS_PM2_PROCESS_NAME)) reporter.line("  ravi channels start");
+    return false;
   }
 
-  const restarted = await restartManagedRuntimeProcesses(previousProcesses);
+  const restarted = await restartManagedRuntimeProcesses(previousProcesses, reporter);
   if (!restarted) {
     fail("Ravi updated, but the managed runtime restart failed. Restart daemon and channels before resuming traffic.");
   }
+  return true;
 }
 
-async function updateViaBun(channel: UpdateChannel): Promise<boolean> {
+async function updateViaBun(packageTag: string, label: string, reporter: UpdateReporter): Promise<boolean> {
   try {
     unlinkSync(join(homedir(), ".bun", "install", "global", "bun.lock"));
   } catch {
     // Lockfile may not exist.
   }
 
-  log(`Updating via bun (${packageTagForChannel(channel)})`);
-  const result = await runCommand("bun", ["install", "-g", "--force", "--no-cache", packageTagForChannel(channel)]);
+  reporter.log(`Updating via bun (${packageTag})`);
+  const result = await runCommand("bun", ["install", "-g", "--force", "--no-cache", packageTag], {
+    stream: !reporter.json,
+  });
   if (!result.success) return false;
-  ok(`Updated via bun (${channel})`);
+  reporter.ok(`Updated via bun (${label})`);
   return true;
 }
 
-async function updateViaNpm(channel: UpdateChannel): Promise<boolean> {
-  log(`Updating via npm (${packageTagForChannel(channel)})`);
-  const result = await runCommand("npm", ["install", "-g", packageTagForChannel(channel)]);
+async function updateViaNpm(packageTag: string, label: string, reporter: UpdateReporter): Promise<boolean> {
+  reporter.log(`Updating via npm (${packageTag})`);
+  const result = await runCommand("npm", ["install", "-g", packageTag], { stream: !reporter.json });
   if (!result.success) return false;
-  ok(`Updated via npm (${channel})`);
+  reporter.ok(`Updated via npm (${label})`);
   return true;
 }
 
@@ -351,7 +480,7 @@ export function detectGlobalInstalls(): Set<"bun" | "npm"> {
   return found;
 }
 
-async function updateSource(channel: UpdateChannel): Promise<void> {
+async function updateSource(channel: UpdateChannel, reporter: UpdateReporter): Promise<void> {
   const sourceRoot = resolveSourceRoot();
   if (!sourceRoot) fail("Could not resolve Ravi source checkout. Set RAVI_REPO or use a global install.");
 
@@ -361,7 +490,7 @@ async function updateSource(channel: UpdateChannel): Promise<void> {
     fail(`Source checkout is dirty: ${sourceRoot}. Commit or stash before running update.`);
   }
 
-  log(`Updating source checkout ${sourceRoot} from origin/${targetBranch}`);
+  reporter.log(`Updating source checkout ${sourceRoot} from origin/${targetBranch}`);
 
   for (const step of [
     ["git", ["fetch", "origin", targetBranch]],
@@ -370,46 +499,125 @@ async function updateSource(channel: UpdateChannel): Promise<void> {
     ["bun", ["install"]],
     ["bun", ["run", "build"]],
   ] as Array<[string, string[]]>) {
-    const result = await runCommand(step[0], step[1], sourceRoot);
+    const result = await runCommand(step[0], step[1], { cwd: sourceRoot, stream: !reporter.json });
     if (!result.success) fail(`Source update failed at: ${step[0]} ${step[1].join(" ")}`);
   }
 
-  ok(`Source checkout updated from ${targetBranch}`);
+  reporter.ok(`Source checkout updated from ${targetBranch}`);
 }
 
-export async function runUpdate(options: { next?: boolean; stable?: boolean; restart?: boolean } = {}): Promise<void> {
-  const channel = resolveUpdateChannel(options);
-  if (options.next || options.stable) persistUpdateChannel(channel);
-  const previousProcesses = getPm2Processes();
+async function performUpdate(options: RaviUpdateOptions, reporter: UpdateReporter): Promise<RaviUpdateResult> {
+  const selectorCount =
+    Number(Boolean(options.next)) + Number(Boolean(options.stable)) + Number(Boolean(options.version));
+  if (selectorCount > 1) {
+    fail("Use only one update selector: --version, --next, or --stable.", "USAGE_ERROR", CONTRACT_EXIT_USAGE);
+  }
+  if (options.expectedIntegrity && !options.version) {
+    fail("--expected-integrity requires --version.", "USAGE_ERROR", CONTRACT_EXIT_USAGE);
+  }
 
-  console.log("\nRavi update");
-  console.log("-----------");
-  console.log(`Channel: ${channel}${channel === "next" ? " (dev builds)" : " (stable)"}`);
+  const exactVersion = options.version ? normalizeExactVersion(options.version) : null;
+  const expectedIntegrity = options.expectedIntegrity ? validateExpectedIntegrity(options.expectedIntegrity) : null;
+  const channel = exactVersion ? null : resolveUpdateChannel(options);
+  const requested = exactVersion ?? (channel as UpdateChannel);
+  const packageTag = exactVersion ? packageTagForVersion(exactVersion) : packageTagForChannel(channel as UpdateChannel);
+  const label = exactVersion ?? (channel as UpdateChannel);
+
+  if (!exactVersion && (options.next || options.stable)) persistUpdateChannel(channel as UpdateChannel);
+  if (exactVersion && expectedIntegrity) await verifyRegistryIntegrity(exactVersion, expectedIntegrity);
+
+  const previousProcesses = getPm2Processes();
+  const previousVersion = detectInstalledVersion();
+
+  reporter.line("\nRavi update");
+  reporter.line("-----------");
+  reporter.line(
+    exactVersion
+      ? `Version: ${exactVersion}${expectedIntegrity ? " (integrity verified)" : ""}`
+      : `Channel: ${channel}${channel === "next" ? " (dev builds)" : " (stable)"}`,
+  );
 
   const installType = detectInstallationType();
-  console.log(`Install: ${installType}\n`);
+  reporter.line(`Install: ${installType}\n`);
 
   if (installType === "unknown") {
-    fail(`No Ravi installation found. Install with: bun install -g ${packageTagForChannel(channel)}`);
+    fail(`No Ravi installation found. Install with: bun install -g ${packageTag}`);
   }
 
   if (installType === "source") {
-    await updateSource(channel);
-    await finishUpdate(options.restart !== false, previousProcesses);
-    return;
+    if (exactVersion) {
+      fail(
+        "Source checkout updates do not accept --version; use --next or --stable.",
+        "USAGE_ERROR",
+        CONTRACT_EXIT_USAGE,
+      );
+    }
+    await updateSource(channel as UpdateChannel, reporter);
+    const restarted = await finishUpdate(options.restart !== false, previousProcesses, reporter);
+    return {
+      success: true,
+      package: PACKAGE_NAME,
+      requested,
+      channel,
+      previousVersion,
+      currentVersion: detectInstalledVersion(),
+      installMethod: installType,
+      restarted,
+      integrityVerified: false,
+    };
   }
 
   const primary = installType as "bun" | "npm";
-  const updated = primary === "bun" ? await updateViaBun(channel) : await updateViaNpm(channel);
+  const updated =
+    primary === "bun"
+      ? await updateViaBun(packageTag, label, reporter)
+      : await updateViaNpm(packageTag, label, reporter);
   if (!updated) fail(`Failed to update via ${primary}`);
 
   const secondary = primary === "bun" ? "npm" : "bun";
   if (detectGlobalInstalls().has(secondary)) {
-    console.log();
-    log(`Also updating ${secondary} global install`);
-    const secondaryUpdated = secondary === "bun" ? await updateViaBun(channel) : await updateViaNpm(channel);
-    if (!secondaryUpdated) console.warn(`Warning: secondary ${secondary} update failed`);
+    reporter.line();
+    reporter.log(`Also updating ${secondary} global install`);
+    const secondaryUpdated =
+      secondary === "bun"
+        ? await updateViaBun(packageTag, label, reporter)
+        : await updateViaNpm(packageTag, label, reporter);
+    if (!secondaryUpdated) reporter.warn(`Warning: secondary ${secondary} update failed`);
   }
 
-  await finishUpdate(options.restart !== false, previousProcesses);
+  const currentVersion = detectInstalledVersion();
+  if (exactVersion && currentVersion !== exactVersion) {
+    fail(`The installation resolved to ${currentVersion ?? "an unknown version"}, not ${exactVersion}.`);
+  }
+  const restarted = await finishUpdate(options.restart !== false, previousProcesses, reporter);
+  return {
+    success: true,
+    package: PACKAGE_NAME,
+    requested,
+    channel,
+    previousVersion,
+    currentVersion,
+    installMethod: primary,
+    restarted,
+    integrityVerified: Boolean(expectedIntegrity),
+  };
+}
+
+export async function runUpdate(options: RaviUpdateOptions = {}): Promise<RaviUpdateResult> {
+  const reporter = createReporter(options.json === true);
+  try {
+    const result = await performUpdate(options, reporter);
+    if (reporter.json) console.log(JSON.stringify(result));
+    return result;
+  } catch (error) {
+    if (!(error instanceof UpdateFailure)) throw error;
+    contractFail("ravi update", error.code, error.message, {
+      asJson: options.json,
+      exitCode: error.exitCode,
+      details: {
+        retryable: error.code === "REGISTRY_UNAVAILABLE" || error.code === "UPDATE_FAILED",
+        suggestedAction: "Verify the requested release and retry.",
+      },
+    });
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,7 @@ import {
 } from "./agent-contract.js";
 import { runDoctor } from "./commands/doctor.js";
 import { runSetup } from "./commands/setup.js";
-import { runUpdate } from "./commands/update.js";
+import { runUpdate, type RaviUpdateOptions } from "./commands/update.js";
 import { runCloudAuthRootCommand, runLogin, runLogout, runWhoami } from "./commands/cloud-auth.js";
 import { emitCliAuditEvent, runWithCliAudit, wasContractErrorAudited } from "./audit.js";
 import { configureCliLogging } from "./logging.js";
@@ -174,17 +174,20 @@ program
 
 program
   .command("update")
-  .description("Update Ravi CLI to the configured npm channel")
+  .description("Update Ravi CLI to an exact release or configured npm channel")
+  .option("--version <version>", "Install one exact Ravi release")
+  .option("--expected-integrity <sri>", "Require the npm sha512 SRI for an exact release")
   .option("--next", "Switch to dev builds (npm @next tag)")
   .option("--stable", "Switch to stable releases (npm @latest tag)")
   .option("--no-restart", "Do not restart managed Ravi processes after updating")
-  .action(async (options: { next?: boolean; stable?: boolean; restart?: boolean }) => {
+  .option("--json", "Print a machine-readable result")
+  .action(async (options: RaviUpdateOptions) => {
     await runWithCliAudit(
       {
         group: "_root",
         name: "update",
         tool: "root_update",
-        input: options,
+        input: { ...options },
         closeLazyConnection: true,
       },
       () => runUpdate(options),


### PR DESCRIPTION
## Objective

Give trusted control planes a deterministic Ravi update contract that installs one exact published version and returns a machine-readable result.

## Problem

The existing command followed moving npm channels and printed mixed human output. A product-managed rollout could not pin the target artifact, verify its published integrity, or reliably parse the outcome.

## Solution

Add `ravi update --version <version> --expected-integrity <sha512-sri> --json`. Exact versions are validated before reaching a package manager, the npm registry integrity must match when supplied, the installed version is verified before restart, and JSON mode suppresses child-process noise. Channel-based updates remain available for operators.

## Practical impact

The Ravi Hub can now authorize a tested artifact by immutable version and integrity, ask each runtime to install it, and observe a stable success or error envelope. Managed daemon and channel processes retain their safe stop/restart order.

## What does NOT change

This does not publish a package, change release channels, auto-update existing installations, or introduce remote control into Ravi. Source checkouts still update from their existing stable or next branches.

## Validation

The repository pre-push hook completed generated-SDK checks, build, typecheck, and the full project test command. The focused update suite passes 11 tests, Biome passes, and the repository quality gate passes against `dev`.

## Risks

Package-manager or registry outages still make an update fail. Runtime callers must retain their previous exact version if they want to perform a rollback after an unsuccessful health check.

## Rollback

Revert this commit to restore the channel-only command. No persisted state migration is required; exact-version calls can also be stopped independently by the invoking control plane.
