### PR TITLE
fix(contacts): preserve non-phone identity status

### DIFF
--- a/src/contacts.identity-model.test.ts
+++ b/src/contacts.identity-model.test.ts
@@ -3,6 +3,7 @@ import { Database } from "bun:sqlite";
 import { join } from "node:path";
 import {
   addContactTag,
+  allowContact,
   archiveCrmPipelineStage,
   backfillInboundContacts,
   buildMentionedContactPromptContexts,
@@ -88,6 +89,28 @@ afterEach(async () => {
 });
 
 describe("contacts identity graph schema", () => {
+  it("allows a Slack-only contact through its compatibility identity", () => {
+    const inbound = ensureContactFromInbound({
+      channel: "slack",
+      instanceId: "slack-main",
+      platformSenderId: "U0BAA2B1LTS",
+      displayName: "Luis",
+      intakeMode: "pending",
+      source: "test",
+    });
+
+    expect(inbound.contact).toMatchObject({
+      phone: "U0BAA2B1LTS",
+      status: "pending",
+    });
+
+    allowContact(inbound.contact!.phone);
+
+    expect(getContact(inbound.contact!.id)?.status).toBe("allowed");
+    expect(getContact("U0BAA2B1LTS")?.status).toBe("allowed");
+    expect(getAllContacts()).toHaveLength(1);
+  });
+
   it("writes canonical contacts, policies, and platform identities directly", () => {
     upsertContact("5511999999999", "Alice", "allowed", "manual");
     const contact = getContact("5511999999999");

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -9151,9 +9151,13 @@ export function deleteContact(phone: string): boolean {
  */
 export function setContactStatus(phone: string, status: ContactStatus): void {
   const database = ensureDb();
-  const normalized = assertPersonOrOrgIdentity(phone, "setContactStatus");
-  const contact = resolveContact(normalized);
+  // Resolve the original reference first. Non-phone identities (for example a
+  // Slack user id) are already canonical platform identities and must not be
+  // passed through phone normalization, which would strip their letters and
+  // update a different compatibility contact.
+  const contact = resolveContact(phone);
   if (!contact) {
+    const normalized = assertPersonOrOrgIdentity(phone, "setContactStatus");
     upsertContact(normalized, null, status);
   } else {
     upsertCanonicalContactPolicy(database, {


### PR DESCRIPTION
## Objective

Make contact status mutations work for canonical contacts that exist only through non-phone platform identities such as Slack user IDs.

## Problem

The status mutation normalized the compatibility identity as a phone number before resolving it. A Slack user ID therefore lost its letters, left the real contact pending, and could create a second shadow contact while the CLI incorrectly reported success.

## Solution

Resolve the original canonical contact reference first. Apply phone normalization only when no existing contact can be resolved and a new phone-backed contact must be created. Add a regression test for a Slack-only pending contact and assert that approval changes the real policy without creating a duplicate.

## Practical impact

Selecting a Slack owner can persist the real contact as allowed, after which Ravi can safely create the exact owner route and elevate only the main session. The same fix also protects block and other status mutations that use non-phone platform identities.

## What does NOT change

Phone and WhatsApp identity normalization remains unchanged. This does not alter Slack OAuth, token storage, routing policy, or permission policy.

## Validation

Build, typecheck, generated SDK drift checks, and the full contact identity-model suite passed. The repository pre-push suite reached one unrelated channel-backend hook timeout; the isolated channel-backend file then passed 9/9.

## Risks

Resolving before normalization changes lookup order only for already-known canonical references. The regression test proves the platform identity resolves to one contact and no compatibility shadow is created.

## Rollback

Revert this pull request. Existing phone-backed contact behavior remains available, but non-phone status mutations would again fail to update their canonical contact.