### PR TITLE
fix(release): publish npm provenance

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -167,5 +167,5 @@ jobs:
             npm dist-tag add "${PACKAGE}@${VERSION}" "${NPM_TAG}"
           else
             echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-            bun publish --access public --tag "${NPM_TAG}"
+            npm publish --access public --tag "${NPM_TAG}" --provenance
           fi


### PR DESCRIPTION
## Objective

Publish Ravi packages with npm provenance so production can verify that a package came from the GitHub Actions release workflow.

## Problem

- `bun publish` accepted the provenance environment variable but the npm registry did not receive an attestation for `3.260817.1`.

## Solution

- Publish new package versions with `npm publish --provenance` inside the existing OIDC-enabled workflow.

## Practical impact

- The next `ravi.bot` release exposes a registry provenance attestation and can be used as the verified production runtime artifact.

## What does NOT change

- Version derivation, dist-tags, package contents, token authentication, and the existing integrity metadata stay unchanged.

## Validation

- `git diff --check`
- `bun run typecheck`
- The failed assumption was verified against the npm registry: `3.260817.1` has integrity metadata but no provenance attestation.

## Risks

- Publishing fails closed if npm cannot create provenance in GitHub Actions.

## Rollback

- Revert this one workflow line; already published package versions are immutable.

## Follow-ups

- Verify the new registry attestation before production installation.