### PR TITLE
fix(contacts): prefer exact platform identity

### DIFF
--- a/src/contacts.identity-model.test.ts
+++ b/src/contacts.identity-model.test.ts
@@ -89,7 +89,8 @@ afterEach(async () => {
 });
 
 describe("contacts identity graph schema", () => {
-  it("allows a Slack-only contact through its compatibility identity", () => {
+  it("prefers an exact Slack identity over a legacy phone-normalized shadow contact", () => {
+    upsertContact("021", "Legacy shadow", "blocked", "manual");
     const inbound = ensureContactFromInbound({
       channel: "slack",
       instanceId: "slack-main",
@@ -108,7 +109,8 @@ describe("contacts identity graph schema", () => {
 
     expect(getContact(inbound.contact!.id)?.status).toBe("allowed");
     expect(getContact("U0BAA2B1LTS")?.status).toBe("allowed");
-    expect(getAllContacts()).toHaveLength(1);
+    expect(getContact("021")?.status).toBe("blocked");
+    expect(getAllContacts()).toHaveLength(2);
   });
 
   it("writes canonical contacts, policies, and platform identities directly", () => {

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -2935,9 +2935,36 @@ function findCanonicalContactByIdentity(database: Database, identity: string): C
     candidates.add(`lid:${normalized}`);
   }
 
+  const byExactId = getCanonicalCompatContactById(database, raw);
+  if (byExactId) return byExactId;
+
+  // Exact platform identities must win over compatibility heuristics. A
+  // legacy contact created by phone-normalizing a Slack id such as
+  // U0BAA2B1LTS to 021 must never shadow the real Slack identity.
+  const exactPlatformIdentity = database
+    .prepare(
+      `
+      SELECT * FROM platform_identities
+      WHERE owner_type = 'contact'
+        AND (
+          id = ?
+          OR normalized_platform_user_id COLLATE NOCASE = ?
+          OR platform_user_id COLLATE NOCASE = ?
+        )
+      ORDER BY is_primary DESC, updated_at DESC
+      LIMIT 1
+    `,
+    )
+    .get(raw, raw, raw) as PlatformIdentityRow | undefined;
+  if (exactPlatformIdentity?.owner_id) {
+    const byExactPlatformIdentity = getCanonicalCompatContactById(database, exactPlatformIdentity.owner_id);
+    if (byExactPlatformIdentity) return byExactPlatformIdentity;
+  }
+
   for (const candidate of candidates) {
-    const byId = getCanonicalCompatContactById(database, candidate);
-    if (byId) return byId;
+    if (candidate === raw) continue;
+    const byCompatibilityId = getCanonicalCompatContactById(database, candidate);
+    if (byCompatibilityId) return byCompatibilityId;
   }
 
   const platformIdentity = findDefaultPlatformIdentityForIdentity(database, raw);


### PR DESCRIPTION
## Objective

Make canonical platform identities win over legacy phone-normalized compatibility contacts during contact lookup.

## Problem

A failed Slack approval on an older runtime could leave a shadow phone contact such as `021`, derived by stripping letters from `U0BAA2B1LTS`. Later lookups of the exact Slack ID consulted the phone heuristic first, resolved the shadow, and left the real Slack contact pending even after the status mutation fix in #413.

## Solution

Resolve an exact canonical contact ID and exact `platform_identities` match before any phone or email compatibility heuristic. Keep the compatibility fallback for genuine phone-backed identities. Extend the Slack regression test with a pre-existing blocked `021` shadow and prove that allowing `U0BAA2B1LTS` updates only the real Slack contact.

## Practical impact

Existing Ravi instances that already encountered the old bug can finish Slack owner activation without database cleanup. The selected Slack contact becomes allowed, while unrelated legacy contacts remain unchanged.

## What does NOT change

This does not delete or merge legacy contacts. It does not change Slack OAuth, gateway token handling, route policy, group policy, or permission elevation rules.

## Validation

The regression test failed before the lookup-order change and passed afterward. Contact identity-model suite: 42 passed, 0 failed. Typecheck, lint, build, generated SDK drift checks, OpenAPI checks, Swift SDK checks, and the complete pre-push suite passed.

## Risks

Lookup precedence changes only when an exact platform identity and a heuristic compatibility identity could both match. Exact provider identity is the less ambiguous source and is now deliberately preferred.

## Rollback

Revert this pull request. Compatibility lookup ordering returns to the prior behavior, including the legacy-shadow collision.
