### PR TITLE
Add Grok Build runtime provider (ACP)

### DIFF
--- a/.ravi/specs/runtime/providers/credential-fallback/SPEC.md
+++ b/.ravi/specs/runtime/providers/credential-fallback/SPEC.md
@@ -59,7 +59,7 @@ Credential fallback is a runtime/provider concern. Routes, sessions, tasks, chan
 
 ## Terminology
 
-- **Runtime provider**: Ravi adapter id such as `claude`, `codex`, or `pi`.
+- **Runtime provider**: Ravi adapter id such as `claude`, `codex`, `pi`, or `grok`.
 - **Upstream provider**: Provider behind a runtime adapter, such as `anthropic`, `openai`, `google`, `openrouter`, `groq`, or `kimi-coding`.
 - **Credential pool**: Ordered set of credentials eligible for a runtime provider, upstream provider, model family, agent, or task scope.
 - **Credential slot**: One configured credential entry with metadata, secret bindings, state, and health.

--- a/.ravi/specs/runtime/providers/grok/CHECKS.md
+++ b/.ravi/specs/runtime/providers/grok/CHECKS.md
@@ -1,0 +1,43 @@
+# Grok Build Provider Checks
+
+## Contract Tests
+
+- Provider id is `grok`.
+- Capability matrix includes every required structured field.
+- Restricted agents are rejected in the ACP MVP.
+- `startSession` starts a fake ACP client and returns a valid runtime handle.
+- `interrupt()` sends `session/cancel` and emits `turn.interrupted`.
+- Resume uses `session/load` with the stored ACP `sessionId` and matching cwd.
+- Spawn args include `agent stdio`, `--no-auto-update`, `--no-alt-screen`, and `--always-approve`.
+- Command override reads `RAVI_GROK_COMMAND`.
+- `xhigh|max|ultra` map to native `--effort high`.
+- `prepareSession` is omitted unless env/tools/approvals become required.
+
+## Event Mapping Tests
+
+- Handshake `sessionId` maps to `thread.started`.
+- Accepted prompt maps to `turn.started`.
+- `agent_message_chunk` maps to `text.delta`.
+- Accumulated assistant chunks map to `assistant.message`.
+- `agent_thought_chunk` does not leak hidden reasoning as assistant output.
+- `tool_call` maps to `tool.started`.
+- `tool_call_update` completed/failed maps to `tool.completed`.
+- `session/prompt` `end_turn` maps to `turn.complete` exactly once.
+- `session/prompt` `cancelled` maps to `turn.interrupted`.
+- `session/prompt` rejection maps to `turn.failed`.
+
+## Negative Tests
+
+- ACP process exits before terminal event.
+- ACP stdout emits malformed JSON.
+- ACP `session/prompt` fails before acceptance.
+- Thought-only turn still emits exactly one terminal event.
+- Resume is requested but the agent does not advertise `loadSession`.
+- Incoming ACP methods other than `session/request_permission` are rejected.
+
+## E2E Smoke
+
+- Text-only prompt completes and saves provider session state. Manual only; not CI.
+- Tool-using prompt emits tool start/end and then completes. Manual only; not CI.
+- Interrupt during text streaming ends as interrupted, not failed. Manual only; not CI.
+- Restart/resume uses Grok session state only when cwd matches. Manual only; not CI.

--- a/.ravi/specs/runtime/providers/grok/RUNBOOK.md
+++ b/.ravi/specs/runtime/providers/grok/RUNBOOK.md
@@ -1,0 +1,47 @@
+# Grok Build Provider Runbook
+
+## Preflight
+
+1. Verify the `grok` executable is available, or set `RAVI_GROK_COMMAND`.
+2. Verify the target cwd exists and is the intended Ravi agent cwd.
+3. Verify Grok authentication: `grok login` or `XAI_API_KEY`.
+4. Verify the Ravi agent does not require restricted tool access in the ACP MVP.
+5. Verify `RuntimeCapabilities` compatibility passes before starting the provider.
+
+## Start A Session
+
+1. Spawn `grok --no-auto-update --no-alt-screen --always-approve agent stdio`.
+2. Attach a strict JSONL reader to stdout.
+3. Capture stderr for logs only.
+4. Send `initialize`, then `authenticate` when auth methods are advertised.
+5. If resuming, validate cwd and call `session/load`. Otherwise call `session/new`.
+6. Emit `thread.started` from the ACP `sessionId`.
+
+## Run A Prompt
+
+1. Wait for a Ravi `RuntimePromptMessage`.
+2. Emit `turn.started`.
+3. Send `session/prompt` with a single text block.
+4. Convert `session/update` notifications to Ravi runtime events while the prompt request is in flight.
+5. When `session/prompt` returns, emit `assistant.message` if text arrived, then exactly one terminal event.
+
+## Interrupt
+
+1. Send ACP `session/cancel` for the current `sessionId`.
+2. Auto-cancel any in-flight `session/request_permission` requests.
+3. Expect `stopReason=cancelled` or a transport error, then emit `turn.interrupted` once.
+
+## Resume
+
+1. Read `RuntimeSessionState.params.sessionId`.
+2. Reject resume when stored cwd does not match.
+3. Call `session/load` only when initialize advertised `loadSession`.
+4. Persist the same `sessionId` on the next `turn.complete`.
+
+## Debug A Stuck Grok Turn
+
+1. Inspect `adapter.request` for provider `grok`, model, cwd, and previous session id.
+2. Inspect `provider.raw` events for `session/update` payloads.
+3. If a tool started, verify there is a matching `tool.completed`.
+4. If the native child exited, verify the provider emitted `turn.failed` or `turn.interrupted`.
+5. If there is no terminal event, inspect ACP `session/prompt` completion and adapter terminality before touching host runtime.

--- a/.ravi/specs/runtime/providers/grok/SPEC.md
+++ b/.ravi/specs/runtime/providers/grok/SPEC.md
@@ -1,0 +1,145 @@
+---
+id: runtime/providers/grok
+title: "Grok Build Runtime Provider"
+kind: feature
+domain: runtime
+capabilities:
+  - providers
+  - grok
+  - acp
+  - rpc
+tags:
+  - runtime
+  - grok
+  - grok-build
+  - coding-agent
+  - acp
+applies_to:
+  - src/runtime/grok-provider.ts
+  - src/runtime/provider-registry.ts
+  - src/runtime/types.ts
+  - src/runtime/provider-contract.test.ts
+  - src/runtime/grok-provider.test.ts
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+# Grok Build Runtime Provider
+
+## Intent
+
+The Grok provider adapts xAI Grok Build (`grok` CLI) into Ravi's canonical runtime provider contract. Grok Build is a local coding-agent execution engine, not a Ravi agent identity, not Grok Bot, and not the xAI chat-completions API. Ravi remains responsible for sessions, routes, permissions, traces, response delivery, and provider capability enforcement.
+
+## Native Surface
+
+Grok Build exposes two machine-friendly surfaces:
+
+- ACP JSON-RPC through `grok agent stdio`: long-lived subprocess over stdin/stdout, with `initialize`, `authenticate`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, and `session/update` notifications.
+- Headless CLI through `grok -p --output-format streaming-json`: one process per prompt, with `--session-id` / `--resume` / `--continue` stored in `~/.grok/sessions`.
+
+The MVP MUST use ACP. Headless streaming-json is a worse fit for Ravi's live session handle: it cannot keep one subprocess across turns, cannot interrupt with `session/cancel`, and forces a new process for every prompt.
+
+## Why ACP
+
+- Pi and Codex already use long-lived subprocess RPC. ACP is the same transport class (`subprocess-rpc`).
+- `session/prompt` plus `session/update` maps onto one Ravi turn with streamed text and tool events.
+- `session/load` is a documented resume path, so `supportsSessionResume` can be true without inventing file-path session state.
+- `session/cancel` maps to `interrupt()` without killing the process for later turns.
+- Official Grok docs present ACP as the IDE/tool integration surface and headless `-p` as the script surface.
+
+## MVP Shape
+
+- Provider id: `grok`.
+- Integration unit: Grok Build CLI (`grok`).
+- Execution mode: subprocess ACP JSON-RPC.
+- Process boundary: one `grok agent stdio` process per Ravi runtime session handle.
+- Command override: `RAVI_GROK_COMMAND`, same pattern as `RAVI_PI_COMMAND`.
+- Spawn flags: `--no-auto-update`, `--no-alt-screen`, `--always-approve`, optional `-m`, `--effort`, and `--append-system-prompt`.
+- Prompt submission: ACP `session/prompt` with `[{ type: "text", text }]`.
+- Session state: ACP `sessionId` plus cwd and model stored in `RuntimeSessionState.params`.
+- Display id: ACP `sessionId`.
+- System prompt mode: append Ravi instructions through `--append-system-prompt`; do not replace Grok's base prompt.
+- Tool mode: Grok uses its own built-in tools. Client ACP `fs` / `terminal` capabilities stay disabled.
+- Permission mode: provider-native. Restricted Ravi tool policy is unsupported and MUST be rejected by capability checks.
+- MCP/plugins/remote spawn: not advertised in the MVP even though `session/new` accepts `mcpServers`.
+
+## Capability Target
+
+Initial advertised capabilities MUST be:
+
+- `runtimeControl`: supported with `turn.interrupt` only.
+- `dynamicTools`: `none`.
+- `execution`: `subprocess-rpc`.
+- `sessionState`: `provider-session-id` with cwd validation.
+- `usage`: `terminal-event`.
+- `tools.permissionMode`: `provider-native`.
+- `tools.accessRequirement`: `tool_and_executable`.
+- `tools.supportsParallelCalls`: false.
+- `systemPrompt`: `append`.
+- `terminalEvents`: `adapter`.
+- `skillVisibility.availability`: `none`.
+- `skillVisibility.loadedState`: `none`.
+- `modelBroker`: `openai-completions` with `principalIsolation: none`.
+- `supportsSessionResume`: true when `session/load` is advertised and a stored `sessionId` exists.
+- `supportsSessionFork`: false. Grok CLI `--fork-session` MUST NOT flip this bit until canonical fork materialization exists.
+- `supportsPartialText`: true.
+- `supportsToolHooks`: false.
+- `supportsHostSessionHooks`: false.
+- `supportsPlugins`: false.
+- `supportsMcpServers`: false.
+- `supportsRemoteSpawn`: false.
+- `toolAccessRequirement`: `tool_and_executable`.
+
+## ACP Mapping
+
+- `initialize` negotiates protocol version `1` and empty client fs/terminal capabilities.
+- `authenticate` uses `xai.api_key` when `XAI_API_KEY` is present and advertised, otherwise `cached_token`.
+- `session/new` creates a session with Ravi cwd and `mcpServers: []`.
+- `session/load` resumes a stored `sessionId` when the agent advertises `loadSession`.
+- `session/prompt` starts a normal Ravi-delivered user prompt.
+- `session/cancel` maps to `interrupt()` and `turn.interrupt`.
+- Incoming `session/request_permission` auto-selects an allow option because the MVP is provider-native and the process is spawned with `--always-approve`.
+- Incoming ACP client methods other than `session/request_permission` MUST be rejected with JSON-RPC method-not-found.
+
+## Event Mapping
+
+- Handshake `sessionId` -> `thread.started`.
+- Accepted Ravi prompt -> adapter-synthesized `turn.started`.
+- ACP `agent_message_chunk` -> `text.delta`; accumulated text -> `assistant.message` on terminal success.
+- ACP `agent_thought_chunk` -> `status: thinking`. Thought text MUST NOT become assistant output.
+- ACP `tool_call` -> `tool.started`.
+- ACP `tool_call_update` with `completed` or `failed` -> `tool.completed`.
+- ACP `plan` -> `status: thinking`.
+- ACP `usage_update.used` -> `RuntimeUsage.inputTokens` when present; otherwise zeroes.
+- `session/prompt` `stopReason=end_turn` -> `turn.complete` exactly once.
+- `session/prompt` `stopReason=cancelled` or host interrupt -> `turn.interrupted`.
+- `session/prompt` rejection or `refusal` / token-limit stop reasons -> `turn.failed`.
+- Subprocess exit or stream end before a terminal result -> recoverable `turn.failed`.
+
+The adapter MUST emit exactly one Ravi terminal event per accepted Ravi prompt.
+
+## Effort Mapping
+
+Grok CLI `--effort` is documented without an enumerated Ravi-compatible set. The MVP maps:
+
+- `none|minimal|low|medium|high` -> same native value
+- `xhigh|max|ultra` -> `high`
+
+That strongest-compatible mapping MUST stay covered by an explicit provider test.
+
+## Invariants
+
+- The provider MUST use strict LF-delimited JSONL. Generic line readers that split on Unicode separators are forbidden.
+- The provider MUST emit `provider.raw` for every native ACP notification that is not too large or sensitive.
+- The provider MUST not leak provider stderr to channel responses.
+- The provider MUST terminate the Grok subprocess when the Ravi session handle is interrupted or closed.
+- The provider MUST turn subprocess exit before terminal result into recoverable `turn.failed`.
+- The provider MUST NOT invent Grok Bot host gateways, A2A, or chat-completions-only HTTP transports.
+- The provider MUST NOT mutate Ravi tasks, emit channel messages, or add host branches in `bot.ts`, `session-launcher.ts`, or `runtime-request-builder.ts`.
+- The provider MUST not expose restricted Ravi agents until Grok permission requests are bridged to Ravi host services.
+- The provider MUST not save ACP session ids as user-visible Ravi session names.
+- The provider MUST validate cwd before resuming a Grok session.
+- Native Grok `--fork-session` MUST NOT flip canonical `supportsSessionFork`.
+- Tests MUST use a fake ACP transport. Live xAI calls are forbidden in CI.

--- a/.ravi/specs/runtime/providers/grok/WHY.md
+++ b/.ravi/specs/runtime/providers/grok/WHY.md
@@ -1,0 +1,46 @@
+# Grok Build Provider Rationale
+
+## Why Grok Build Is A Runtime Provider
+
+Grok Build runs local coding-agent sessions through the official `grok` CLI. Ravi already has agent identity, routing, sessions, tasks, traces, contacts, and channel delivery. Treating Grok as a Ravi agent, a Slack/WhatsApp inbound, or Grok Bot would duplicate concepts and blur ownership.
+
+The clean boundary is:
+
+- Ravi agent/session decides what should run.
+- Runtime provider executes the turn.
+- Ravi host event loop normalizes results, persistence, delivery, traces, and policy.
+
+## Why ACP Instead Of Headless `-p`
+
+Headless `grok -p --output-format streaming-json` is documented for scripts. It is the wrong first adapter for Ravi:
+
+- Each prompt is a new process, so the live `RuntimeSessionHandle` cannot own one native session.
+- Interrupt becomes process kill instead of `session/cancel`.
+- Resume exists (`--session-id`, `--resume`), but the transport is still one-shot CLI rather than the Pi/Codex RPC pattern.
+
+ACP (`grok agent stdio`) is the IDE/tool integration surface. It gives Ravi a narrow operational boundary that already matches Pi:
+
+- Easy to launch and kill.
+- Easy to fixture with a fake JSON-RPC transport.
+- Native methods already cover prompting, streamed updates, cancel, and session load.
+- Grok internals can evolve without Ravi importing undocumented Bot host gateways.
+
+## Why Not Grok Bot Or The Chat API
+
+Grok Bot is a cloud teammate product. The xAI chat-completions/responses API is a model endpoint, not a coding-agent runtime. Both would violate the provider contract: they are not local execution engines that Ravi can adapt through `RuntimeStartRequest` -> native transport -> `RuntimeEvent`.
+
+## Why Tools Stay Provider-Native
+
+Grok has its own tools and ACP permission requests. Ravi has its own permission model and currently tracks one active tool in the host event loop.
+
+Bridging tools before the adapter is proven would create a confusing hybrid:
+
+- Some tools would obey Ravi policy.
+- Some tools would obey Grok internals.
+- Client ACP `fs` / `terminal` methods would make Ravi an IDE host instead of a runtime adapter.
+
+The MVP declares full Grok tool ownership, auto-approves through `--always-approve`, and blocks restricted Ravi agents.
+
+## Why Resume Is Session-Id, Not File-Backed
+
+ACP identifies sessions by `sessionId`. Grok also stores headless sessions under `~/.grok/sessions`, but the ACP path does not require Ravi to open those files. The adapter stores the ACP id and cwd, then calls `session/load`. Canonical fork stays false until Ravi prompt-atom mapping exists.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The goal is simple: an agent should be able to keep working across days, chats, 
 - Contacts, chats, platform identities, agents, messages, and sessions have separate meanings, so raw channel ids do not become the product model.
 - Generated outputs become artifacts with lineage, versions, assets, events, and restore/publish paths.
 - Specs under `.ravi/specs` give agents durable rules before they touch governed areas of the codebase.
-- Runtime providers such as Claude Code, Codex, and Pi are adapters. Ravi keeps ownership of queueing, permissions, traces, tasks, responses, and continuity.
+- Runtime providers such as Claude Code, Codex, Pi, and Grok Build are adapters. Ravi keeps ownership of queueing, permissions, traces, tasks, responses, and continuity.
 
 ## Quick Start
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "3b65296b2ad245f3"
+    "version": "291f4dbeee37152e"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -66248,7 +66248,7 @@
                     "type": "string"
                   },
                   "provider": {
-                    "description": "Runtime provider id, e.g. claude, codex, pi",
+                    "description": "Runtime provider id, e.g. claude, codex, pi, grok",
                     "type": "string"
                   },
                   "readOnly": {
@@ -74685,7 +74685,7 @@
                     "type": "string"
                   },
                   "provider": {
-                    "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+                    "description": "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
                     "type": "string"
                   }
                 },

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "3b65296b2ad245f3"
+    "version": "291f4dbeee37152e"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -66248,7 +66248,7 @@
                     "type": "string"
                   },
                   "provider": {
-                    "description": "Runtime provider id, e.g. claude, codex, pi",
+                    "description": "Runtime provider id, e.g. claude, codex, pi, grok",
                     "type": "string"
                   },
                   "readOnly": {
@@ -74685,7 +74685,7 @@
                     "type": "string"
                   },
                   "provider": {
-                    "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+                    "description": "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
                     "type": "string"
                   }
                 },

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
@@ -54482,7 +54482,7 @@ class RaviSchemas {
       "type": "string"
     },
     "provider": {
-      "description": "Runtime provider id, e.g. claude, codex, pi",
+      "description": "Runtime provider id, e.g. claude, codex, pi, grok",
       "type": "string"
     },
     "readOnly": {
@@ -60627,7 +60627,7 @@ class RaviSchemas {
       "type": "string"
     },
     "provider": {
-      "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+      "description": "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
       "type": "string"
     }
   },

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk dart check`.
 
 const raviSdkVersion = "0.1.0";
-const raviRegistryHash = "sha256:0630aca3d70badd1031f783b39f791605813c012aa897f46d67618ab7c82093b";
-const raviGitSha = "060619672e23";
+const raviRegistryHash = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce";
+const raviGitSha = "3b8c64919d3d";

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -53687,7 +53687,7 @@ export const RuntimeCredentialsAddInputSchema = {
       "type": "string"
     },
     "provider": {
-      "description": "Runtime provider id, e.g. claude, codex, pi",
+      "description": "Runtime provider id, e.g. claude, codex, pi, grok",
       "type": "string"
     },
     "readOnly": {
@@ -59678,7 +59678,7 @@ export const SessionsSetProviderInputSchema = {
       "type": "string"
     },
     "provider": {
-      "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+      "description": "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
       "type": "string"
     }
   },

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:0630aca3d70badd1031f783b39f791605813c012aa897f46d67618ab7c82093b";
+export const REGISTRY_HASH = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "060619672e23";
+export const GIT_SHA = "3b8c64919d3d";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -54482,7 +54482,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "provider": {
-        "description": "Runtime provider id, e.g. claude, codex, pi",
+        "description": "Runtime provider id, e.g. claude, codex, pi, grok",
         "type": "string"
       },
       "readOnly": {
@@ -60627,7 +60627,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "provider": {
-        "description": "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+        "description": "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
         "type": "string"
       }
     },

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:0630aca3d70badd1031f783b39f791605813c012aa897f46d67618ab7c82093b"
-public let RAVI_GIT_SHA = "060619672e23"
+public let RAVI_REGISTRY_HASH = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce"
+public let RAVI_GIT_SHA = "3b8c64919d3d"

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -400,6 +400,15 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
   });
 
+  it("passes when the Grok provider focused test is in the diff", () => {
+    const cwd = makeWorkspace();
+
+    const result = runCoverageGate(["src/runtime/grok-provider.ts", "src/runtime/grok-provider.test.ts"], cwd);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
+  });
+
   it("accepts approval service focused tests for approval service changes", () => {
     const cwd = makeWorkspace();
 

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -71,6 +71,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
     "src/runtime/claude-local-skills.test.ts",
     "src/runtime/claude-provider.test.ts",
     "src/runtime/codex-provider.test.ts",
+    "src/runtime/grok-provider.test.ts",
   ],
   "src/session-trace/": ["src/session-trace/session-trace.test.ts"],
   "src/triggers/": ["src/triggers/triggers.test.ts"],

--- a/src/cli/commands/runtime-credentials.ts
+++ b/src/cli/commands/runtime-credentials.ts
@@ -281,7 +281,7 @@ export class RuntimeCredentialsCommands {
   @CommandAccess({ kind: "mutate", resource: "runtime.credentials", action: "add", risk: "medium" })
   @Returns(runtimeCredentialEnvelopeReturnSchema)
   add(
-    @Option({ flags: "--provider <id>", description: "Runtime provider id, e.g. claude, codex, pi" }) provider?: string,
+    @Option({ flags: "--provider <id>", description: "Runtime provider id, e.g. claude, codex, pi, grok" }) provider?: string,
     @Option({ flags: "--label <label>", description: "Human label that does not contain secrets" }) label?: string,
     @Option({ flags: "--upstream <id>", description: "Upstream provider id, e.g. anthropic, openai" })
     upstream?: string,

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -3312,7 +3312,7 @@ export class SessionCommands {
   setProvider(
     @Arg("nameOrKey", { description: "Session name or key" }) nameOrKey: string,
     @Arg("provider", {
-      description: "Runtime provider id (codex, claude, pi) or 'clear' to remove override",
+      description: "Runtime provider id (codex, claude, pi, grok) or 'clear' to remove override",
     })
     provider: string,
     @Option({ flags: "--json", description: "Print raw JSON result" })

--- a/src/plugins/internal/ravi-system/skills/agents/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/agents/SKILL.md
@@ -193,7 +193,7 @@ ravi agents set <id> <key> <value>
 Keys:
 - `name` — Nome do agent
 - `cwd` — Diretório de trabalho
-- `provider` — Runtime provider (`claude`, `codex`, `pi`, ou outro provider registrado)
+- `provider` — Runtime provider (`claude`, `codex`, `pi`, `grok`, ou outro provider registrado)
 - `model` — Modelo/selector interpretado pelo provider atual
 - `dmScope` — Escopo de sessão DM:
   - `main` — Todas as DMs numa sessão só

--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -23,10 +23,7 @@ class FakeGrokAcpTransport implements GrokAcpTransport {
   readonly starts: GrokAcpStartInput[] = [];
   readonly requests: Array<{ method: string; params?: Record<string, unknown> }> = [];
   readonly notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
-  responseFor?: (
-    method: string,
-    params?: Record<string, unknown>,
-  ) => unknown | Promise<unknown>;
+  responseFor?: (method: string, params?: Record<string, unknown>) => unknown | Promise<unknown>;
   closed = false;
   closeCalls = 0;
 
@@ -158,9 +155,9 @@ describe("Grok Build runtime provider", () => {
   });
 
   it("prefers xai.api_key when the env key is present", () => {
-    expect(
-      selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], { XAI_API_KEY: "xai-test" }),
-    ).toBe("xai.api_key");
+    expect(selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], { XAI_API_KEY: "xai-test" })).toBe(
+      "xai.api_key",
+    );
     expect(selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], {})).toBe("cached_token");
   });
 

--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -1,0 +1,610 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildGrokAcpProcessArgs,
+  buildGrokAcpSpawnEnv,
+  createGrokRuntimeProvider,
+  selectGrokAuthMethod,
+  selectGrokPermissionOutcome,
+  toGrokEffort,
+  type GrokAcpNotification,
+  type GrokAcpStartInput,
+  type GrokAcpTransport,
+} from "./grok-provider.js";
+import type { RuntimeEvent, RuntimePromptMessage, RuntimeStartRequest } from "./types.js";
+
+interface TestQueue<T> extends AsyncIterable<T> {
+  push(value: T): void;
+  end(): void;
+  fail(error: unknown): void;
+}
+
+class FakeGrokAcpTransport implements GrokAcpTransport {
+  readonly events: TestQueue<GrokAcpNotification> = createTestQueue<GrokAcpNotification>();
+  readonly starts: GrokAcpStartInput[] = [];
+  readonly requests: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  readonly notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  responseFor?: (
+    method: string,
+    params?: Record<string, unknown>,
+  ) => unknown | Promise<unknown>;
+  closed = false;
+  closeCalls = 0;
+
+  async start(input: GrokAcpStartInput): Promise<void> {
+    this.starts.push(input);
+  }
+
+  async request(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    this.requests.push({ method, params });
+    const response = await this.responseFor?.(method, params);
+    if (response !== undefined) {
+      return response;
+    }
+    return defaultGrokResponse(method);
+  }
+
+  async notify(method: string, params?: Record<string, unknown>): Promise<void> {
+    this.notifications.push({ method, params });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.closeCalls += 1;
+  }
+
+  pushEvent(event: GrokAcpNotification): void {
+    this.events.push(event);
+  }
+
+  endEvents(): void {
+    this.events.end();
+  }
+}
+
+describe("Grok Build runtime provider", () => {
+  it("advertises an explicit subprocess RPC capability matrix", () => {
+    expect(createGrokRuntimeProvider().getCapabilities()).toMatchObject({
+      runtimeControl: {
+        supported: true,
+        operations: ["turn.interrupt"],
+      },
+      dynamicTools: {
+        mode: "none",
+      },
+      execution: {
+        mode: "subprocess-rpc",
+      },
+      sessionState: {
+        mode: "provider-session-id",
+        requiresCwdMatch: true,
+      },
+      usage: {
+        semantics: "terminal-event",
+      },
+      tools: {
+        permissionMode: "provider-native",
+        accessRequirement: "tool_and_executable",
+        supportsParallelCalls: false,
+      },
+      systemPrompt: {
+        mode: "append",
+      },
+      terminalEvents: {
+        guarantee: "adapter",
+      },
+      skillVisibility: {
+        availability: "none",
+        loadedState: "none",
+      },
+      modelBroker: {
+        protocols: ["openai-completions"],
+        principalIsolation: "none",
+      },
+      supportsSessionResume: true,
+      supportsSessionFork: false,
+      supportsPartialText: true,
+      supportsToolHooks: false,
+      supportsHostSessionHooks: false,
+      supportsPlugins: false,
+      supportsMcpServers: false,
+      supportsRemoteSpawn: false,
+    });
+  });
+
+  it("never reintroduces daemon secrets into the subprocess spawn envelope", () => {
+    const previous = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "daemon-secret-must-not-leak";
+    try {
+      const env = buildGrokAcpSpawnEnv({ env: { PATH: "/usr/bin", XAI_API_KEY: "from-request" } });
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env).toEqual({ PATH: "/usr/bin", XAI_API_KEY: "from-request" });
+    } finally {
+      if (previous === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = previous;
+    }
+  });
+
+  it("spawns grok agent stdio with conservative headless flags", () => {
+    expect(
+      buildGrokAcpProcessArgs({
+        model: "grok-4",
+        effort: "ultra",
+        systemPromptAppend: "Ravi instructions",
+      }),
+    ).toEqual([
+      "--no-auto-update",
+      "--no-alt-screen",
+      "--always-approve",
+      "-m",
+      "grok-4",
+      "--effort",
+      "high",
+      "--append-system-prompt",
+      "Ravi instructions",
+      "agent",
+      "stdio",
+    ]);
+  });
+
+  it("maps strongest Ravi effort values onto Grok high", () => {
+    expect(toGrokEffort("none")).toBe("none");
+    expect(toGrokEffort("minimal")).toBe("minimal");
+    expect(toGrokEffort("low")).toBe("low");
+    expect(toGrokEffort("medium")).toBe("medium");
+    expect(toGrokEffort("high")).toBe("high");
+    expect(toGrokEffort("xhigh")).toBe("high");
+    expect(toGrokEffort("max")).toBe("high");
+    expect(toGrokEffort("ultra")).toBe("high");
+  });
+
+  it("prefers xai.api_key when the env key is present", () => {
+    expect(
+      selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], { XAI_API_KEY: "xai-test" }),
+    ).toBe("xai.api_key");
+    expect(selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], {})).toBe("cached_token");
+  });
+
+  it("auto-selects an allow permission option", () => {
+    expect(
+      selectGrokPermissionOutcome([
+        { optionId: "reject-once", kind: "reject_once" },
+        { optionId: "allow-once", kind: "allow_once" },
+      ]),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+  });
+
+  it("closes the Grok ACP transport idempotently", async () => {
+    const transport = new FakeGrokAcpTransport();
+    const handle = createGrokRuntimeProvider({ transport }).startSession(createStartRequest("close"));
+
+    await handle.close?.();
+    await handle.close?.();
+
+    expect(transport.closeCalls).toBe(1);
+  });
+
+  it("normalizes a successful ACP prompt into canonical runtime events", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        transport.pushEvent(
+          sessionUpdate("agent_thought_chunk", {
+            content: { type: "text", text: "hidden reasoning" },
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "ola" },
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: " mundo" },
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("usage_update", {
+            used: 42,
+            size: 200000,
+          }),
+        );
+        return { stopReason: "end_turn" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("faz um teste")).events,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "thread.started",
+      "turn.started",
+      "provider.raw",
+      "status",
+      "provider.raw",
+      "text.delta",
+      "provider.raw",
+      "text.delta",
+      "provider.raw",
+      "assistant.message",
+      "turn.complete",
+    ]);
+    expect(events.find((event) => event.type === "assistant.message")).toMatchObject({
+      type: "assistant.message",
+      text: "ola mundo",
+    });
+    expect(events.filter((event) => event.type === "turn.complete")).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({
+      type: "turn.complete",
+      providerSessionId: "grok-session-1",
+      session: {
+        displayId: "grok-session-1",
+        params: {
+          integration: "acp",
+          cwd: "/tmp",
+          sessionId: "grok-session-1",
+          model: "grok-4",
+        },
+      },
+      execution: {
+        provider: "grok",
+        model: "grok-4",
+        billingType: "unknown",
+      },
+      usage: {
+        inputTokens: 42,
+        outputTokens: 0,
+      },
+    });
+    expect(transport.starts[0]).toMatchObject({
+      cwd: "/tmp",
+      model: "grok-4",
+      effort: "high",
+    });
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "authenticate",
+      "session/new",
+      "session/prompt",
+    ]);
+    expect(transport.requests.find((request) => request.method === "session/prompt")?.params).toEqual({
+      sessionId: "grok-session-1",
+      prompt: [{ type: "text", text: "faz um teste" }],
+    });
+    expect(transport.closed).toBe(true);
+  });
+
+  it("maps tool_call updates into canonical tool events", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        transport.pushEvent(
+          sessionUpdate("tool_call", {
+            toolCallId: "call_1",
+            title: "Read file",
+            kind: "read",
+            rawInput: { path: "README.md" },
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("tool_call_update", {
+            toolCallId: "call_1",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "ok" } }],
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "li o arquivo" },
+          }),
+        );
+        return { stopReason: "end_turn" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("leia")).events,
+    );
+
+    expect(events.find((event) => event.type === "tool.started")).toMatchObject({
+      type: "tool.started",
+      toolUse: {
+        id: "call_1",
+        name: "Read file",
+        input: { path: "README.md" },
+      },
+    });
+    expect(events.find((event) => event.type === "tool.completed")).toMatchObject({
+      type: "tool.completed",
+      toolUseId: "call_1",
+      isError: false,
+    });
+    expect(events.filter((event) => event.type.startsWith("turn.")).map((event) => event.type)).toEqual([
+      "turn.started",
+      "turn.complete",
+    ]);
+  });
+
+  it("resumes an ACP session with session/load when stored state exists", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "continuidade" },
+          }),
+        );
+        return { stopReason: "end_turn" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(
+        createStartRequest("continua", {
+          resume: "stored-session",
+          resumeSession: {
+            params: { sessionId: "stored-session", cwd: "/tmp" },
+            displayId: "stored-session",
+          },
+        }),
+      ).events,
+    );
+
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "authenticate",
+      "session/load",
+      "session/prompt",
+    ]);
+    expect(transport.requests.find((request) => request.method === "session/load")?.params).toEqual({
+      sessionId: "stored-session",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "turn.complete",
+      providerSessionId: "stored-session",
+    });
+  });
+
+  it("emits a failed terminal event when Grok rejects a prompt", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        return Promise.reject(new Error("Grok prompt was rejected"));
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("falha")).events,
+    );
+
+    expect(events.filter((event) => event.type.startsWith("turn.")).map((event) => event.type)).toEqual([
+      "turn.started",
+      "turn.failed",
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: "turn.failed",
+      error: "Grok prompt was rejected",
+      recoverable: true,
+    });
+  });
+
+  it("emits turn.interrupted when session/prompt stops as cancelled", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        return { stopReason: "cancelled" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const handle = createGrokRuntimeProvider({ transport }).startSession(createStartRequest("aborta"));
+    const events = await collectRuntimeEvents(handle.events);
+
+    expect(events.filter((event) => event.type.startsWith("turn.")).map((event) => event.type)).toEqual([
+      "turn.started",
+      "turn.interrupted",
+    ]);
+    expect(events.filter((event) => event.type === "turn.interrupted")).toHaveLength(1);
+  });
+
+  it("sends session/cancel from interrupt and control", async () => {
+    const transport = new FakeGrokAcpTransport();
+    let releasePrompt: ((value: unknown) => void) | undefined;
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        return new Promise((resolve) => {
+          releasePrompt = resolve;
+        });
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const handle = createGrokRuntimeProvider({ transport }).startSession(createStartRequest("controle"));
+    const collected: RuntimeEvent[] = [];
+    const consuming = (async () => {
+      for await (const event of handle.events) {
+        collected.push(event);
+      }
+    })();
+
+    await waitFor(() => transport.requests.some((request) => request.method === "session/prompt"));
+    await handle.interrupt();
+    const control = await handle.control?.({ operation: "turn.interrupt" });
+    releasePrompt?.({ stopReason: "cancelled" });
+    await consuming;
+
+    expect(transport.notifications.filter((notification) => notification.method === "session/cancel")).toHaveLength(2);
+    expect(control).toMatchObject({
+      ok: true,
+      operation: "turn.interrupt",
+    });
+    expect(collected.filter((event) => event.type === "turn.interrupted")).toHaveLength(1);
+  });
+
+  it("does not leak thought chunks as assistant text", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        transport.pushEvent(
+          sessionUpdate("agent_thought_chunk", {
+            content: { type: "text", text: "secret chain of thought" },
+          }),
+        );
+        return { stopReason: "end_turn" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("pense")).events,
+    );
+
+    expect(events.some((event) => event.type === "assistant.message")).toBe(false);
+    expect(events.filter((event) => event.type === "text.delta")).toHaveLength(0);
+    expect(events.at(-1)?.type).toBe("turn.complete");
+  });
+});
+
+function createStartRequest(text: string, overrides: Partial<RuntimeStartRequest> = {}): RuntimeStartRequest {
+  return {
+    prompt: onePrompt(text),
+    model: "grok-4",
+    effort: "high",
+    cwd: "/tmp",
+    abortController: new AbortController(),
+    systemPromptAppend: "Ravi runtime instructions",
+    ...overrides,
+  };
+}
+
+async function* onePrompt(text: string): AsyncGenerator<RuntimePromptMessage> {
+  yield {
+    type: "user",
+    message: {
+      role: "user",
+      content: text,
+    },
+    session_id: "session",
+    parent_tool_use_id: null,
+  };
+}
+
+async function collectRuntimeEvents(events: AsyncIterable<RuntimeEvent>): Promise<RuntimeEvent[]> {
+  const collected: RuntimeEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+function sessionUpdate(sessionUpdate: string, extra: Record<string, unknown> = {}): GrokAcpNotification {
+  return {
+    method: "session/update",
+    params: {
+      sessionId: "grok-session-1",
+      update: {
+        sessionUpdate,
+        ...extra,
+      },
+    },
+  };
+}
+
+function defaultGrokResponse(method: string): unknown {
+  if (method === "initialize") {
+    return {
+      protocolVersion: 1,
+      authMethods: [{ id: "cached_token" }],
+      agentCapabilities: { loadSession: true },
+    };
+  }
+  if (method === "authenticate") {
+    return {};
+  }
+  if (method === "session/new") {
+    return { sessionId: "grok-session-1" };
+  }
+  if (method === "session/load") {
+    return {};
+  }
+  if (method === "session/prompt") {
+    return { stopReason: "end_turn" };
+  }
+  return {};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("Timed out waiting for Grok fake transport condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function createTestQueue<T>(): TestQueue<T> {
+  const values: T[] = [];
+  const waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let ended = false;
+  let failure: unknown;
+
+  return {
+    push(value) {
+      if (ended || failure) {
+        return;
+      }
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve({ value, done: false });
+        return;
+      }
+      values.push(value);
+    },
+    end() {
+      if (ended || failure) {
+        return;
+      }
+      ended = true;
+      while (waiters.length > 0) {
+        waiters.shift()!.resolve({ value: undefined as T, done: true });
+      }
+    },
+    fail(error) {
+      if (ended || failure) {
+        return;
+      }
+      failure = error;
+      while (waiters.length > 0) {
+        waiters.shift()!.reject(error);
+      }
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (values.length > 0) {
+            return Promise.resolve({ value: values.shift()!, done: false });
+          }
+          if (failure) {
+            return Promise.reject(failure);
+          }
+          if (ended) {
+            return Promise.resolve({ value: undefined as T, done: true });
+          }
+          return new Promise<IteratorResult<T>>((resolve, reject) => {
+            waiters.push({ resolve, reject });
+          });
+        },
+      };
+    },
+  };
+}

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -222,7 +222,7 @@ export function createGrokAcpSubprocessTransport(
     pending.clear();
   };
 
-  const writeMessage = (message: Record<string, unknown>): Promise<void> => {
+  const writeMessage = (message: object): Promise<void> => {
     if (!child || closed) {
       return Promise.reject(closeFailure ?? new Error("Grok ACP transport is not connected"));
     }
@@ -432,7 +432,9 @@ export function createGrokAcpSubprocessTransport(
   };
 }
 
-export function buildGrokAcpProcessArgs(input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend">): string[] {
+export function buildGrokAcpProcessArgs(
+  input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend">,
+): string[] {
   const args = ["--no-auto-update", "--no-alt-screen", "--always-approve"];
   const model = input.model?.trim();
   if (model && model !== "default") {
@@ -483,7 +485,9 @@ export function selectGrokAuthMethod(authMethods: unknown[], env: NodeJS.Process
   return ids[0];
 }
 
-export function selectGrokPermissionOutcome(options: unknown): { outcome: "selected"; optionId: string } | { outcome: "cancelled" } {
+export function selectGrokPermissionOutcome(
+  options: unknown,
+): { outcome: "selected"; optionId: string } | { outcome: "cancelled" } {
   const list = Array.isArray(options) ? options : [];
   const allow = list.find((option) => {
     if (!isRecord(option)) {
@@ -834,10 +838,10 @@ function extractGrokContentText(content: unknown): string {
   if (typeof content === "string") {
     return content;
   }
-  if (!isRecord(content)) {
-    return "";
+  if (isRecord(content) && typeof content.text === "string") {
+    return content.text;
   }
-  return firstString(content.text) ?? "";
+  return "";
 }
 
 function buildGrokRuntimeSessionState(sessionId: string | undefined, context: GrokEventContext): RuntimeSessionState {
@@ -930,38 +934,34 @@ async function safeGrokNotify(
   }
 }
 
-async function* consumeUntilSettled<T, R>(
-  iterator: AsyncIterator<T>,
-  settled: Promise<R>,
-): AsyncGenerator<T> {
-  let pendingNext: Promise<IteratorResult<T>> | undefined;
-  let done = false;
+async function* consumeUntilSettled<T, R>(iterator: AsyncIterator<T>, settled: Promise<R>): AsyncGenerator<T> {
+  let pendingNext = iterator.next();
+  let settledValue: { current: R } | undefined;
   const settledBox = settled.then((value) => {
-    done = true;
+    settledValue = { current: value };
     return value;
   });
 
-  while (!done) {
-    pendingNext ??= iterator.next();
+  while (!settledValue) {
     const winner = await Promise.race([
       pendingNext.then((result) => ({ tag: "item" as const, result })),
-      settledBox.then((value) => ({ tag: "settled" as const, value })),
+      settledBox.then(() => ({ tag: "settled" as const })),
     ]);
     if (winner.tag === "settled") {
       break;
     }
-    pendingNext = undefined;
     if (winner.result.done) {
-      break;
+      await settledBox;
+      return;
     }
     yield winner.result.value;
+    pendingNext = iterator.next();
   }
 
-  while (pendingNext) {
+  while (true) {
     const leftover = await peekIfResolved(pendingNext);
-    pendingNext = undefined;
     if (!leftover || leftover.done) {
-      break;
+      return;
     }
     yield leftover.value;
     pendingNext = iterator.next();

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -1,0 +1,1098 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import type { RuntimeEffort } from "./effort.js";
+import { createRuntimeTerminalEventTracker } from "./terminality.js";
+import type {
+  RuntimeControlOperation,
+  RuntimeControlRequest,
+  RuntimeControlResult,
+  RuntimeControlState,
+  RuntimeEvent,
+  RuntimeEventMetadata,
+  RuntimePromptMessage,
+  RuntimeSessionHandle,
+  RuntimeSessionState,
+  RuntimeStartRequest,
+  RuntimeToolUse,
+  RuntimeUsage,
+  SessionRuntimeProvider,
+} from "./types.js";
+
+const DEFAULT_GROK_COMMAND = "grok";
+const DEFAULT_GROK_RPC_TIMEOUT_MS = 30_000;
+const GROK_INTERRUPT_GRACE_MS = 1_000;
+const GROK_RUNTIME_CONTROL_OPERATIONS: RuntimeControlOperation[] = ["turn.interrupt"];
+const GROK_ACP_PROTOCOL_VERSION = 1;
+
+export type GrokEffort = "none" | "minimal" | "low" | "medium" | "high";
+
+export interface GrokAcpStartInput {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  model?: string;
+  effort?: RuntimeEffort;
+  systemPromptAppend?: string;
+}
+
+export interface GrokJsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface GrokJsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface GrokAcpNotification extends Record<string, unknown> {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface GrokAcpTransport {
+  events: AsyncIterable<GrokAcpNotification>;
+  start(input: GrokAcpStartInput): Promise<void> | void;
+  request(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  notify(method: string, params?: Record<string, unknown>): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface AsyncQueue<T> extends AsyncIterable<T> {
+  push(value: T): void;
+  end(): void;
+  fail(error: unknown): void;
+}
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+interface GrokSessionRuntimeState {
+  activeTurn: boolean;
+  interrupted: boolean;
+  sessionId?: string;
+  transport?: GrokAcpTransport;
+  loadSessionSupported: boolean;
+}
+
+interface CreateGrokAcpSubprocessTransportOptions {
+  command?: string;
+  commandArgs?: string[];
+  responseTimeoutMs?: number;
+  promptTimeoutMs?: number;
+}
+
+export interface CreateGrokRuntimeProviderOptions extends CreateGrokAcpSubprocessTransportOptions {
+  transport?: GrokAcpTransport;
+}
+
+export interface GrokRuntimeProvider extends SessionRuntimeProvider {
+  startSession(input: RuntimeStartRequest): RuntimeSessionHandle;
+}
+
+interface GrokEventContext {
+  cwd: string;
+  model?: string;
+  promptMessage: RuntimePromptMessage;
+  turnIndex: number;
+  sessionId?: string;
+  assistantText: string;
+  usage: RuntimeUsage;
+}
+
+export function createGrokRuntimeProvider(options: CreateGrokRuntimeProviderOptions = {}): GrokRuntimeProvider {
+  return {
+    id: "grok",
+    getCapabilities() {
+      return {
+        runtimeControl: {
+          supported: true,
+          operations: GROK_RUNTIME_CONTROL_OPERATIONS,
+        },
+        dynamicTools: {
+          mode: "none",
+        },
+        execution: {
+          mode: "subprocess-rpc",
+        },
+        sessionState: {
+          mode: "provider-session-id",
+          requiresCwdMatch: true,
+        },
+        usage: {
+          semantics: "terminal-event",
+        },
+        tools: {
+          permissionMode: "provider-native",
+          accessRequirement: "tool_and_executable",
+          supportsParallelCalls: false,
+        },
+        systemPrompt: {
+          mode: "append",
+        },
+        terminalEvents: {
+          guarantee: "adapter",
+        },
+        skillVisibility: {
+          availability: "none",
+          loadedState: "none",
+        },
+        modelBroker: {
+          protocols: ["openai-completions"],
+          principalIsolation: "none",
+        },
+        supportsSessionResume: true,
+        supportsSessionFork: false,
+        supportsPartialText: true,
+        supportsToolHooks: false,
+        supportsHostSessionHooks: false,
+        supportsPlugins: false,
+        supportsMcpServers: false,
+        supportsRemoteSpawn: false,
+        toolAccessRequirement: "tool_and_executable",
+      };
+    },
+    startSession(input) {
+      const transport =
+        options.transport ??
+        createGrokAcpSubprocessTransport({
+          command: options.command,
+          commandArgs: options.commandArgs,
+          responseTimeoutMs: options.responseTimeoutMs,
+          promptTimeoutMs: options.promptTimeoutMs,
+        });
+      const state: GrokSessionRuntimeState = {
+        activeTurn: false,
+        interrupted: false,
+        loadSessionSupported: false,
+        transport,
+      };
+
+      return {
+        provider: "grok",
+        events: runGrokTurns(input, transport, state),
+        interrupt: async () => {
+          state.interrupted = true;
+          if (state.sessionId) {
+            await safeGrokNotify(transport, "session/cancel", { sessionId: state.sessionId });
+          }
+        },
+        close: async () => {
+          const current = state.transport;
+          state.transport = undefined;
+          await current?.close();
+        },
+        control: (request) => controlGrokRuntime(state, request),
+      };
+    },
+  };
+}
+
+export function createGrokAcpSubprocessTransport(
+  options: CreateGrokAcpSubprocessTransportOptions = {},
+): GrokAcpTransport {
+  const command = options.command ?? process.env.RAVI_GROK_COMMAND ?? DEFAULT_GROK_COMMAND;
+  const commandArgs = options.commandArgs ?? [];
+  const responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_GROK_RPC_TIMEOUT_MS;
+  const promptTimeoutMs = options.promptTimeoutMs ?? 0;
+  const queue = createAsyncQueue<GrokAcpNotification>();
+  const pending = new Map<number, PendingRequest>();
+
+  let child: ChildProcessWithoutNullStreams | null = null;
+  let nextRequestId = 1;
+  let stderr = "";
+  let stopStdoutReader: (() => void) | null = null;
+  let closed = true;
+  let intentionalClose = false;
+  let closeFailure: Error | null = null;
+  let interrupted = false;
+
+  const failPending = (error: unknown) => {
+    for (const request of pending.values()) {
+      if (request.timeout) {
+        clearTimeout(request.timeout);
+      }
+      request.reject(error);
+    }
+    pending.clear();
+  };
+
+  const writeMessage = (message: Record<string, unknown>): Promise<void> => {
+    if (!child || closed) {
+      return Promise.reject(closeFailure ?? new Error("Grok ACP transport is not connected"));
+    }
+    return new Promise((resolve, reject) => {
+      child!.stdin.write(`${JSON.stringify(message)}\n`, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  };
+
+  const handleIncomingRequest = (message: Record<string, unknown>) => {
+    const id = message.id;
+    if (typeof id !== "number" && typeof id !== "string") {
+      return;
+    }
+    const method = firstString(message.method);
+    const params = isRecord(message.params) ? message.params : {};
+    let result: Record<string, unknown>;
+    if (method === "session/request_permission") {
+      result = interrupted
+        ? { outcome: { outcome: "cancelled" } }
+        : { outcome: selectGrokPermissionOutcome(params.options) };
+    } else {
+      void writeMessage({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Method not found: ${method ?? "unknown"}` },
+      }).catch(() => {});
+      return;
+    }
+    void writeMessage({
+      jsonrpc: "2.0",
+      id,
+      result,
+    }).catch(() => {});
+  };
+
+  const handleLine = (line: string) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      const failure = new Error(
+        `Invalid Grok ACP JSONL event: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      queue.fail(failure);
+      failPending(failure);
+      return;
+    }
+
+    if (!isRecord(parsed) || parsed.jsonrpc !== "2.0") {
+      return;
+    }
+
+    if (parsed.id !== undefined && pending.has(Number(parsed.id))) {
+      const request = pending.get(Number(parsed.id))!;
+      pending.delete(Number(parsed.id));
+      if (request.timeout) {
+        clearTimeout(request.timeout);
+      }
+      if (isRecord(parsed.error)) {
+        request.reject(new Error(firstString(parsed.error.message) ?? "Grok ACP request failed"));
+        return;
+      }
+      request.resolve(parsed.result);
+      return;
+    }
+
+    if (typeof parsed.method === "string" && parsed.id !== undefined) {
+      handleIncomingRequest(parsed);
+      return;
+    }
+
+    if (typeof parsed.method === "string") {
+      queue.push({
+        method: parsed.method,
+        ...(isRecord(parsed.params) ? { params: parsed.params } : {}),
+      });
+    }
+  };
+
+  return {
+    events: queue,
+    async start(input) {
+      if (child) {
+        throw new Error("Grok ACP transport is already started");
+      }
+
+      const args = [...commandArgs, ...buildGrokAcpProcessArgs(input)];
+      stderr = "";
+      closeFailure = null;
+      closed = false;
+      intentionalClose = false;
+      interrupted = false;
+      child = spawn(command, args, {
+        cwd: input.cwd,
+        env: buildGrokAcpSpawnEnv(input),
+        stdio: ["pipe", "pipe", "pipe"],
+      }) as ChildProcessWithoutNullStreams;
+
+      child.stderr.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      stopStdoutReader = attachStrictJsonlLineReader(child.stdout, handleLine);
+      child.once("error", (error) => {
+        closed = true;
+        closeFailure = error;
+        queue.fail(error);
+        failPending(error);
+      });
+      child.once("close", (code, signal) => {
+        closed = true;
+        if (intentionalClose) {
+          queue.end();
+          failPending(new Error("Grok ACP process closed"));
+          return;
+        }
+        const suffix = stderr.trim() ? ` Stderr: ${stderr.trim()}` : "";
+        const failure =
+          code === 0 && signal === null
+            ? null
+            : new Error(`Grok ACP process exited with code ${code ?? "unknown"} signal ${signal ?? "none"}.${suffix}`);
+        if (failure) {
+          closeFailure = failure;
+          queue.fail(failure);
+          failPending(failure);
+        } else {
+          closeFailure = new Error("Grok ACP process closed");
+          queue.end();
+          failPending(closeFailure);
+        }
+      });
+    },
+    request(method, params) {
+      if (!child || closed) {
+        return Promise.reject(closeFailure ?? new Error("Grok ACP transport is not connected"));
+      }
+
+      const id = nextRequestId++;
+      const timeoutMs = method === "session/prompt" ? promptTimeoutMs : responseTimeoutMs;
+      const message: GrokJsonRpcRequest = {
+        jsonrpc: "2.0",
+        id,
+        method,
+        ...(params ? { params } : {}),
+      };
+
+      return new Promise<unknown>((resolve, reject) => {
+        const timeout =
+          timeoutMs > 0
+            ? setTimeout(() => {
+                pending.delete(id);
+                reject(new Error(`Timeout waiting for Grok ACP response to ${method}`));
+              }, timeoutMs)
+            : undefined;
+        pending.set(id, { resolve, reject, timeout });
+        void writeMessage(message).catch((error) => {
+          pending.delete(id);
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+          reject(error);
+        });
+      });
+    },
+    async notify(method, params) {
+      if (method === "session/cancel") {
+        interrupted = true;
+      }
+      await writeMessage({
+        jsonrpc: "2.0",
+        method,
+        ...(params ? { params } : {}),
+      });
+    },
+    async close() {
+      stopStdoutReader?.();
+      stopStdoutReader = null;
+      const currentChild = child;
+      child = null;
+      if (!currentChild || closed) {
+        queue.end();
+        failPending(new Error("Grok ACP transport closed"));
+        return;
+      }
+
+      closed = true;
+      intentionalClose = true;
+      currentChild.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          currentChild.kill("SIGKILL");
+          resolve();
+        }, GROK_INTERRUPT_GRACE_MS);
+        currentChild.once("close", () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+      queue.end();
+      failPending(new Error("Grok ACP transport closed"));
+    },
+  };
+}
+
+export function buildGrokAcpProcessArgs(input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend">): string[] {
+  const args = ["--no-auto-update", "--no-alt-screen", "--always-approve"];
+  const model = input.model?.trim();
+  if (model && model !== "default") {
+    args.push("-m", model);
+  }
+  const effort = toGrokEffort(input.effort);
+  if (effort) {
+    args.push("--effort", effort);
+  }
+  const systemPromptAppend = input.systemPromptAppend?.trim();
+  if (systemPromptAppend) {
+    args.push("--append-system-prompt", systemPromptAppend);
+  }
+  args.push("agent", "stdio");
+  return args;
+}
+
+export function buildGrokAcpSpawnEnv(input: Pick<GrokAcpStartInput, "env">): NodeJS.ProcessEnv {
+  return { ...input.env };
+}
+
+export function toGrokEffort(value?: RuntimeEffort): GrokEffort | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value === "xhigh" || value === "max" || value === "ultra") {
+    return "high";
+  }
+  return value;
+}
+
+export function selectGrokAuthMethod(authMethods: unknown[], env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const ids = authMethods
+    .map((method) => (isRecord(method) ? firstString(method.id) : undefined))
+    .filter((id): id is string => Boolean(id));
+  if (ids.length === 0) {
+    return undefined;
+  }
+  if (env.XAI_API_KEY?.trim() && ids.includes("xai.api_key")) {
+    return "xai.api_key";
+  }
+  if (ids.includes("cached_token")) {
+    return "cached_token";
+  }
+  if (ids.includes("xai.api_key")) {
+    return "xai.api_key";
+  }
+  return ids[0];
+}
+
+export function selectGrokPermissionOutcome(options: unknown): { outcome: "selected"; optionId: string } | { outcome: "cancelled" } {
+  const list = Array.isArray(options) ? options : [];
+  const allow = list.find((option) => {
+    if (!isRecord(option)) {
+      return false;
+    }
+    const kind = firstString(option.kind)?.toLowerCase() ?? "";
+    const optionId = firstString(option.optionId, option.id)?.toLowerCase() ?? "";
+    return kind.includes("allow") || optionId.includes("allow");
+  });
+  const fallback = list.find((option) => isRecord(option) && firstString(option.optionId, option.id));
+  const optionId = isRecord(allow)
+    ? firstString(allow.optionId, allow.id)
+    : isRecord(fallback)
+      ? firstString(fallback.optionId, fallback.id)
+      : undefined;
+  if (!optionId) {
+    return { outcome: "cancelled" };
+  }
+  return { outcome: "selected", optionId };
+}
+
+async function* runGrokTurns(
+  input: RuntimeStartRequest,
+  transport: GrokAcpTransport,
+  state: GrokSessionRuntimeState,
+): AsyncGenerator<RuntimeEvent> {
+  const abortSignal = input.abortController.signal;
+  const startInput: GrokAcpStartInput = {
+    cwd: input.cwd,
+    env: input.env ?? process.env,
+    model: input.model,
+    effort: input.effort,
+    systemPromptAppend: input.systemPromptAppend,
+  };
+  const eventIterator = transport.events[Symbol.asyncIterator]();
+
+  try {
+    await transport.start(startInput);
+    await initializeGrokSession(transport, input, state);
+
+    if (state.sessionId) {
+      yield {
+        type: "thread.started",
+        thread: { id: state.sessionId },
+        metadata: buildGrokEventMetadata({ method: "session/new" }, { sessionId: state.sessionId }),
+      };
+    }
+
+    let turnIndex = 0;
+    for await (const promptMessage of input.prompt) {
+      if (abortSignal.aborted || state.interrupted) {
+        break;
+      }
+
+      const prompt = extractPromptText(promptMessage);
+      if (!prompt) {
+        continue;
+      }
+      if (!state.sessionId) {
+        throw new Error("Grok ACP session is not initialized");
+      }
+
+      const terminalTracker = createRuntimeTerminalEventTracker();
+      turnIndex += 1;
+      const context: GrokEventContext = {
+        cwd: input.cwd,
+        model: input.model,
+        promptMessage,
+        turnIndex,
+        sessionId: state.sessionId,
+        assistantText: "",
+        usage: emptyUsage(),
+      };
+
+      state.activeTurn = true;
+      const abortListener = () => {
+        state.interrupted = true;
+        void safeGrokNotify(transport, "session/cancel", { sessionId: state.sessionId });
+      };
+      abortSignal.addEventListener("abort", abortListener, { once: true });
+
+      const turn = { id: `grok-turn-${turnIndex}`, status: "running" };
+      yield {
+        type: "turn.started",
+        turn,
+        metadata: buildGrokEventMetadata({ method: "session/prompt" }, context),
+      };
+
+      try {
+        const promptPromise = transport.request("session/prompt", {
+          sessionId: state.sessionId,
+          prompt: [{ type: "text", text: prompt }],
+        });
+
+        for await (const notification of consumeUntilSettled(eventIterator, promptPromise)) {
+          for (const runtimeEvent of normalizeGrokNotification(notification, context)) {
+            if (!terminalTracker.accept(runtimeEvent)) {
+              continue;
+            }
+            yield runtimeEvent;
+          }
+        }
+
+        const result = await promptPromise;
+        const stopReason = firstString(isRecord(result) ? result.stopReason : undefined) ?? "end_turn";
+        const metadata = buildGrokEventMetadata(
+          { method: "session/prompt", stopReason, ...(isRecord(result) ? result : {}) },
+          context,
+        );
+
+        if (state.interrupted || abortSignal.aborted || stopReason === "cancelled") {
+          const terminal = terminalTracker.interrupt({
+            rawEvent: isRecord(result) ? result : { stopReason },
+            metadata,
+          });
+          if (terminal) {
+            yield terminal;
+          }
+          continue;
+        }
+
+        if (stopReason === "refusal" || stopReason === "max_tokens" || stopReason === "max_turn_requests") {
+          const terminal = terminalTracker.fail({
+            error: `Grok turn stopped: ${stopReason}`,
+            recoverable: stopReason !== "refusal",
+            rawEvent: isRecord(result) ? result : { stopReason },
+            metadata,
+          });
+          if (terminal) {
+            yield terminal;
+          }
+          continue;
+        }
+
+        if (context.assistantText) {
+          const message: RuntimeEvent = {
+            type: "assistant.message",
+            text: context.assistantText,
+            rawEvent: isRecord(result) ? result : { stopReason },
+            metadata,
+          };
+          if (terminalTracker.accept(message)) {
+            yield message;
+          }
+        }
+
+        const session = buildGrokRuntimeSessionState(state.sessionId, context);
+        const terminal: RuntimeEvent = {
+          type: "turn.complete",
+          providerSessionId: state.sessionId,
+          session,
+          execution: {
+            provider: "grok",
+            model: context.model ?? null,
+            billingType: "unknown",
+          },
+          usage: context.usage,
+          rawEvent: isRecord(result) ? result : { stopReason },
+          metadata,
+        };
+        if (terminalTracker.accept(terminal)) {
+          yield terminal;
+        }
+      } catch (error) {
+        if (abortSignal.aborted || state.interrupted) {
+          const terminal = terminalTracker.interrupt({
+            rawEvent: { type: "stream.error", reason: "interrupt" },
+            metadata: buildGrokEventMetadata({ method: "session/cancel" }, context),
+          });
+          if (terminal) {
+            yield { type: "status", status: "idle", metadata: terminal.metadata };
+            yield terminal;
+          }
+          continue;
+        }
+
+        const terminal = terminalTracker.fail({
+          error: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+          rawEvent: { type: "stream.error" },
+          metadata: buildGrokEventMetadata({ method: "session/prompt" }, context),
+        });
+        if (terminal) {
+          yield terminal;
+        }
+      } finally {
+        abortSignal.removeEventListener("abort", abortListener);
+        state.activeTurn = false;
+        state.interrupted = false;
+      }
+    }
+  } finally {
+    await transport.close();
+    if (state.transport === transport) {
+      state.transport = undefined;
+    }
+  }
+}
+
+async function initializeGrokSession(
+  transport: GrokAcpTransport,
+  input: RuntimeStartRequest,
+  state: GrokSessionRuntimeState,
+): Promise<void> {
+  const init = await transport.request("initialize", {
+    protocolVersion: GROK_ACP_PROTOCOL_VERSION,
+    clientInfo: {
+      name: "ravi",
+      title: "Ravi Runtime",
+    },
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+  });
+  const initRecord = isRecord(init) ? init : {};
+  const agentCapabilities = isRecord(initRecord.agentCapabilities) ? initRecord.agentCapabilities : {};
+  state.loadSessionSupported = agentCapabilities.loadSession === true;
+
+  const authMethods = Array.isArray(initRecord.authMethods) ? initRecord.authMethods : [];
+  const methodId = selectGrokAuthMethod(authMethods, input.env ?? process.env);
+  if (methodId) {
+    await transport.request("authenticate", {
+      methodId,
+      _meta: { headless: true },
+    });
+  } else if (authMethods.length > 0) {
+    throw new Error("Run `grok login` first, or set XAI_API_KEY.");
+  }
+
+  const resumeSessionId = readGrokResumeSessionId(input);
+  if (resumeSessionId && !input.forkSession) {
+    if (!state.loadSessionSupported) {
+      throw new Error("Grok ACP agent does not advertise session/load; cannot resume");
+    }
+    await transport.request("session/load", {
+      sessionId: resumeSessionId,
+      cwd: input.cwd,
+      mcpServers: [],
+    });
+    state.sessionId = resumeSessionId;
+    return;
+  }
+
+  const created = await transport.request("session/new", {
+    cwd: input.cwd,
+    mcpServers: [],
+  });
+  const sessionId = firstString(isRecord(created) ? created.sessionId : undefined);
+  if (!sessionId) {
+    throw new Error("Grok ACP session/new did not return a sessionId");
+  }
+  state.sessionId = sessionId;
+}
+
+function readGrokResumeSessionId(input: RuntimeStartRequest): string | undefined {
+  return firstString(input.resumeSession?.params?.sessionId, input.resume);
+}
+
+function normalizeGrokNotification(notification: GrokAcpNotification, context: GrokEventContext): RuntimeEvent[] {
+  const rawEvent = notification as Record<string, unknown>;
+  const metadata = buildGrokEventMetadata(rawEvent, context);
+  const events: RuntimeEvent[] = [{ type: "provider.raw", rawEvent, metadata }];
+  if (notification.method !== "session/update") {
+    return events;
+  }
+
+  const params = isRecord(notification.params) ? notification.params : {};
+  const update = isRecord(params.update) ? params.update : params;
+  const sessionUpdate = firstString(update.sessionUpdate, update.type);
+  const sessionId = firstString(params.sessionId);
+  if (sessionId) {
+    context.sessionId = sessionId;
+  }
+
+  switch (sessionUpdate) {
+    case "agent_message_chunk": {
+      const text = extractGrokContentText(update.content);
+      if (text) {
+        context.assistantText += text;
+        events.push({ type: "text.delta", text, metadata });
+      }
+      break;
+    }
+    case "agent_thought_chunk":
+      events.push({ type: "status", status: "thinking", rawEvent, metadata });
+      break;
+    case "tool_call": {
+      const toolUse = buildGrokToolUse(update);
+      if (toolUse) {
+        events.push({ type: "tool.started", toolUse, rawEvent, metadata });
+      }
+      break;
+    }
+    case "tool_call_update": {
+      const status = firstString(update.status);
+      if (status === "completed" || status === "failed") {
+        events.push({
+          type: "tool.completed",
+          toolUseId: firstString(update.toolCallId, update.toolCallID),
+          toolName: firstString(update.title, update.kind),
+          content: update.content,
+          isError: status === "failed",
+          rawEvent,
+          metadata,
+        });
+      }
+      break;
+    }
+    case "plan":
+      events.push({ type: "status", status: "thinking", rawEvent, metadata });
+      break;
+    case "usage_update":
+      context.usage = mapGrokUsage(update, context.usage);
+      break;
+    default:
+      break;
+  }
+
+  return events;
+}
+
+function buildGrokToolUse(update: Record<string, unknown>): RuntimeToolUse | null {
+  const id = firstString(update.toolCallId, update.toolCallID);
+  const name = firstString(update.title, update.kind, update.toolName) ?? "tool";
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    input: update.rawInput ?? update.input ?? update.arguments,
+  };
+}
+
+function mapGrokUsage(update: Record<string, unknown>, fallback: RuntimeUsage): RuntimeUsage {
+  const used = numberOrZero(update.used);
+  if (used === 0 && fallback.inputTokens === 0 && fallback.outputTokens === 0) {
+    return fallback;
+  }
+  return {
+    inputTokens: used || fallback.inputTokens,
+    outputTokens: fallback.outputTokens,
+  };
+}
+
+function extractGrokContentText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!isRecord(content)) {
+    return "";
+  }
+  return firstString(content.text) ?? "";
+}
+
+function buildGrokRuntimeSessionState(sessionId: string | undefined, context: GrokEventContext): RuntimeSessionState {
+  return {
+    params: {
+      integration: "acp",
+      cwd: context.cwd,
+      ...(sessionId ? { sessionId } : {}),
+      ...(context.model ? { model: context.model } : {}),
+    },
+    displayId: sessionId ?? null,
+  };
+}
+
+function buildGrokEventMetadata(
+  rawEvent: Record<string, unknown>,
+  context: Pick<GrokEventContext, "sessionId"> & { turnIndex?: number },
+): RuntimeEventMetadata {
+  return {
+    provider: "grok",
+    nativeEvent: firstString(rawEvent.method, rawEvent.sessionUpdate, rawEvent.type),
+    ...(context.sessionId ? { thread: { id: context.sessionId } } : {}),
+    ...(context.turnIndex
+      ? {
+          turn: {
+            id: `grok-turn-${context.turnIndex}`,
+          },
+        }
+      : {}),
+  };
+}
+
+async function controlGrokRuntime(
+  state: GrokSessionRuntimeState,
+  request: RuntimeControlRequest,
+): Promise<RuntimeControlResult> {
+  const controlState = (): RuntimeControlState => ({
+    provider: "grok",
+    threadId: state.sessionId,
+    activeTurn: state.activeTurn,
+    supportedOperations: GROK_RUNTIME_CONTROL_OPERATIONS,
+  });
+
+  if (request.operation !== "turn.interrupt") {
+    return {
+      ok: false,
+      operation: request.operation,
+      state: controlState(),
+      error: `Grok runtime does not support ${request.operation}`,
+    };
+  }
+
+  state.interrupted = true;
+  if (!state.sessionId || !state.transport) {
+    return {
+      ok: false,
+      operation: request.operation,
+      state: controlState(),
+      error: "Grok ACP session is not connected",
+    };
+  }
+
+  try {
+    await state.transport.notify("session/cancel", { sessionId: state.sessionId });
+    return {
+      ok: true,
+      operation: request.operation,
+      state: controlState(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      operation: request.operation,
+      state: controlState(),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function safeGrokNotify(
+  transport: GrokAcpTransport,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await transport.notify(method, params);
+  } catch {
+    // Interrupt paths must be best-effort. The stream terminality layer handles
+    // subprocess exit or missing terminal events.
+  }
+}
+
+async function* consumeUntilSettled<T, R>(
+  iterator: AsyncIterator<T>,
+  settled: Promise<R>,
+): AsyncGenerator<T> {
+  let pendingNext: Promise<IteratorResult<T>> | undefined;
+  let done = false;
+  const settledBox = settled.then((value) => {
+    done = true;
+    return value;
+  });
+
+  while (!done) {
+    pendingNext ??= iterator.next();
+    const winner = await Promise.race([
+      pendingNext.then((result) => ({ tag: "item" as const, result })),
+      settledBox.then((value) => ({ tag: "settled" as const, value })),
+    ]);
+    if (winner.tag === "settled") {
+      break;
+    }
+    pendingNext = undefined;
+    if (winner.result.done) {
+      break;
+    }
+    yield winner.result.value;
+  }
+
+  while (pendingNext) {
+    const leftover = await peekIfResolved(pendingNext);
+    pendingNext = undefined;
+    if (!leftover || leftover.done) {
+      break;
+    }
+    yield leftover.value;
+    pendingNext = iterator.next();
+  }
+}
+
+function peekIfResolved<T>(promise: Promise<T>): Promise<T | undefined> {
+  return Promise.race([promise, Promise.resolve(undefined)]);
+}
+
+function extractPromptText(message: RuntimePromptMessage): string {
+  return message.message.content.trim();
+}
+
+function emptyUsage(): RuntimeUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+}
+
+function attachStrictJsonlLineReader(stream: NodeJS.ReadableStream, onLine: (line: string) => void): () => void {
+  const decoder = new StringDecoder("utf8");
+  let buffer = "";
+
+  const emitLine = (line: string) => {
+    onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+  };
+
+  const onData = (chunk: string | Buffer) => {
+    buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
+    while (true) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+      emitLine(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+    }
+  };
+
+  const onEnd = () => {
+    buffer += decoder.end();
+    if (buffer.length > 0) {
+      emitLine(buffer);
+      buffer = "";
+    }
+  };
+
+  stream.on("data", onData);
+  stream.on("end", onEnd);
+
+  return () => {
+    stream.off("data", onData);
+    stream.off("end", onEnd);
+  };
+}
+
+function createAsyncQueue<T>(): AsyncQueue<T> {
+  const values: T[] = [];
+  const waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let ended = false;
+  let failure: unknown;
+
+  return {
+    push(value) {
+      if (ended || failure) {
+        return;
+      }
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve({ value, done: false });
+        return;
+      }
+      values.push(value);
+    },
+    end() {
+      if (ended || failure) {
+        return;
+      }
+      ended = true;
+      while (waiters.length > 0) {
+        waiters.shift()!.resolve({ value: undefined as T, done: true });
+      }
+    },
+    fail(error) {
+      if (ended || failure) {
+        return;
+      }
+      failure = error;
+      while (waiters.length > 0) {
+        waiters.shift()!.reject(error);
+      }
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          if (values.length > 0) {
+            return Promise.resolve({ value: values.shift()!, done: false });
+          }
+          if (failure) {
+            return Promise.reject(failure);
+          }
+          if (ended) {
+            return Promise.resolve({ value: undefined as T, done: true });
+          }
+          return new Promise<IteratorResult<T>>((resolve, reject) => {
+            waiters.push({ resolve, reject });
+          });
+        },
+      };
+    },
+  };
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -15,7 +15,7 @@ describe("runtime compatibility preflight", () => {
     expect(DEFAULT_RUNTIME_PROVIDER_ID).toBe("codex");
     expect(createRuntimeProvider().id).toBe("codex");
     expect(listRegisteredRuntimeProviderIds()).toContain("claude");
-    expect(listRegisteredRuntimeProviderIds()).toEqual(expect.arrayContaining(["codex", "claude", "pi"]));
+    expect(listRegisteredRuntimeProviderIds()).toEqual(expect.arrayContaining(["codex", "claude", "grok", "pi"]));
   });
 
   it("allows Claude providers to satisfy restricted tool access", () => {
@@ -86,6 +86,14 @@ describe("runtime compatibility preflight", () => {
 
   it("blocks restricted tool access for Pi until Ravi-hosted tool hooks exist", () => {
     const issues = getRuntimeCompatibilityIssues(createRuntimeProvider("pi"), {
+      toolAccessMode: "restricted",
+    });
+
+    expect(issues.map((issue) => issue.code)).toEqual(["restricted_tool_access_unsupported"]);
+  });
+
+  it("blocks restricted tool access for Grok until Ravi-hosted tool hooks exist", () => {
+    const issues = getRuntimeCompatibilityIssues(createRuntimeProvider("grok"), {
       toolAccessMode: "restricted",
     });
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -9,6 +9,7 @@ export * from "./model-broker.js";
 export * from "./model-broker-registry.js";
 export * from "./claude-provider.js";
 export * from "./codex-provider.js";
+export * from "./grok-provider.js";
 export * from "./pi-provider.js";
 export * from "./context-registry.js";
 export * from "./model-validation.js";

--- a/src/runtime/provider-contract.test.ts
+++ b/src/runtime/provider-contract.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClaudeRuntimeProvider } from "./claude-provider.js";
 import { createCodexRuntimeProvider } from "./codex-provider.js";
+import { createGrokRuntimeProvider } from "./grok-provider.js";
 import { createPiRuntimeProvider } from "./pi-provider.js";
 import type { RuntimeCapabilities, RuntimeHostServices, RuntimePrepareSessionResult } from "./types.js";
 
@@ -83,6 +84,7 @@ describe("runtime provider contract", () => {
   const builtInProviders = [
     { providerId: "claude", createProvider: createClaudeRuntimeProvider },
     { providerId: "codex", createProvider: createCodexRuntimeProvider },
+    { providerId: "grok", createProvider: createGrokRuntimeProvider },
     { providerId: "pi", createProvider: createPiRuntimeProvider },
   ] as const;
 
@@ -207,6 +209,50 @@ describe("runtime provider contract", () => {
       supportsMcpServers: false,
       supportsRemoteSpawn: false,
       toolAccessRequirement: "tool_surface",
+    });
+
+    expect(createGrokRuntimeProvider().getCapabilities()).toMatchObject({
+      runtimeControl: {
+        supported: true,
+        operations: ["turn.interrupt"],
+      },
+      dynamicTools: {
+        mode: "none",
+      },
+      execution: {
+        mode: "subprocess-rpc",
+      },
+      sessionState: {
+        mode: "provider-session-id",
+        requiresCwdMatch: true,
+      },
+      usage: {
+        semantics: "terminal-event",
+      },
+      tools: {
+        permissionMode: "provider-native",
+        accessRequirement: "tool_and_executable",
+        supportsParallelCalls: false,
+      },
+      systemPrompt: {
+        mode: "append",
+      },
+      terminalEvents: {
+        guarantee: "adapter",
+      },
+      skillVisibility: {
+        availability: "none",
+        loadedState: "none",
+      },
+      supportsSessionResume: true,
+      supportsSessionFork: false,
+      supportsPartialText: true,
+      supportsToolHooks: false,
+      supportsHostSessionHooks: false,
+      supportsPlugins: false,
+      supportsMcpServers: false,
+      supportsRemoteSpawn: false,
+      toolAccessRequirement: "tool_and_executable",
     });
 
     expect(createPiRuntimeProvider().getCapabilities()).toMatchObject({

--- a/src/runtime/provider-registry.ts
+++ b/src/runtime/provider-registry.ts
@@ -1,5 +1,6 @@
 import { createClaudeRuntimeProvider } from "./claude-provider.js";
 import { createCodexRuntimeProvider } from "./codex-provider.js";
+import { createGrokRuntimeProvider } from "./grok-provider.js";
 import { createPiRuntimeProvider } from "./pi-provider.js";
 import type {
   RuntimeCompatibilityIssue,
@@ -16,10 +17,11 @@ export const DEFAULT_RUNTIME_PROVIDER_ID: RuntimeProviderId = "codex";
 const runtimeProviderFactories = new Map<RuntimeProviderId, RuntimeProviderFactory>([
   ["claude", createClaudeRuntimeProvider],
   ["codex", createCodexRuntimeProvider],
+  ["grok", createGrokRuntimeProvider],
   ["pi", createPiRuntimeProvider],
 ]);
 
-const builtInRuntimeProviderIds = new Set<RuntimeProviderId>(["claude", "codex", "pi"]);
+const builtInRuntimeProviderIds = new Set<RuntimeProviderId>(["claude", "codex", "grok", "pi"]);
 
 export function registerRuntimeProvider(providerId: RuntimeProviderId, factory: RuntimeProviderFactory): void {
   runtimeProviderFactories.set(providerId, factory);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Add a first-class Ravi runtime provider that adapts xAI Grok Build (`grok` CLI) the same way Pi/Codex adapt their CLIs. Grok is a local subprocess execution engine, not Grok Bot, not the xAI chat API, and not a new host branch.

## Problem

- Ravi already has Claude, Codex, and Pi adapters, but no first-class path for Grok Build.
- Treating Grok as Grok Bot inbound, A2A, or a chat-completions HTTP client would violate the runtime provider contract.

## Solution

- Register provider id `grok` through `registerRuntimeProvider`.
- Use ACP (`grok agent stdio`) instead of headless `grok -p --output-format streaming-json`. ACP is a long-lived JSON-RPC subprocess, so it matches the Pi/Codex `subprocess-rpc` pattern, supports `session/load` resume, and maps `session/cancel` to interrupt. Headless `-p` is one process per prompt and a worse fit for a live session handle.
- Conservative v1 capabilities: provider-native tools, no MCP/plugins/remote spawn, no canonical fork, adapter-enforced terminal events.
- Command override via `RAVI_GROK_COMMAND`. Spawn flags include `--no-auto-update`, `--no-alt-screen`, and `--always-approve`.
- Fake-transport unit tests prove `startSession` + one prompt → `turn.started` → `assistant.message` / `text.delta` → exactly one `turn.complete`. No live xAI calls.

## Practical impact

- Agents can set `provider=grok` through the existing CLI (`ravi agents set <id> provider grok`).
- Restricted-tool agents are rejected until Grok permissions are bridged to Ravi host services.

## What does NOT change

- No branches in `bot.ts`, `session-launcher.ts`, or `runtime-request-builder.ts`.
- No Slack/WhatsApp wiring, secrets, Grok Bot gateways, or model-catalog listing (Pi is also unlisted).
- No `prepareSession` (env/tools/approvals are not needed for this cut).

## Validation

- `bun test src/runtime/grok-provider.test.ts src/runtime/provider-contract.test.ts src/runtime/index.test.ts` — 26 pass
- `bunx tsc --noEmit --pretty false`
- Pre-push hook (`bun test` plus generated SDK/OpenAPI/Swift checks) passed on push

## Risks

- ACP client fs/terminal capabilities are disabled; Grok uses its own tools. If a future Grok build requires those client methods, the adapter must grow handlers.
- Effort `xhigh|max|ultra` maps to native `high` until Grok documents a stronger native value.
- `--always-approve` is required so ACP permission prompts do not hang a headless daemon.

## Rollback

- Revert the PR. Built-in provider registration is the only host wiring.

## Follow-ups

- Bridge `session/request_permission` to Ravi host services if restricted agents should run on Grok.
- Canonical fork only after Grok session state can be mapped to Ravi prompt atoms.
- Optional later headless `-p` fallback if ACP is unavailable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4211c464-eabf-43e3-9aa6-99f4996dc7a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4211c464-eabf-43e3-9aa6-99f4996dc7a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

