### PR TITLE
fix(channels): deliver generated media across surfaces

### DIFF
--- a/src/bot.runtime-guards.fixture.ts
+++ b/src/bot.runtime-guards.fixture.ts
@@ -794,6 +794,120 @@ function attachOutputForSession(sessionKey: string): void {
   });
 }
 
+function ensureSessionRow(sessionKey: string): void {
+  const now = Date.now();
+  actualRouterDbModule
+    .getDb()
+    .prepare(
+      `
+      INSERT OR IGNORE INTO sessions (session_key, name, agent_id, agent_cwd, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+    )
+    .run(sessionKey, sessionKey, "main", "/tmp/ravi-test-bot/main", now, now);
+}
+
+function makeRuntimeGuardChat(input: {
+  suffix: string;
+  channel: string;
+  accountId: string;
+  platformChatId: string;
+  chatType?: "dm" | "group" | "thread";
+}) {
+  return actualRouterDbModule.dbUpsertChat({
+    channel: input.channel,
+    instanceId: input.accountId,
+    platformChatId: input.platformChatId,
+    chatType: input.chatType ?? "dm",
+    title: `test-${input.suffix}`,
+  });
+}
+
+function attachMultiSurfaceOutputForSession(input: {
+  sessionKey: string;
+  defaultChat: ReturnType<typeof makeRuntimeGuardChat>;
+  sourceChat: ReturnType<typeof makeRuntimeGuardChat>;
+}): void {
+  ensureSessionRow(input.sessionKey);
+  actualRouterDbModule.dbCreateSessionChatSubscription({
+    sessionKey: input.sessionKey,
+    chatId: input.defaultChat.id,
+    attachedReason: "runtime-guard-test-default-output",
+    outputAttachedAt: Date.now(),
+    speechMode: "speak",
+    speechReason: "runtime-guard-test-default-output",
+  });
+  actualRouterDbModule.dbCreateSessionChatSubscription({
+    sessionKey: input.sessionKey,
+    chatId: input.sourceChat.id,
+    attachedReason: "runtime-guard-test-source-speak",
+    speechMode: "speak",
+    speechReason: "runtime-guard-test-source-speak",
+  });
+}
+
+function promptForChat(text: string, chat: ReturnType<typeof makeRuntimeGuardChat>) {
+  const separator = chat.platformChatId.indexOf("#");
+  const chatId = separator === -1 ? chat.platformChatId : chat.platformChatId.slice(0, separator);
+  const threadId = separator === -1 ? undefined : chat.platformChatId.slice(separator + 1);
+  return {
+    prompt: text,
+    source: {
+      channel: chat.channel,
+      accountId: chat.instanceId,
+      instanceId: chat.instanceId,
+      chatId,
+      ...(threadId ? { threadId } : {}),
+      canonicalChatId: chat.id,
+      actorType: "contact",
+    },
+  };
+}
+
+const TINY_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function streamGeneratedImageTurn(finalText: string, options: { duplicateCompletion?: boolean } = {}) {
+  runtimeStartImpl = (providerId, request) => ({
+    provider: providerId,
+    events: (async function* () {
+      await request.prompt.next();
+      yield {
+        type: "tool.started",
+        toolUse: { id: "image-gen", name: "image_gen.imagegen", input: { prompt: "test image" } },
+      };
+      const completion = {
+        type: "tool.completed",
+        toolUseId: "image-gen",
+        toolName: "image_gen.imagegen",
+        content: { id: "generated-image-1", result: TINY_PNG_BASE64 },
+        isError: false,
+        metadata: {
+          provider: "codex",
+          nativeEvent: "item.completed",
+          item: { id: "item-generated-image-1", type: "imageGeneration", status: "completed" },
+        },
+      };
+      yield completion;
+      if (options.duplicateCompletion) yield { ...completion };
+      yield {
+        type: "assistant.message",
+        text: finalText,
+        metadata: {
+          provider: "codex",
+          nativeEvent: "item.completed",
+          item: { id: "item-final-answer-1", type: "message", phase: "final_answer" },
+        },
+      };
+      yield {
+        type: "turn.complete",
+        providerSessionId: `${providerId}-session`,
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    })(),
+    interrupt: async () => {},
+  });
+}
+
 async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -2383,6 +2497,199 @@ describe("RaviBot streaming session lifecycle", () => {
     await (bot as any).handlePromptImmediate(sessionKey, prompt);
 
     expect(streamingSession.currentSource?.chatId).toBe("new-chat");
+  });
+
+  it("attaches generated media to the WhatsApp response target even when Slack is the default output", async () => {
+    const sessionKey = "agent:main:generated-media-wa-source";
+    const slackDefault = makeRuntimeGuardChat({
+      suffix: "generated-media-slack-default",
+      channel: "slack",
+      accountId: "slack-main",
+      platformChatId: "DDEFAULT#1781574894.010449",
+      chatType: "thread",
+    });
+    const whatsappSource = makeRuntimeGuardChat({
+      suffix: "generated-media-whatsapp-source",
+      channel: "whatsapp",
+      accountId: "main",
+      platformChatId: "5511999999999@s.whatsapp.net",
+    });
+    attachMultiSurfaceOutputForSession({ sessionKey, defaultChat: slackDefault, sourceChat: whatsappSource });
+    streamGeneratedImageTurn("imagem pronta");
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate(sessionKey, promptForChat("gera imagem", whatsappSource));
+    await waitFor(() => emittedEvents.some((entry) => entry.topic === `ravi.session.${sessionKey}.response`));
+
+    const response = emittedEvents.find((entry) => entry.topic === `ravi.session.${sessionKey}.response`)?.data;
+    expect(response?.target).toMatchObject({
+      channel: "whatsapp",
+      accountId: "main",
+      chatId: "5511999999999@s.whatsapp.net",
+      canonicalChatId: whatsappSource.id,
+    });
+    expect(response?.target?.channel).not.toBe("slack");
+    expect(response?.content).toEqual([
+      expect.objectContaining({
+        type: "media",
+        media: expect.objectContaining({
+          type: "image",
+          filename: expect.stringContaining("ravi-generated-media"),
+          mimeType: "image/png",
+          source: "runtime.generated_media",
+        }),
+      }),
+      { type: "text", text: "imagem pronta" },
+    ]);
+    const generatedMediaEvents = emittedEvents.filter(
+      (entry) =>
+        entry.topic === `ravi.session.${sessionKey}.runtime` || entry.topic === `ravi.session.${sessionKey}.tool`,
+    );
+    expect(JSON.stringify(generatedMediaEvents)).not.toContain(TINY_PNG_BASE64);
+    const persistedTracePayloads = actualRouterDbModule
+      .getDb()
+      .prepare("SELECT payload_json FROM session_events WHERE session_key = ?")
+      .all(sessionKey);
+    expect(JSON.stringify(persistedTracePayloads)).not.toContain(TINY_PNG_BASE64);
+  });
+
+  it("attaches generated media to the Slack response target even when WhatsApp is the default output", async () => {
+    const sessionKey = "agent:main:generated-media-slack-source";
+    const whatsappDefault = makeRuntimeGuardChat({
+      suffix: "generated-media-whatsapp-default",
+      channel: "whatsapp",
+      accountId: "main",
+      platformChatId: "5511888888888@s.whatsapp.net",
+    });
+    const slackSource = makeRuntimeGuardChat({
+      suffix: "generated-media-slack-source",
+      channel: "slack",
+      accountId: "slack-main",
+      platformChatId: "CSOURCE#1781575000.010449",
+      chatType: "thread",
+    });
+    attachMultiSurfaceOutputForSession({ sessionKey, defaultChat: whatsappDefault, sourceChat: slackSource });
+    streamGeneratedImageTurn("slack pronto");
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate(sessionKey, promptForChat("gera imagem no slack", slackSource));
+    await waitFor(() => emittedEvents.some((entry) => entry.topic === `ravi.session.${sessionKey}.response`));
+
+    const response = emittedEvents.find((entry) => entry.topic === `ravi.session.${sessionKey}.response`)?.data;
+    expect(response?.target).toMatchObject({
+      channel: "slack",
+      accountId: "slack-main",
+      chatId: "CSOURCE",
+      threadId: "1781575000.010449",
+      canonicalChatId: slackSource.id,
+    });
+    expect(response?.target?.channel).not.toBe("whatsapp");
+    expect(response?.content).toEqual([
+      expect.objectContaining({
+        type: "media",
+        media: expect.objectContaining({
+          type: "image",
+          filename: expect.stringContaining("ravi-generated-media"),
+          mimeType: "image/png",
+          source: "runtime.generated_media",
+        }),
+      }),
+      { type: "text", text: "slack pronto" },
+    ]);
+  });
+
+  it("emits generated media on a native Slack backend turn without duplicating the backend-owned text", async () => {
+    const sessionKey = "agent:main:generated-media-slack-backend";
+    const whatsappDefault = makeRuntimeGuardChat({
+      suffix: "generated-media-backend-whatsapp-default",
+      channel: "whatsapp",
+      accountId: "main",
+      platformChatId: "5511777777777@s.whatsapp.net",
+    });
+    const slackSource = makeRuntimeGuardChat({
+      suffix: "generated-media-slack-backend-source",
+      channel: "slack",
+      accountId: "slack-main",
+      platformChatId: "CBACKEND#1781576000.010449",
+      chatType: "thread",
+    });
+    attachMultiSurfaceOutputForSession({ sessionKey, defaultChat: whatsappDefault, sourceChat: slackSource });
+    streamGeneratedImageTurn("texto do backend");
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate(sessionKey, {
+      ...promptForChat("gera imagem no backend slack", slackSource),
+      _channelBackend: {
+        protocol: "ravi.channel.backend",
+        schemaVersion: 1,
+        ingressRequestId: "request-generated-media-slack-backend",
+        correlationId: "correlation-generated-media-slack-backend",
+        binding: {
+          channelInstanceId: "slack-main",
+          agentId: "main",
+          chatId: slackSource.id,
+          messageId: "message-generated-media-slack-backend",
+          sessionId: sessionKey,
+          turnId: "turn-generated-media-slack-backend",
+        },
+        target: {
+          channelKind: "slack",
+          connectionId: "slack-main",
+          conversationId: "CBACKEND",
+        },
+      },
+    });
+    await waitFor(() => emittedEvents.some((entry) => entry.topic === `ravi.session.${sessionKey}.response`));
+
+    const responses = emittedEvents.filter((entry) => entry.topic === `ravi.session.${sessionKey}.response`);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.data).toMatchObject({
+      response: "",
+      target: {
+        channel: "slack",
+        accountId: "slack-main",
+        chatId: "CBACKEND",
+        threadId: "1781576000.010449",
+        canonicalChatId: slackSource.id,
+      },
+      content: [
+        {
+          type: "media",
+          media: {
+            type: "image",
+            mimeType: "image/png",
+            source: "runtime.generated_media",
+          },
+        },
+      ],
+    });
+    expect(responses[0]?.data.content.some((part: { type?: string }) => part.type === "text")).toBe(false);
+  });
+
+  it("deduplicates repeated generated-image completions inside the runtime turn", async () => {
+    const sessionKey = "agent:main:generated-media-duplicate-completion";
+    const whatsappSource = makeRuntimeGuardChat({
+      suffix: "generated-media-duplicate-source",
+      channel: "whatsapp",
+      accountId: "main",
+      platformChatId: "5511666666666@s.whatsapp.net",
+    });
+    attachOutputForSession(sessionKey);
+    actualRouterDbModule.dbCreateSessionChatSubscription({
+      sessionKey,
+      chatId: whatsappSource.id,
+      attachedReason: "runtime-guard-test-generated-media-dedupe",
+      speechMode: "speak",
+      speechReason: "runtime-guard-test-generated-media-dedupe",
+    });
+    streamGeneratedImageTurn("imagem única", { duplicateCompletion: true });
+
+    const bot = createBot();
+    await (bot as any).handlePromptImmediate(sessionKey, promptForChat("gera uma imagem", whatsappSource));
+    await waitFor(() => emittedEvents.some((entry) => entry.topic === `ravi.session.${sessionKey}.response`));
+
+    const response = emittedEvents.find((entry) => entry.topic === `ravi.session.${sessionKey}.response`)?.data;
+    expect(response?.content.filter((part: { type?: string }) => part.type === "media")).toHaveLength(1);
   });
 
   it("routes runtime control requests to the active session handle", async () => {

--- a/src/gateway-native-delivery.test.ts
+++ b/src/gateway-native-delivery.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { configStore } from "./config-store.js";
 import type { ChannelOutboundJob } from "./channels/outbound-stream.js";
 import type { ResponseMessage } from "./runtime/message-types.js";
+import { dbUpsertInstance, getDb } from "./router/router-db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "./test/ravi-state.js";
 
 const publishedJobs: ChannelOutboundJob[] = [];
+const slackMediaSends: Array<Record<string, unknown>> = [];
 const decoder = new TextDecoder();
 const acceptedMsgIds = new Set<string>();
 let publishBehavior: "ok" | "timeoutOnceThenOk" | "timeoutAlwaysBeforePublish" | "failBeforePublish" = "ok";
@@ -63,11 +66,27 @@ mock.module("./nats.js", () => ({
   },
 }));
 
+mock.module("./channels/slack/media.js", () => ({
+  sendSlackMedia: mock(async (input: Record<string, unknown>) => {
+    slackMediaSends.push(input);
+    return {
+      transport: "slack-native",
+      provider: "slack",
+      success: true,
+      status: "sent",
+      fileId: "F123",
+      messageId: "1720000000.000100",
+      raw: { ok: true },
+    };
+  }),
+}));
+
 let stateDir: string | null = null;
 
 beforeEach(async () => {
   stateDir = await createIsolatedRaviState("ravi-gateway-native-test-");
   publishedJobs.length = 0;
+  slackMediaSends.length = 0;
   acceptedMsgIds.clear();
   publishBehavior = "ok";
   publishAttempts = 0;
@@ -83,6 +102,7 @@ async function createGateway() {
   const { Gateway } = await import("./gateway.js");
   const emitted: Array<[string, Record<string, unknown>]> = [];
   const omniSend = mock(async () => ({ messageId: "omni-1" }));
+  const omniSendMedia = mock(async () => ({ messageId: "omni-media-1" }));
   const gateway = new Gateway({
     omniSender: {
       send: omniSend,
@@ -90,7 +110,7 @@ async function createGateway() {
       sendReaction: mock(async () => {}),
       deleteMessage: mock(async () => {}),
       editMessage: mock(async () => {}),
-      sendMedia: mock(async () => ({})),
+      sendMedia: omniSendMedia,
       markRead: mock(async () => {}),
     } as never,
     omniConsumer: {
@@ -102,7 +122,19 @@ async function createGateway() {
       emitted.push([topic, payload]);
     }),
   });
-  return { gateway, emitted, omniSend };
+  return { gateway, emitted, omniSend, omniSendMedia };
+}
+
+function ensureGatewaySession(sessionName: string): void {
+  const now = Date.now();
+  getDb()
+    .prepare(
+      `
+      INSERT OR IGNORE INTO sessions (session_key, name, agent_id, agent_cwd, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+    )
+    .run(`agent:main:${sessionName}`, sessionName, "main", "/tmp/ravi-gateway-test/main", now, now);
 }
 
 async function getPublishOutboxJob(idempotencyKey: string) {
@@ -189,6 +221,179 @@ describe("Gateway native channel outbound queue", () => {
     expect(record).toMatchObject({
       jobId: "runtime:main-slack:emit-1",
       status: "published",
+    });
+  });
+
+  it("delivers response media to the WhatsApp target through Omni media without using session defaults", async () => {
+    dbUpsertInstance({
+      name: "main",
+      instanceId: "11111111-1111-1111-1111-111111111111",
+      channel: "whatsapp",
+    });
+    configStore.refresh();
+    const { gateway, emitted, omniSend, omniSendMedia } = await createGateway();
+
+    await handleResponse(gateway, "main-whatsapp", {
+      _emitId: "emit-media-wa",
+      response: "imagem pronta",
+      content: [
+        {
+          type: "media",
+          media: {
+            type: "image",
+            filePath: "/tmp/generated.png",
+            filename: "generated.png",
+            mimeType: "image/png",
+            idempotencyKey: "media-key-wa",
+          },
+        },
+        { type: "text", text: "imagem pronta" },
+      ],
+      target: {
+        channel: "whatsapp",
+        accountId: "main",
+        instanceId: "11111111-1111-1111-1111-111111111111",
+        chatId: "group:120363407390920496",
+        canonicalChatId: "chat_whatsapp_source",
+      },
+    });
+
+    expect(omniSendMedia).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "120363407390920496@g.us",
+      "/tmp/generated.png",
+      "image",
+      "generated.png",
+      undefined,
+      undefined,
+    );
+    expect(omniSend).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "120363407390920496@g.us",
+      "imagem pronta",
+      undefined,
+    );
+    expect(emitted.map((entry) => entry[1].contentType)).toEqual(["media", "text"]);
+    expect(emitted[0]?.[1]).toMatchObject({
+      status: "delivered",
+      target: {
+        channel: "whatsapp",
+        chatId: "group:120363407390920496",
+        canonicalChatId: "chat_whatsapp_source",
+      },
+      mediaType: "image",
+      filename: "generated.png",
+    });
+  });
+
+  it("delivers response media to the Slack target natively and queues the Slack text part", async () => {
+    const { gateway, emitted, omniSend, omniSendMedia } = await createGateway();
+
+    await handleResponse(gateway, "main-slack", {
+      _emitId: "emit-media-slack",
+      response: "slack pronto",
+      content: [
+        {
+          type: "media",
+          media: {
+            type: "image",
+            filePath: "/tmp/generated-slack.png",
+            filename: "generated-slack.png",
+            mimeType: "image/png",
+            idempotencyKey: "media-key-slack",
+          },
+        },
+        { type: "text", text: "slack pronto" },
+      ],
+      target: {
+        channel: "slack",
+        accountId: "slack",
+        instanceId: "slack-main",
+        chatId: "C123",
+        canonicalChatId: "chat_slack_C123",
+        threadId: "1710000000.000100",
+      },
+    });
+
+    expect(omniSend).not.toHaveBeenCalled();
+    expect(omniSendMedia).not.toHaveBeenCalled();
+    expect(slackMediaSends).toEqual([
+      {
+        accountId: "slack",
+        chatId: "C123",
+        threadId: "1710000000.000100",
+        filePath: "/tmp/generated-slack.png",
+        filename: "generated-slack.png",
+        caption: undefined,
+      },
+    ]);
+    expect(publishedJobs).toHaveLength(1);
+    expect(publishedJobs[0]).toMatchObject({
+      jobId: "runtime:main-slack:emit-media-slack:text:1",
+      request: {
+        targetChatId: "C123",
+        targetThreadId: "1710000000.000100",
+        content: { type: "text", text: "slack pronto" },
+      },
+    });
+    expect(emitted.map((entry) => entry[1].contentType)).toEqual(["media", "text"]);
+    expect(emitted[0]?.[1]).toMatchObject({
+      status: "delivered",
+      target: {
+        channel: "slack",
+        chatId: "C123",
+        threadId: "1710000000.000100",
+      },
+      mediaType: "image",
+      filename: "generated-slack.png",
+      fileId: "F123",
+    });
+  });
+
+  it("does not redeliver generated media after a gateway restart", async () => {
+    const sessionName = "main-whatsapp-media-dedupe";
+    ensureGatewaySession(sessionName);
+    dbUpsertInstance({
+      name: "main",
+      instanceId: "11111111-1111-1111-1111-111111111111",
+      channel: "whatsapp",
+    });
+    configStore.refresh();
+    const firstGateway = await createGateway();
+    const response: ResponseMessage = {
+      _emitId: "media-duplicate-proof",
+      response: "",
+      content: [
+        {
+          type: "media",
+          media: {
+            type: "image",
+            filePath: "/tmp/generated-dedupe.png",
+            filename: "generated-dedupe.png",
+            mimeType: "image/png",
+            idempotencyKey: "runtime.generated_media:session:item:hash",
+          },
+        },
+      ],
+      target: {
+        channel: "whatsapp",
+        accountId: "main",
+        instanceId: "11111111-1111-1111-1111-111111111111",
+        chatId: "5511999999999@s.whatsapp.net",
+        canonicalChatId: "chat_whatsapp_dedupe",
+      },
+    };
+
+    await handleResponse(firstGateway.gateway, sessionName, response);
+    const secondGateway = await createGateway();
+    await handleResponse(secondGateway.gateway, sessionName, response);
+
+    expect(firstGateway.omniSendMedia).toHaveBeenCalledTimes(1);
+    expect(secondGateway.omniSendMedia).not.toHaveBeenCalled();
+    expect(secondGateway.emitted.at(-1)?.[1]).toMatchObject({
+      status: "dropped",
+      reason: "duplicate_media",
+      idempotencyKey: "runtime.generated_media:session:item:hash",
     });
   });
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -21,8 +21,9 @@
  *   ravi.config.changed        -> reload router config
  */
 
+import { unlink } from "node:fs/promises";
 import { nats } from "./nats.js";
-import type { ResponseMessage } from "./runtime/message-types.js";
+import type { ResponseContentPart, ResponseMediaAttachment, ResponseMessage } from "./runtime/message-types.js";
 import { configStore } from "./config-store.js";
 import { recordDeliveryTrace, recordPresenceTrace, recordResponseEmittedTrace } from "./session-trace/channel-trace.js";
 import { listRecentSessionEventsByType } from "./session-trace/session-trace-db.js";
@@ -49,6 +50,7 @@ import { resolveOmniConnection } from "./omni-config.js";
 import { resolveOmniGroupMetadata } from "./omni/group-metadata-cache.js";
 import { buildRaviTtsRequest, handleRaviTtsRequest, RAVI_TTS_TOPIC, shouldAutoTtsForAgent } from "./audio/tts.js";
 import { handleSlackThreadCreationDelivery, reconcileSlackThreadLifecycle } from "./channels/slack/thread-lifecycle.js";
+import { sendSlackMedia } from "./channels/slack/media.js";
 
 const log = logger.child("gateway");
 const PRESENCE_RENEW_THROTTLE_MS = 4_000;
@@ -88,6 +90,67 @@ function mergeMentions(...lists: Array<readonly OmniUserMention[] | undefined>):
   }
   const mentions = Array.from(byId.values());
   return mentions.length ? mentions : undefined;
+}
+
+function isResponseMediaType(value: unknown): value is ResponseMediaAttachment["type"] {
+  return value === "image" || value === "video" || value === "audio" || value === "document";
+}
+
+function normalizeResponseMediaAttachment(value: unknown): ResponseMediaAttachment | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    !isResponseMediaType(record.type) ||
+    typeof record.filePath !== "string" ||
+    !record.filePath.trim() ||
+    typeof record.filename !== "string" ||
+    !record.filename.trim()
+  ) {
+    return null;
+  }
+
+  return {
+    type: record.type,
+    filePath: record.filePath,
+    filename: record.filename,
+    ...(typeof record.mimeType === "string" ? { mimeType: record.mimeType } : {}),
+    ...(typeof record.caption === "string" ? { caption: record.caption } : {}),
+    ...(record.voiceNote === true ? { voiceNote: true } : {}),
+    ...(typeof record.idempotencyKey === "string" ? { idempotencyKey: record.idempotencyKey } : {}),
+    ...(typeof record.source === "string" ? { source: record.source } : {}),
+    ...(record.metadata && typeof record.metadata === "object" && !Array.isArray(record.metadata)
+      ? { metadata: record.metadata as Record<string, unknown> }
+      : {}),
+  };
+}
+
+function normalizeResponseContentParts(
+  response: ResponseMessage,
+  fallbackText: string | undefined,
+): ResponseContentPart[] {
+  const explicitParts = Array.isArray(response.content)
+    ? response.content.flatMap((part): ResponseContentPart[] => {
+        if (!part || typeof part !== "object" || Array.isArray(part)) return [];
+        const record = part as Record<string, unknown>;
+        if (record.type === "text" && typeof record.text === "string") {
+          return [{ type: "text", text: record.text }];
+        }
+        if (record.type === "media") {
+          const media = normalizeResponseMediaAttachment(record.media);
+          return media ? [{ type: "media", media }] : [];
+        }
+        return [];
+      })
+    : [];
+
+  const text = fallbackText?.trim() ? fallbackText : undefined;
+  if (explicitParts.length === 0) {
+    return text ? [{ type: "text", text }] : [];
+  }
+  if (text && !explicitParts.some((part) => part.type === "text")) {
+    return [...explicitParts, { type: "text", text }];
+  }
+  return explicitParts;
 }
 
 function parsePresenceTarget(value: unknown): PresenceTarget | null {
@@ -897,24 +960,36 @@ export class Gateway {
   private async handleResponseEvent(sessionName: string, response: ResponseMessage): Promise<void> {
     this.recordResponseTrace(sessionName, response);
 
-    const emitDelivery = (data: Record<string, unknown>) => this.emitDeliveryEvent(sessionName, response, data);
-
     const target = response.target;
+    const emitDelivery = (data: Record<string, unknown>, deliveryResponse: ResponseMessage = response) =>
+      this.emitDeliveryEvent(sessionName, deliveryResponse, data);
     if (!target) {
       await emitDelivery({ status: "dropped", reason: "missing_target" });
       return;
     }
 
-    const text = response.error ? `Error: ${response.error}` : response.response;
+    const fallbackText = response.error ? `Error: ${response.error}` : response.response;
+    const parts = normalizeResponseContentParts(response, fallbackText);
+    const hasMedia = parts.some((part) => part.type === "media");
+    const textLen = parts
+      .filter((part): part is Extract<ResponseContentPart, { type: "text" }> => part.type === "text")
+      .reduce((total, part) => total + part.text.length, 0);
 
-    if (text && text.trim() === SILENT_TOKEN) {
+    if (
+      !hasMedia &&
+      parts.length > 0 &&
+      parts.every((part) => part.type === "text" && (!part.text.trim() || part.text.trim() === SILENT_TOKEN))
+    ) {
       log.debug("Silent response, not sending to channel", { sessionName });
       await this.stopPresenceForSession(sessionName, target);
       await emitDelivery({ status: "dropped", reason: "silent", target });
       return;
     }
 
-    if (!text) {
+    const deliverableParts = parts.filter(
+      (part) => part.type === "media" || (part.text.trim() && part.text.trim() !== SILENT_TOKEN),
+    );
+    if (deliverableParts.length === 0) {
       await emitDelivery({ status: "dropped", reason: "empty_response", target });
       return;
     }
@@ -922,14 +997,67 @@ export class Gateway {
     if (!response._emitId) {
       log.warn("GHOST RESPONSE DROPPED", {
         sessionName,
-        textPreview: text.slice(0, 200),
+        textPreview: String(fallbackText ?? "").slice(0, 200),
       });
-      await emitDelivery({ status: "dropped", reason: "missing_emit_id", target, textLen: text.length });
+      await emitDelivery({ status: "dropped", reason: "missing_emit_id", target, textLen });
       return;
     }
 
+    for (let index = 0; index < deliverableParts.length; index++) {
+      const part = deliverableParts[index]!;
+      if (part.type === "media") {
+        await this.deliverResponseMediaPart(sessionName, response, target, part.media, index);
+      } else {
+        await this.deliverResponseTextPart(sessionName, response, target, part.text, index, deliverableParts.length);
+      }
+    }
+  }
+
+  private buildTextPartResponse(
+    response: ResponseMessage,
+    text: string,
+    partIndex: number,
+    totalParts: number,
+  ): ResponseMessage {
+    if (!response.content && totalParts === 1) {
+      return response;
+    }
+    if (totalParts === 1) {
+      return {
+        ...response,
+        response: text,
+        error: undefined,
+        content: undefined,
+      };
+    }
+    return {
+      ...response,
+      response: text,
+      error: undefined,
+      content: undefined,
+      _emitId: `${response._emitId}:text:${partIndex}`,
+    };
+  }
+
+  private async deliverResponseTextPart(
+    sessionName: string,
+    response: ResponseMessage,
+    target: NonNullable<ResponseMessage["target"]>,
+    text: string,
+    partIndex: number,
+    totalParts: number,
+  ): Promise<void> {
+    const partResponse = this.buildTextPartResponse(response, text, partIndex, totalParts);
+    const emitDelivery = (data: Record<string, unknown>) =>
+      this.emitDeliveryEvent(sessionName, partResponse, {
+        ...data,
+        contentType: "text",
+        partIndex,
+        partCount: totalParts,
+      });
+
     if (this.shouldQueueNativeOutbound(target)) {
-      const built = buildChannelOutboundJobFromResponse(sessionName, response);
+      const built = buildChannelOutboundJobFromResponse(sessionName, partResponse);
       if (!built.ok) {
         await emitDelivery({ status: "dropped", reason: built.reason, target, textLen: text.length });
         return;
@@ -1011,7 +1139,6 @@ export class Gateway {
       this.schedulePostDeliveryPresenceRenewal(sessionName, target);
       await emitDelivery({
         status: "delivered",
-        emitId: response._emitId,
         messageId: delivered.messageId,
         target,
         deliveredAt: Date.now(),
@@ -1035,6 +1162,143 @@ export class Gateway {
         durationMs: Date.now() - t0,
       });
     }
+  }
+
+  private async deliverResponseMediaPart(
+    sessionName: string,
+    response: ResponseMessage,
+    target: NonNullable<ResponseMessage["target"]>,
+    media: ResponseMediaAttachment,
+    partIndex: number,
+  ): Promise<void> {
+    const emitDelivery = (data: Record<string, unknown>) =>
+      this.emitDeliveryEvent(sessionName, response, {
+        ...data,
+        contentType: "media",
+        mediaType: media.type,
+        filename: media.filename,
+        mimeType: media.mimeType,
+        idempotencyKey: media.idempotencyKey,
+        partIndex,
+      });
+    const channel = target.channel.toLowerCase();
+    const t0 = Date.now();
+
+    if (this.wasResponseMediaDelivered(sessionName, media.idempotencyKey, target)) {
+      log.info("Skipping already delivered response media", {
+        sessionName,
+        channel,
+        filename: media.filename,
+        idempotencyKey: media.idempotencyKey,
+      });
+      await emitDelivery({
+        status: "dropped",
+        reason: "duplicate_media",
+        target,
+        durationMs: Date.now() - t0,
+      });
+      return;
+    }
+
+    try {
+      if (channel === "slack") {
+        const delivered = await sendSlackMedia({
+          accountId: target.accountId,
+          chatId: target.chatId,
+          threadId: target.threadId,
+          filePath: media.filePath,
+          filename: media.filename,
+          caption: media.caption,
+        });
+        this.recordOutboundContactInteraction(sessionName, target);
+        this.schedulePostDeliveryPresenceRenewal(sessionName, target);
+        await emitDelivery({
+          status: "delivered",
+          target,
+          deliveredAt: Date.now(),
+          durationMs: Date.now() - t0,
+          transport: delivered.transport,
+          provider: delivered.provider,
+          fileId: delivered.fileId,
+          ...(delivered.messageId ? { messageId: delivered.messageId } : {}),
+        });
+        await this.cleanupResponseMediaFile(media);
+        return;
+      }
+
+      const instanceId = configStore.resolveInstanceId(target.accountId);
+      if (!instanceId) {
+        await emitDelivery({ status: "dropped", reason: "missing_instance", target });
+        return;
+      }
+
+      const chatId = normalizeOutboundJid(target.chatId);
+      const delivered = await this.omniSender.sendMedia(
+        instanceId,
+        chatId,
+        media.filePath,
+        media.type,
+        media.filename,
+        media.caption,
+        media.voiceNote,
+      );
+      this.recordOutboundContactInteraction(sessionName, target);
+      this.schedulePostDeliveryPresenceRenewal(sessionName, target);
+      await emitDelivery({
+        status: "delivered",
+        target,
+        instanceId,
+        chatId,
+        deliveredAt: Date.now(),
+        durationMs: Date.now() - t0,
+        ...(delivered.messageId ? { messageId: delivered.messageId } : {}),
+      });
+      await this.cleanupResponseMediaFile(media);
+    } catch (err) {
+      log.error("Failed to send response media", {
+        target,
+        mediaType: media.type,
+        filename: media.filename,
+        error: err,
+      });
+      await emitDelivery({
+        status: "failed",
+        reason: "send_error",
+        target,
+        textLen: 0,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - t0,
+      });
+    }
+  }
+
+  private wasResponseMediaDelivered(
+    sessionName: string,
+    idempotencyKey: string | undefined,
+    target: NonNullable<ResponseMessage["target"]>,
+  ): boolean {
+    if (!idempotencyKey) return false;
+    const session = getSessionByName(sessionName);
+    if (!session) return false;
+
+    return listRecentSessionEventsByType(session.sessionKey, "delivery.delivered", { limit: 1000 }).some((event) => {
+      const payload = event.payloadJson;
+      if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return false;
+      const record = payload as Record<string, unknown>;
+      if (record.idempotencyKey !== idempotencyKey) return false;
+      const deliveredTarget = parsePresenceTarget(record.target);
+      return deliveredTarget !== null && this.presenceSurfacesMatch(deliveredTarget, target);
+    });
+  }
+
+  private async cleanupResponseMediaFile(media: ResponseMediaAttachment): Promise<void> {
+    if (media.source !== "runtime.generated_media") return;
+    await unlink(media.filePath).catch((error) => {
+      log.debug("Failed to clean generated response media file", {
+        filePath: media.filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   private shouldQueueNativeOutbound(target: NonNullable<ResponseMessage["target"]>): boolean {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { calculateCost, prewarmPricingCatalog } from "../costs/pricing-catalog.js";
 import { projectChannelRuntimeEvent } from "../channels/runtime-events.js";
 import { backfillProviderSessionId, getRecentHistory, saveMessage } from "../db.js";
@@ -78,6 +82,7 @@ import type {
 } from "./types.js";
 import { classifyTurnProvenance } from "./turn-provenance.js";
 import { buildRuntimeToolPresentation } from "./tool-presentation.js";
+import type { ResponseContentPart, ResponseMediaAttachment } from "./message-types.js";
 
 const log = logger.child("bot");
 
@@ -90,6 +95,9 @@ const RUNTIME_SESSION_CLOSE_TIMEOUT_MS = 5_000;
 const USER_FACING_LIMIT_SUPPRESSION_DEFAULT_MS = 60 * 60_000;
 const USER_FACING_LIMIT_SUPPRESSION_MAX_MS = 24 * 60 * 60_000;
 const USER_FACING_LIMIT_SUPPRESSION_RESET_GRACE_MS = 60_000;
+const GENERATED_IMAGE_ITEM_TYPE = "imageGeneration";
+const GENERATED_MEDIA_FILE_PREFIX = "ravi-generated-media";
+const MAX_GENERATED_MEDIA_BYTES = 50 * 1024 * 1024;
 
 const userFacingRuntimeLimitSuppressions = new Map<string, number>();
 
@@ -178,6 +186,155 @@ function firstNumber(...values: unknown[]): number | undefined {
     }
   }
   return undefined;
+}
+
+function isGeneratedImageToolCompletion(event: Extract<RuntimeEvent, { type: "tool.completed" }>): boolean {
+  return event.isError !== true && event.metadata?.item?.type === GENERATED_IMAGE_ITEM_TYPE;
+}
+
+function extractGeneratedImagePayload(content: unknown): { id?: string; base64: string } | null {
+  if (typeof content === "string" && content.trim()) {
+    return { base64: content.trim() };
+  }
+
+  const record = asRecord(content);
+  if (!record) return null;
+
+  const base64 = firstString(record.result, record.image, record.base64, record.b64_json, record.data);
+  if (!base64) return null;
+
+  return {
+    base64,
+    ...(firstString(record.id, record.imageId, record.itemId)
+      ? { id: firstString(record.id, record.imageId, record.itemId) }
+      : {}),
+  };
+}
+
+function decodeBase64ImagePayload(value: string): Buffer | null {
+  const trimmed = value.trim();
+  const dataUrlMatch = /^data:[^;,]+;base64,(.*)$/s.exec(trimmed);
+  if (trimmed.startsWith("data:") && !dataUrlMatch) return null;
+  const payload = dataUrlMatch?.[1] ?? trimmed;
+  const normalized = payload.replace(/\s+/g, "");
+  if (!normalized) return null;
+
+  const estimatedBytes = Math.floor((normalized.length * 3) / 4);
+  if (estimatedBytes > MAX_GENERATED_MEDIA_BYTES) return null;
+
+  const bytes = Buffer.from(normalized, "base64");
+  return bytes.byteLength > 0 && bytes.byteLength <= MAX_GENERATED_MEDIA_BYTES ? bytes : null;
+}
+
+function inferImageFormat(bytes: Buffer): { mimeType: string; extension: string } | null {
+  if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return { mimeType: "image/png", extension: "png" };
+  }
+  if (bytes.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) {
+    return { mimeType: "image/jpeg", extension: "jpg" };
+  }
+  if (
+    bytes.byteLength >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return { mimeType: "image/webp", extension: "webp" };
+  }
+  const gifHeader = bytes.subarray(0, 6).toString("ascii");
+  if (gifHeader === "GIF87a" || gifHeader === "GIF89a") {
+    return { mimeType: "image/gif", extension: "gif" };
+  }
+  return null;
+}
+
+function safeFileComponent(value: unknown, fallback: string): string {
+  const normalized = String(value ?? "")
+    .replace(/[^a-zA-Z0-9_.-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80);
+  return normalized || fallback;
+}
+
+async function materializeGeneratedImageAttachment(input: {
+  sessionKey: string;
+  sessionName: string;
+  provider: RuntimeProviderId;
+  toolUseId?: string;
+  content: unknown;
+  metadata?: RuntimeEventMetadata;
+}): Promise<ResponseMediaAttachment | null> {
+  const payload = extractGeneratedImagePayload(input.content);
+  if (!payload) return null;
+
+  const bytes = decodeBase64ImagePayload(payload.base64);
+  if (!bytes) return null;
+
+  const format = inferImageFormat(bytes);
+  if (!format) return null;
+
+  const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+  const itemId = payload.id ?? input.metadata?.item?.id ?? input.toolUseId ?? "image";
+  const filename = `${GENERATED_MEDIA_FILE_PREFIX}-${safeFileComponent(input.sessionName, "session")}-${safeFileComponent(itemId, "image")}-${hash}.${format.extension}`;
+  const filePath = join(tmpdir(), filename);
+  await writeFile(filePath, bytes);
+
+  return {
+    type: "image",
+    filePath,
+    filename,
+    mimeType: format.mimeType,
+    idempotencyKey: `runtime.generated_media:${input.sessionKey}:${itemId}:${hash}`,
+    source: "runtime.generated_media",
+    metadata: {
+      provider: input.provider,
+      ...(input.toolUseId ? { toolUseId: input.toolUseId } : {}),
+      ...(payload.id ? { providerOutputId: payload.id } : {}),
+      ...(input.metadata?.item?.id ? { providerItemId: input.metadata.item.id } : {}),
+    },
+  };
+}
+
+function summarizeGeneratedImageToolOutput(input: {
+  content: unknown;
+  attachment?: ResponseMediaAttachment | null;
+  metadata?: RuntimeEventMetadata;
+}): Record<string, unknown> {
+  const payload = extractGeneratedImagePayload(input.content);
+  return {
+    type: "generated_image",
+    ...(input.attachment !== undefined ? { materialized: input.attachment !== null } : {}),
+    ...(input.attachment
+      ? {
+          filename: input.attachment.filename,
+          mimeType: input.attachment.mimeType,
+          idempotencyKey: input.attachment.idempotencyKey,
+        }
+      : {}),
+    ...(payload?.id ? { providerOutputId: payload.id } : {}),
+    ...(input.metadata?.item?.id ? { providerItemId: input.metadata.item.id } : {}),
+  };
+}
+
+function redactGeneratedImageProviderRawEvent(
+  rawEvent: Record<string, unknown>,
+  metadata: RuntimeEventMetadata | undefined,
+): Record<string, unknown> {
+  if (metadata?.item?.type !== GENERATED_IMAGE_ITEM_TYPE) return rawEvent;
+
+  const payloadKeys = new Set(["result", "image", "base64", "b64_json", "data"]);
+  const redact = (value: unknown, key?: string): unknown => {
+    if (key && payloadKeys.has(key) && typeof value === "string") {
+      return "[generated image payload redacted]";
+    }
+    if (Array.isArray(value)) return value.map((item) => redact(item));
+    const record = asRecord(value);
+    if (!record) return value;
+    return Object.fromEntries(
+      Object.entries(record).map(([nestedKey, nestedValue]) => [nestedKey, redact(nestedValue, nestedKey)]),
+    );
+  };
+
+  return redact(rawEvent) as Record<string, unknown>;
 }
 
 function headerValue(value: unknown): string | number | undefined {
@@ -343,6 +500,12 @@ function buildProviderRawRuntimeEvent(
 function stripRuntimeRawEvent<T extends RuntimeEvent>(event: T): T {
   const safeEvent: Record<string, unknown> = { ...event };
   delete safeEvent.rawEvent;
+  if (event.type === "tool.completed" && isGeneratedImageToolCompletion(event)) {
+    safeEvent.content = summarizeGeneratedImageToolOutput({
+      content: event.content,
+      metadata: event.metadata,
+    });
+  }
   return safeEvent as T;
 }
 
@@ -707,6 +870,19 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
   let providerRawEventCount = 0;
   let responseText = "";
   let channelResponseText = "";
+  let pendingGeneratedMedia: ResponseMediaAttachment[] = [];
+  const generatedMediaKeys = new Set<string>();
+  const clearPendingGeneratedMedia = () => {
+    pendingGeneratedMedia = [];
+    generatedMediaKeys.clear();
+  };
+  const queueGeneratedMedia = (attachment: ResponseMediaAttachment): boolean => {
+    const key = attachment.idempotencyKey ?? attachment.filePath;
+    if (generatedMediaKeys.has(key)) return false;
+    generatedMediaKeys.add(key);
+    pendingGeneratedMedia.push(attachment);
+    return true;
+  };
   let observationSequence = 0;
   let observedUserTurnId: string | undefined;
   let restartStashedReason: string | undefined;
@@ -1048,7 +1224,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     removePendingProviderRawEvent(pending);
     if (suppressProviderRawForCurrentTurn || !pending.safetyFenced || !canReleaseProviderRawEvent()) return;
 
-    await emitLegacyProviderEvent(pending.event.rawEvent);
+    await emitLegacyProviderEvent(redactGeneratedImageProviderRawEvent(pending.event.rawEvent, pending.event.metadata));
     await emitRuntimeEvent(
       buildProviderRawRuntimeEvent(runtimeSession.provider, pending.event.rawEvent, pending.event.metadata),
     );
@@ -1060,7 +1236,9 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       // do not prove that assistant content or tool arguments crossed a durable
       // replay-safety fence. Drop their raw envelopes fail-closed.
       if (!pending.safetyFenced || suppressProviderRawForCurrentTurn || !canReleaseProviderRawEvent()) continue;
-      await emitLegacyProviderEvent(pending.event.rawEvent);
+      await emitLegacyProviderEvent(
+        redactGeneratedImageProviderRawEvent(pending.event.rawEvent, pending.event.metadata),
+      );
       await emitRuntimeEvent(
         buildProviderRawRuntimeEvent(runtimeSession.provider, pending.event.rawEvent, pending.event.metadata),
       );
@@ -1420,14 +1598,23 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
   };
 
   const emitResponse = async (text: string, metadata?: RuntimeEventMetadata) => {
-    if (streaming.currentChannelBackend) {
+    const mediaParts = isCommentaryResponse(metadata) ? [] : pendingGeneratedMedia.splice(0);
+    const channelBackendOwnsText = streaming.currentChannelBackend !== undefined;
+    if (channelBackendOwnsText && mediaParts.length === 0) {
       log.debug("Channel backend response deferred to terminal projection", {
         sessionName,
-        turnId: streaming.currentChannelBackend.binding.turnId,
+        turnId: streaming.currentChannelBackend?.binding.turnId,
       });
       return;
     }
-    const emitId = Math.random().toString(36).slice(2, 8);
+    const responseText = channelBackendOwnsText ? "" : text;
+    const emitId =
+      mediaParts.length > 0
+        ? `media-${createHash("sha256")
+            .update(mediaParts.map((media) => media.idempotencyKey ?? media.filePath).join("\n"))
+            .digest("hex")
+            .slice(0, 16)}`
+        : Math.random().toString(36).slice(2, 8);
     // Resolve the target chat per `.ravi/specs/sessions/attach/SPEC.md`.
     // Attach selects the chat that receives this session's external output.
     // Sentinel agents observe silently → no target.
@@ -1445,17 +1632,28 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           sessionName,
           source: resolvedSource,
         });
+        clearPendingGeneratedMedia();
         return;
       }
     }
+    const content =
+      mediaParts.length > 0
+        ? ([
+            ...mediaParts.map((media) => ({ type: "media" as const, media })),
+            ...(responseText.trim() ? [{ type: "text" as const, text: responseText }] : []),
+          ] satisfies ResponseContentPart[])
+        : undefined;
     log.info("Emitting response", {
       sessionName,
       emitId,
-      textLen: text.length,
+      textLen: responseText.length,
+      mediaCount: mediaParts.length,
       targetSource: resolvedSource,
+      channelBackendOwnsText,
     });
     await nats.emit(`ravi.session.${sessionName}.response`, {
-      response: text,
+      response: responseText,
+      ...(content ? { content } : {}),
       target: resolvedTarget,
       ...(metadata ? { metadata } : {}),
       _emitId: emitId,
@@ -2133,7 +2331,43 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         const toolId = streaming.currentToolId ?? event.toolUseId ?? "unknown";
         const toolName = streaming.currentToolName ?? event.toolName ?? "unknown";
         const toolInput = streaming.currentToolInput;
-        const output = truncateOutput(event.content);
+        const generatedImageCompletion = isGeneratedImageToolCompletion(event);
+        let generatedImageAttachment: ResponseMediaAttachment | null = null;
+        if (generatedImageCompletion) {
+          try {
+            generatedImageAttachment = await materializeGeneratedImageAttachment({
+              sessionKey: session.sessionKey,
+              sessionName,
+              provider: runtimeSession.provider,
+              toolUseId: toolId,
+              content: event.content,
+              metadata: event.metadata,
+            });
+            if (generatedImageAttachment) {
+              const queued = queueGeneratedMedia(generatedImageAttachment);
+              log.info(queued ? "Generated image queued for next response" : "Duplicate generated image ignored", {
+                sessionName,
+                toolId,
+                filename: generatedImageAttachment.filename,
+                idempotencyKey: generatedImageAttachment.idempotencyKey,
+              });
+            } else {
+              log.warn("Generated image tool completed without materializable image payload", {
+                sessionName,
+                toolId,
+              });
+            }
+          } catch (error) {
+            log.warn("Failed to materialize generated image", { sessionName, toolId, error });
+          }
+        }
+        const output = generatedImageCompletion
+          ? summarizeGeneratedImageToolOutput({
+              content: event.content,
+              attachment: generatedImageAttachment,
+              metadata: event.metadata,
+            })
+          : truncateOutput(event.content);
         ensureCurrentTurnUserObservation();
         pushObservationEvent("tool.end", {
           preview: toolName,
@@ -2175,6 +2409,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           metadata: event.metadata,
           ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
         }).catch((err) => log.warn("Failed to emit tool end", { error: err }));
+
         updateRuntimeLiveState(sessionName, {
           activity: event.isError ? "blocked" : "thinking",
           summary: event.isError ? `${toolName} failed` : `${toolName} completed`,
@@ -2409,6 +2644,11 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           streaming.abortController.abort();
         }
 
+        if (!streaming.interrupted && pendingGeneratedMedia.length > 0) {
+          markCurrentTurnAttemptSafety({ materializedOutput: true });
+          await emitResponse("", event.metadata);
+        }
+
         if (!streaming.interrupted && responseText.trim()) {
           const sdkId = event.providerSessionId;
           saveMessage(sessionName, "assistant", responseText.trim(), sdkId, {
@@ -2423,6 +2663,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         // Reset for next turn
         responseText = "";
         channelResponseText = "";
+        clearPendingGeneratedMedia();
         clearActiveToolState();
         streaming.compacting = false;
         streaming.lastToolFailure = undefined;
@@ -2470,6 +2711,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         streaming.interrupted = true;
         responseText = "";
         channelResponseText = "";
+        clearPendingGeneratedMedia();
         clearActiveToolState();
         streaming.compacting = false;
         streaming.lastToolFailure = undefined;
@@ -2564,6 +2806,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
 
         responseText = "";
         channelResponseText = "";
+        clearPendingGeneratedMedia();
         clearActiveToolState();
         streaming.compacting = false;
         streaming.lastToolFailure = undefined;

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -221,10 +221,35 @@ export interface PromptMessage {
 
 export type RuntimeLaunchPrompt = PromptMessage;
 
+export type ResponseMediaType = "image" | "video" | "audio" | "document";
+
+export interface ResponseMediaAttachment {
+  type: ResponseMediaType;
+  filePath: string;
+  filename: string;
+  mimeType?: string;
+  caption?: string;
+  voiceNote?: boolean;
+  idempotencyKey?: string;
+  source?: "runtime.generated_media" | (string & {});
+  metadata?: Record<string, unknown>;
+}
+
+export type ResponseContentPart =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "media";
+      media: ResponseMediaAttachment;
+    };
+
 /** Response message structure */
 export interface ResponseMessage {
   response?: string;
   error?: string;
+  content?: ResponseContentPart[];
   target?: MessageTarget;
   metadata?: RuntimeEventMetadata | null;
   /** Unique emit ID to detect ghost/duplicate responses */

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getRecentHistory, saveMessage } from "../db.js";
 import { nats } from "../nats.js";
@@ -1052,6 +1052,107 @@ describe("runtime session trace instrumentation", () => {
       usage: { inputTokens: 1, outputTokens: 1 },
     },
   ];
+
+  it("projects a Codex imageGeneration completion into ordered response media without persisting base64", async () => {
+    attachSpeakingOutputChat();
+    const imageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    const streaming = makeStreamingSession({
+      agentMode: "active",
+      currentTurnProvenance: classifyTurnProvenance({ source }),
+    });
+    seedAdapterTrace(streaming, "turn-generated-image");
+
+    const responses: Array<{
+      response?: string;
+      content?: Array<{
+        type?: string;
+        text?: string;
+        media?: { type?: string; filePath?: string; filename?: string; mimeType?: string; source?: string };
+      }>;
+    }> = [];
+    const emitted: Array<{ topic: string; data: unknown }> = [];
+    let generatedFilePath: string | undefined;
+    const emitSpy = spyOn(nats, "emit").mockImplementation(async (topic: string, data: unknown) => {
+      if (topic === `ravi.session.${SESSION_NAME}.response` && data && typeof data === "object") {
+        responses.push(data as (typeof responses)[number]);
+      }
+    });
+
+    try {
+      await runTraceLoop(
+        streaming,
+        {
+          ...makeRuntimeSession([
+            {
+              type: "tool.started",
+              toolUse: { id: "image-gen-1", name: "image_gen.imagegen", input: { prompt: "tiny image" } },
+            },
+            {
+              type: "tool.completed",
+              toolUseId: "image-gen-1",
+              toolName: "image_gen.imagegen",
+              content: { id: "generated-image-1", result: imageBase64 },
+              rawEvent: {
+                type: "item.completed",
+                item: { id: "provider-item-1", type: "imageGeneration", result: imageBase64 },
+              },
+              metadata: {
+                provider: "codex",
+                nativeEvent: "item.completed",
+                item: { id: "provider-item-1", type: "imageGeneration", status: "completed" },
+              },
+            },
+            {
+              type: "assistant.message",
+              text: "imagem pronta",
+              metadata: {
+                provider: "codex",
+                nativeEvent: "item.completed",
+                item: { id: "assistant-item-1", type: "message", phase: "final_answer" },
+              },
+            },
+            {
+              type: "turn.complete",
+              providerSessionId: "codex-session-after",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+          provider: "codex",
+        },
+        {
+          safeEmit: async (topic, data) => {
+            emitted.push({ topic, data });
+          },
+        },
+      );
+
+      expect(responses).toHaveLength(1);
+      expect(responses[0]?.response).toBe("imagem pronta");
+      expect(responses[0]?.content).toEqual([
+        {
+          type: "media",
+          media: expect.objectContaining({
+            type: "image",
+            filename: expect.stringContaining("ravi-generated-media"),
+            mimeType: "image/png",
+            source: "runtime.generated_media",
+          }),
+        },
+        { type: "text", text: "imagem pronta" },
+      ]);
+
+      generatedFilePath = responses[0]?.content?.[0]?.media?.filePath;
+      expect(generatedFilePath).toBeDefined();
+      expect(existsSync(generatedFilePath!)).toBe(true);
+      expect(readFileSync(generatedFilePath!).subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
+      expect(JSON.stringify({ emitted, trace: listSessionEvents(SESSION_KEY) })).not.toContain(imageBase64);
+    } finally {
+      emitSpy.mockRestore();
+      if (generatedFilePath) rmSync(generatedFilePath, { force: true });
+    }
+  });
 
   it("emits external compaction announcements for a human/channel turn", async () => {
     attachSpeakingOutputChat();


### PR DESCRIPTION
## Objective

Deliver generated image outputs through the canonical response pipeline so image generation and edits reach the chat selected by the session output policy, including WhatsApp and native Slack surfaces.

## Problem

The runtime observed and traced imageGeneration tool completions but never projected their bytes into a deliverable response. Native channel backends also deferred the generic response path to their text sink, which silently dropped generated media.

## Solution

- Add ordered, provider-neutral text and media response parts.
- Validate image signatures, enforce a 50 MB limit, and materialize deterministic temporary files from generated output.
- Dispatch media through the resolved response target: Omni-backed channel delivery for WhatsApp and native media upload for Slack.
- Preserve backend-owned Slack text delivery without duplicating the message.
- Add target-aware replay deduplication, delivered-file cleanup, and base64 redaction from events and traces.

## Practical impact

After merge, an image generated or edited during a turn is delivered to the same source/default chat that receives normal responses. WhatsApp and Slack both receive the media while existing text responses continue through their established channel path.

## What does NOT change

Text-only response targeting and delivery semantics remain unchanged. This PR does not deploy or restart the live daemon, alter routes or credentials, add a database migration, or change user-facing channel configuration.

## Validation

- bun test src/bot.runtime-guards.test.ts
- bun test src/gateway-native-delivery.test.ts
- bun test src/channels/slack/media.test.ts src/gateway-session-trace.test.ts src/gateway-typing.test.ts
- bun run typecheck
- bun run build
- bun test src/ci/quality-gate.test.ts
- full repository pre-push suite passed

## Risks

Slack media upload and queued Slack text are independent channel operations, so this change does not claim transactional ordering across those two provider calls. Failed generated deliveries retain their temporary file for retry or operating-system cleanup; successful deliveries remove it.

## Rollback

Revert commit b45d254b. The change has no schema migration or persisted-format dependency, so rollback restores the previous text-only response behavior without a data rollback.

## Follow-ups

A durable native media outbox can be added later if strict cross-part ordering or provider-atomic delivery becomes a product requirement.