### PR TITLE
Allow full-access Pi agents to run scheduled jobs

### DIFF
--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -15,7 +15,13 @@ import { nats } from "../nats.js";
 import { authorizeRuntimeContext, requestPollAnswer, type ApprovalTarget } from "../approval/service.js";
 import { buildAuditContextProvenance } from "../permissions/audit-provenance.js";
 import { emitPermissionDeniedAudit, recordAndEmitPermissionDenial } from "../permissions/denials.js";
-import { agentCan, canWithCapabilityContext, isDelegatedAuthorityContext } from "../permissions/provider-runtime.js";
+import {
+  agentCan,
+  canWithCapabilities,
+  canWithCapabilityContext,
+  isDelegatedAuthorityContext,
+  materializeSubjectCapabilities,
+} from "../permissions/provider-runtime.js";
 import type { ContextRecord } from "../router/index.js";
 import type {
   RuntimeApprovalResult,
@@ -52,27 +58,61 @@ export interface RuntimeHostServicesOptions {
   onSkillGatePersisted?: (skillVisibility: RuntimeSkillVisibilitySnapshot) => void;
 }
 
+function agentHasMaterializedCapability(
+  agentId: string,
+  permission: string,
+  objectType: string,
+  objectId: string,
+): boolean {
+  return canWithCapabilities(materializeSubjectCapabilities("agent", agentId), permission, objectType, objectId);
+}
+
+function capabilitySnapshotHasUnrestrictedToolExecution(capabilities: ContextRecord["capabilities"]): boolean {
+  return (
+    canWithCapabilities(capabilities, "admin", "system", "*") ||
+    (canWithCapabilities(capabilities, "use", "tool", "*") &&
+      canWithCapabilities(capabilities, "execute", "executable", "*"))
+  );
+}
+
+function capabilitySnapshotHasUnrestrictedToolSurface(capabilities: ContextRecord["capabilities"]): boolean {
+  return (
+    canWithCapabilities(capabilities, "admin", "system", "*") || canWithCapabilities(capabilities, "use", "tool", "*")
+  );
+}
+
 function hasUnrestrictedToolExecution(agentId: string): boolean {
   return (
     agentCan(agentId, "admin", "system", "*") ||
-    (agentCan(agentId, "use", "tool", "*") && agentCan(agentId, "execute", "executable", "*"))
+    agentHasMaterializedCapability(agentId, "admin", "system", "*") ||
+    ((agentCan(agentId, "use", "tool", "*") || agentHasMaterializedCapability(agentId, "use", "tool", "*")) &&
+      (agentCan(agentId, "execute", "executable", "*") ||
+        agentHasMaterializedCapability(agentId, "execute", "executable", "*")))
   );
 }
 
 function hasUnrestrictedToolSurface(agentId: string): boolean {
-  return agentCan(agentId, "admin", "system", "*") || agentCan(agentId, "use", "tool", "*");
+  return (
+    agentCan(agentId, "admin", "system", "*") ||
+    agentHasMaterializedCapability(agentId, "admin", "system", "*") ||
+    agentCan(agentId, "use", "tool", "*") ||
+    agentHasMaterializedCapability(agentId, "use", "tool", "*")
+  );
 }
 
 export function getRuntimeToolAccessMode(
   capabilities: RuntimeCapabilities,
   agentId: string,
-  context?: Pick<ContextRecord, "kind" | "metadata">,
+  context?: Pick<ContextRecord, "kind" | "metadata" | "capabilities">,
 ): RuntimeToolAccessMode {
+  const accessRequirement = capabilities.tools?.accessRequirement ?? capabilities.toolAccessRequirement;
   if (context && isDelegatedAuthorityContext(context)) {
-    return "restricted";
+    if (accessRequirement === "tool_surface") {
+      return capabilitySnapshotHasUnrestrictedToolSurface(context.capabilities) ? "unrestricted" : "restricted";
+    }
+    return capabilitySnapshotHasUnrestrictedToolExecution(context.capabilities) ? "unrestricted" : "restricted";
   }
 
-  const accessRequirement = capabilities.tools?.accessRequirement ?? capabilities.toolAccessRequirement;
   if (accessRequirement === "tool_surface") {
     return hasUnrestrictedToolSurface(agentId) ? "unrestricted" : "restricted";
   }

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -43,6 +43,35 @@ describe("runtime request context authority", () => {
     stateDir = null;
   });
 
+  it("treats agent runtime full-access defaults as unrestricted tool access", () => {
+    dbCreateAgent({ id: "pi-agent", cwd: "/tmp/pi-agent" });
+    dbUpdateAgent("pi-agent", { defaults: { runtimePermissions: { profile: "full-access" } } });
+
+    expect(getRuntimeToolAccessMode({} as Parameters<typeof getRuntimeToolAccessMode>[0], "pi-agent")).toBe(
+      "unrestricted",
+    );
+  });
+
+  it("treats full-access agent identity turn contexts as unrestricted tool access", () => {
+    expect(
+      getRuntimeToolAccessMode({} as Parameters<typeof getRuntimeToolAccessMode>[0], "pi-agent", {
+        kind: "turn-runtime",
+        capabilities: [{ permission: "admin", objectType: "system", objectId: "*" }],
+        metadata: { authorityMode: "agent-identity" },
+      }),
+    ).toBe("unrestricted");
+  });
+
+  it("keeps partially authorized agent identity turns restricted", () => {
+    expect(
+      getRuntimeToolAccessMode({} as Parameters<typeof getRuntimeToolAccessMode>[0], "pi-agent", {
+        kind: "turn-runtime",
+        capabilities: [{ permission: "use", objectType: "tool", objectId: "*" }],
+        metadata: { authorityMode: "agent-identity" },
+      }),
+    ).toBe("restricted");
+  });
+
   it("uses agent identity authority by default when the env var is unset", () => {
     const previous = process.env.RAVI_TURN_SCOPED_AUTHORITY;
     delete process.env.RAVI_TURN_SCOPED_AUTHORITY;

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -23,7 +23,6 @@ import {
   type RuntimeUserMessage,
 } from "./host-session.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
-import { shouldUseTurnScopedAuthorityForPrompt } from "./runtime-request-context.js";
 import { buildRuntimeStartRequest, resolveRuntimePromptSource } from "./runtime-request-builder.js";
 import { resolveRuntimeSession } from "./session-resolver.js";
 import { markRuntimeTaskAcceptedForPrompt, resolveRuntimeForPrompt } from "./task-runtime-context.js";
@@ -240,9 +239,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     assertRuntimeCompatibility(runtimeProvider, {
       requiresMcpServers: !!agent.specMode,
       requiresRemoteSpawn: !!agent.remote,
-      toolAccessMode: shouldUseTurnScopedAuthorityForPrompt(prompt, resolvedSource)
-        ? "restricted"
-        : getRuntimeToolAccessMode(runtimeCapabilities, agent.id),
+      toolAccessMode: getRuntimeToolAccessMode(runtimeCapabilities, agent.id),
     });
 
     const resumableProviderSessionId = canResumeStoredSession ? storedProviderSessionId : undefined;


### PR DESCRIPTION
## Objective

Allow Pi-backed agents that are explicitly configured with full tool and executable access to start scheduled and other runtime sessions.

## Problem

The runtime launcher unconditionally marked every prompt as restricted before provider compatibility was checked. Pi cannot use Ravi permission hooks, so it correctly rejects restricted sessions. This also rejected the Antigravity Pi agent even though its agent profile already granted full access.

## Solution

Resolve the tool access mode from the provider requirement and the actual authority available to the agent or runtime context. Full-access agent profiles and complete agent-identity snapshots resolve to unrestricted. Delegated contexts still require an explicit full snapshot. The launcher now uses that resolved mode instead of forcing restricted mode. Tests cover full access, full agent-identity snapshots, and partial snapshots.

## Practical impact

Scheduled jobs for the full-access Pi agent can start again. Agents without both the required tool and executable permissions remain blocked rather than receiving broader access.

## What does NOT change

Pi still does not receive Ravi-hosted permission hooks. Restricted Pi sessions remain unsupported and fail closed. No provider capability, agent profile, credential, or cron configuration is broadened by this change.

## Validation

Ran type checking, CLI build, formatting checks, whitespace checks, and 60 focused runtime tests covering request authority, preflight compatibility, provider contracts, and Pi transport behavior.

## Risks

The main risk is incorrectly classifying a context as unrestricted. The implementation only does so for full materialized agent permissions or a complete runtime capability snapshot; a tool-only snapshot is covered by a regression test and remains restricted.

## Rollback

Revert this single commit. Pi sessions will return to their previous fail-closed behavior without changing stored agent or cron data.

## Follow-ups

After merge and release, run the affected scheduled job once and confirm a successful Pi runtime start in its session trace.
