### PR TITLE
feat(slack): add secure Hub gateway transport

### DIFF
--- a/src/channels/slack/client.test.ts
+++ b/src/channels/slack/client.test.ts
@@ -2,6 +2,40 @@ import { describe, expect, it, mock } from "bun:test";
 import { SlackWebApiClient } from "./client.js";
 
 describe("Slack Web API client", () => {
+  it("routes requests and private file downloads through the authenticated Hub gateway", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      if (String(url).endsWith("/files")) {
+        return new Response(Buffer.from("file"), { headers: { "content-type": "text/plain" } });
+      }
+      return jsonResponse({ ok: true, team: "RBBT", user: "Ravi", team_id: "T1", user_id: "U1" });
+    }) as unknown as typeof fetch;
+    const client = new SlackWebApiClient({
+      appToken: "runtime-credential",
+      botToken: "runtime-credential",
+      apiBaseUrl: "https://hub.test/api/runtime/v1/slack/web-api/",
+      fileProxyUrl: "https://hub.test/api/runtime/v1/slack/files",
+      defaultHeaders: { "x-ravi-runtime-id": "runtime-1" },
+      fetchImpl,
+    });
+
+    await client.authTest();
+    const file = await client.downloadFile({ url: "https://files.slack.com/private/F1", maxBytes: 10 });
+
+    expect(calls[0]?.url).toBe("https://hub.test/api/runtime/v1/slack/web-api/auth.test");
+    expect(calls[0]?.init.headers).toMatchObject({
+      authorization: "Bearer runtime-credential",
+      "x-ravi-runtime-id": "runtime-1",
+    });
+    expect(calls[1]?.url).toBe("https://hub.test/api/runtime/v1/slack/files");
+    expect(JSON.parse(String(calls[1]?.init.body))).toEqual({
+      url: "https://files.slack.com/private/F1",
+      maxBytes: 10,
+    });
+    expect(file.buffer.toString()).toBe("file");
+  });
+
   it("reads token scopes from auth.test response headers", async () => {
     let requestSignal: AbortSignal | null | undefined;
     const fetchImpl = mock(async (_url: string | URL | Request, init?: RequestInit) => {

--- a/src/channels/slack/client.ts
+++ b/src/channels/slack/client.ts
@@ -5,6 +5,8 @@ export interface SlackWebApiClientOptions {
   readonly appToken: string;
   readonly botToken: string;
   readonly apiBaseUrl?: string;
+  readonly fileProxyUrl?: string;
+  readonly defaultHeaders?: Readonly<Record<string, string>>;
   readonly fetchImpl?: typeof fetch;
 }
 
@@ -95,6 +97,10 @@ export interface SlackAuthTestResponse extends SlackApiResponse {
   readonly bot_id?: string;
   readonly scopes?: string[];
   readonly acceptedScopes?: string[];
+}
+
+export interface SlackUserInfoResponse extends SlackApiResponse {
+  readonly user?: unknown;
 }
 
 export interface SlackConversationListInput {
@@ -324,12 +330,16 @@ export class SlackWebApiClient {
   private readonly appToken: string;
   private readonly botToken: string;
   private readonly apiBaseUrl: string;
+  private readonly fileProxyUrl?: string;
+  private readonly defaultHeaders: Readonly<Record<string, string>>;
   private readonly fetchImpl: typeof fetch;
 
   constructor(options: SlackWebApiClientOptions) {
     this.appToken = options.appToken;
     this.botToken = options.botToken;
-    this.apiBaseUrl = options.apiBaseUrl ?? "https://slack.com/api";
+    this.apiBaseUrl = (options.apiBaseUrl ?? "https://slack.com/api").replace(/\/+$/, "");
+    this.fileProxyUrl = options.fileProxyUrl;
+    this.defaultHeaders = options.defaultHeaders ?? {};
     this.fetchImpl = options.fetchImpl ?? fetch;
   }
 
@@ -518,6 +528,10 @@ export class SlackWebApiClient {
       scopes: parseSlackScopeHeader(headers.get("x-oauth-scopes")),
       acceptedScopes: parseSlackScopeHeader(headers.get("x-accepted-oauth-scopes")),
     };
+  }
+
+  async usersInfo(user: string): Promise<SlackUserInfoResponse> {
+    return this.apiRequest<SlackUserInfoResponse>("users.info", this.botToken, { user });
   }
 
   async addReaction(input: SlackReactionInput): Promise<Record<string, unknown>> {
@@ -730,10 +744,16 @@ export class SlackWebApiClient {
   }
 
   async downloadFile(input: SlackDownloadFileInput): Promise<SlackDownloadFileResult> {
-    const res = await this.fetchImpl(input.url, {
+    const res = await this.fetchImpl(this.fileProxyUrl ?? input.url, {
+      method: this.fileProxyUrl ? "POST" : "GET",
       headers: {
+        ...this.defaultHeaders,
         authorization: `Bearer ${this.botToken}`,
+        ...(this.fileProxyUrl ? { "content-type": "application/json; charset=utf-8" } : {}),
       },
+      ...(this.fileProxyUrl
+        ? { body: JSON.stringify({ url: input.url, ...(input.maxBytes ? { maxBytes: input.maxBytes } : {}) }) }
+        : {}),
       signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
@@ -776,6 +796,7 @@ export class SlackWebApiClient {
     const res = await this.fetchImpl(`${this.apiBaseUrl}/${method}`, {
       method: "POST",
       headers: {
+        ...this.defaultHeaders,
         authorization: `Bearer ${token}`,
         "content-type": "application/json; charset=utf-8",
       },
@@ -802,6 +823,7 @@ export class SlackWebApiClient {
     const res = await this.fetchImpl(`${this.apiBaseUrl}/${method}`, {
       method: "POST",
       headers: {
+        ...this.defaultHeaders,
         authorization: `Bearer ${token}`,
         "content-type": "application/x-www-form-urlencoded",
       },

--- a/src/channels/slack/credentials.test.ts
+++ b/src/channels/slack/credentials.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
   credentialConnectionForChannel,
+  isSlackGatewayChannel,
   parseSlackSecretPayload,
   resolveSlackCredentialConfigFromEnv,
 } from "./credentials.js";
@@ -146,14 +147,67 @@ describe("Slack credential config", () => {
     ).toBe("rbbt-secret");
     expect(credentialConnectionForChannel(slackChannel({ name: "ravi-rbbt-slack" }))).toBeUndefined();
   });
+
+  it("resolves the Hub gateway without hydrating Slack tokens", async () => {
+    const resolveSecret = mock(async () => {
+      throw new Error("broker must not be called");
+    });
+    const channel = slackChannel({
+      name: "slack-main",
+      defaults: { transport: "hub_gateway_v1" },
+    });
+    const credential = "runtime-credential-".padEnd(48, "x");
+
+    const config = await resolveSlackCredentialConfigFromEnv(
+      {
+        RAVI_SLACK_GATEWAY_URL: "https://ravi.example.test/",
+        RAVI_RUNTIME_ID: "11111111-1111-4111-8111-111111111111",
+        RAVI_RUNTIME_CREDENTIAL: credential,
+      },
+      { channel, channels: { "slack-main": channel }, resolveSecret },
+    );
+
+    expect(resolveSecret).not.toHaveBeenCalled();
+    expect(isSlackGatewayChannel(channel)).toBeTrue();
+    expect(config).toMatchObject({
+      source: "gateway",
+      accountId: "slack-main",
+      apiBaseUrl: "https://ravi.example.test/api/runtime/v1/slack/web-api",
+      fileProxyUrl: "https://ravi.example.test/api/runtime/v1/slack/files",
+      requestHeaders: {
+        authorization: `Bearer ${credential}`,
+        "x-ravi-runtime-id": "11111111-1111-4111-8111-111111111111",
+      },
+    });
+  });
+
+  it("rejects an insecure remote Hub gateway", async () => {
+    const channel = slackChannel({ name: "slack-main", defaults: { transport: "hub_gateway_v1" } });
+    await expect(
+      resolveSlackCredentialConfigFromEnv(
+        {
+          RAVI_SLACK_GATEWAY_URL: "http://ravi.example.test",
+          RAVI_RUNTIME_ID: "11111111-1111-4111-8111-111111111111",
+          RAVI_RUNTIME_CREDENTIAL: "runtime-credential-".padEnd(48, "x"),
+        },
+        { channel },
+      ),
+    ).rejects.toThrow("must use HTTPS");
+  });
 });
 
-function slackChannel(input: { name: string; credentialConnection?: string; enabled?: boolean }) {
+function slackChannel(input: {
+  name: string;
+  credentialConnection?: string;
+  enabled?: boolean;
+  defaults?: Record<string, unknown>;
+}) {
   return {
     name: input.name,
     provider: "slack",
     enabled: input.enabled ?? true,
     ...(input.credentialConnection ? { credentialConnection: input.credentialConnection } : {}),
+    ...(input.defaults ? { defaults: input.defaults } : {}),
     createdAt: 1,
     updatedAt: 1,
   };

--- a/src/channels/slack/credentials.ts
+++ b/src/channels/slack/credentials.ts
@@ -9,7 +9,15 @@ export interface SlackCredentialConfig {
   channel: string;
   instanceId: string;
   connection: string;
-  source: "broker";
+  source: "broker" | "gateway";
+  apiBaseUrl?: string;
+  fileProxyUrl?: string;
+  requestHeaders?: Readonly<Record<string, string>>;
+  gateway?: {
+    claimUrl: string;
+    completionBaseUrl: string;
+    requestHeaders: Readonly<Record<string, string>>;
+  };
 }
 
 export interface SlackSecretPayload {
@@ -24,7 +32,7 @@ export type SlackCredentialResolver = (input: {
 }) => Promise<{ secret: string; connection?: { connection: string } }>;
 
 export async function resolveSlackCredentialConfigFromEnv(
-  _env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = process.env,
   options: {
     resolveSecret?: SlackCredentialResolver;
     action?: string;
@@ -33,6 +41,9 @@ export async function resolveSlackCredentialConfigFromEnv(
   } = {},
 ): Promise<SlackCredentialConfig | null> {
   const channel = options.channel;
+  if (channel && isSlackGatewayChannel(channel)) {
+    return resolveSlackGatewayCredentialConfig(env, channel);
+  }
   const connection = credentialConnectionForChannel(channel);
   if (connection) {
     const resolved = await (options.resolveSecret ?? resolveCredentialSecret)({
@@ -56,6 +67,68 @@ export async function resolveSlackCredentialConfigFromEnv(
   }
 
   return null;
+}
+
+export function isSlackGatewayChannel(channel: ChannelConfig | null | undefined): boolean {
+  return (
+    Boolean(channel) &&
+    channel?.enabled !== false &&
+    channel?.provider === "slack" &&
+    channel.defaults?.transport === "hub_gateway_v1"
+  );
+}
+
+function resolveSlackGatewayCredentialConfig(env: NodeJS.ProcessEnv, channel: ChannelConfig): SlackCredentialConfig {
+  const hubUrl = validatedHubUrl(env.RAVI_SLACK_GATEWAY_URL);
+  const runtimeId = env.RAVI_RUNTIME_ID?.trim() ?? "";
+  const credential = env.RAVI_RUNTIME_CREDENTIAL?.trim() ?? "";
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(runtimeId)) {
+    throw new Error("RAVI_RUNTIME_ID is required for the Slack Hub gateway.");
+  }
+  if (!/^[A-Za-z0-9_-]{40,100}$/.test(credential)) {
+    throw new Error("RAVI_RUNTIME_CREDENTIAL is invalid for the Slack Hub gateway.");
+  }
+  const requestHeaders = Object.freeze({
+    authorization: `Bearer ${credential}`,
+    "x-ravi-runtime-id": runtimeId,
+  });
+  return {
+    appToken: credential,
+    botToken: credential,
+    accountId: channel.name,
+    routeAccountId: channel.name,
+    channel: channel.name,
+    instanceId: channel.name,
+    connection: `hub-gateway:${runtimeId}`,
+    source: "gateway",
+    apiBaseUrl: `${hubUrl}/api/runtime/v1/slack/web-api`,
+    fileProxyUrl: `${hubUrl}/api/runtime/v1/slack/files`,
+    requestHeaders,
+    gateway: {
+      claimUrl: `${hubUrl}/api/runtime/v1/slack/events/claim`,
+      completionBaseUrl: `${hubUrl}/api/runtime/v1/slack/events`,
+      requestHeaders,
+    },
+  };
+}
+
+function validatedHubUrl(value: string | undefined): string {
+  const normalized = value?.trim().replace(/\/+$/, "");
+  if (!normalized) throw new Error("RAVI_SLACK_GATEWAY_URL is required for the Slack Hub gateway.");
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    throw new Error("RAVI_SLACK_GATEWAY_URL must be a valid URL.");
+  }
+  const isLoopback = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+  if ((url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback)) || url.username || url.password) {
+    throw new Error("RAVI_SLACK_GATEWAY_URL must use HTTPS.");
+  }
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("RAVI_SLACK_GATEWAY_URL must be an origin without a path.");
+  }
+  return url.origin;
 }
 
 export function credentialConnectionForChannel(channel: ChannelConfig | null | undefined): string | undefined {

--- a/src/channels/slack/gateway-mode.test.ts
+++ b/src/channels/slack/gateway-mode.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, mock } from "bun:test";
+import { SlackGatewayModeService } from "./gateway-mode.js";
+
+describe("Slack Hub gateway mode", () => {
+  it("claims one event, processes it and confirms the exact lease", async () => {
+    const requests: Array<{ url: string; body: unknown; headers: Headers }> = [];
+    let delivered!: () => void;
+    const completed = new Promise<void>((resolve) => {
+      delivered = resolve;
+    });
+    const fetchImpl = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      requests.push({ url: String(url), body, headers });
+      if (String(url).endsWith("/claim")) {
+        if (requests.filter((item) => item.url.endsWith("/claim")).length > 1) {
+          return Response.json({ event: null });
+        }
+        return Response.json({
+          event: {
+            id: "11111111-1111-4111-8111-111111111111",
+            claimId: "22222222-2222-4222-8222-222222222222",
+            envelope: { envelope_id: "Ev1", type: "events_api", payload: { type: "event_callback" } },
+          },
+        });
+      }
+      delivered();
+      return Response.json({ accepted: true });
+    }) as unknown as typeof fetch;
+    const handleEnvelope = mock(async () => "processed" as const);
+    const service = new SlackGatewayModeService({
+      claimUrl: "https://hub.test/claim",
+      completionBaseUrl: "https://hub.test/events",
+      requestHeaders: { authorization: "Bearer runtime", "x-ravi-runtime-id": "runtime-1" },
+      processor: {
+        handleEnvelope,
+        resumePendingInboundEnvelopes: async () => ({}),
+      },
+      fetchImpl,
+    });
+
+    service.start();
+    await completed;
+    await service.stop();
+
+    expect(handleEnvelope).toHaveBeenCalledWith({
+      envelope_id: "Ev1",
+      type: "events_api",
+      payload: { type: "event_callback" },
+    });
+    const completion = requests.find((request) => request.url.includes("/complete"));
+    expect(completion?.url).toBe("https://hub.test/events/11111111-1111-4111-8111-111111111111/complete");
+    expect(completion?.body).toEqual({
+      claimId: "22222222-2222-4222-8222-222222222222",
+      status: "delivered",
+    });
+    expect(completion?.headers.get("authorization")).toBe("Bearer runtime");
+    expect(service.status().state).toBe("stopped");
+  });
+
+  it("does not misreport a processed event as failed when only its acknowledgement fails", async () => {
+    const completions: unknown[] = [];
+    let completionAttempted!: () => void;
+    const attempted = new Promise<void>((resolve) => {
+      completionAttempted = resolve;
+    });
+    let claimed = false;
+    const fetchImpl = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/claim")) {
+        if (claimed) return Response.json({ event: null });
+        claimed = true;
+        return Response.json({
+          event: {
+            id: "11111111-1111-4111-8111-111111111111",
+            claimId: "22222222-2222-4222-8222-222222222222",
+            envelope: { envelope_id: "Ev1", type: "events_api", payload: { type: "event_callback" } },
+          },
+        });
+      }
+      completions.push(JSON.parse(String(init?.body ?? "{}")));
+      completionAttempted();
+      return Response.json({ error: "unavailable" }, { status: 502 });
+    }) as unknown as typeof fetch;
+    const service = new SlackGatewayModeService({
+      claimUrl: "https://hub.test/claim",
+      completionBaseUrl: "https://hub.test/events",
+      requestHeaders: { authorization: "Bearer runtime" },
+      processor: {
+        handleEnvelope: async () => "processed",
+        resumePendingInboundEnvelopes: async () => ({}),
+      },
+      fetchImpl,
+      retryDelayMs: 60_000,
+    });
+
+    service.start();
+    await attempted;
+    await service.stop();
+
+    expect(completions).toEqual([{ claimId: "22222222-2222-4222-8222-222222222222", status: "delivered" }]);
+  });
+});

--- a/src/channels/slack/gateway-mode.ts
+++ b/src/channels/slack/gateway-mode.ts
@@ -1,0 +1,200 @@
+import type { SlackSocketModeStatus } from "./socket-mode.js";
+import type { SlackSocketEnvelope } from "./types.js";
+
+interface SlackGatewayClaimedEvent {
+  readonly id: string;
+  readonly claimId: string;
+  readonly envelope: SlackSocketEnvelope;
+}
+
+interface SlackGatewayClaimResponse {
+  readonly event: SlackGatewayClaimedEvent | null;
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface SlackGatewayEnvelopeProcessor {
+  handleEnvelope(envelope: SlackSocketEnvelope): Promise<"duplicate" | "ignored" | "processed">;
+  resumePendingInboundEnvelopes(): Promise<unknown>;
+}
+
+export interface SlackGatewayModeServiceOptions {
+  readonly claimUrl: string;
+  readonly completionBaseUrl: string;
+  readonly requestHeaders: Readonly<Record<string, string>>;
+  readonly processor: SlackGatewayEnvelopeProcessor;
+  readonly fetchImpl?: typeof fetch;
+  readonly retryDelayMs?: number;
+  readonly now?: () => number;
+}
+
+export class SlackGatewayModeService {
+  private readonly fetchImpl: typeof fetch;
+  private readonly retryDelayMs: number;
+  private readonly now: () => number;
+  private running = false;
+  private loopPromise: Promise<void> | null = null;
+  private activeRequest: AbortController | null = null;
+  private interruptRetryDelay: (() => void) | null = null;
+  private lifecycleState: SlackSocketModeStatus["state"] = "stopped";
+  private lifecycleReason: SlackSocketModeStatus["reason"] = "stopped";
+  private connectedAt: number | undefined;
+  private lastPollAt: number | undefined;
+  private reconnectCount = 0;
+
+  constructor(private readonly options: SlackGatewayModeServiceOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.retryDelayMs = options.retryDelayMs ?? 2_000;
+    this.now = options.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.connectedAt = undefined;
+    this.reconnectCount = 0;
+    this.setLifecycle("connecting", "polling_gateway");
+    this.loopPromise = this.runLoop();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.activeRequest?.abort();
+    this.activeRequest = null;
+    this.interruptRetryDelay?.();
+    this.interruptRetryDelay = null;
+    await this.loopPromise?.catch(() => {});
+    this.loopPromise = null;
+    this.connectedAt = undefined;
+    this.setLifecycle("stopped", "stopped");
+  }
+
+  status(): SlackSocketModeStatus {
+    return {
+      state: this.lifecycleState,
+      ...(this.connectedAt !== undefined ? { connectedAt: this.connectedAt } : {}),
+      ...(this.lastPollAt !== undefined ? { lastPongAt: this.lastPollAt } : {}),
+      reconnectCount: this.reconnectCount,
+      ...(this.lifecycleReason ? { reason: this.lifecycleReason } : {}),
+    };
+  }
+
+  private async runLoop(): Promise<void> {
+    await this.options.processor.resumePendingInboundEnvelopes().catch(() => {});
+    while (this.running) {
+      try {
+        const claim = await this.claim();
+        if (!this.running) return;
+        const observedAt = this.now();
+        this.lastPollAt = observedAt;
+        if (this.connectedAt === undefined) this.connectedAt = observedAt;
+        this.setLifecycle("connected", "polling_gateway");
+        if (claim.event) await this.process(claim.event);
+      } catch {
+        if (!this.running) return;
+        this.connectedAt = undefined;
+        this.reconnectCount += 1;
+        this.setLifecycle("reconnecting", "gateway_unavailable");
+        await this.delay(Math.min(15_000, this.retryDelayMs * Math.max(1, this.reconnectCount)));
+      }
+    }
+  }
+
+  private async claim(): Promise<SlackGatewayClaimResponse> {
+    const response = await this.request(this.options.claimUrl, {});
+    const payload = (await response.json()) as unknown;
+    if (!isClaimResponse(payload)) throw new Error("Invalid Slack gateway claim response");
+    return payload;
+  }
+
+  private async process(event: SlackGatewayClaimedEvent): Promise<void> {
+    try {
+      await this.options.processor.handleEnvelope(event.envelope);
+    } catch {
+      await this.complete(event, {
+        status: "failed",
+        error: "O runtime não conseguiu processar o evento do Slack.",
+      }).catch(() => {});
+      throw new Error("Slack gateway event processing failed");
+    }
+    await this.complete(event, { status: "delivered" });
+  }
+
+  private async complete(
+    event: SlackGatewayClaimedEvent,
+    result: { status: "delivered" } | { status: "failed"; error: string },
+  ): Promise<void> {
+    await this.request(`${this.options.completionBaseUrl}/${encodeURIComponent(event.id)}/complete`, {
+      claimId: event.claimId,
+      ...result,
+    });
+  }
+
+  private async request(url: string, body: Record<string, unknown>): Promise<Response> {
+    const controller = new AbortController();
+    this.activeRequest = controller;
+    const timer = setTimeout(() => controller.abort(), 25_000);
+    try {
+      const response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          ...this.options.requestHeaders,
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`Slack gateway request failed (${response.status})`);
+      return response;
+    } finally {
+      clearTimeout(timer);
+      if (this.activeRequest === controller) this.activeRequest = null;
+    }
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    if (!this.running || milliseconds <= 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      let settled = false;
+      const complete = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this.interruptRetryDelay === complete) this.interruptRetryDelay = null;
+        resolve();
+      };
+      const timer = setTimeout(complete, milliseconds);
+      timer.unref?.();
+      this.interruptRetryDelay = complete;
+    });
+  }
+
+  private setLifecycle(state: SlackSocketModeStatus["state"], reason: SlackSocketModeStatus["reason"]): void {
+    this.lifecycleState = state;
+    this.lifecycleReason = reason;
+  }
+}
+
+function isClaimResponse(value: unknown): value is SlackGatewayClaimResponse {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const event = (value as Record<string, unknown>).event;
+  if (event === null) return true;
+  if (!event || typeof event !== "object" || Array.isArray(event)) return false;
+  const record = event as Record<string, unknown>;
+  const envelope = record.envelope;
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) return false;
+  const envelopeRecord = envelope as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    UUID_PATTERN.test(record.id) &&
+    typeof record.claimId === "string" &&
+    UUID_PATTERN.test(record.claimId) &&
+    typeof envelopeRecord.envelope_id === "string" &&
+    envelopeRecord.envelope_id.length > 0 &&
+    envelopeRecord.envelope_id.length <= 256 &&
+    (envelopeRecord.type === "events_api" || envelopeRecord.type === "interactive") &&
+    Boolean(envelopeRecord.payload) &&
+    typeof envelopeRecord.payload === "object" &&
+    !Array.isArray(envelopeRecord.payload)
+  );
+}

--- a/src/channels/slack/index.ts
+++ b/src/channels/slack/index.ts
@@ -37,10 +37,13 @@ export type {
 } from "./client.js";
 export {
   credentialConnectionForChannel,
+  isSlackGatewayChannel,
   parseSlackSecretPayload,
   resolveSlackCredentialConfigFromEnv,
 } from "./credentials.js";
 export type { SlackCredentialConfig, SlackSecretPayload } from "./credentials.js";
+export { SlackGatewayModeService } from "./gateway-mode.js";
+export type { SlackGatewayEnvelopeProcessor, SlackGatewayModeServiceOptions } from "./gateway-mode.js";
 export {
   respondToSlackInteraction,
   storeSlackInteractionResponseUrl,

--- a/src/channels/slack/interactions.test.ts
+++ b/src/channels/slack/interactions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { isAllowedSlackInteractionResponseUrl } from "./interactions.js";
+
+describe("Slack interaction response boundary", () => {
+  it("allows only action response handles hosted by Slack", () => {
+    expect(isAllowedSlackInteractionResponseUrl("https://hooks.slack.com/actions/T1/B1/secret")).toBe(true);
+    expect(isAllowedSlackInteractionResponseUrl("http://hooks.slack.com/actions/T1/B1/secret")).toBe(false);
+    expect(isAllowedSlackInteractionResponseUrl("https://hooks.slack.com.attacker.test/actions/T1/B1/secret")).toBe(
+      false,
+    );
+    expect(isAllowedSlackInteractionResponseUrl("https://hooks.slack.com/services/T1/B1/secret")).toBe(false);
+  });
+});

--- a/src/channels/slack/interactions.ts
+++ b/src/channels/slack/interactions.ts
@@ -26,6 +26,9 @@ interface SlackInteractionResponseUrlRow {
 }
 
 export function storeSlackInteractionResponseUrl(input: SlackInteractionResponseUrlInput): string {
+  if (!isAllowedSlackInteractionResponseUrl(input.responseUrl)) {
+    throw new Error("Slack interaction response URL is not trusted.");
+  }
   ensureSlackInteractionResponseUrlTable();
   pruneExpiredSlackInteractionResponseUrls();
 
@@ -64,6 +67,9 @@ export async function respondToSlackInteraction(
     .get(input.responseUrlId) as SlackInteractionResponseUrlRow | undefined;
   if (!row) throw new Error(`Slack interaction response handle not found: ${input.responseUrlId}`);
   if (row.expires_at <= now) throw new Error(`Slack interaction response handle expired: ${input.responseUrlId}`);
+  if (!isAllowedSlackInteractionResponseUrl(row.response_url)) {
+    throw new Error(`Slack interaction response handle is not trusted: ${input.responseUrlId}`);
+  }
 
   const response = await fetch(row.response_url, {
     method: "POST",
@@ -86,6 +92,24 @@ export async function respondToSlackInteraction(
     status: response.status,
     body: text,
   };
+}
+
+export function isAllowedSlackInteractionResponseUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return (
+    url.protocol === "https:" &&
+    url.hostname === "hooks.slack.com" &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    !url.hash &&
+    url.pathname.startsWith("/actions/")
+  );
 }
 
 function ensureSlackInteractionResponseUrlTable(): void {

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -84,13 +84,17 @@ export async function sendSlackMedia(
 
   const bytes = await readFile(input.filePath);
   const fetchImpl = dependencies.fetchImpl ?? fetch;
-  const apiBaseUrl = (dependencies.apiBaseUrl ?? DEFAULT_SLACK_API_BASE_URL).replace(/\/+$/, "");
+  const apiBaseUrl = (dependencies.apiBaseUrl ?? credentials.apiBaseUrl ?? DEFAULT_SLACK_API_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
 
   const uploadTicket = await slackFormRequest<SlackUploadUrlResponse>({
     fetchImpl,
     apiBaseUrl,
     method: "files.getUploadURLExternal",
     botToken: credentials.botToken,
+    defaultHeaders: credentials.requestHeaders,
     body: {
       filename: input.filename,
       length: String(bytes.byteLength),
@@ -119,6 +123,7 @@ export async function sendSlackMedia(
     apiBaseUrl,
     method: "files.completeUploadExternal",
     botToken: credentials.botToken,
+    defaultHeaders: credentials.requestHeaders,
     body: {
       files: JSON.stringify([{ id: ticketFileId, title: input.filename }]),
       channel_id: input.chatId,
@@ -146,11 +151,13 @@ async function slackFormRequest<T extends SlackApiResponse>(input: {
   readonly apiBaseUrl: string;
   readonly method: string;
   readonly botToken: string;
+  readonly defaultHeaders?: Readonly<Record<string, string>>;
   readonly body: Record<string, string>;
 }): Promise<T> {
   const response = await input.fetchImpl(`${input.apiBaseUrl}/${input.method}`, {
     method: "POST",
     headers: {
+      ...input.defaultHeaders,
       authorization: `Bearer ${input.botToken}`,
       "content-type": "application/x-www-form-urlencoded; charset=utf-8",
     },

--- a/src/channels/slack/routing.test.ts
+++ b/src/channels/slack/routing.test.ts
@@ -97,6 +97,7 @@ describe("Slack routing policy", () => {
     expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: " ", ts: "1.0" })).toBe(false);
     expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: "C1", ts: " " })).toBe(false);
     expect(isSlackMessageEventStructurallyEligible({ type: "message", channel: "C1", ts: "1.0" })).toBe(true);
+    expect(isSlackMessageEventStructurallyEligible({ type: "app_mention", channel: "C1", ts: "1.0" })).toBe(true);
   });
 
   it("ignores the local bot by either bot_id or user id", () => {

--- a/src/channels/slack/routing.ts
+++ b/src/channels/slack/routing.ts
@@ -125,7 +125,7 @@ export function shouldIgnoreSlackMessageEvent(
 
 export function isSlackMessageEventStructurallyEligible(event: SlackEventPayload): boolean {
   return (
-    event.type === "message" &&
+    (event.type === "message" || event.type === "app_mention") &&
     event.hidden !== true &&
     Boolean(cleanSlackId(event.channel)) &&
     Boolean(cleanSlackId(event.ts)) &&

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -4,7 +4,9 @@ import { configStore } from "../../config-store.js";
 import {
   createContact,
   ensureContactFromInbound,
+  getPendingContacts,
   linkContactIdentity,
+  listAccountPendingContacts,
   resolvePlatformIdentity,
   upsertAgentPlatformIdentity,
 } from "../../contacts.js";
@@ -210,6 +212,107 @@ describe("Slack Socket Mode routing", () => {
         chatId: "C456",
       }),
     ).toBe(false);
+  });
+
+  it("holds an unknown Slack DM for owner review and hydrates its human profile", async () => {
+    dbUpsertInstance({
+      name: "slack-main",
+      instanceId: "slack-main",
+      channel: "slack",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      contactIntakeMode: "pending",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const usersInfo = mock(async () => ({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "luis",
+        profile: { display_name: "Luis", real_name: "Luis Filipe", image_72: "https://avatars.slack-edge.com/u123" },
+      },
+    }));
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "slack-main",
+      instanceId: "slack-main",
+      getRouterConfig: () => ({
+        agents: { "ravi-hil": { id: "ravi-hil", cwd: "/tmp/ravi-hil", dmScope: "per-peer" } },
+        routes: [],
+        defaultAgent: "ravi-hil",
+        defaultDmScope: "per-peer",
+        accountAgents: {},
+        instanceToAccount: { "slack-main": "slack-main" },
+        instances: {
+          "slack-main": {
+            name: "slack-main",
+            instanceId: "slack-main",
+            channel: "slack",
+            dmPolicy: "pairing",
+            groupPolicy: "allowlist",
+            contactIntakeMode: "pending",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      }),
+      publishPrompt: async (sessionName, payload) => {
+        published.push({ sessionName, payload });
+      },
+      webClient: { usersInfo } as never,
+    });
+
+    await service.handleEnvelope({
+      envelope_id: "Ev-owner-candidate",
+      type: "events_api",
+      payload: {
+        type: "event_callback",
+        team_id: "T123",
+        event_id: "Ev-owner-candidate",
+        event_time: 1_713_000_000,
+        event: {
+          type: "message",
+          channel: "D123",
+          channel_type: "im",
+          user: "U123",
+          text: "oi Ravi",
+          ts: "1713000000.000100",
+        },
+      },
+    });
+
+    expect(published).toHaveLength(0);
+    expect(usersInfo).toHaveBeenCalledWith("U123");
+    expect(listAccountPendingContacts("slack-main")).toMatchObject([
+      { accountId: "slack-main", phone: "U123", name: "Luis", chatId: "D123", isGroup: false },
+    ]);
+    const contact = getPendingContacts()[0];
+    expect(contact?.name).toBe("Luis");
+    expect(
+      resolvePlatformIdentity({ channel: "slack", instanceId: "slack-main", platformUserId: "U123" }),
+    ).toMatchObject({ ownerType: "contact", platformDisplayName: "Luis" });
+  });
+
+  it("keeps identical Slack user ids isolated between workspace instances", () => {
+    const first = ensureContactFromInbound({
+      channel: "slack",
+      instanceId: "slack-workspace-a",
+      platformSenderId: "U123",
+      displayName: "Luis A",
+      intakeMode: "pending",
+    });
+    const second = ensureContactFromInbound({
+      channel: "slack",
+      instanceId: "slack-workspace-b",
+      platformSenderId: "U123",
+      displayName: "Luis B",
+      intakeMode: "pending",
+    });
+
+    expect(first.contact?.id).toBeTruthy();
+    expect(second.contact?.id).toBeTruthy();
+    expect(first.contact?.id).not.toBe(second.contact?.id);
   });
 
   it("loads explicit Slack instance UUID aliases into outbound runtime scope", async () => {
@@ -948,7 +1051,7 @@ describe("Slack Socket Mode routing", () => {
             ts: "1713000000.000100",
             thread_ts: "1713000000.000100",
           },
-          response_url: "https://hooks.slack.test/secret",
+          response_url: "https://hooks.slack.com/actions/T1/B1/secret",
           actions: [
             {
               type: "button",
@@ -1003,7 +1106,7 @@ describe("Slack Socket Mode routing", () => {
         }),
       },
     ]);
-    expect(JSON.stringify(interactions[0]?.payload)).not.toContain("hooks.slack.test");
+    expect(JSON.stringify(interactions[0]?.payload)).not.toContain("hooks.slack.com");
   });
 
   it("publishes Slack Work Object link and detail events as inbound interactions", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,7 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
 import { WebSocket as NodeWebSocket } from "ws";
 import { configStore } from "../../config-store.js";
-import { resolvePlatformIdentity, type PlatformIdentity } from "../../contacts.js";
+import {
+  ensureContactFromInbound,
+  resolvePlatformIdentity,
+  saveAccountPending,
+  type PlatformIdentity,
+} from "../../contacts.js";
 import { publish } from "../../nats.js";
 import { publishSessionPrompt } from "../../omni/session-stream.js";
 import {
@@ -45,6 +50,7 @@ import {
 } from "../backend.js";
 import { SlackWebApiClient } from "./client.js";
 import { resolveSlackCredentialConfigFromEnv, type SlackCredentialResolver } from "./credentials.js";
+import { SlackGatewayModeService } from "./gateway-mode.js";
 import {
   buildSlackInstanceProvenance,
   resolveScopedSlackIdentity,
@@ -103,6 +109,11 @@ type PublishInteraction = (topic: string, payload: Record<string, unknown>) => P
 type WebSocketFactory = (url: string) => NodeWebSocket;
 type SocketTimer = ReturnType<typeof setTimeout>;
 
+interface SlackUserProfile {
+  readonly displayName: string | null;
+  readonly avatarUrl: string | null;
+}
+
 export type SlackSocketModeState = "stopped" | "connecting" | "connected" | "reconnecting";
 
 export type SlackSocketModeReason =
@@ -114,7 +125,9 @@ export type SlackSocketModeReason =
   | "heartbeat_timeout"
   | "socket_error"
   | "socket_closed"
-  | "slack_disconnect";
+  | "slack_disconnect"
+  | "polling_gateway"
+  | "gateway_unavailable";
 
 export interface SlackSocketModeStatus {
   readonly state: SlackSocketModeState;
@@ -187,7 +200,7 @@ export interface SlackNativeRuntime {
   readonly delivery: NativeTextDelivery;
   readonly actions: NativeChatActionDelivery;
   readonly presence: NativePresenceDelivery;
-  readonly socketMode: SlackSocketModeService;
+  readonly socketMode: SlackSocketModeService | SlackGatewayModeService;
 }
 
 export interface SlackTargetScope {
@@ -583,6 +596,7 @@ export class SlackSocketModeService {
   private readonly authTestTimeoutMs: number;
   private readonly now: () => number;
   private readonly seenEnvelopeIds = new RecentIdCache();
+  private readonly userProfiles = new Map<string, SlackUserProfile | null>();
   private localBotIdentity: SlackLocalBotIdentity | null = null;
   private localBotIdentityInFlight: Promise<SlackLocalBotIdentity | null> | null = null;
   private nextLocalBotIdentityAttemptAt = 0;
@@ -1318,6 +1332,83 @@ export class SlackSocketModeService {
     });
   }
 
+  private async slackUserProfile(userId: string): Promise<SlackUserProfile | null> {
+    const cached = this.userProfiles.get(userId);
+    if (cached !== undefined) return cached;
+    const usersInfo = (this.webClient as Partial<SlackWebApiClient>).usersInfo;
+    if (typeof usersInfo !== "function") return null;
+    try {
+      const response = await usersInfo.call(this.webClient, userId);
+      const user = recordField(response, "user");
+      const profile = recordField(user, "profile");
+      const resolved = {
+        displayName:
+          stringField(profile, "display_name_normalized") ??
+          stringField(profile, "display_name") ??
+          stringField(profile, "real_name_normalized") ??
+          stringField(profile, "real_name") ??
+          stringField(user, "real_name") ??
+          stringField(user, "name") ??
+          null,
+        avatarUrl:
+          stringField(profile, "image_192") ??
+          stringField(profile, "image_72") ??
+          stringField(profile, "image_48") ??
+          null,
+      } satisfies SlackUserProfile;
+      if (this.userProfiles.size >= 1_000) {
+        const oldest = this.userProfiles.keys().next().value;
+        if (oldest) this.userProfiles.delete(oldest);
+      }
+      this.userProfiles.set(userId, resolved);
+      return resolved;
+    } catch (error) {
+      log.warn("Slack user profile could not be resolved", {
+        accountId: this.options.accountId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  private async holdSlackSenderForReview(input: {
+    message: SlackNormalizedMessage;
+    accountId: string;
+    instanceId: string;
+    intakeMode: "off" | "discovered" | "pending";
+    isGroup: boolean;
+  }): Promise<void> {
+    const profile = input.isGroup ? null : await this.slackUserProfile(input.message.userId);
+    if (!input.isGroup) {
+      ensureContactFromInbound({
+        channel: "slack",
+        instanceId: input.instanceId,
+        platformSenderId: input.message.userId,
+        contactIdentity: input.message.userId,
+        displayName: profile?.displayName ?? null,
+        avatarUrl: profile?.avatarUrl ?? null,
+        profileData: {
+          source: "slack.event",
+          accountId: input.accountId,
+          teamId: input.message.teamId,
+          channelId: input.message.channelId,
+        },
+        chatId: input.message.channelId,
+        chatType: "dm",
+        sourceEventId: input.message.eventId ?? input.message.envelopeId ?? null,
+        providerMessageId: input.message.ts,
+        intakeMode: input.intakeMode,
+        source: "slack.event",
+      });
+    }
+    saveAccountPending(input.accountId, input.isGroup ? input.message.channelId : input.message.userId, {
+      name: profile?.displayName ?? null,
+      chatId: input.message.channelId,
+      isGroup: input.isGroup,
+    });
+  }
+
   private async routeMessage(message: SlackNormalizedMessage): Promise<void> {
     const routerConfig = this.getRouterConfig();
     const peerKind = slackPeerKindForChannelType(message.channelType);
@@ -1327,6 +1418,9 @@ export class SlackSocketModeService {
     const receivedInstanceId = this.options.instanceId ?? this.options.accountId;
     const instanceAliases = resolveSlackInstanceAliases(routerConfig, receivedInstanceId);
     const instanceId = instanceAliases.canonical;
+    const instanceConfig =
+      instanceAliases.scopedAliases.map((alias) => routerConfig.instances?.[alias]).find(Boolean) ??
+      routerConfig.instances?.[routeAccountId];
     const canonicalChat = dbUpsertChat({
       channel: "slack",
       instanceId,
@@ -1357,7 +1451,8 @@ export class SlackSocketModeService {
     });
 
     const existingSubscription = findSessionByAttachedChat(canonicalChat.id);
-    if (existingSubscription && (!matched || existingSubscription.sessionKey !== matched.sessionKey)) {
+    let trustedSubscription = false;
+    if (existingSubscription) {
       const ownerSession = getSession(existingSubscription.sessionKey);
       const ownerAgent = ownerSession ? routerConfig.agents[ownerSession.agentId] : undefined;
       const compatibleSession = isChatCompatibleWithSession(canonicalChat.id, existingSubscription.sessionKey);
@@ -1368,18 +1463,21 @@ export class SlackSocketModeService {
           routeSessionKey: matched?.sessionKey,
         });
       } else if (ownerSession && ownerAgent) {
-        log.info("Slack inbound rerouted by session subscription", {
-          chatId: canonicalChat.id,
-          fromSessionKey: matched?.sessionKey,
-          toSessionKey: existingSubscription.sessionKey,
-        });
-        matched = {
-          agentId: ownerSession.agentId,
-          agent: ownerAgent,
-          sessionKey: existingSubscription.sessionKey,
-          dmScope: matched?.dmScope ?? ownerAgent.dmScope ?? routerConfig.defaultDmScope,
-          route: matched?.route,
-        } satisfies MatchedRoute;
+        if (!matched || existingSubscription.sessionKey !== matched.sessionKey) {
+          log.info("Slack inbound rerouted by session subscription", {
+            chatId: canonicalChat.id,
+            fromSessionKey: matched?.sessionKey,
+            toSessionKey: existingSubscription.sessionKey,
+          });
+          matched = {
+            agentId: ownerSession.agentId,
+            agent: ownerAgent,
+            sessionKey: existingSubscription.sessionKey,
+            dmScope: matched?.dmScope ?? ownerAgent.dmScope ?? routerConfig.defaultDmScope,
+            route: matched?.route,
+          } satisfies MatchedRoute;
+        }
+        trustedSubscription = true;
       } else {
         log.warn("Slack subscription points to a missing session or agent - falling back to route resolution", {
           chatId: canonicalChat.id,
@@ -1389,6 +1487,40 @@ export class SlackSocketModeService {
         });
       }
     }
+
+    const explicitRoute = trustedSubscription || Boolean(matched?.route && matched.route.pattern !== "*");
+    const routePolicy = matched?.route?.policy;
+    const inboundPolicy = isGroup
+      ? (routePolicy ?? instanceConfig?.groupPolicy ?? "open")
+      : (routePolicy ?? instanceConfig?.dmPolicy ?? "open");
+    const needsReview =
+      !matched ||
+      (!explicitRoute && ((isGroup && inboundPolicy === "allowlist") || (!isGroup && inboundPolicy === "pairing")));
+    if (needsReview) {
+      await this.holdSlackSenderForReview({
+        message,
+        accountId: routeAccountId,
+        instanceId,
+        intakeMode: instanceConfig?.contactIntakeMode ?? "off",
+        isGroup,
+      });
+      log.info("Slack inbound held for owner review", {
+        accountId: routeAccountId,
+        channelId: message.channelId,
+        userId: message.userId,
+        reviewKind: isGroup ? "chat" : "contact",
+      });
+      return;
+    }
+    if (!explicitRoute && inboundPolicy === "closed") {
+      log.info("Slack inbound rejected by closed instance policy", {
+        accountId: routeAccountId,
+        channelId: message.channelId,
+        userId: message.userId,
+      });
+      return;
+    }
+
     if (!matched) {
       log.info("Slack inbound skipped: no route matched", {
         accountId: routeAccountId,
@@ -2241,8 +2373,11 @@ export async function createSlackNativeRuntimeFromEnv(
   const webClient = new SlackWebApiClient({
     appToken: credentials.appToken,
     botToken: credentials.botToken,
+    apiBaseUrl: credentials.apiBaseUrl,
+    fileProxyUrl: credentials.fileProxyUrl,
+    defaultHeaders: credentials.requestHeaders,
   });
-  const socketMode = new SlackSocketModeService({
+  const processor = new SlackSocketModeService({
     appToken: credentials.appToken,
     botToken: credentials.botToken,
     accountId: credentials.accountId,
@@ -2251,6 +2386,14 @@ export async function createSlackNativeRuntimeFromEnv(
     routingPolicy,
     webClient,
   });
+  const socketMode = credentials.gateway
+    ? new SlackGatewayModeService({
+        claimUrl: credentials.gateway.claimUrl,
+        completionBaseUrl: credentials.gateway.completionBaseUrl,
+        requestHeaders: credentials.gateway.requestHeaders,
+        processor,
+      })
+    : processor;
   const delivery = new SlackTextDelivery(webClient, routingPolicy, scope);
   const actions = new SlackChatActionDelivery(webClient, scope);
   const reactionPresence = new SlackReactionPresence(

--- a/src/cli/commands/slack.test.ts
+++ b/src/cli/commands/slack.test.ts
@@ -100,6 +100,8 @@ mock.module("../../config-store.js", () => ({
 }));
 
 mock.module("../../channels/slack/credentials.js", () => ({
+  isSlackGatewayChannel: (channel?: { enabled?: boolean; provider?: string; defaults?: { transport?: string } }) =>
+    channel?.enabled !== false && channel?.provider === "slack" && channel?.defaults?.transport === "hub_gateway_v1",
   resolveSlackCredentialConfigFromEnv: async (
     _env: NodeJS.ProcessEnv,
     options?: { action?: string; channel?: { name?: string; credentialConnection?: string } },

--- a/src/cli/commands/slack.ts
+++ b/src/cli/commands/slack.ts
@@ -31,7 +31,11 @@ import { buildSlackTopology } from "../../channels/slack/topology.js";
 import type { SlackSocketEnvelope } from "../../channels/slack/types.js";
 import { configStore } from "../../config-store.js";
 import { getContact } from "../../contacts.js";
-import { resolveSlackCredentialConfigFromEnv, type SlackCredentialConfig } from "../../channels/slack/credentials.js";
+import {
+  isSlackGatewayChannel,
+  resolveSlackCredentialConfigFromEnv,
+  type SlackCredentialConfig,
+} from "../../channels/slack/credentials.js";
 import { dbFindChat, dbFindChatMessage, type ChannelConfig } from "../../router/router-db.js";
 import {
   appendArtifactEvent,
@@ -258,7 +262,7 @@ function resolveSlackOpsTarget(channelName: string | undefined, contract: SlackC
     );
   }
 
-  if (!channel.credentialConnection?.trim()) {
+  if (!channel.credentialConnection?.trim() && !isSlackGatewayChannel(channel)) {
     contractFail(
       contract.op,
       "CREDENTIALS_NOT_CONFIGURED",
@@ -278,7 +282,7 @@ function resolveSlackOpsTarget(channelName: string | undefined, contract: SlackC
     summary: {
       accountId: channel.name,
       instanceId: channel.name,
-      source: "broker",
+      source: isSlackGatewayChannel(channel) ? "gateway" : "broker",
     },
   };
 }
@@ -319,6 +323,9 @@ async function createSlackOpsContext(
     client: new SlackWebApiClient({
       appToken: config.appToken,
       botToken: config.botToken,
+      apiBaseUrl: config.apiBaseUrl,
+      fileProxyUrl: config.fileProxyUrl,
+      defaultHeaders: config.requestHeaders,
     }),
   };
 }
@@ -3375,6 +3382,9 @@ export class SlackCommands {
       client: new SlackWebApiClient({
         appToken: config.appToken,
         botToken: config.botToken,
+        apiBaseUrl: config.apiBaseUrl,
+        fileProxyUrl: config.fileProxyUrl,
+        defaultHeaders: config.requestHeaders,
       }),
     };
   }

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -7655,6 +7655,7 @@ export function ensureContactFromInbound(input: EnsureContactFromInboundInput): 
   const platformSenderId = input.platformSenderId.trim();
   if (!platformSenderId) throw new Error("Platform sender id is required");
   const contactIdentity = (input.contactIdentity?.trim() || platformSenderId).trim();
+  const scopedPlatformIdentityOnly = channel === "slack";
   const desiredStatus = contactStatusFromIntakeMode(input.intakeMode ?? "off");
   const intakeSource = input.source?.trim() || "inbound_contact_intake";
   const eventIds: string[] = [];
@@ -7682,7 +7683,7 @@ export function ensureContactFromInbound(input: EnsureContactFromInboundInput): 
         contact = getCanonicalCompatContactById(database, existingIdentity.owner_id);
         platformIdentity = rowToPlatformIdentity(existingIdentity);
       }
-      if (!contact && contactIdentity) {
+      if (!contact && contactIdentity && !scopedPlatformIdentityOnly) {
         contact = findCanonicalContactByIdentity(database, contactIdentity);
       }
 
@@ -7700,13 +7701,32 @@ export function ensureContactFromInbound(input: EnsureContactFromInboundInput): 
       const evidence = inboundIntakeEventEvidence(input);
 
       if (!contact) {
-        contact = createCanonicalContactForIdentity(database, contactIdentity, {
-          name: input.displayName ?? null,
-          status: desiredStatus!,
-          source: "inbound",
-          tags: [],
-          notes: {},
-        });
+        if (scopedPlatformIdentityOnly) {
+          const id = generateId();
+          upsertCanonicalContactRecord(database, {
+            id,
+            displayName: input.displayName ?? null,
+            metadata: { source: "contacts", identityModel: "canonical" },
+          });
+          upsertCanonicalContactPolicy(database, {
+            contactId: id,
+            status: desiredStatus!,
+            replyMode: "auto",
+            tags: [],
+            notes: {},
+            source: "inbound",
+          });
+          contact = getCanonicalCompatContactById(database, id);
+        } else {
+          contact = createCanonicalContactForIdentity(database, contactIdentity, {
+            name: input.displayName ?? null,
+            status: desiredStatus!,
+            source: "inbound",
+            tags: [],
+            notes: {},
+          });
+        }
+        if (!contact) throw new Error("Inbound contact was not created.");
         createdContact = true;
         const createdEvent = insertContactEvent(database, {
           contactId: contact.id,


### PR DESCRIPTION
## Objective

Add a secure native Slack transport that lets a Ravi runtime communicate through the Ravi Hub without receiving Slack app secrets or workspace tokens.

## Problem

The existing native Slack channel assumes direct access to a Slack token and direct event delivery. A multi-tenant Hub cannot safely copy customer workspace tokens into every isolated runtime, and unknown direct-message senders must not reach an agent before the owner explicitly approves a route.

## Solution

Introduce an HTTPS Hub gateway mode for the native Slack channel. The runtime claims durable normalized events with an installation-scoped credential, completes delivery explicitly, and sends allowlisted Slack Web API and private-file requests through the Hub. Unknown direct messages become pending owner candidates, app mentions are supported, interaction response URLs are validated, and canonical Slack identities are scoped to the connected workspace instance.

## Practical impact

Customers can install one distributed Ravi Slack app through OAuth while each Ravi keeps its existing native channel behavior and policy engine. Workspace tokens remain centralized in the Hub, retries survive transient runtime outages, and selecting the primary Slack contact remains an explicit Ravi access decision.

## What does NOT change

The Hub does not decide who may talk to an agent and does not bypass Ravi permissions, routes, contacts, or subscriptions. Existing direct-token and Socket Mode Slack configurations continue to use their current native transports, and no WhatsApp behavior changes in this pull request.

## Validation

Validated with bun run build, bun run typecheck, bun run lint, the complete bun run test suite, the repository quality gate, SDK generation checks, and OpenAPI consistency checks. All local checks passed for commit 65fd7fd0.

## Risks

A malformed gateway configuration could interrupt Slack delivery, and a Hub outage delays events until the runtime can claim them again. Configuration validation fails closed, event completion is explicit, unknown senders are held before publication, response URLs are restricted, and Slack identities cannot merge across workspace installations.

## Rollback

Revert this pull request and keep runtimes on the previous exact Ravi release. The existing direct token and Socket Mode transports remain untouched, so deployments that do not enable gateway mode can continue without a data migration.