### PR TITLE
fix(update): rebind managed runtime to updated bundle

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "38af99ae073f84d7"
+    "version": "329416f7a668bd2e"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -38387,6 +38387,226 @@
                       "additionalProperties": {},
                       "properties": {},
                       "type": "object"
+                    },
+                    "runtime": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alignment": {
+                          "enum": [
+                            "aligned",
+                            "drifted",
+                            "unknown",
+                            "not_running"
+                          ],
+                          "type": "string"
+                        },
+                        "channels": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managed": {
+                              "type": "boolean"
+                            },
+                            "matchesCli": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "online": {
+                              "type": "boolean"
+                            },
+                            "pid": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "managed",
+                            "online",
+                            "status",
+                            "pid",
+                            "bundlePath",
+                            "cwd",
+                            "version",
+                            "matchesCli"
+                          ],
+                          "type": "object"
+                        },
+                        "cli": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "bundlePath",
+                            "cwd",
+                            "version"
+                          ],
+                          "type": "object"
+                        },
+                        "daemon": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managed": {
+                              "type": "boolean"
+                            },
+                            "matchesCli": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "online": {
+                              "type": "boolean"
+                            },
+                            "pid": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "managed",
+                            "online",
+                            "status",
+                            "pid",
+                            "bundlePath",
+                            "cwd",
+                            "version",
+                            "matchesCli"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "alignment",
+                        "cli",
+                        "daemon",
+                        "channels"
+                      ],
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -38394,6 +38614,7 @@
                     "processName",
                     "ravi",
                     "infrastructure",
+                    "runtime",
                     "processes"
                   ],
                   "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "38af99ae073f84d7"
+    "version": "329416f7a668bd2e"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -38387,6 +38387,226 @@
                       "additionalProperties": {},
                       "properties": {},
                       "type": "object"
+                    },
+                    "runtime": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alignment": {
+                          "enum": [
+                            "aligned",
+                            "drifted",
+                            "unknown",
+                            "not_running"
+                          ],
+                          "type": "string"
+                        },
+                        "channels": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managed": {
+                              "type": "boolean"
+                            },
+                            "matchesCli": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "online": {
+                              "type": "boolean"
+                            },
+                            "pid": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "managed",
+                            "online",
+                            "status",
+                            "pid",
+                            "bundlePath",
+                            "cwd",
+                            "version",
+                            "matchesCli"
+                          ],
+                          "type": "object"
+                        },
+                        "cli": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "bundlePath",
+                            "cwd",
+                            "version"
+                          ],
+                          "type": "object"
+                        },
+                        "daemon": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "bundlePath": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managed": {
+                              "type": "boolean"
+                            },
+                            "matchesCli": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "online": {
+                              "type": "boolean"
+                            },
+                            "pid": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "managed",
+                            "online",
+                            "status",
+                            "pid",
+                            "bundlePath",
+                            "cwd",
+                            "version",
+                            "matchesCli"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "alignment",
+                        "cli",
+                        "daemon",
+                        "channels"
+                      ],
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -38394,6 +38614,7 @@
                     "processName",
                     "ravi",
                     "infrastructure",
+                    "runtime",
                     "processes"
                   ],
                   "type": "object"

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -31634,6 +31634,226 @@ export const DaemonStatusReturnSchema = {
       "additionalProperties": {},
       "properties": {},
       "type": "object"
+    },
+    "runtime": {
+      "additionalProperties": false,
+      "properties": {
+        "alignment": {
+          "enum": [
+            "aligned",
+            "drifted",
+            "unknown",
+            "not_running"
+          ],
+          "type": "string"
+        },
+        "channels": {
+          "additionalProperties": false,
+          "properties": {
+            "bundlePath": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cwd": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "managed": {
+              "type": "boolean"
+            },
+            "matchesCli": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "online": {
+              "type": "boolean"
+            },
+            "pid": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "managed",
+            "online",
+            "status",
+            "pid",
+            "bundlePath",
+            "cwd",
+            "version",
+            "matchesCli"
+          ],
+          "type": "object"
+        },
+        "cli": {
+          "additionalProperties": false,
+          "properties": {
+            "bundlePath": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cwd": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "bundlePath",
+            "cwd",
+            "version"
+          ],
+          "type": "object"
+        },
+        "daemon": {
+          "additionalProperties": false,
+          "properties": {
+            "bundlePath": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cwd": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "managed": {
+              "type": "boolean"
+            },
+            "matchesCli": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "online": {
+              "type": "boolean"
+            },
+            "pid": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "managed",
+            "online",
+            "status",
+            "pid",
+            "bundlePath",
+            "cwd",
+            "version",
+            "matchesCli"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "alignment",
+        "cli",
+        "daemon",
+        "channels"
+      ],
+      "type": "object"
     }
   },
   "required": [
@@ -31641,6 +31861,7 @@ export const DaemonStatusReturnSchema = {
     "processName",
     "ravi",
     "infrastructure",
+    "runtime",
     "processes"
   ],
   "type": "object"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -6340,6 +6340,36 @@ export type DaemonStatusReturn = {
   processName: string;
   processes: Array<Record<string, unknown>>;
   ravi: Record<string, unknown>;
+  runtime: {
+    alignment: "aligned" | "drifted" | "unknown" | "not_running";
+    channels: {
+      bundlePath: string | null;
+      cwd: string | null;
+      managed: boolean;
+      matchesCli: boolean | null;
+      name: string;
+      online: boolean;
+      pid: number | null;
+      status: string;
+      version: string | null;
+    };
+    cli: {
+      bundlePath: string | null;
+      cwd: string | null;
+      version: string | null;
+    };
+    daemon: {
+      bundlePath: string | null;
+      cwd: string | null;
+      managed: boolean;
+      matchesCli: boolean | null;
+      name: string;
+      online: boolean;
+      pid: number | null;
+      status: string;
+      version: string | null;
+    };
+  };
   [k: string]: unknown;
 };
 

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:186bd8e8f035dc7f1c94f303bc738c1a1bb42e205fdfaa85059ba0a396131233";
+export const REGISTRY_HASH = "sha256:98726921f6d2ba005a4b91b690daf4f35f456c0864f51e436dd093b2ca1400de";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "d912bb85a471";
+export const GIT_SHA = "3f2a3b7e9b37";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -32050,6 +32050,226 @@ public enum RaviSchemas {
         "additionalProperties": {},
         "properties": {},
         "type": "object"
+      },
+      "runtime": {
+        "additionalProperties": false,
+        "properties": {
+          "alignment": {
+            "enum": [
+              "aligned",
+              "drifted",
+              "unknown",
+              "not_running"
+            ],
+            "type": "string"
+          },
+          "channels": {
+            "additionalProperties": false,
+            "properties": {
+              "bundlePath": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cwd": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managed": {
+                "type": "boolean"
+              },
+              "matchesCli": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "online": {
+                "type": "boolean"
+              },
+              "pid": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "managed",
+              "online",
+              "status",
+              "pid",
+              "bundlePath",
+              "cwd",
+              "version",
+              "matchesCli"
+            ],
+            "type": "object"
+          },
+          "cli": {
+            "additionalProperties": false,
+            "properties": {
+              "bundlePath": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cwd": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "bundlePath",
+              "cwd",
+              "version"
+            ],
+            "type": "object"
+          },
+          "daemon": {
+            "additionalProperties": false,
+            "properties": {
+              "bundlePath": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cwd": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "managed": {
+                "type": "boolean"
+              },
+              "matchesCli": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "online": {
+                "type": "boolean"
+              },
+              "pid": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "managed",
+              "online",
+              "status",
+              "pid",
+              "bundlePath",
+              "cwd",
+              "version",
+              "matchesCli"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "alignment",
+          "cli",
+          "daemon",
+          "channels"
+        ],
+        "type": "object"
       }
     },
     "required": [
@@ -32057,6 +32277,7 @@ public enum RaviSchemas {
       "processName",
       "ravi",
       "infrastructure",
+      "runtime",
       "processes"
     ],
     "type": "object"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -9358,13 +9358,15 @@ public struct DaemonStatusReturn: Codable, Sendable {
   public var processName: String
   public var processes: [[String: RaviJSON]]
   public var ravi: [String: RaviJSON]
+  public var runtime: RaviJSON
 
-  public init(infrastructure: [String: RaviJSON], pm2Available: Bool, processName: String, processes: [[String: RaviJSON]], ravi: [String: RaviJSON]) {
+  public init(infrastructure: [String: RaviJSON], pm2Available: Bool, processName: String, processes: [[String: RaviJSON]], ravi: [String: RaviJSON], runtime: RaviJSON) {
     self.infrastructure = infrastructure
     self.pm2Available = pm2Available
     self.processName = processName
     self.processes = processes
     self.ravi = ravi
+    self.runtime = runtime
   }
 
   enum CodingKeys: String, CodingKey {
@@ -9373,6 +9375,7 @@ public struct DaemonStatusReturn: Codable, Sendable {
     case processName = "processName"
     case processes = "processes"
     case ravi = "ravi"
+    case runtime = "runtime"
   }
 }
 

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:186bd8e8f035dc7f1c94f303bc738c1a1bb42e205fdfaa85059ba0a396131233"
-public let RAVI_GIT_SHA = "d912bb85a471"
+public let RAVI_REGISTRY_HASH = "sha256:98726921f6d2ba005a4b91b690daf4f35f456c0864f51e436dd093b2ca1400de"
+public let RAVI_GIT_SHA = "3f2a3b7e9b37"

--- a/src/channels/pm2-env.ts
+++ b/src/channels/pm2-env.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import { CHANNELS_PM2_PROCESS_NAME } from "../pm2.js";
+
+const RUNNER_ENV_KEYS = [
+  "RAVI_CHANNELS_CONSUME_OUTBOUND",
+  "RAVI_SLACK_SUBSCRIPTION_SCOPE",
+  "RAVI_SLACK_THREAD_REPLY_MODE",
+  "RAVI_SLACK_ROOT_REPLY_MODE",
+  "RAVI_SLACK_WORKING_REACTION",
+] as const;
+
+function cleanEnvValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readExistingPm2Env(processName: string): Record<string, unknown> {
+  const result = spawnSync("pm2", ["jlist"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  if ((result.status ?? 1) !== 0 || !result.stdout.trim()) return {};
+  try {
+    const list = JSON.parse(result.stdout) as unknown;
+    if (!Array.isArray(list)) return {};
+    const processInfo = list.find((item) => {
+      return item && typeof item === "object" && (item as { name?: unknown }).name === processName;
+    }) as { pm2_env?: { env?: Record<string, unknown> } } | undefined;
+    return processInfo?.pm2_env?.env ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function buildRunnerPm2Env(): Record<string, string> {
+  const existingPm2Env = readExistingPm2Env(CHANNELS_PM2_PROCESS_NAME);
+  const envOverrides: Record<string, string> = {};
+  for (const key of RUNNER_ENV_KEYS) {
+    const value = cleanEnvValue(process.env[key]) ?? cleanEnvValue(existingPm2Env[key]);
+    if (value) envOverrides[key] = value;
+  }
+  return envOverrides;
+}

--- a/src/channels/runner.test.ts
+++ b/src/channels/runner.test.ts
@@ -22,6 +22,57 @@ import type { NativeInboundChannelActionHandler } from "./native/driver.js";
 import type { ChannelRuntimeEventSink } from "./runtime-events.js";
 import { createSlackNativeChannelDriver } from "./slack/driver.js";
 import type { ChannelOutboundJob } from "./outbound-stream.js";
+import { buildRunnerPm2Env } from "./pm2-env.js";
+
+describe("channel runner PM2 environment", () => {
+  it("does not use Slack connection env as runner configuration", () => {
+    const previousConnection = process.env.RAVI_SLACK_CONNECTION;
+    const previousConnections = process.env.RAVI_SLACK_CONNECTIONS;
+    const previousCredentialConnection = process.env.RAVI_SLACK_CREDENTIAL_CONNECTION;
+
+    try {
+      process.env.RAVI_SLACK_CONNECTION = "primary-slack";
+      process.env.RAVI_SLACK_CONNECTIONS = "primary-slack,secondary-slack";
+      process.env.RAVI_SLACK_CREDENTIAL_CONNECTION = "legacy";
+
+      const env = buildRunnerPm2Env();
+
+      expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTION");
+      expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTIONS");
+      expect(env).not.toHaveProperty("RAVI_SLACK_CREDENTIAL_CONNECTION");
+    } finally {
+      setOptionalEnv("RAVI_SLACK_CONNECTION", previousConnection);
+      setOptionalEnv("RAVI_SLACK_CONNECTIONS", previousConnections);
+      setOptionalEnv("RAVI_SLACK_CREDENTIAL_CONNECTION", previousCredentialConnection);
+    }
+  });
+
+  it("preserves channel runner behavior flags", () => {
+    const previousConsumeOutbound = process.env.RAVI_CHANNELS_CONSUME_OUTBOUND;
+    const previousThreadReplyMode = process.env.RAVI_SLACK_THREAD_REPLY_MODE;
+
+    try {
+      process.env.RAVI_CHANNELS_CONSUME_OUTBOUND = "0";
+      process.env.RAVI_SLACK_THREAD_REPLY_MODE = "thread";
+
+      expect(buildRunnerPm2Env()).toMatchObject({
+        RAVI_CHANNELS_CONSUME_OUTBOUND: "0",
+        RAVI_SLACK_THREAD_REPLY_MODE: "thread",
+      });
+    } finally {
+      setOptionalEnv("RAVI_CHANNELS_CONSUME_OUTBOUND", previousConsumeOutbound);
+      setOptionalEnv("RAVI_SLACK_THREAD_REPLY_MODE", previousThreadReplyMode);
+    }
+  });
+});
+
+function setOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
 
 describe("channel runner native delivery registry", () => {
   it("registers optional text, chat action, and presence adapters together", () => {

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -24,7 +24,6 @@ mock.module("../context.js", () => ({
 
 const {
   buildChannelsLiveStatusJson,
-  buildRunnerPm2Env,
   ChannelsCommands,
   classifyChannelRunnerHealth,
   validateChannelRunnerRuntimeTarget,
@@ -49,30 +48,6 @@ afterEach(async () => {
     const dir = tempDirs.pop();
     if (dir) rmSync(dir, { recursive: true, force: true });
   }
-});
-
-describe("channels command runner env", () => {
-  it("does not use Slack connection env as runner configuration", () => {
-    process.env.RAVI_SLACK_CONNECTION = "ravi-rbbt-slack";
-    process.env.RAVI_SLACK_CONNECTIONS = "ravi-rbbt-slack,hana-slack";
-    process.env.RAVI_SLACK_CREDENTIAL_CONNECTION = "legacy";
-
-    const env = buildRunnerPm2Env();
-
-    expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTION");
-    expect(env).not.toHaveProperty("RAVI_SLACK_CONNECTIONS");
-    expect(env).not.toHaveProperty("RAVI_SLACK_CREDENTIAL_CONNECTION");
-  });
-
-  it("preserves channel runner behavior flags", () => {
-    process.env.RAVI_CHANNELS_CONSUME_OUTBOUND = "0";
-    process.env.RAVI_SLACK_THREAD_REPLY_MODE = "thread";
-
-    expect(buildRunnerPm2Env()).toMatchObject({
-      RAVI_CHANNELS_CONSUME_OUTBOUND: "0",
-      RAVI_SLACK_THREAD_REPLY_MODE: "thread",
-    });
-  });
 });
 
 describe("channels runner lifecycle", () => {

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -1,10 +1,15 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { createChannelRunnerHealthSnapshot, type ChannelRunnerRuntimeStatus } from "../../channels/health.js";
 import { dbGetChannel } from "../../router/router-db.js";
-import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ravi-state.js";
+import {
+  cleanupIsolatedRaviState,
+  createIsolatedRaviState,
+  withoutRaviRuntimeContextEnv,
+} from "../../test/ravi-state.js";
 
 // Manual v2 contract: hasContext() true makes the contract helpers throw
 // ContractError instead of process.exit, which is what tests need.
@@ -68,6 +73,86 @@ describe("channels command runner env", () => {
       RAVI_SLACK_THREAD_REPLY_MODE: "thread",
     });
   });
+});
+
+describe("channels runner lifecycle", () => {
+  it("recreates a stopped PM2 entry from the current bundle and persists it", () => {
+    const root = mkdtempSync(join(tmpdir(), "ravi-channels-restart-"));
+    tempDirs.push(root);
+    const runtimeRoot = join(root, "runtime");
+    const bundlePath = join(runtimeRoot, "dist", "bundle", "index.js");
+    const fakeBinDir = join(root, "bin");
+    const fakePm2Path = join(fakeBinDir, "pm2");
+    const pm2LogPath = join(root, "pm2.log");
+
+    mkdirSync(join(bundlePath, ".."), { recursive: true });
+    mkdirSync(fakeBinDir, { recursive: true });
+    writeFileSync(join(runtimeRoot, "package.json"), JSON.stringify({ name: "ravi.bot", version: "test" }), "utf8");
+    writeFileSync(bundlePath, "", "utf8");
+    writeFileSync(
+      fakePm2Path,
+      [
+        "#!/bin/sh",
+        'printf "%s\\n" "$*" >> "$CHANNELS_TEST_PM2_LOG"',
+        'if [ "$1" = "jlist" ]; then',
+        `  printf '%s\\n' '${JSON.stringify([
+          {
+            name: "ravi",
+            pm_id: 1,
+            pid: 1234,
+            pm2_env: {
+              status: "online",
+              pm_exec_path: bundlePath,
+              pm_cwd: runtimeRoot,
+              args: ["daemon", "run"],
+              env: {},
+            },
+            monit: { cpu: 0, memory: 0 },
+          },
+          {
+            name: "ravi-channels",
+            pm_id: 2,
+            pid: 0,
+            pm2_env: {
+              status: "stopped",
+              pm_exec_path: "/old/bun",
+              pm_cwd: "/old",
+              args: ["/old/index.js", "channels", "run"],
+              env: {},
+            },
+            monit: { cpu: 0, memory: 0 },
+          },
+        ])}'`,
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      "utf8",
+    );
+    chmodSync(fakePm2Path, 0o755);
+
+    const result = spawnSync("bun", ["src/cli/index.ts", "channels", "restart", "--json"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...withoutRaviRuntimeContextEnv(process.env),
+        HOME: join(root, "home"),
+        PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ""}`,
+        RAVI_STATE_DIR: join(root, "state"),
+        RAVI_CREDENTIALS_PATH: join(root, "missing-credentials.json"),
+        RAVI_BUNDLE: bundlePath,
+        RAVI_DAEMON_CWD: runtimeRoot,
+        RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+        CHANNELS_TEST_PM2_LOG: pm2LogPath,
+      },
+    });
+    const pm2Log = readFileSync(pm2LogPath, "utf8");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(pm2Log).toContain("delete ravi-channels");
+    expect(pm2Log).toContain(`start bun --name ravi-channels -- ${realpathSync(bundlePath)} channels run`);
+    expect(pm2Log).toContain("save --force");
+  }, 20_000);
 });
 
 describe("channels config commands", () => {

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -12,6 +12,7 @@ import {
   type ChannelRunnerHealthSnapshot,
 } from "../../channels/health.js";
 import { ChannelRunner, runChannelRunnerFromEnv } from "../../channels/runner.js";
+import { buildRunnerPm2Env } from "../../channels/pm2-env.js";
 import { getCredentialConnection, listCredentialConnections } from "../../credentials/index.js";
 import { nats } from "../../nats.js";
 import {
@@ -251,14 +252,6 @@ function isClearValue(value: string): boolean {
   return ["-", "null", "none", "undefined", ""].includes(value.trim().toLowerCase());
 }
 
-const RUNNER_ENV_KEYS = [
-  "RAVI_CHANNELS_CONSUME_OUTBOUND",
-  "RAVI_SLACK_SUBSCRIPTION_SCOPE",
-  "RAVI_SLACK_THREAD_REPLY_MODE",
-  "RAVI_SLACK_ROOT_REPLY_MODE",
-  "RAVI_SLACK_WORKING_REACTION",
-] as const;
-
 function runPm2Quiet(
   args: string[],
   options: { cwd?: string; envOverrides?: Record<string, string> } = {},
@@ -272,41 +265,11 @@ function runPm2Quiet(
   return { status: result.status ?? 1 };
 }
 
-function cleanEnvValue(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
+function persistPm2ProcessList(): number {
+  return runPm2Quiet(["save", "--force"]).status;
 }
 
-function readExistingPm2Env(processName: string): Record<string, unknown> {
-  const result = spawnSync("pm2", ["jlist"], {
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
-  });
-  if ((result.status ?? 1) !== 0 || !result.stdout.trim()) return {};
-  try {
-    const list = JSON.parse(result.stdout) as unknown;
-    if (!Array.isArray(list)) return {};
-    const processInfo = list.find((item) => {
-      return item && typeof item === "object" && (item as { name?: unknown }).name === processName;
-    }) as { pm2_env?: { env?: Record<string, unknown> } } | undefined;
-    return processInfo?.pm2_env?.env ?? {};
-  } catch {
-    return {};
-  }
-}
-
-export function buildRunnerPm2Env(): Record<string, string> {
-  const existingPm2Env = readExistingPm2Env(CHANNELS_PM2_PROCESS_NAME);
-  const envOverrides: Record<string, string> = {};
-
-  for (const key of RUNNER_ENV_KEYS) {
-    const value = cleanEnvValue(process.env[key]) ?? cleanEnvValue(existingPm2Env[key]);
-    if (value) envOverrides[key] = value;
-  }
-
-  return envOverrides;
-}
+export { buildRunnerPm2Env };
 
 function publicRunnerEnv(envOverrides: Record<string, string>): Record<string, unknown> {
   return {
@@ -766,7 +729,7 @@ export class ChannelsCommands {
     const runnerEnv = buildRunnerPm2Env();
     const target = requireRuntimeTarget(build);
 
-    if (isPm2ProcessRunning(CHANNELS_PM2_PROCESS_NAME)) {
+    if (getPm2Process(CHANNELS_PM2_PROCESS_NAME)) {
       const stopped = asJson
         ? runPm2Quiet(["delete", CHANNELS_PM2_PROCESS_NAME])
         : runPm2(["delete", CHANNELS_PM2_PROCESS_NAME]);
@@ -777,9 +740,10 @@ export class ChannelsCommands {
     const { status } = asJson
       ? runPm2Quiet(args, { cwd: target.cwd, envOverrides: runnerEnv })
       : runPm2(args, runnerEnv, { cwd: target.cwd });
+    const saveStatus = status === 0 ? persistPm2ProcessList() : null;
     const payload = {
       action: "restart" as const,
-      changed: status === 0,
+      changed: status === 0 && saveStatus === 0,
       pm2Status: status,
       target,
       runnerEnv: publicRunnerEnv(runnerEnv),
@@ -788,10 +752,12 @@ export class ChannelsCommands {
     if (asJson) {
       printJson(payload);
       if (status !== 0) fail("Failed to restart channel runner");
+      if (saveStatus !== 0) fail("Channel runner restarted, but failed to save the PM2 process list");
       return payload;
     }
-    if (status === 0) console.log("Channel runner restarted");
-    else fail("Failed to restart channel runner");
+    if (status !== 0) fail("Failed to restart channel runner");
+    if (saveStatus !== 0) fail("Channel runner restarted, but failed to save the PM2 process list");
+    console.log("Channel runner restarted and PM2 startup state saved");
     return payload;
   }
 

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -243,7 +243,9 @@ describe("daemon runtime target", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).not.toContain('"mode": "handoff"');
-    expect(readFileSync(pm2LogPath, "utf8")).toContain(`start ${realpathSync(fakeBundlePath)}`);
+    const pm2Log = readFileSync(pm2LogPath, "utf8");
+    expect(pm2Log).toContain(`start ${realpathSync(fakeBundlePath)}`);
+    expect(pm2Log).toContain("save --force");
     expect(existsSync(childMarkerPath)).toBe(false);
   }, 20_000);
 });
@@ -266,6 +268,7 @@ describe("DaemonCommands --json", () => {
     const payload = JSON.parse(lines[0] ?? "{}");
     expect(typeof payload.pm2Available).toBe("boolean");
     expect(payload.processName).toBe("ravi");
+    expect(["aligned", "drifted", "unknown", "not_running"]).toContain(payload.runtime.alignment);
     expect(payload.ravi).toEqual(
       expect.objectContaining({
         name: "ravi",

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -19,6 +19,7 @@ import {
   daemonStatusReturnSchema,
 } from "./operational-return-schemas.js";
 import { isPm2Available, runPm2, isRaviRunning, getRaviPid, getPm2Processes, PM2_PROCESS_NAME } from "../../pm2.js";
+import { buildManagedRuntimeIdentity } from "../../managed-runtime.js";
 import {
   ADMIN_BOOTSTRAP_AGENT_ID,
   ADMIN_BOOTSTRAP_KIND,
@@ -153,6 +154,10 @@ function capturePm2(
   };
 }
 
+function persistPm2ProcessList(): number {
+  return runPm2Quiet(["save", "--force"]).status;
+}
+
 function serializePm2Process(process: Pm2ProcessSnapshot | undefined, fallbackName: string): Record<string, unknown> {
   if (!process) {
     return {
@@ -185,6 +190,7 @@ function buildDaemonStatusJson(): Record<string, unknown> {
   const pm2Available = isPm2Available();
   const processes = pm2Available ? getPm2Processes() : [];
   const findProcess = (name: string) => processes.find((process) => process.name === name);
+  const runtime = buildManagedRuntimeIdentity(processes, process.env.RAVI_BUNDLE ?? process.argv[1]);
 
   return {
     pm2Available,
@@ -194,6 +200,7 @@ function buildDaemonStatusJson(): Record<string, unknown> {
       omniNats: serializePm2Process(findProcess("omni-nats"), "omni-nats"),
       omniApi: serializePm2Process(findProcess("omni-api"), "omni-api"),
     },
+    runtime,
     processes: processes.map((process) => serializePm2Process(process, process.name)),
   };
 }
@@ -505,7 +512,8 @@ export class DaemonCommands {
 
     let pm2Status = 0;
     const previousRunning = isRaviRunning();
-    if (isRaviRunning()) {
+    const daemonManaged = getPm2Processes().some((process) => process.name === PM2_PROCESS_NAME);
+    if (daemonManaged) {
       const stop = asJson ? runPm2Quiet(["delete", PM2_PROCESS_NAME]) : runPm2(["delete", PM2_PROCESS_NAME]);
       pm2Status = stop.status;
       if (stop.status !== 0) {
@@ -525,11 +533,13 @@ export class DaemonCommands {
       ];
       const { status } = asJson ? runPm2Quiet(args, { cwd: target.cwd }) : runPm2(args, undefined, { cwd: target.cwd });
       pm2Status = status;
+      const saveStatus = status === 0 ? persistPm2ProcessList() : null;
       const payload = {
         action: "restart" as const,
-        changed: status === 0,
+        changed: status === 0 && saveStatus === 0,
         previousRunning,
         pm2Status,
+        saveStatus,
         build: buildResult,
         message,
         target,
@@ -538,13 +548,12 @@ export class DaemonCommands {
       if (asJson) {
         printJson(payload);
         if (status !== 0) fail("Failed to restart daemon");
+        if (saveStatus !== 0) fail("Daemon restarted, but failed to save the PM2 process list");
         return payload;
       }
-      if (status === 0) {
-        console.log("Daemon restarted");
-      } else {
-        fail("Failed to restart daemon");
-      }
+      if (status !== 0) fail("Failed to restart daemon");
+      if (saveStatus !== 0) fail("Daemon restarted, but failed to save the PM2 process list");
+      console.log("Daemon restarted and PM2 startup state saved");
       return payload;
     } else {
       const args = [
@@ -560,11 +569,13 @@ export class DaemonCommands {
       ];
       if (asJson) {
         const { status } = runPm2Quiet(args, { cwd: target.cwd });
+        const saveStatus = status === 0 ? persistPm2ProcessList() : null;
         const payload = {
           action: "restart" as const,
-          changed: status === 0,
+          changed: status === 0 && saveStatus === 0,
           previousRunning,
           pm2Status: status,
+          saveStatus,
           build: buildResult,
           message,
           target,
@@ -572,15 +583,19 @@ export class DaemonCommands {
         };
         printJson(payload);
         if (status !== 0) fail("Failed to restart daemon");
+        if (saveStatus !== 0) fail("Daemon started, but failed to save the PM2 process list");
         return payload;
       }
       const startResult = this.start();
       const startPm2Status = startResult && "pm2Status" in startResult ? startResult.pm2Status : null;
+      const saveStatus = startPm2Status === 0 ? persistPm2ProcessList() : null;
+      if (saveStatus !== 0) fail("Daemon started, but failed to save the PM2 process list");
       return {
         action: "restart" as const,
-        changed: startResult?.changed ?? false,
+        changed: Boolean(startResult?.changed) && saveStatus === 0,
         previousRunning,
         pm2Status: startPm2Status,
+        saveStatus,
         build: buildResult,
         message,
         target,
@@ -608,6 +623,7 @@ export class DaemonCommands {
     const ravi = procs.find((p) => p.name === PM2_PROCESS_NAME);
     const omniApi = procs.find((p) => p.name === "omni-api");
     const omniNats = procs.find((p) => p.name === "omni-nats");
+    const runtime = buildManagedRuntimeIdentity(procs, process.env.RAVI_BUNDLE ?? process.argv[1]);
 
     console.log("\nRavi Daemon Status");
     console.log("──────────────────");
@@ -617,6 +633,15 @@ export class DaemonCommands {
       console.log(`  ravi:      ${ravi.status === "online" ? "online" : ravi.status}  (PID ${ravi.pid}, ${mem}MB)`);
     } else {
       console.log("  ravi:      stopped");
+    }
+
+    const runtimeVersion = runtime.daemon.version ?? runtime.channels.version ?? runtime.cli.version;
+    console.log(`  runtime:   ${runtime.alignment}${runtimeVersion ? ` (${runtimeVersion})` : ""}`);
+    if (runtime.alignment === "drifted") {
+      console.log(`    cli:      ${runtime.cli.version ?? "unknown"}  ${runtime.cli.bundlePath ?? "-"}`);
+      console.log(`    daemon:   ${runtime.daemon.version ?? "unknown"}  ${runtime.daemon.bundlePath ?? "-"}`);
+      console.log(`    channels: ${runtime.channels.version ?? "unknown"}  ${runtime.channels.bundlePath ?? "-"}`);
+      console.log("    fix:      ravi update");
     }
 
     if (omniNats) {

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -1596,12 +1596,42 @@ export const projectFixturesSeedReturnSchema = z
   })
   .passthrough();
 
+const managedRuntimeMemberReturnSchema = z
+  .object({
+    name: z.string(),
+    managed: z.boolean(),
+    online: z.boolean(),
+    status: z.string(),
+    pid: z.number().nullable(),
+    bundlePath: z.string().nullable(),
+    cwd: z.string().nullable(),
+    version: z.string().nullable(),
+    matchesCli: z.boolean().nullable(),
+  })
+  .strict();
+
+const managedRuntimeIdentityReturnSchema = z
+  .object({
+    alignment: z.enum(["aligned", "drifted", "unknown", "not_running"]),
+    cli: z
+      .object({
+        bundlePath: z.string().nullable(),
+        cwd: z.string().nullable(),
+        version: z.string().nullable(),
+      })
+      .strict(),
+    daemon: managedRuntimeMemberReturnSchema,
+    channels: managedRuntimeMemberReturnSchema,
+  })
+  .strict();
+
 export const daemonStatusReturnSchema = z
   .object({
     pm2Available: z.boolean(),
     processName: z.string(),
     ravi: looseObjectSchema,
     infrastructure: looseObjectSchema,
+    runtime: managedRuntimeIdentityReturnSchema,
     processes: z.array(looseObjectSchema),
   })
   .passthrough();

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -1,18 +1,62 @@
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolveManagedRuntimeTargetFromPackageRoot } from "../../managed-runtime.js";
+import {
+  buildManagedRuntimeRebindPlan,
+  buildManagedRuntimeRebindSupervisorInvocation,
+  decodeManagedRuntimeRebindRequest,
+  rebindManagedRuntimeProcesses,
+} from "../../managed-runtime-rebind.js";
+import type { Pm2Process } from "../../pm2.js";
 import {
   detectFromBinaryPath,
   findPackageRoot,
-  managedRuntimeMatchesSnapshot,
   packageTagForChannel,
   packageTagForVersion,
-  planManagedRuntimeRestart,
+  resolveUpdatedManagedRuntimeTarget,
   resolveUpdateChannel,
   validateExpectedIntegrity,
 } from "./update.js";
+
+const MANAGED_RUNTIME_REBIND_ENV = "RAVI_INTERNAL_UPDATE_RUNTIME_REBIND";
+
+function createRuntimePackage(version = "3.260812.2") {
+  const root = mkdtempSync(join(tmpdir(), "ravi-update-runtime-"));
+  const bundlePath = join(root, "dist", "bundle", "index.js");
+  mkdirSync(join(bundlePath, ".."), { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "ravi.bot", version }), "utf8");
+  writeFileSync(bundlePath, "", "utf8");
+  return {
+    root: realpathSync(root),
+    bundlePath: realpathSync(bundlePath),
+    target: resolveManagedRuntimeTargetFromPackageRoot(root)!,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function pm2Process(
+  name: "ravi" | "ravi-channels",
+  bundlePath: string,
+  cwd: string,
+  overrides: Partial<Pm2Process> = {},
+): Pm2Process {
+  return {
+    name,
+    pm_id: name === "ravi" ? 1 : 2,
+    pid: name === "ravi" ? 101 : 202,
+    status: "online",
+    cpu: 0,
+    memory: 0,
+    execPath: name === "ravi" ? bundlePath : "/usr/local/bin/bun",
+    cwd,
+    args: name === "ravi" ? ["daemon", "run"] : [bundlePath, "channels", "run"],
+    createdAt: 2,
+    ...overrides,
+  };
+}
 
 describe("update command helpers", () => {
   it("resolves explicit channel flags before persisted config", () => {
@@ -80,47 +124,135 @@ describe("update command helpers", () => {
     expect(pkg.name).toBe("ravi.bot");
   });
 
-  it("stops channel intake before restarting a mixed managed runtime", () => {
+  it("resolves the explicitly updated package before the currently executing bundle", () => {
+    const runtime = createRuntimePackage();
+    try {
+      expect(resolveUpdatedManagedRuntimeTarget(runtime.root)).toEqual(runtime.target);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
+  it("recreates managed processes from the updated bundle and saves PM2", () => {
+    const target = { bundlePath: "/new/dist/bundle/index.js", cwd: "/new", version: "3.2.0" };
+    const plan = buildManagedRuntimeRebindPlan(
+      [
+        { name: "ravi", status: "online", pid: 10, createdAt: 1 },
+        { name: "ravi-channels", status: "online", pid: 20, createdAt: 1 },
+      ],
+      target,
+      "/usr/bin/bun",
+    );
+
     expect(
-      planManagedRuntimeRestart([
-        { name: "ravi", status: "online" },
-        { name: "ravi-channels", status: "online" },
-      ]),
+      plan.map(({ action, ...step }) => ({
+        action,
+        ...("processName" in step ? { processName: step.processName } : {}),
+      })),
     ).toEqual([
-      { action: "stop", processName: "ravi-channels" },
-      { action: "restart", processName: "ravi" },
-      { action: "restart", processName: "ravi-channels" },
+      { action: "delete", processName: "ravi-channels" },
+      { action: "delete", processName: "ravi" },
+      { action: "start", processName: "ravi" },
+      { action: "start", processName: "ravi-channels" },
+      { action: "save" },
     ]);
+    expect(plan[2]).toMatchObject({ cwd: target.cwd });
+    expect(plan[2]?.args.slice(0, 2)).toEqual(["start", target.bundlePath]);
+    expect(plan[3]).toMatchObject({ cwd: target.cwd });
+    expect(plan[3]?.args.slice(0, 2)).toEqual(["start", "/usr/bin/bun"]);
   });
 
-  it("preserves which managed processes were running before the update", () => {
-    expect(
-      planManagedRuntimeRestart([
-        { name: "ravi", status: "online" },
-        { name: "ravi-channels", status: "stopped" },
-      ]),
-    ).toEqual([{ action: "restart", processName: "ravi" }]);
-    expect(planManagedRuntimeRestart([{ name: "ravi", status: "stopped" }])).toEqual([]);
+  it("removes stopped stale entries without starting them", () => {
+    const plan = buildManagedRuntimeRebindPlan(
+      [
+        { name: "ravi", status: "online", pid: 10, createdAt: 1 },
+        { name: "ravi-channels", status: "stopped", pid: 0, createdAt: 1 },
+      ],
+      { bundlePath: "/new/dist/bundle/index.js", cwd: "/new", version: "3.2.0" },
+      "/usr/bin/bun",
+    );
+    expect(plan.filter((step) => step.action === "start").map((step) => step.processName)).toEqual(["ravi"]);
+    expect(plan.map((step) => step.action)).toEqual(["delete", "delete", "start", "save"]);
+    expect(buildManagedRuntimeRebindPlan([], { bundlePath: "/new", cwd: "/new", version: "3.2.0" })).toEqual([]);
   });
 
-  it("verifies every previously running process is online after restart", () => {
-    const previous = [
-      { name: "ravi", status: "online" },
-      { name: "ravi-channels", status: "online" },
-      { name: "unrelated", status: "online" },
-    ];
+  it("launches the supervisor from the updated bundle with a sanitized request", () => {
+    const runtime = createRuntimePackage();
+    try {
+      const invocation = buildManagedRuntimeRebindSupervisorInvocation(
+        runtime.target,
+        [pm2Process("ravi", "/old/index.js", "/old", { pid: 10, createdAt: 1 })],
+        { ...process.env, RAVI_CONTEXT_KEY: "secret", RAVI_REPO: "/old" },
+      );
+      expect(invocation).toMatchObject({
+        command: process.execPath,
+        args: [runtime.bundlePath],
+        cwd: runtime.root,
+      });
+      expect(invocation.env).not.toHaveProperty("RAVI_CONTEXT_KEY");
+      expect(invocation.env.RAVI_BUNDLE).toBe(runtime.bundlePath);
+      const request = decodeManagedRuntimeRebindRequest(invocation.env[MANAGED_RUNTIME_REBIND_ENV]!);
+      expect(request).toEqual({
+        schemaVersion: 1,
+        target: runtime.target,
+        previousProcesses: [{ name: "ravi", status: "online", pid: 10, createdAt: 1 }],
+      });
+    } finally {
+      runtime.cleanup();
+    }
+  });
 
-    expect(
-      managedRuntimeMatchesSnapshot(previous, [
-        { name: "ravi", status: "online" },
-        { name: "ravi-channels", status: "online" },
-      ]),
-    ).toBe(true);
-    expect(
-      managedRuntimeMatchesSnapshot(previous, [
-        { name: "ravi", status: "online" },
-        { name: "ravi-channels", status: "errored" },
-      ]),
-    ).toBe(false);
+  it("deletes, recreates, verifies, and persists the managed runtime", async () => {
+    const runtime = createRuntimePackage();
+    try {
+      const old = createRuntimePackage("3.260730.3");
+      try {
+        let processes: Pm2Process[] = [
+          pm2Process("ravi", old.bundlePath, old.root, { pid: 10, createdAt: 1 }),
+          pm2Process("ravi-channels", old.bundlePath, old.root, { pid: 20, createdAt: 1 }),
+        ];
+        const calls: string[] = [];
+        const ok = await rebindManagedRuntimeProcesses(
+          processes.map(({ name, status, pid, createdAt }) => ({ name, status, pid, createdAt: createdAt ?? null })),
+          runtime.target,
+          {
+            bunPath: "/usr/bin/bun",
+            runnerEnv: () => ({ RAVI_CHANNELS_CONSUME_OUTBOUND: "1" }),
+            getProcesses: () => processes,
+            run: async (_command, args, options) => {
+              calls.push(args.join(" "));
+              if (args[0] === "delete") {
+                processes = processes.filter((process) => process.name !== args[1]);
+              } else if (args[0] === "start") {
+                const name = args[args.indexOf("--name") + 1] as "ravi" | "ravi-channels";
+                processes.push(
+                  pm2Process(name, runtime.bundlePath, runtime.root, {
+                    pid: name === "ravi" ? 11 : 21,
+                    createdAt: 2,
+                  }),
+                );
+                if (name === "ravi-channels") {
+                  expect(options?.env?.RAVI_CHANNELS_CONSUME_OUTBOUND).toBe("1");
+                }
+              }
+              return { success: true, output: "" };
+            },
+          },
+        );
+
+        expect(ok).toBe(true);
+        expect(calls.map((call) => call.split(" ").slice(0, 2).join(" "))).toEqual([
+          "delete ravi-channels",
+          "delete ravi",
+          `start ${runtime.bundlePath}`,
+          "start /usr/bin/bun",
+          "save --force",
+        ]);
+      } finally {
+        old.cleanup();
+      }
+    } finally {
+      runtime.cleanup();
+    }
   });
 });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,9 +1,15 @@
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
-import { buildPm2Env, CHANNELS_PM2_PROCESS_NAME, getPm2Processes, PM2_PROCESS_NAME } from "../../pm2.js";
+import {
+  findRaviPackageRoot,
+  readRaviVersion,
+  resolveManagedRuntimeTargetFromPackageRoot,
+  type ManagedRuntimeTarget,
+} from "../../managed-runtime.js";
+import { managedRuntimeSnapshot, runManagedRuntimeRebindSupervisor } from "../../managed-runtime-rebind.js";
+import { getPm2Processes, type Pm2Process } from "../../pm2.js";
 import { getRaviStateDir } from "../../utils/paths.js";
 import { CONTRACT_EXIT_USAGE, contractFail } from "../agent-contract.js";
 
@@ -55,15 +61,12 @@ interface UpdateReporter {
   warn(message: string): void;
 }
 
-export type ManagedRuntimeRestartStep = {
-  action: "stop" | "restart";
-  processName: typeof PM2_PROCESS_NAME | typeof CHANNELS_PM2_PROCESS_NAME;
-};
-
 const PACKAGE_NAME = "ravi.bot";
 const LOCAL_BIN = join(homedir(), ".local", "bin");
 const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
 const SRI_PATTERN = /^sha512-[A-Za-z0-9+/]+={0,2}$/;
+
+export { findRaviPackageRoot as findPackageRoot };
 
 class UpdateFailure extends Error {
   constructor(
@@ -194,39 +197,6 @@ export function detectFromBinaryPath(binaryPath: string): InstallationType | nul
   return null;
 }
 
-function isRaviPackageRoot(dir: string): boolean {
-  const packagePath = join(dir, "package.json");
-  if (!existsSync(packagePath)) return false;
-  try {
-    const pkg = JSON.parse(readFileSync(packagePath, "utf8")) as { name?: string };
-    return pkg.name === PACKAGE_NAME || pkg.name === "@filipelabs/ravi";
-  } catch {
-    return false;
-  }
-}
-
-export function findPackageRoot(startPath: string | null | undefined): string | null {
-  const trimmed = startPath?.trim();
-  if (!trimmed) return null;
-
-  let dir = trimmed;
-  try {
-    const realPath = realpathSync(trimmed);
-    dir = statSync(realPath).isDirectory() ? realPath : dirname(realPath);
-  } catch {
-    dir = dirname(trimmed);
-  }
-
-  while (dir) {
-    if (isRaviPackageRoot(dir)) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return null;
-}
-
 function sourceRootFromPackageRoot(packageRoot: string | null): string | null {
   if (!packageRoot) return null;
   return existsSync(join(packageRoot, ".git")) ? packageRoot : null;
@@ -234,10 +204,11 @@ function sourceRootFromPackageRoot(packageRoot: string | null): string | null {
 
 function resolveSourceRoot(): string | null {
   const configured = process.env.RAVI_REPO?.trim();
-  if (configured && isRaviPackageRoot(configured) && existsSync(join(configured, ".git"))) {
-    return safeRealpath(configured);
+  const configuredRoot = findRaviPackageRoot(configured);
+  if (configuredRoot && existsSync(join(configuredRoot, ".git"))) {
+    return safeRealpath(configuredRoot);
   }
-  return sourceRootFromPackageRoot(findPackageRoot(process.argv[1]));
+  return sourceRootFromPackageRoot(findRaviPackageRoot(process.argv[1]));
 }
 
 export function detectInstallationType(config = readUpdateConfig()): InstallationType {
@@ -281,23 +252,13 @@ export function validateExpectedIntegrity(value: string): string {
   return integrity;
 }
 
-function packageVersionAt(packageRoot: string | null): string | null {
-  if (!packageRoot) return null;
-  try {
-    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as { version?: unknown };
-    return typeof pkg.version === "string" ? pkg.version : null;
-  } catch {
-    return null;
-  }
-}
-
 export function detectInstalledVersion(): string | null {
   const which = runCommandSilent("which", ["ravi"]);
   if (which.success) {
-    const fromPath = packageVersionAt(findPackageRoot(which.output.trim()));
+    const fromPath = readRaviVersion(findRaviPackageRoot(which.output.trim()));
     if (fromPath) return fromPath;
   }
-  return packageVersionAt(findPackageRoot(process.argv[1]));
+  return readRaviVersion(findRaviPackageRoot(process.argv[1]));
 }
 
 async function verifyRegistryIntegrity(version: string, expectedIntegrity: string): Promise<void> {
@@ -323,122 +284,45 @@ async function verifyRegistryIntegrity(version: string, expectedIntegrity: strin
   }
 }
 
-export function planManagedRuntimeRestart(
-  processes: Array<{ name: string; status: string }>,
-): ManagedRuntimeRestartStep[] {
-  const online = new Set(processes.filter((process) => process.status === "online").map((process) => process.name));
-  const daemonWasRunning = online.has(PM2_PROCESS_NAME);
-  const channelsWereRunning = online.has(CHANNELS_PM2_PROCESS_NAME);
-  const plan: ManagedRuntimeRestartStep[] = [];
-
-  // Stop channel intake before changing the daemon bundle. This prevents an
-  // old channel runner from reading a schema migrated by a newer process.
-  if (channelsWereRunning) {
-    plan.push({ action: "stop", processName: CHANNELS_PM2_PROCESS_NAME });
+export function resolveUpdatedManagedRuntimeTarget(preferredPackageRoot?: string | null): ManagedRuntimeTarget | null {
+  const which = runCommandSilent("which", ["ravi"]);
+  const candidates = [
+    preferredPackageRoot,
+    which.success ? findRaviPackageRoot(which.output.trim()) : null,
+    findRaviPackageRoot(process.argv[1]),
+  ];
+  for (const candidate of candidates) {
+    const target = resolveManagedRuntimeTargetFromPackageRoot(candidate);
+    if (target) return target;
   }
-  if (daemonWasRunning) {
-    plan.push({ action: "restart", processName: PM2_PROCESS_NAME });
-  }
-  if (channelsWereRunning) {
-    plan.push({ action: "restart", processName: CHANNELS_PM2_PROCESS_NAME });
-  }
-
-  return plan;
-}
-
-export function managedRuntimeMatchesSnapshot(
-  previousProcesses: Array<{ name: string; status: string }>,
-  currentProcesses: Array<{ name: string; status: string }>,
-): boolean {
-  const expectedOnline = previousProcesses
-    .filter(
-      (process) =>
-        process.status === "online" &&
-        (process.name === PM2_PROCESS_NAME || process.name === CHANNELS_PM2_PROCESS_NAME),
-    )
-    .map((process) => process.name);
-  const currentOnline = new Set(
-    currentProcesses.filter((process) => process.status === "online").map((process) => process.name),
-  );
-  return expectedOnline.every((processName) => currentOnline.has(processName));
-}
-
-async function waitForManagedRuntime(
-  previousProcesses: Array<{ name: string; status: string }>,
-  timeoutMs = 10_000,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (managedRuntimeMatchesSnapshot(previousProcesses, getPm2Processes())) return true;
-    await delay(250);
-  }
-  return managedRuntimeMatchesSnapshot(previousProcesses, getPm2Processes());
-}
-
-async function restartManagedRuntimeProcesses(
-  processes: Array<{ name: string; status: string }>,
-  reporter: UpdateReporter,
-): Promise<boolean> {
-  const plan = planManagedRuntimeRestart(processes);
-  if (plan.length === 0) return true;
-
-  reporter.log("Restarting managed Ravi runtime with the updated bundle");
-  let channelsStopped = false;
-  for (const step of plan) {
-    const result = await runCommand("pm2", [step.action, step.processName], {
-      env: buildPm2Env(),
-      stream: !reporter.json,
-    });
-    if (result.success) {
-      if (step.action === "stop" && step.processName === CHANNELS_PM2_PROCESS_NAME) {
-        channelsStopped = true;
-      }
-      if (step.action === "restart" && step.processName === CHANNELS_PM2_PROCESS_NAME) {
-        channelsStopped = false;
-      }
-      continue;
-    }
-
-    // Do not leave channel intake stopped if a later daemon transition fails.
-    if (channelsStopped && step.processName !== CHANNELS_PM2_PROCESS_NAME) {
-      await runCommand("pm2", ["restart", CHANNELS_PM2_PROCESS_NAME], {
-        env: buildPm2Env(),
-        stream: !reporter.json,
-      });
-    }
-    return false;
-  }
-
-  if (!(await waitForManagedRuntime(processes))) return false;
-  reporter.ok("Managed Ravi runtime restarted");
-  return true;
+  return null;
 }
 
 async function finishUpdate(
   restart: boolean,
-  previousProcesses: Array<{ name: string; status: string }>,
+  previousProcesses: Pm2Process[],
+  target: ManagedRuntimeTarget,
   reporter: UpdateReporter,
 ): Promise<boolean> {
   reporter.line();
   reporter.ok("Ravi CLI updated");
 
   if (!restart) {
-    reporter.line("Managed runtime restart skipped by request.");
-    reporter.line("Before handling new channel traffic, run:");
-    const online = new Set(
-      previousProcesses.filter((process) => process.status === "online").map((process) => process.name),
-    );
-    if (online.has(CHANNELS_PM2_PROCESS_NAME)) reporter.line("  ravi channels stop");
-    if (online.has(PM2_PROCESS_NAME)) reporter.line('  ravi daemon restart -m "load Ravi update"');
-    if (online.has(CHANNELS_PM2_PROCESS_NAME)) reporter.line("  ravi channels start");
+    reporter.line("Managed runtime reconciliation skipped; running processes were left unchanged.");
     return false;
   }
 
-  const restarted = await restartManagedRuntimeProcesses(previousProcesses, reporter);
-  if (!restarted) {
-    fail("Ravi updated, but the managed runtime restart failed. Restart daemon and channels before resuming traffic.");
+  const snapshot = managedRuntimeSnapshot(previousProcesses);
+  if (snapshot.length === 0) return false;
+  reporter.log(`Rebinding managed runtime to Ravi ${target.version}`);
+  const reconciled = await runManagedRuntimeRebindSupervisor(target, previousProcesses);
+  if (!reconciled) {
+    fail(
+      "Ravi updated, but PM2 did not converge on the updated runtime. Run `ravi daemon status` before resuming traffic.",
+    );
   }
-  return true;
+  reporter.ok(`Managed runtime reconciled to Ravi ${target.version}; PM2 startup state saved`);
+  return snapshot.some((process) => process.status === "online");
 }
 
 async function updateViaBun(packageTag: string, label: string, reporter: UpdateReporter): Promise<boolean> {
@@ -480,7 +364,7 @@ export function detectGlobalInstalls(): Set<"bun" | "npm"> {
   return found;
 }
 
-async function updateSource(channel: UpdateChannel, reporter: UpdateReporter): Promise<void> {
+async function updateSource(channel: UpdateChannel, reporter: UpdateReporter): Promise<string> {
   const sourceRoot = resolveSourceRoot();
   if (!sourceRoot) fail("Could not resolve Ravi source checkout. Set RAVI_REPO or use a global install.");
 
@@ -504,6 +388,7 @@ async function updateSource(channel: UpdateChannel, reporter: UpdateReporter): P
   }
 
   reporter.ok(`Source checkout updated from ${targetBranch}`);
+  return sourceRoot;
 }
 
 async function performUpdate(options: RaviUpdateOptions, reporter: UpdateReporter): Promise<RaviUpdateResult> {
@@ -552,15 +437,17 @@ async function performUpdate(options: RaviUpdateOptions, reporter: UpdateReporte
         CONTRACT_EXIT_USAGE,
       );
     }
-    await updateSource(channel as UpdateChannel, reporter);
-    const restarted = await finishUpdate(options.restart !== false, previousProcesses, reporter);
+    const sourceRoot = await updateSource(channel as UpdateChannel, reporter);
+    const target = resolveUpdatedManagedRuntimeTarget(sourceRoot);
+    if (!target) fail("Ravi updated, but its runnable bundle could not be resolved.");
+    const restarted = await finishUpdate(options.restart !== false, previousProcesses, target, reporter);
     return {
       success: true,
       package: PACKAGE_NAME,
       requested,
       channel,
       previousVersion,
-      currentVersion: detectInstalledVersion(),
+      currentVersion: target.version,
       installMethod: installType,
       restarted,
       integrityVerified: false,
@@ -589,14 +476,19 @@ async function performUpdate(options: RaviUpdateOptions, reporter: UpdateReporte
   if (exactVersion && currentVersion !== exactVersion) {
     fail(`The installation resolved to ${currentVersion ?? "an unknown version"}, not ${exactVersion}.`);
   }
-  const restarted = await finishUpdate(options.restart !== false, previousProcesses, reporter);
+  const target = resolveUpdatedManagedRuntimeTarget();
+  if (!target) fail("Ravi updated, but its runnable bundle could not be resolved.");
+  if (currentVersion && target.version !== currentVersion) {
+    fail(`The updated CLI reports ${currentVersion}, but its runtime bundle reports ${target.version}.`);
+  }
+  const restarted = await finishUpdate(options.restart !== false, previousProcesses, target, reporter);
   return {
     success: true,
     package: PACKAGE_NAME,
     requested,
     channel,
     previousVersion,
-    currentVersion,
+    currentVersion: target.version,
     installMethod: primary,
     restarted,
     integrityVerified: Boolean(expectedIntegrity),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./agent-contract.js";
 import { runDoctor } from "./commands/doctor.js";
 import { runSetup } from "./commands/setup.js";
+import { maybeRunManagedRuntimeRebindFromEnv } from "../managed-runtime-rebind.js";
 import { runUpdate, type RaviUpdateOptions } from "./commands/update.js";
 import { runCloudAuthRootCommand, runLogin, runLogout, runWhoami } from "./commands/cloud-auth.js";
 import { emitCliAuditEvent, runWithCliAudit, wasContractErrorAudited } from "./audit.js";
@@ -355,6 +356,8 @@ void bootstrapCli().catch(async (error: unknown) => {
 });
 
 async function bootstrapCli(): Promise<void> {
+  if (await maybeRunManagedRuntimeRebindFromEnv()) return;
+
   const handledByAppAlias = await maybeRunAppAliasRoute(process.argv.slice(2), {
     staticRootCommands: rootCommandNames(program),
   });

--- a/src/managed-runtime-rebind.ts
+++ b/src/managed-runtime-rebind.ts
@@ -1,0 +1,289 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { buildRunnerPm2Env } from "./channels/pm2-env.js";
+import {
+  managedRuntimeMatchesTarget,
+  normalizeRuntimePath,
+  resolveManagedRuntimeTargetFromPackageRoot,
+  type ManagedRuntimeProcessSnapshot,
+  type ManagedRuntimeTarget,
+} from "./managed-runtime.js";
+import { buildPm2Env, CHANNELS_PM2_PROCESS_NAME, getPm2Processes, PM2_PROCESS_NAME, type Pm2Process } from "./pm2.js";
+
+const MANAGED_RUNTIME_REBIND_ENV = "RAVI_INTERNAL_UPDATE_RUNTIME_REBIND";
+const MANAGED_RUNTIME_REBIND_TIMEOUT_MS = 30_000;
+
+type RunResult = {
+  success: boolean;
+  output: string;
+};
+
+type RunOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stream?: boolean;
+};
+
+export type ManagedRuntimeRebindStep =
+  | {
+      action: "delete";
+      processName: typeof PM2_PROCESS_NAME | typeof CHANNELS_PM2_PROCESS_NAME;
+      args: string[];
+    }
+  | {
+      action: "start";
+      processName: typeof PM2_PROCESS_NAME | typeof CHANNELS_PM2_PROCESS_NAME;
+      args: string[];
+      cwd: string;
+    }
+  | { action: "save"; args: string[] };
+
+type ManagedRuntimeRebindRequest = {
+  schemaVersion: 1;
+  target: ManagedRuntimeTarget;
+  previousProcesses: ManagedRuntimeProcessSnapshot[];
+};
+
+type ManagedRuntimeRebindDependencies = {
+  run?: (command: string, args: string[], options?: RunOptions) => Promise<RunResult>;
+  getProcesses?: () => Pm2Process[];
+  runnerEnv?: () => Record<string, string>;
+  bunPath?: string;
+};
+
+function runCommand(command: string, args: string[], options: RunOptions = {}): Promise<RunResult> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, args, {
+        cwd: options.cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...(options.env ?? process.env), FORCE_COLOR: options.stream === false ? "0" : "1" },
+      });
+    } catch (error) {
+      resolve({ success: false, output: error instanceof Error ? error.message : String(error) });
+      return;
+    }
+
+    const output: string[] = [];
+    child.stdout?.on("data", (data) => output.push(data.toString()));
+    child.stderr?.on("data", (data) => output.push(data.toString()));
+    child.once("close", (code) => resolve({ success: code === 0, output: output.join("") }));
+    child.once("error", (error) => resolve({ success: false, output: error.message }));
+  });
+}
+
+export function managedRuntimeSnapshot(processes: Pm2Process[]): ManagedRuntimeProcessSnapshot[] {
+  return processes
+    .filter((process) => process.name === PM2_PROCESS_NAME || process.name === CHANNELS_PM2_PROCESS_NAME)
+    .map(({ name, status, pid, createdAt }) => ({ name, status, pid, createdAt: createdAt ?? null }));
+}
+
+export function buildManagedRuntimeRebindPlan(
+  previousProcesses: ManagedRuntimeProcessSnapshot[],
+  target: ManagedRuntimeTarget,
+  bunPath = process.execPath,
+): ManagedRuntimeRebindStep[] {
+  const daemon = previousProcesses.find((process) => process.name === PM2_PROCESS_NAME);
+  const channels = previousProcesses.find((process) => process.name === CHANNELS_PM2_PROCESS_NAME);
+  const plan: ManagedRuntimeRebindStep[] = [];
+
+  // Stop intake before replacing the daemon so both processes always use one bundle.
+  if (channels) {
+    plan.push({
+      action: "delete",
+      processName: CHANNELS_PM2_PROCESS_NAME,
+      args: ["delete", CHANNELS_PM2_PROCESS_NAME],
+    });
+  }
+  if (daemon) {
+    plan.push({ action: "delete", processName: PM2_PROCESS_NAME, args: ["delete", PM2_PROCESS_NAME] });
+  }
+  if (daemon?.status === "online") {
+    plan.push({
+      action: "start",
+      processName: PM2_PROCESS_NAME,
+      args: ["start", target.bundlePath, "--name", PM2_PROCESS_NAME, "--interpreter", bunPath, "--", "daemon", "run"],
+      cwd: target.cwd,
+    });
+  }
+  if (channels?.status === "online") {
+    plan.push({
+      action: "start",
+      processName: CHANNELS_PM2_PROCESS_NAME,
+      args: ["start", bunPath, "--name", CHANNELS_PM2_PROCESS_NAME, "--", target.bundlePath, "channels", "run"],
+      cwd: target.cwd,
+    });
+  }
+  if (daemon || channels) plan.push({ action: "save", args: ["save", "--force"] });
+  return plan;
+}
+
+function encodeManagedRuntimeRebindRequest(request: ManagedRuntimeRebindRequest): string {
+  return Buffer.from(JSON.stringify(request), "utf8").toString("base64url");
+}
+
+export function decodeManagedRuntimeRebindRequest(encoded: string): ManagedRuntimeRebindRequest {
+  if (!encoded || encoded.length > 32_768) throw new Error("Invalid managed runtime rebind request");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("Invalid managed runtime rebind request");
+  }
+  if (!parsed || typeof parsed !== "object") throw new Error("Invalid managed runtime rebind request");
+  const input = parsed as Partial<ManagedRuntimeRebindRequest>;
+  if (input.schemaVersion !== 1 || !input.target || !Array.isArray(input.previousProcesses)) {
+    throw new Error("Invalid managed runtime rebind request");
+  }
+
+  const target = resolveManagedRuntimeTargetFromPackageRoot(input.target.cwd);
+  if (
+    !target ||
+    normalizeRuntimePath(target.bundlePath) !== normalizeRuntimePath(input.target.bundlePath) ||
+    target.version !== input.target.version
+  ) {
+    throw new Error("Managed runtime rebind target is not the requested Ravi bundle");
+  }
+
+  const seen = new Set<string>();
+  const previousProcesses = input.previousProcesses.map((entry) => {
+    if (!entry || typeof entry !== "object") throw new Error("Invalid managed runtime process snapshot");
+    if (entry.name !== PM2_PROCESS_NAME && entry.name !== CHANNELS_PM2_PROCESS_NAME) {
+      throw new Error("Invalid managed runtime process name");
+    }
+    if (seen.has(entry.name)) throw new Error("Duplicate managed runtime process snapshot");
+    seen.add(entry.name);
+    if (
+      typeof entry.status !== "string" ||
+      typeof entry.pid !== "number" ||
+      (entry.createdAt !== null && typeof entry.createdAt !== "number")
+    ) {
+      throw new Error("Invalid managed runtime process snapshot");
+    }
+    return { name: entry.name, status: entry.status, pid: entry.pid, createdAt: entry.createdAt };
+  });
+
+  return { schemaVersion: 1, target, previousProcesses };
+}
+
+async function waitForManagedRuntimeTarget(
+  previousProcesses: ManagedRuntimeProcessSnapshot[],
+  target: ManagedRuntimeTarget,
+  getProcesses: () => Pm2Process[],
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (managedRuntimeMatchesTarget(previousProcesses, getProcesses(), target)) return true;
+    await delay(250);
+  }
+  return managedRuntimeMatchesTarget(previousProcesses, getProcesses(), target);
+}
+
+export async function rebindManagedRuntimeProcesses(
+  previousProcesses: ManagedRuntimeProcessSnapshot[],
+  target: ManagedRuntimeTarget,
+  dependencies: ManagedRuntimeRebindDependencies = {},
+): Promise<boolean> {
+  const run = dependencies.run ?? runCommand;
+  const getProcesses = dependencies.getProcesses ?? getPm2Processes;
+  const plan = buildManagedRuntimeRebindPlan(previousProcesses, target, dependencies.bunPath);
+  if (plan.length === 0) return true;
+
+  const runtimeEnv = buildPm2Env({ RAVI_BUNDLE: target.bundlePath, RAVI_DAEMON_CWD: target.cwd });
+  delete runtimeEnv[MANAGED_RUNTIME_REBIND_ENV];
+  if (existsSync(join(target.cwd, ".git"))) runtimeEnv.RAVI_REPO = target.cwd;
+  else delete runtimeEnv.RAVI_REPO;
+  const runnerEnv = (dependencies.runnerEnv ?? buildRunnerPm2Env)();
+
+  for (const step of plan) {
+    if (step.action === "save") continue;
+    const env =
+      step.action === "start" && step.processName === CHANNELS_PM2_PROCESS_NAME
+        ? { ...runtimeEnv, ...runnerEnv }
+        : runtimeEnv;
+    const result = await run("pm2", step.args, {
+      cwd: step.action === "start" ? step.cwd : undefined,
+      env,
+      stream: false,
+    });
+    if (!result.success) return false;
+  }
+
+  if (!(await waitForManagedRuntimeTarget(previousProcesses, target, getProcesses))) return false;
+  const saveStep = plan.find((step) => step.action === "save");
+  if (saveStep) {
+    const saved = await run("pm2", saveStep.args, { env: runtimeEnv, stream: false });
+    if (!saved.success) return false;
+  }
+  return managedRuntimeMatchesTarget(previousProcesses, getProcesses(), target);
+}
+
+export function buildManagedRuntimeRebindSupervisorInvocation(
+  target: ManagedRuntimeTarget,
+  processes: Pm2Process[],
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): { command: string; args: string[]; cwd: string; env: Record<string, string> } {
+  const request: ManagedRuntimeRebindRequest = {
+    schemaVersion: 1,
+    target,
+    previousProcesses: managedRuntimeSnapshot(processes),
+  };
+  const env = buildPm2Env({
+    ...(baseEnv as Record<string, string>),
+    RAVI_BUNDLE: target.bundlePath,
+    RAVI_DAEMON_CWD: target.cwd,
+  });
+  if (existsSync(join(target.cwd, ".git"))) env.RAVI_REPO = target.cwd;
+  else delete env.RAVI_REPO;
+  env[MANAGED_RUNTIME_REBIND_ENV] = encodeManagedRuntimeRebindRequest(request);
+  return { command: process.execPath, args: [target.bundlePath], cwd: target.cwd, env };
+}
+
+export async function maybeRunManagedRuntimeRebindFromEnv(): Promise<boolean> {
+  const encoded = process.env[MANAGED_RUNTIME_REBIND_ENV];
+  if (!encoded) return false;
+  delete process.env[MANAGED_RUNTIME_REBIND_ENV];
+  const request = decodeManagedRuntimeRebindRequest(encoded);
+  if (!(await rebindManagedRuntimeProcesses(request.previousProcesses, request.target))) {
+    throw new Error("Managed Ravi runtime did not converge on the updated bundle");
+  }
+  return true;
+}
+
+export async function runManagedRuntimeRebindSupervisor(
+  target: ManagedRuntimeTarget,
+  processes: Pm2Process[],
+): Promise<boolean> {
+  const invocation = buildManagedRuntimeRebindSupervisorInvocation(target, processes);
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(invocation.command, invocation.args, {
+        cwd: invocation.cwd,
+        env: invocation.env,
+        detached: true,
+        stdio: "ignore",
+      });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (success: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      child.unref();
+      resolve(success);
+    };
+    timer = setTimeout(() => finish(false), MANAGED_RUNTIME_REBIND_TIMEOUT_MS);
+    child.once("error", () => finish(false));
+    child.once("close", (code) => finish(code === 0));
+  });
+}

--- a/src/managed-runtime.test.ts
+++ b/src/managed-runtime.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildManagedRuntimeIdentity,
+  managedRuntimeMatchesTarget,
+  resolveManagedRuntimeTargetFromPackageRoot,
+} from "./managed-runtime.js";
+import type { Pm2Process } from "./pm2.js";
+
+function createPackage(version: string) {
+  const cwd = mkdtempSync(join(tmpdir(), "ravi-managed-runtime-"));
+  const bundlePath = join(cwd, "dist", "bundle", "index.js");
+  mkdirSync(join(bundlePath, ".."), { recursive: true });
+  writeFileSync(join(cwd, "package.json"), JSON.stringify({ name: "ravi.bot", version }), "utf8");
+  writeFileSync(bundlePath, "", "utf8");
+  return {
+    cwd: realpathSync(cwd),
+    bundlePath: realpathSync(bundlePath),
+    cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+  };
+}
+
+function pm2Process(
+  name: "ravi" | "ravi-channels",
+  bundlePath: string,
+  cwd: string,
+  overrides: Partial<Pm2Process> = {},
+): Pm2Process {
+  return {
+    name,
+    pm_id: name === "ravi" ? 1 : 2,
+    pid: name === "ravi" ? 100 : 200,
+    status: "online",
+    cpu: 0,
+    memory: 0,
+    execPath: name === "ravi" ? bundlePath : "/usr/local/bin/bun",
+    cwd,
+    args: name === "ravi" ? ["daemon", "run"] : [bundlePath, "channels", "run"],
+    createdAt: 10,
+    ...overrides,
+  };
+}
+
+describe("managed runtime identity", () => {
+  it("reports one aligned version across CLI, daemon, and channels", () => {
+    const pkg = createPackage("3.1.0");
+    try {
+      const identity = buildManagedRuntimeIdentity(
+        [pm2Process("ravi", pkg.bundlePath, pkg.cwd), pm2Process("ravi-channels", pkg.bundlePath, pkg.cwd)],
+        pkg.bundlePath,
+        999,
+      );
+      expect(identity).toMatchObject({
+        alignment: "aligned",
+        cli: { version: "3.1.0" },
+        daemon: { version: "3.1.0", matchesCli: true },
+        channels: { version: "3.1.0", matchesCli: true },
+      });
+    } finally {
+      pkg.cleanup();
+    }
+  });
+
+  it("makes divergent installations explicit even when versions match", () => {
+    const cli = createPackage("3.1.0");
+    const stale = createPackage("3.1.0");
+    try {
+      const identity = buildManagedRuntimeIdentity(
+        [pm2Process("ravi", stale.bundlePath, stale.cwd), pm2Process("ravi-channels", stale.bundlePath, stale.cwd)],
+        cli.bundlePath,
+        999,
+      );
+      expect(identity.alignment).toBe("drifted");
+      expect(identity.daemon.matchesCli).toBe(false);
+      expect(identity.channels.matchesCli).toBe(false);
+    } finally {
+      cli.cleanup();
+      stale.cleanup();
+    }
+  });
+
+  it("includes stopped managed entries when detecting persisted drift", () => {
+    const current = createPackage("3.2.0");
+    const stale = createPackage("3.1.0");
+    try {
+      const identity = buildManagedRuntimeIdentity(
+        [
+          pm2Process("ravi", current.bundlePath, current.cwd),
+          pm2Process("ravi-channels", stale.bundlePath, stale.cwd, { status: "stopped", pid: 0 }),
+        ],
+        current.bundlePath,
+        999,
+      );
+      expect(identity.alignment).toBe("drifted");
+      expect(identity.channels).toMatchObject({ online: false, version: "3.1.0", matchesCli: false });
+    } finally {
+      current.cleanup();
+      stale.cleanup();
+    }
+  });
+});
+
+describe("managed runtime target verification", () => {
+  it("requires recreated online processes to use the target bundle and cwd", () => {
+    const targetPackage = createPackage("3.2.0");
+    try {
+      const target = resolveManagedRuntimeTargetFromPackageRoot(targetPackage.cwd)!;
+      const previous = [
+        { name: "ravi", status: "online", pid: 10, createdAt: 1 },
+        { name: "ravi-channels", status: "online", pid: 20, createdAt: 1 },
+      ];
+      const current = [
+        pm2Process("ravi", target.bundlePath, target.cwd, { pid: 11, createdAt: 2 }),
+        pm2Process("ravi-channels", target.bundlePath, target.cwd, { pid: 21, createdAt: 2 }),
+      ];
+
+      expect(managedRuntimeMatchesTarget(previous, current, target)).toBe(true);
+      expect(managedRuntimeMatchesTarget(previous, [current[0]!, { ...current[1]!, cwd: "/tmp/old" }], target)).toBe(
+        false,
+      );
+      expect(managedRuntimeMatchesTarget(previous, [current[0]!], target)).toBe(false);
+      expect(
+        managedRuntimeMatchesTarget(
+          [{ name: "ravi", status: "online", pid: 11, createdAt: null }],
+          [current[0]!],
+          target,
+        ),
+      ).toBe(false);
+    } finally {
+      targetPackage.cleanup();
+    }
+  });
+
+  it("requires stale stopped entries to be removed from PM2", () => {
+    const targetPackage = createPackage("3.2.0");
+    try {
+      const target = resolveManagedRuntimeTargetFromPackageRoot(targetPackage.cwd)!;
+      expect(
+        managedRuntimeMatchesTarget([{ name: "ravi-channels", status: "stopped", pid: 0, createdAt: 1 }], [], target),
+      ).toBe(true);
+      expect(
+        managedRuntimeMatchesTarget(
+          [{ name: "ravi-channels", status: "stopped", pid: 0, createdAt: 1 }],
+          [pm2Process("ravi-channels", target.bundlePath, target.cwd, { status: "stopped" })],
+          target,
+        ),
+      ).toBe(false);
+    } finally {
+      targetPackage.cleanup();
+    }
+  });
+});

--- a/src/managed-runtime.ts
+++ b/src/managed-runtime.ts
@@ -1,0 +1,219 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CHANNELS_PM2_PROCESS_NAME, PM2_PROCESS_NAME, type Pm2Process } from "./pm2.js";
+
+const RAVI_PACKAGE_NAMES = new Set(["ravi.bot", "@filipelabs/ravi"]);
+
+export type ManagedRuntimeTarget = {
+  bundlePath: string;
+  cwd: string;
+  version: string;
+};
+
+export type ManagedRuntimeProcessSnapshot = {
+  name: string;
+  status: string;
+  pid: number;
+  createdAt: number | null;
+};
+
+export type ManagedRuntimeMemberIdentity = {
+  name: string;
+  managed: boolean;
+  online: boolean;
+  status: string;
+  pid: number | null;
+  bundlePath: string | null;
+  cwd: string | null;
+  version: string | null;
+  matchesCli: boolean | null;
+};
+
+export type ManagedRuntimeIdentity = {
+  alignment: "aligned" | "drifted" | "unknown" | "not_running";
+  cli: {
+    bundlePath: string | null;
+    cwd: string | null;
+    version: string | null;
+  };
+  daemon: ManagedRuntimeMemberIdentity;
+  channels: ManagedRuntimeMemberIdentity;
+};
+
+export function safeRuntimeRealpath(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    return realpathSync(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+export function normalizeRuntimePath(value: string | null | undefined): string | null {
+  return safeRuntimeRealpath(value)?.toLowerCase() ?? null;
+}
+
+function isRaviPackageRoot(dir: string): boolean {
+  const packagePath = join(dir, "package.json");
+  if (!existsSync(packagePath)) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(packagePath, "utf8")) as { name?: unknown };
+    return typeof pkg.name === "string" && RAVI_PACKAGE_NAMES.has(pkg.name);
+  } catch {
+    return false;
+  }
+}
+
+export function findRaviPackageRoot(startPath: string | null | undefined): string | null {
+  const trimmed = startPath?.trim();
+  if (!trimmed) return null;
+
+  let dir = trimmed;
+  try {
+    const realPath = realpathSync(trimmed);
+    dir = statSync(realPath).isDirectory() ? realPath : dirname(realPath);
+  } catch {
+    dir = dirname(trimmed);
+  }
+
+  while (dir) {
+    if (isRaviPackageRoot(dir)) return safeRuntimeRealpath(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export function readRaviVersion(packageRoot: string | null | undefined): string | null {
+  if (!packageRoot) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as {
+      version?: unknown;
+    };
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveManagedRuntimeTargetFromPackageRoot(
+  packageRoot: string | null | undefined,
+): ManagedRuntimeTarget | null {
+  const cwd = findRaviPackageRoot(packageRoot);
+  if (!cwd) return null;
+  const bundlePath = safeRuntimeRealpath(join(cwd, "dist", "bundle", "index.js"));
+  const version = readRaviVersion(cwd);
+  if (!bundlePath || !version) return null;
+  try {
+    if (!statSync(bundlePath).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return { bundlePath, cwd, version };
+}
+
+export function resolveManagedRuntimeTargetFromBundle(
+  bundlePath: string | null | undefined,
+): ManagedRuntimeTarget | null {
+  const actualBundle = safeRuntimeRealpath(bundlePath);
+  const target = resolveManagedRuntimeTargetFromPackageRoot(findRaviPackageRoot(actualBundle));
+  if (!actualBundle || !target) return null;
+  return normalizeRuntimePath(actualBundle) === normalizeRuntimePath(target.bundlePath) ? target : null;
+}
+
+export function managedRuntimeBundlePath(process: Pm2Process | undefined): string | null {
+  if (!process) return null;
+  if (process.name === PM2_PROCESS_NAME) return safeRuntimeRealpath(process.execPath);
+  if (process.name === CHANNELS_PM2_PROCESS_NAME) return safeRuntimeRealpath(process.args?.[0]);
+  return null;
+}
+
+function identityForProcess(
+  name: typeof PM2_PROCESS_NAME | typeof CHANNELS_PM2_PROCESS_NAME,
+  process: Pm2Process | undefined,
+  cliBundlePath: string | null,
+): ManagedRuntimeMemberIdentity {
+  const bundlePath = managedRuntimeBundlePath(process);
+  const target = resolveManagedRuntimeTargetFromBundle(bundlePath);
+  const normalizedCli = normalizeRuntimePath(cliBundlePath);
+  const normalizedBundle = normalizeRuntimePath(bundlePath);
+  return {
+    name,
+    managed: Boolean(process),
+    online: process?.status === "online",
+    status: process?.status ?? "not_managed_by_pm2",
+    pid: process?.pid ?? null,
+    bundlePath,
+    cwd: safeRuntimeRealpath(process?.cwd),
+    version: target?.version ?? readRaviVersion(findRaviPackageRoot(bundlePath)),
+    matchesCli: normalizedCli && normalizedBundle ? normalizedCli === normalizedBundle : null,
+  };
+}
+
+export function buildManagedRuntimeIdentity(
+  processes: Pm2Process[],
+  cliBundleCandidate: string | null | undefined,
+  currentProcessPid = process.pid,
+): ManagedRuntimeIdentity {
+  const daemonProcess = processes.find((entry) => entry.name === PM2_PROCESS_NAME);
+  const channelsProcess = processes.find((entry) => entry.name === CHANNELS_PM2_PROCESS_NAME);
+  const daemonBundlePath = managedRuntimeBundlePath(daemonProcess);
+  const cliBundlePath =
+    daemonProcess?.pid === currentProcessPid ? daemonBundlePath : safeRuntimeRealpath(cliBundleCandidate);
+  const cliTarget = resolveManagedRuntimeTargetFromBundle(cliBundlePath);
+  const daemon = identityForProcess(PM2_PROCESS_NAME, daemonProcess, cliBundlePath);
+  const channels = identityForProcess(CHANNELS_PM2_PROCESS_NAME, channelsProcess, cliBundlePath);
+  const onlineMembers = [daemon, channels].filter((member) => member.online);
+  const managedMembers = [daemon, channels].filter((member) => member.managed);
+
+  let alignment: ManagedRuntimeIdentity["alignment"] = "not_running";
+  if (onlineMembers.length > 0) {
+    const paths = [cliBundlePath, ...managedMembers.map((member) => member.bundlePath)].map(normalizeRuntimePath);
+    alignment = paths.some((path) => !path) ? "unknown" : new Set(paths as string[]).size === 1 ? "aligned" : "drifted";
+  }
+
+  return {
+    alignment,
+    cli: {
+      bundlePath: cliBundlePath,
+      cwd: cliTarget?.cwd ?? findRaviPackageRoot(cliBundlePath),
+      version: cliTarget?.version ?? readRaviVersion(findRaviPackageRoot(cliBundlePath)),
+    },
+    daemon,
+    channels,
+  };
+}
+
+export function managedRuntimeMatchesTarget(
+  previousProcesses: ManagedRuntimeProcessSnapshot[],
+  currentProcesses: Pm2Process[],
+  target: ManagedRuntimeTarget,
+): boolean {
+  for (const name of [PM2_PROCESS_NAME, CHANNELS_PM2_PROCESS_NAME] as const) {
+    const previous = previousProcesses.find((process) => process.name === name);
+    if (!previous) continue;
+    const current = currentProcesses.find((process) => process.name === name);
+
+    if (previous.status !== "online") {
+      if (current) return false;
+      continue;
+    }
+
+    if (!current || current.status !== "online") return false;
+    if (normalizeRuntimePath(managedRuntimeBundlePath(current)) !== normalizeRuntimePath(target.bundlePath))
+      return false;
+    if (normalizeRuntimePath(current.cwd) !== normalizeRuntimePath(target.cwd)) return false;
+    if (resolveManagedRuntimeTargetFromBundle(managedRuntimeBundlePath(current))?.version !== target.version)
+      return false;
+    if (
+      previous.pid > 0 &&
+      current.pid === previous.pid &&
+      (previous.createdAt === null || current.createdAt === previous.createdAt)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/pm2.test.ts
+++ b/src/pm2.test.ts
@@ -6,6 +6,7 @@ describe("buildPm2Env", () => {
   it("strips runtime context identity from PM2 child processes", () => {
     const env = buildPm2Env({
       RAVI_CONTEXT_KEY: "rctx_child",
+      RAVI_INTERNAL_UPDATE_RUNTIME_REBIND: "internal-request",
       RAVI_SESSION_KEY: "session_key",
       RAVI_SESSION_NAME: "main",
       RAVI_AGENT_ID: "agent-main",
@@ -19,6 +20,7 @@ describe("buildPm2Env", () => {
     });
 
     expect(env).not.toHaveProperty("RAVI_CONTEXT_KEY");
+    expect(env).not.toHaveProperty("RAVI_INTERNAL_UPDATE_RUNTIME_REBIND");
     expect(env).not.toHaveProperty("RAVI_SESSION_KEY");
     expect(env).not.toHaveProperty("RAVI_SESSION_NAME");
     expect(env).not.toHaveProperty("RAVI_AGENT_ID");

--- a/src/pm2.ts
+++ b/src/pm2.ts
@@ -10,6 +10,7 @@ export const PM2_PROCESS_NAME = "ravi";
 export const CHANNELS_PM2_PROCESS_NAME = "ravi-channels";
 const PM2_ENV_DENYLIST = [
   "RAVI_CONTEXT_KEY",
+  "RAVI_INTERNAL_UPDATE_RUNTIME_REBIND",
   "RAVI_SESSION_KEY",
   "RAVI_SESSION_NAME",
   "RAVI_AGENT_ID",
@@ -71,13 +72,17 @@ export function capturePm2(...args: string[]): string {
   }
 }
 
-interface Pm2Process {
+export interface Pm2Process {
   name: string;
   pm_id: number;
   pid: number;
   status: string;
   cpu: number;
   memory: number;
+  execPath?: string | null;
+  cwd?: string | null;
+  args?: string[];
+  createdAt?: number | null;
 }
 
 /**
@@ -99,6 +104,12 @@ function parsePm2List(): Pm2Process[] {
       status: p.pm2_env?.status ?? "unknown",
       cpu: p.monit?.cpu ?? 0,
       memory: p.monit?.memory ?? 0,
+      execPath: typeof p.pm2_env?.pm_exec_path === "string" ? p.pm2_env.pm_exec_path : null,
+      cwd: typeof p.pm2_env?.pm_cwd === "string" ? p.pm2_env.pm_cwd : null,
+      args: Array.isArray(p.pm2_env?.args)
+        ? p.pm2_env.args.filter((arg: unknown): arg is string => typeof arg === "string")
+        : [],
+      createdAt: typeof p.pm2_env?.created_at === "number" ? p.pm2_env.created_at : null,
     }));
   } catch {
     return [];


### PR DESCRIPTION
## Objective

Ensure a Ravi update cannot leave PM2-managed processes running or resurrecting an older runtime bundle.

## Problem

PM2 restart preserves the executable path stored when a process was first created. Updating the CLI could therefore restart the daemon and channel runner from an older checkout, and a later PM2 save made that stale identity persistent.

## Solution

Resolve the runnable bundle after installation, hand reconciliation to that updated bundle, delete stale managed entries, and recreate only the processes that were previously online. Verify bundle path, working directory, package version, and new process identity before saving the PM2 startup state or reporting success. Daemon status now exposes aligned, drifted, unknown, or not-running runtime identity.

## Practical impact

A normal Ravi update now converges the daemon and channel runner on the newly installed version and persists that version for PM2 resurrection. Stopped services remain stopped, and stale stopped definitions are removed. Updates using --no-restart explicitly leave running processes unchanged.

## What does NOT change

Channel routing, provider behavior, session state, user data, and non-Ravi PM2 processes are not modified. The change is limited to Ravi daemon and Ravi channel-runner lifecycle management.

## Validation

- Full repository test suite passed locally.
- TypeScript typecheck and Biome lint passed.
- CLI, TUI, and packaged plugin builds passed.
- TypeScript SDK, OpenAPI, and Swift SDK drift checks passed.
- The pre-push quality hook repeated the complete validation successfully.

## Risks

Reconciliation briefly stops channel intake while replacing managed processes. If process startup, identity verification, or PM2 persistence fails, the update reports failure instead of claiming a healthy runtime.

## Rollback

Revert this commit to restore the previous restart behavior. Operators can then recreate the daemon and channel-runner PM2 entries manually from the intended bundle and save the corrected PM2 process list.