### PR TITLE
fix(slack): route direct messages by sender identity

### DIFF
--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -294,6 +294,81 @@ describe("Slack Socket Mode routing", () => {
     ).toMatchObject({ ownerType: "contact", platformDisplayName: "Luis" });
   });
 
+  it("routes an approved Slack DM by the sender identity instead of the conversation id", async () => {
+    dbUpsertInstance({
+      name: "slack-main",
+      instanceId: "slack-main",
+      channel: "slack",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      contactIntakeMode: "pending",
+    });
+    const published: Array<{ sessionName: string; payload: Record<string, unknown> }> = [];
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "slack-main",
+      instanceId: "slack-main",
+      getRouterConfig: () => ({
+        agents: { "ravi-hil": { id: "ravi-hil", cwd: "/tmp/ravi-hil", dmScope: "per-peer" } },
+        routes: [
+          {
+            pattern: "u123",
+            accountId: "slack-main",
+            agent: "ravi-hil",
+            session: "main",
+            priority: 1_000,
+            policy: "open",
+            channel: "slack",
+            dmScope: "per-peer",
+          },
+        ],
+        defaultAgent: "ravi-hil",
+        defaultDmScope: "per-peer",
+        accountAgents: {},
+        instanceToAccount: { "slack-main": "slack-main" },
+        instances: {
+          "slack-main": {
+            name: "slack-main",
+            instanceId: "slack-main",
+            channel: "slack",
+            dmPolicy: "pairing",
+            groupPolicy: "allowlist",
+            contactIntakeMode: "pending",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      }),
+      publishPrompt: async (sessionName, payload) => {
+        published.push({ sessionName, payload });
+      },
+      webClient: {} as never,
+    });
+
+    await service.handleEnvelope({
+      envelope_id: "Ev-approved-owner",
+      type: "events_api",
+      payload: {
+        type: "event_callback",
+        team_id: "T123",
+        event_id: "Ev-approved-owner",
+        event_time: 1_713_000_000,
+        event: {
+          type: "message",
+          channel: "D123",
+          channel_type: "im",
+          user: "U123",
+          text: "oi Ravi",
+          ts: "1713000000.000200",
+        },
+      },
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.sessionName).toBe("main");
+  });
+
   it("keeps identical Slack user ids isolated between workspace instances", () => {
     const first = ensureContactFromInbound({
       channel: "slack",

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1421,6 +1421,7 @@ export class SlackSocketModeService {
     const instanceConfig =
       instanceAliases.scopedAliases.map((alias) => routerConfig.instances?.[alias]).find(Boolean) ??
       routerConfig.instances?.[routeAccountId];
+    const routePeerId = isGroup ? message.channelId : (message.slackUserId ?? message.userId);
     const canonicalChat = dbUpsertChat({
       channel: "slack",
       instanceId,
@@ -1441,7 +1442,7 @@ export class SlackSocketModeService {
       seenAt: message.eventTimeMs,
     });
     let matched = matchRoute(routerConfig, {
-      phone: message.channelId,
+      phone: routePeerId,
       channel: "slack",
       accountId: routeAccountId,
       isGroup,
@@ -1531,7 +1532,7 @@ export class SlackSocketModeService {
     }
 
     const resolved = commitMatchedRoute(matched, {
-      phone: message.channelId,
+      phone: routePeerId,
       isGroup,
       groupId: isGroup ? message.channelId : undefined,
       peerKind,


### PR DESCRIPTION
## Objective

Make an approved Slack owner reach the configured Ravi session through a direct message without weakening the inbound access policy.

## Problem

Slack direct messages carry a conversation ID (`D...`) and a sender ID (`U...`). Exact owner routes are bound to the sender identity, but inbound routing compared them with the conversation ID, so a securely approved owner was treated as unknown after the Hub had delivered the event.

## Solution

Use the sender's Slack user ID as the route peer for direct messages. Continue using the conversation ID for channels and group conversations. Use the same peer consistently when matching and committing the route.

## Practical impact

After the owner is selected in the Hub, their Slack DM resolves to the explicit owner route and reaches the intended `main` session. The runtime can then produce a reply through the existing gateway.

## What does NOT change

Unknown direct messages remain behind pairing review. Public channels, private channels, group DMs, workspace isolation, token custody, signature validation, and group allowlists keep their existing behavior.

## Validation

The regression test failed before the implementation and passes afterward. The Slack adapter suite has 65 passing tests. Typecheck and Biome pass, and the full pre-push build, test, SDK, OpenAPI, and Swift drift gate is green.

## Risks

The behavior changes only for Slack direct-message route selection. A malformed event without a usable sender still cannot match the explicit owner route, while non-DM routing continues to use its conversation identity.

## Rollback

Revert commit `a01ddfbb748f2437ea8055f6289e6945f9cf3d56` and publish the preceding Ravi version. No schema or data migration needs reversal.
