### PR TITLE
fix(runtime): track long-running tool liveness by progress

### DIFF
--- a/src/channels/runtime-events.test.ts
+++ b/src/channels/runtime-events.test.ts
@@ -871,6 +871,8 @@ describe("channel runtime event projection", () => {
     const agent = dbGetAgent(metadata.binding.agentId);
     if (!session || !agent) throw new Error("accepted fixture did not create local runtime identities");
     const streaming = streamingSession(metadata, runtimeSession);
+    streaming.currentTraceTurnId = "trace-unterminated-channel-turn";
+    streaming.currentTraceTurnStartedAt = Date.now();
 
     await runRuntimeEventLoop({
       runId: "channel-runtime-run-unterminated",

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -1909,6 +1909,11 @@ const send = (message) => {
 rl.on("line", (line) => {
   const message = JSON.parse(line);
   if (message.id && message.method === "initialize") {
+    const optOut = message.params?.capabilities?.optOutNotificationMethods ?? [];
+    if (optOut.includes("item/commandExecution/outputDelta")) {
+      send({ id: message.id, error: { code: -32602, message: "command progress was disabled" } });
+      return;
+    }
     send({ id: message.id, result: {} });
     return;
   }
@@ -1974,6 +1979,16 @@ rl.on("line", (line) => {
     });
     send({
       jsonrpc: "2.0",
+      method: "item/commandExecution/outputDelta",
+      params: {
+        threadId: "thread_app",
+        turnId: "turn_app",
+        itemId: "cmd_app",
+        delta: "private command output",
+      },
+    });
+    send({
+      jsonrpc: "2.0",
       method: "item/completed",
       params: {
         item: {
@@ -2032,6 +2047,7 @@ rl.on("line", (line) => {
     const itemStarted = findEventsByType(events, "item.started");
     const commandStarted = itemStarted.find((event) => event.item?.type === "command_execution");
     const toolStarted = findEventsByType(events, "tool.started");
+    const toolProgress = findEventsByType(events, "tool.progress");
     const assistantMessages = findEventsByType(events, "assistant.message");
     const completions = findEventsByType(events, "turn.complete");
     const statuses = findEventsByType(events, "status").map((event) => event.status);
@@ -2051,6 +2067,16 @@ rl.on("line", (line) => {
       name: "shell",
       input: { command: "pwd" },
     });
+    expect(toolProgress).toHaveLength(1);
+    expect(toolProgress[0]).toMatchObject({
+      type: "tool.progress",
+      toolUseId: "cmd_app",
+      metadata: {
+        nativeEvent: "item/commandExecution/outputDelta",
+        item: { id: "cmd_app" },
+      },
+    });
+    expect(JSON.stringify(events)).not.toContain("private command output");
     expect(assistantMessages[0]?.text).toBe("done");
     expect(assistantMessages[0]?.metadata?.item?.phase).toBe("commentary");
     expect(completions[0]?.usage).toEqual({

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -614,7 +614,7 @@ async function* normalizeCodexEvents(
             threadId: turnSessionId,
             turnId: activeTurnId,
           });
-          if (event.type !== "agent_message.delta") {
+          if (event.type !== "agent_message.delta" && event.type !== "tool.progress") {
             yield { type: "provider.raw", rawEvent, metadata };
           }
 
@@ -629,6 +629,18 @@ async function* normalizeCodexEvents(
               yield {
                 type: "text.delta",
                 text: delta,
+                metadata,
+              };
+            }
+            continue;
+          }
+
+          if (event.type === "tool.progress") {
+            const toolUseId = firstString(event.tool_use_id, event.toolUseId, event.item_id, event.itemId);
+            if (toolUseId) {
+              yield {
+                type: "tool.progress",
+                toolUseId,
                 metadata,
               };
             }
@@ -1622,6 +1634,27 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         }
         break;
       }
+      case "item/commandExecution/outputDelta":
+      case "item/commandExecution/terminalInteraction":
+      case "item/mcpToolCall/progress": {
+        if (turn && notificationMatchesActiveTurn(turn, params)) {
+          const toolUseId = firstString(params.itemId);
+          if (toolUseId) {
+            // Output and progress content can be large or sensitive. The host
+            // only needs an identity-scoped liveness signal.
+            turn.queue.push({
+              type: "tool.progress",
+              native_event: method,
+              source: "codex.app-server",
+              thread_id: firstString(notificationThreadId(params), turn.threadId, currentThreadId),
+              turn_id: firstString(notificationTurnId(params), turn.turnId),
+              item_id: toolUseId,
+              tool_use_id: toolUseId,
+            });
+          }
+        }
+        break;
+      }
       case "thread/tokenUsage/updated": {
         if (turn && notificationMatchesActiveTurn(turn, params)) {
           turn.lastUsage = extractAppServerUsage(params.tokenUsage);
@@ -2527,7 +2560,7 @@ function buildCodexEventMetadata(
   return {
     provider: "codex",
     source: firstString(event.source) ?? "codex",
-    nativeEvent: typeof event.type === "string" ? event.type : undefined,
+    nativeEvent: firstString(event.native_event, event.nativeEvent, event.type),
     ...(thread ? { thread } : {}),
     ...(turn ? { turn } : {}),
     ...(item ? { item } : {}),
@@ -3567,7 +3600,6 @@ const CODEX_APP_SERVER_OPTOUT_METHODS = [
   "codex/event/task_started",
   "codex/event/token_count",
   "codex/event/user_message",
-  "item/commandExecution/outputDelta",
   "item/plan/delta",
   "item/reasoning/summaryTextDelta",
   "item/reasoning/textDelta",

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -83,6 +83,7 @@ import type {
 import { classifyTurnProvenance } from "./turn-provenance.js";
 import { buildRuntimeToolPresentation } from "./tool-presentation.js";
 import type { ResponseContentPart, ResponseMediaAttachment } from "./message-types.js";
+import { createToolLivenessLease, DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS } from "./tool-liveness.js";
 
 const log = logger.child("bot");
 
@@ -90,6 +91,7 @@ const MAX_OUTPUT_LENGTH = 1000;
 const MAX_TURN_FAILURE_LOG_DETAIL = 1800;
 const PROVIDER_INACTIVE_AFTER_TOOL_REASON = "provider_inactive";
 const PROVIDER_TURN_INACTIVITY_REASON = "provider_turn_inactive";
+const TOOL_INACTIVITY_REASON = "tool_inactive";
 const IDLE_SESSION_TTL_REASON = "idle_session_ttl";
 const RUNTIME_SESSION_CLOSE_TIMEOUT_MS = 5_000;
 const USER_FACING_LIMIT_SUPPRESSION_DEFAULT_MS = 60 * 60_000;
@@ -526,7 +528,12 @@ function formatRuntimeFailureDetails(event: { error: string; rawEvent?: Record<s
 }
 
 function runtimeEventLogLevel(eventType: string): "debug" | "info" {
-  return eventType === "text.delta" || eventType === "provider.raw" || eventType === "status" ? "debug" : "info";
+  return eventType === "text.delta" ||
+    eventType === "provider.raw" ||
+    eventType === "status" ||
+    eventType === "tool.progress"
+    ? "debug"
+    : "info";
 }
 
 function isRecoverableInterruptionFailure(event: {
@@ -1007,7 +1014,6 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     skills: runtimeSession.skillVisibility?.skills,
     loadedSkills: runtimeSession.skillVisibility?.loadedSkills,
   });
-  const STUCK_TOOL_TIMEOUT_MS = 5 * 60 * 1000;
   // Tight timeout for the well-known codex bug: after we deliver a tool result,
   // codex's app-server occasionally drops the JSON-RPC callback and never asks
   // the model for the next step. The agent can't make progress until we abort.
@@ -1027,8 +1033,50 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     Math.max(1_000, Math.floor(PROVIDER_TURN_INACTIVITY_TIMEOUT_MS / 10)),
   );
   const IDLE_SESSION_TTL_MS = resolveRuntimeIdleSessionTtlMs();
-  let toolStuckTimer: ReturnType<typeof setTimeout> | undefined;
   let providerInactivityTimer: ReturnType<typeof setTimeout> | undefined;
+  const toolLivenessLease = createToolLivenessLease({
+    inactivityTimeoutMs: DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS,
+    onInactive: (toolUseId) => {
+      if (!streaming.toolRunning || streaming.currentToolId !== toolUseId) return;
+      const inactiveTool = streaming.currentToolName ?? "unknown";
+      log.warn("Tool inactive — aborting session", {
+        sessionName,
+        tool: inactiveTool,
+        toolId: toolUseId,
+        timeoutMs: DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS,
+      });
+      pushObservationEvent("tool.inactive", {
+        preview: inactiveTool,
+        payload: {
+          toolId: toolUseId,
+          toolName: inactiveTool,
+          timeoutMs: DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS,
+        },
+      });
+      safeEmit(`ravi.session.${sessionName}.runtime`, {
+        type: "tool.inactive",
+        reason: TOOL_INACTIVITY_REASON,
+        tool: inactiveTool,
+        toolId: toolUseId,
+        timeoutMs: DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS,
+        sessionName,
+      }).catch(() => {});
+      updateRuntimeLiveState(sessionName, {
+        activity: "blocked",
+        summary: `${inactiveTool} inactive`,
+        agentId: agent.id,
+        runId,
+        provider: runtimeSession.provider,
+        model,
+        toolName: inactiveTool,
+        source: streaming.currentSource,
+      });
+      if (!streaming.abortController.signal.aborted) {
+        streaming.internalAbortReason = TOOL_INACTIVITY_REASON;
+        streaming.abortController.abort();
+      }
+    },
+  });
   const clearProviderInactivityWatch = () => {
     if (providerInactivityTimer !== undefined) {
       clearTimeout(providerInactivityTimer);
@@ -1101,10 +1149,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     streaming.idleSessionEvictionTimer.unref?.();
   };
   const clearActiveToolState = () => {
-    if (toolStuckTimer !== undefined) {
-      clearTimeout(toolStuckTimer);
-      toolStuckTimer = undefined;
-    }
+    toolLivenessLease.clear();
     streaming.toolRunning = false;
     streaming.toolResultDeliveryPending = false;
     streaming.currentToolId = undefined;
@@ -1368,7 +1413,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     const timedOut =
       reason === PROVIDER_INACTIVE_AFTER_TOOL_REASON ||
       reason === PROVIDER_TURN_INACTIVITY_REASON ||
-      reason === "stuck_tool";
+      reason === TOOL_INACTIVITY_REASON;
     const status = streaming.currentCrashRecoveryTerminal?.status ?? (timedOut ? "timeout" : "aborted");
     const eventType = runtimeTurnAttemptTerminalEventType(status);
 
@@ -1494,10 +1539,10 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     });
   };
 
-  const projectUnterminatedChannelTurn = async () => {
+  const projectUnterminatedChannelTurn = async (terminalRecordedBeforeFinalization: boolean) => {
     if (
       !streaming.currentChannelBackend ||
-      streaming.currentCrashRecoveryTerminal ||
+      terminalRecordedBeforeFinalization ||
       restartStashedReason ||
       (crashRecovery?.ownershipFailure && !streaming.currentCrashRecoveryAttemptId)
     ) {
@@ -1509,7 +1554,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     const timedOut =
       reason === PROVIDER_INACTIVE_AFTER_TOOL_REASON ||
       reason === PROVIDER_TURN_INACTIVITY_REASON ||
-      reason === "stuck_tool";
+      reason === TOOL_INACTIVITY_REASON;
     await projectRuntimeEventToChannel(
       timedOut
         ? {
@@ -1883,6 +1928,16 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         fencePendingProviderRawEvent(correlatedProviderRawEvent);
       }
 
+      if (event.type === "tool.progress") {
+        if (!toolLivenessLease.progress(event.toolUseId)) {
+          log.debug("Ignoring progress for inactive tool", {
+            sessionName,
+            toolId: event.toolUseId,
+          });
+        }
+        continue;
+      }
+
       const receivedFailureClassification =
         event.type === "turn.failed"
           ? (() => {
@@ -2093,27 +2148,9 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           tool: event.toolUse.name,
           toolId: event.toolUse.id,
         });
-        // Arm stuck-tool watchdog: if tool.completed never fires within the window, abort the session.
-        if (toolStuckTimer !== undefined) clearTimeout(toolStuckTimer);
-        toolStuckTimer = setTimeout(() => {
-          toolStuckTimer = undefined;
-          const stuckTool = streaming.currentToolName ?? "unknown";
-          log.warn("Tool stuck — aborting session", {
-            sessionName,
-            tool: stuckTool,
-            timeoutMs: STUCK_TOOL_TIMEOUT_MS,
-          });
-          safeEmit(`ravi.session.${sessionName}.runtime`, {
-            type: "tool.stuck",
-            tool: stuckTool,
-            timeoutMs: STUCK_TOOL_TIMEOUT_MS,
-            sessionName,
-          }).catch(() => {});
-          if (!streaming.abortController.signal.aborted) {
-            streaming.internalAbortReason = "stuck_tool";
-            streaming.abortController.abort();
-          }
-        }, STUCK_TOOL_TIMEOUT_MS);
+        // Expire only after a full inactivity window. Provider progress events
+        // renew this lease without exposing their output to channels or traces.
+        toolLivenessLease.start(event.toolUse.id);
         streaming.currentToolSafety = getToolSafety(
           event.toolUse.name,
           (event.toolUse.input as Record<string, unknown> | undefined) ?? {},
@@ -2313,10 +2350,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       if (event.type === "tool.result_delivered") {
         // Tool handler finished and result was sent to the runtime provider.
         // The provider is now responsible (model thinking). Clear the stuck-tool watchdog.
-        if (toolStuckTimer !== undefined) {
-          clearTimeout(toolStuckTimer);
-          toolStuckTimer = undefined;
-        }
+        toolLivenessLease.clear();
         // Arm provider inactivity watchdog: catches cases where the provider
         // (e.g. codex's API call to OpenAI) hangs silently with no further events.
         armProviderInactivityWatch();
@@ -3100,9 +3134,12 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     log.info("Streaming session ended", { runId, sessionName });
 
     try {
+      const terminalRecordedBeforeFinalization = Boolean(
+        streaming.currentCrashRecoveryTerminal || streaming.currentTraceTurnTerminalRecorded,
+      );
       prepareUnterminatedTurnRecovery();
       recordUnterminatedTurnExit();
-      await projectUnterminatedChannelTurn();
+      await projectUnterminatedChannelTurn(terminalRecordedBeforeFinalization);
     } catch (error) {
       // A lost crash-recovery fence has already made the coordinator reject
       // new work. It must not prevent provider/process cleanup below.
@@ -3133,10 +3170,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     streaming.durableTurnPreparationFailed = false;
     clearProviderInactivityWatch();
     clearIdleSessionEvictionTimer();
-    if (toolStuckTimer !== undefined) {
-      clearTimeout(toolStuckTimer);
-      toolStuckTimer = undefined;
-    }
+    toolLivenessLease.clear();
     streaming.done = true;
     streaming.starting = false;
     streaming.turnActive = false;

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -733,6 +733,7 @@ describe("runtime session trace instrumentation", () => {
     const streaming = makeStreamingSession();
     seedAdapterTrace(streaming);
     const crashRecoveryAttemptId = streaming.currentCrashRecoveryAttemptId!;
+    const emitted: Array<{ topic: string; data: Record<string, unknown> }> = [];
 
     await runTraceLoop(
       streaming,
@@ -740,6 +741,10 @@ describe("runtime session trace instrumentation", () => {
         {
           type: "tool.started",
           toolUse: { id: "tool-1", name: "Bash", input: { cmd: "rg trace" } },
+        },
+        {
+          type: "tool.progress",
+          toolUseId: "tool-1",
         },
         {
           type: "tool.completed",
@@ -760,6 +765,11 @@ describe("runtime session trace instrumentation", () => {
           usage: { inputTokens: 10, outputTokens: 4, cacheReadTokens: 2, cacheCreationTokens: 1 },
         },
       ]),
+      {
+        safeEmit: async (topic, data) => {
+          emitted.push({ topic, data });
+        },
+      },
     );
 
     const events = listSessionEvents(SESSION_KEY);
@@ -769,6 +779,7 @@ describe("runtime session trace instrumentation", () => {
       "tool.end",
       "turn.complete",
     ]);
+    expect(emitted.some(({ data }) => data.type === "tool.progress")).toBe(false);
     expect(events.map((event) => event.seq)).toEqual([1, 2, 3, 4]);
     expect(events.map((event) => event.runId)).toEqual(["run-1", "run-1", "run-1", "run-1"]);
     expect(events.map((event) => event.turnId)).toEqual(["turn-1", "turn-1", "turn-1", "turn-1"]);

--- a/src/runtime/tool-liveness.test.ts
+++ b/src/runtime/tool-liveness.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { createToolLivenessLease, type ToolLivenessSchedule } from "./tool-liveness.js";
+
+interface ScheduledCallback {
+  at: number;
+  callback: () => void;
+  cancelled: boolean;
+}
+
+function createManualScheduler() {
+  let now = 0;
+  const callbacks: ScheduledCallback[] = [];
+  const schedule: ToolLivenessSchedule = (callback, delayMs) => {
+    const scheduled = { at: now + delayMs, callback, cancelled: false };
+    callbacks.push(scheduled);
+    return () => {
+      scheduled.cancelled = true;
+    };
+  };
+  const advance = (durationMs: number) => {
+    const target = now + durationMs;
+    while (true) {
+      const next = callbacks
+        .filter((scheduled) => !scheduled.cancelled && scheduled.at <= target)
+        .sort((left, right) => left.at - right.at)[0];
+      if (!next) break;
+      next.cancelled = true;
+      now = next.at;
+      next.callback();
+    }
+    now = target;
+  };
+  return { advance, schedule };
+}
+
+describe("tool liveness lease", () => {
+  it("keeps a long-running tool alive while matching progress continues", () => {
+    const clock = createManualScheduler();
+    const inactive: string[] = [];
+    const lease = createToolLivenessLease({
+      inactivityTimeoutMs: 5 * 60_000,
+      onInactive: (toolUseId) => inactive.push(toolUseId),
+      schedule: clock.schedule,
+    });
+
+    lease.start("tool-1");
+    clock.advance(4 * 60_000);
+    expect(lease.progress("tool-1")).toBe(true);
+    clock.advance(4 * 60_000);
+    expect(lease.progress("tool-1")).toBe(true);
+    clock.advance(4 * 60_000);
+
+    expect(inactive).toEqual([]);
+    clock.advance(60_000);
+    expect(inactive).toEqual(["tool-1"]);
+  });
+
+  it("does not renew one tool from another tool's progress", () => {
+    const clock = createManualScheduler();
+    const inactive: string[] = [];
+    const lease = createToolLivenessLease({
+      inactivityTimeoutMs: 100,
+      onInactive: (toolUseId) => inactive.push(toolUseId),
+      schedule: clock.schedule,
+    });
+
+    lease.start("tool-1");
+    clock.advance(90);
+    expect(lease.progress("tool-2")).toBe(false);
+    clock.advance(10);
+
+    expect(inactive).toEqual(["tool-1"]);
+  });
+
+  it("cancels the inactivity deadline when the tool completes", () => {
+    const clock = createManualScheduler();
+    const inactive: string[] = [];
+    const lease = createToolLivenessLease({
+      inactivityTimeoutMs: 100,
+      onInactive: (toolUseId) => inactive.push(toolUseId),
+      schedule: clock.schedule,
+    });
+
+    lease.start("tool-1");
+    clock.advance(90);
+    lease.clear();
+    clock.advance(100);
+
+    expect(inactive).toEqual([]);
+  });
+});

--- a/src/runtime/tool-liveness.ts
+++ b/src/runtime/tool-liveness.ts
@@ -1,0 +1,64 @@
+export const DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type ToolLivenessSchedule = (callback: () => void, delayMs: number) => () => void;
+
+export interface ToolLivenessLease {
+  start(toolUseId: string): void;
+  progress(toolUseId: string): boolean;
+  clear(): void;
+}
+
+export function createToolLivenessLease(options: {
+  inactivityTimeoutMs?: number;
+  onInactive(toolUseId: string): void;
+  schedule?: ToolLivenessSchedule;
+}): ToolLivenessLease {
+  const inactivityTimeoutMs = options.inactivityTimeoutMs ?? DEFAULT_TOOL_INACTIVITY_TIMEOUT_MS;
+  if (!Number.isFinite(inactivityTimeoutMs) || inactivityTimeoutMs <= 0) {
+    throw new Error("Tool inactivity timeout must be a positive finite number");
+  }
+
+  const schedule = options.schedule ?? scheduleTimeout;
+  let activeToolUseId: string | undefined;
+  let cancelExpiry: (() => void) | undefined;
+  let generation = 0;
+
+  const clearExpiry = () => {
+    generation++;
+    cancelExpiry?.();
+    cancelExpiry = undefined;
+  };
+
+  const arm = () => {
+    clearExpiry();
+    const scheduledGeneration = generation;
+    cancelExpiry = schedule(() => {
+      if (scheduledGeneration !== generation || !activeToolUseId) return;
+      const inactiveToolUseId = activeToolUseId;
+      activeToolUseId = undefined;
+      cancelExpiry = undefined;
+      options.onInactive(inactiveToolUseId);
+    }, inactivityTimeoutMs);
+  };
+
+  return {
+    start(toolUseId) {
+      activeToolUseId = toolUseId;
+      arm();
+    },
+    progress(toolUseId) {
+      if (toolUseId !== activeToolUseId) return false;
+      arm();
+      return true;
+    },
+    clear() {
+      clearExpiry();
+      activeToolUseId = undefined;
+    },
+  };
+}
+
+function scheduleTimeout(callback: () => void, delayMs: number): () => void {
+  const timer = setTimeout(callback, delayMs);
+  return () => clearTimeout(timer);
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -489,6 +489,10 @@ export type RuntimeEvent =
       rawEvent?: Record<string, unknown>;
     } & RuntimeEventBase)
   | ({
+      type: "tool.progress";
+      toolUseId: string;
+    } & RuntimeEventBase)
+  | ({
       type: "tool.completed";
       toolUseId?: string;
       toolName?: string;


### PR DESCRIPTION
## Objective

Prevent active long-running runtime tools from being terminated only because their total execution time exceeds the watchdog window. Keep genuine silent hangs bounded and observable without exposing provider output.

## Problem

- The tool watchdog measured a fixed duration from `tool.started` and ignored provider progress.
- Commands that were still producing output could be classified as stuck after five minutes.
- A locally terminalized traced turn could skip the channel terminal projection and leave readback appearing active.

## Solution

- Add a provider-neutral `tool.progress` runtime event and a small inactivity lease keyed by tool-use ID.
- Convert Codex command and MCP progress notifications into sanitized heartbeats; output text is discarded in the provider adapter.
- Renew the existing five-minute watchdog only when progress belongs to the active tool.
- Keep progress internal to the host loop, while true inactivity emits a sanitized operational event, marks the session blocked, aborts the turn, and projects a terminal channel state.

## Practical impact

- Long-running tools may run beyond five minutes while they continue making progress.
- Tools that produce no matching progress for five minutes are still stopped deterministically.
- Channel readback no longer remains active after this local timeout path.

## What does NOT change

- The five-minute inactivity threshold is unchanged and no new environment variable is introduced.
- Tool output deltas are not published to channels, runtime NATS events, provider raw events, or session traces.
- Tool retries are not added, so potentially side-effecting work is never replayed automatically.
- Providers that do not emit progress retain the existing bounded watchdog behavior.

## Validation

- `bun test src/runtime/tool-liveness.test.ts src/runtime/codex-provider.test.ts src/runtime/session-trace.test.ts src/channels/runtime-events.test.ts` (122 passed)
- `bun run build`
- `make quality`
- Repository pre-push gate, including the canonical test matrix, generated SDK drift checks, OpenAPI snapshots, and Swift SDK checks

## Risks

- Enabling Codex command progress notifications adds internal event traffic while commands produce output. The adapter strips content immediately and the host consumes the heartbeat without external projection.
- A provider that reports progress with an incorrect tool-use ID will not renew the active tool lease and will retain the bounded timeout behavior.

## Rollback

- Revert this PR to restore the fixed-duration tool watchdog and the previous Codex notification opt-out.

## Follow-ups

- Other runtime providers can map native progress signals to the same canonical event when their transports expose reliable tool identity.
