### PR TITLE
feat(cli): add agent-first foundation

### DIFF
--- a/.ravi/specs/cli/foundation/CHECKS.md
+++ b/.ravi/specs/cli/foundation/CHECKS.md
@@ -1,0 +1,66 @@
+# Agent-first CLI foundation / CHECKS
+
+## Output integrity
+
+- A native process test MUST parse a piped JSON response larger than 64 KiB.
+- Success and failure paths MUST complete pending output before process exit.
+- The test MUST exercise the real CLI process boundary.
+- Direct `fail()` termination MUST route through the top-level flush boundary.
+- Native isolated tool tests with `RAVI_SUPPRESS_AUDIT_EVENTS=1` MUST NOT contact
+  the global NATS audit transport.
+- Interactive loops and child-process lifecycle callbacks listed in
+  `RUNBOOK.md` MUST NOT be represented as migrated one-shot command exits.
+
+## Public errors
+
+- Expected safe failures MUST preserve their public code, message, retryability,
+  suggested action, and exit code.
+- Unexpected failures MUST NOT expose stack traces, SQL, paths, tokens, provider
+  bodies, or internal exception messages.
+- Invalid shared pagination values MUST return `USAGE_ERROR` with exit code `2`.
+
+## Field selection
+
+- One unknown field among valid fields MUST fail with `acceptedFields`.
+- Only unknown fields MUST fail instead of returning empty objects.
+- An empty result set MUST still validate requested fields.
+- These checks apply to `agents list` in this foundation PR and to each command
+  only after its domain declares a stable accepted field set.
+
+## Effect metadata and brakes
+
+- Agent-discoverable command manifests MUST include operation kind, effect
+  class, risk, and confirmation requirement.
+- The host runtime dynamic-tool catalog MUST preserve the same safety metadata
+  instead of stripping it during projection.
+- Legacy mutations without a reviewed effect class MUST be exported as
+  `unclassified` with `classificationSource: legacy-unclassified`; they MUST NOT
+  default to a safe class.
+- The shared brake MUST have a native synthetic proof. Each real command
+  requiring confirmation MUST add a domain-owned proof that its unconfirmed
+  path performs no effect before leaving `unclassified`.
+- A command's exported metadata MUST match its registered decorators and actual
+  brake behavior.
+
+## SDK drift portability
+
+- Generated SDK comparison MUST accept only line-ending conversion and the
+  already-informational `GIT_SHA` difference.
+- Added, removed, or changed source content MUST continue to fail the drift
+  check on every platform.
+
+## Commands
+
+- `bun test src/cli/commands/usage-exit.smoke.test.ts`
+- `bun test src/cli/process-output.native.test.ts`
+- `bun test src/cli/agent-contract.foundation.test.ts`
+- `bun test src/runtime/host-services.foundation.test.ts`
+- `bun test src/cli/pagination.test.ts`
+- `bun test src/cli/tools-export.test.ts`
+- `bun test src/cli/confirmation-policy.test.ts`
+- `bun run test:agent-contract`
+- `bun run test:sdk`
+- `bun test src/sdk/client-codegen/codegen.test.ts`
+- `bun run sdk:check`
+- `bun run build`
+- `bun run typecheck`

--- a/.ravi/specs/cli/foundation/CHECKS.md
+++ b/.ravi/specs/cli/foundation/CHECKS.md
@@ -4,6 +4,10 @@
 
 - A native process test MUST parse a piped JSON response larger than 64 KiB.
 - Success and failure paths MUST complete pending output before process exit.
+- A permanently stuck stream MUST hit a bounded flush timeout without a busy
+  loop, and termination MUST still complete.
+- Native child-process checks MUST kill and observe a timed-out child before
+  returning, so a failed check cannot leave an orphan process.
 - The test MUST exercise the real CLI process boundary.
 - Direct `fail()` termination MUST route through the top-level flush boundary.
 - Native isolated tool tests with `RAVI_SUPPRESS_AUDIT_EVENTS=1` MUST NOT contact

--- a/.ravi/specs/cli/foundation/RUNBOOK.md
+++ b/.ravi/specs/cli/foundation/RUNBOOK.md
@@ -7,6 +7,9 @@
    parsed.
 3. If the payload is incomplete, inspect the common output writer and all
    immediate `process.exit()` paths before changing a domain command.
+4. If a process remains alive with no output progress, confirm that the common
+   writer reaches its five-second flush bound and that termination runs from the
+   guaranteed cleanup path. Never replace the bound with an unbounded poll.
 
 The migrated boundary covers registered one-shot CLI commands. The remaining
 direct exits are explicit lifecycle exceptions: daemon log/follow callbacks,

--- a/.ravi/specs/cli/foundation/RUNBOOK.md
+++ b/.ravi/specs/cli/foundation/RUNBOOK.md
@@ -1,0 +1,46 @@
+# Agent-first CLI foundation / RUNBOOK
+
+## Diagnose an incomplete response
+
+1. Re-run the command with `--json` and stdout redirected through a pipe.
+2. Confirm that the process exits only after the complete JSON document can be
+   parsed.
+3. If the payload is incomplete, inspect the common output writer and all
+   immediate `process.exit()` paths before changing a domain command.
+
+The migrated boundary covers registered one-shot CLI commands. The remaining
+direct exits are explicit lifecycle exceptions: daemon log/follow callbacks,
+interactive setup/session loops, instance connection listeners, and spawned
+service callbacks. They do not establish the output guarantee for structured
+one-shot responses and must be migrated and tested in their owning domain PRs.
+
+## Diagnose a generic error
+
+1. Decide whether the failure is expected and safe to disclose.
+2. Expected validation failures use a typed public error with a domain code.
+3. Caller mistakes use `USAGE_ERROR` and exit code `2`.
+4. Unexpected exceptions keep a generic public message; inspect protected logs
+   for internal details.
+
+## Diagnose field selection
+
+1. Read `acceptedFields` from the command's usage-error envelope.
+2. Retry with only declared public fields.
+3. If unknown fields succeed on an empty result set, validation is occurring too
+   late and the foundation contract has regressed.
+
+## Diagnose a confirmation mismatch
+
+1. Inspect the exported effect, risk, and confirmation metadata.
+2. Run the command without confirmation against an isolated native test state.
+3. Verify that no database write, event, provider call, child process, or remote
+   request occurred.
+4. Treat a metadata-only pass as a failed safety check.
+
+## Diagnose catalog drift
+
+1. Compare `ravi tools ... --json` with the host runtime dynamic-tool catalog.
+2. Confirm both surfaces carry operation kind, effect class, risk,
+   confirmation requirement, and classification source.
+3. Treat `unclassified` as an unresolved migration state, never as permission
+   to execute without the command's existing authorization and brake.

--- a/.ravi/specs/cli/foundation/SPEC.md
+++ b/.ravi/specs/cli/foundation/SPEC.md
@@ -41,6 +41,9 @@ belongs to this capability; business rules remain in domain specs.
   boundary before pending stdout, stderr, audit, and required transport work has
   completed or failed explicitly. Interactive loops and child-process lifecycle
   callbacks remain explicit migration exceptions listed in `RUNBOOK.md`.
+- Output flushing MUST be bounded. A stream that never reports progress MUST
+  time out without busy-spinning, and the requested process termination MUST
+  still occur so a broken pipe cannot hold the CLI indefinitely.
 - Large JSON responses MUST be emitted as one complete document when stdout is
   a pipe.
 - Expected failures MUST carry a public, typed, non-secret message. Unexpected
@@ -104,6 +107,9 @@ for a read, or retained as a legacy unknown.
 
 - A native process test receives a valid JSON payload larger than 64 KiB through
   a pipe with no truncation and exit code `0`.
+- A synthetic stuck stream reaches its bounded timeout without holding the
+  process, and a native timed-out child is killed and observed before the test
+  returns.
 - Expected safe messages remain visible; unexpected internal messages do not
   leak.
 - Unknown `--fields` values fail before projection with `acceptedFields` and

--- a/.ravi/specs/cli/foundation/SPEC.md
+++ b/.ravi/specs/cli/foundation/SPEC.md
@@ -1,0 +1,117 @@
+---
+id: cli/foundation
+title: Agent-first CLI foundation
+kind: capability
+domain: cli
+capabilities:
+  - output-integrity
+  - public-errors
+  - field-selection
+  - pagination
+  - effect-metadata
+tags:
+  - cli
+  - agent-first
+  - safety
+applies_to:
+  - src/cli
+  - src/permissions/scope.ts
+  - src/runtime/host-services.ts
+  - src/runtime/types.ts
+  - src/sdk/client-codegen
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# Agent-first CLI foundation
+
+## Intent
+
+Agent consumers must be able to trust that a completed CLI process delivered a
+complete response with a stable meaning. Shared transport and contract behavior
+belongs to this capability; business rules remain in domain specs.
+
+## Invariants
+
+- A registered one-shot CLI command MUST NOT terminate at its top-level command
+  boundary before pending stdout, stderr, audit, and required transport work has
+  completed or failed explicitly. Interactive loops and child-process lifecycle
+  callbacks remain explicit migration exceptions listed in `RUNBOOK.md`.
+- Large JSON responses MUST be emitted as one complete document when stdout is
+  a pipe.
+- Expected failures MUST carry a public, typed, non-secret message. Unexpected
+  failures MUST retain a generic public message and keep internal details out of
+  the response.
+- Caller mistakes MUST use `USAGE_ERROR` and exit code `2`. Operational or
+  domain failures, including unavailable retryable dependencies, MUST use exit
+  code `1`; retryability is carried separately in the envelope. Exit code `3`
+  is reserved for policy or confirmation blocks that prevent an effect safely.
+- A domain command migrated to strict field selection MUST validate against a
+  stable public field set before projecting records. For those migrated
+  commands, any unknown field MUST fail with `USAGE_ERROR`, exit code `2`, and
+  `acceptedFields`, including when the result set is empty. Legacy callers of
+  `pickFields` remain permissive until their domain pull request supplies the
+  accepted field set.
+- Pagination inputs MUST be validated before querying. Invalid limits, offsets,
+  or cursors MUST fail as usage errors rather than operational failures.
+- SDK drift checks MUST ignore checkout-only CRLF/LF conversion while still
+  rejecting any source-content difference.
+- Existing offset pagination responses MUST remain backward compatible while a
+  domain is migrated. Mutable operational datasets SHOULD adopt cursor-based
+  continuation in their domain pull request.
+- Every public command MUST expose its operation kind, effect class, risk, and
+  confirmation requirement through agent-discoverable command manifests and
+  the host runtime's dynamic-tool catalog. Unreviewed mutations MUST remain
+  visibly `unclassified`.
+- A command that declares confirmation MUST be proven to stop before its first
+  effect when confirmation is absent. Metadata alone MUST NOT count as a brake.
+
+## Ownership boundary
+
+The foundation owns one-shot command writers and termination, public error
+types, shared validators, manifest fields, runtime catalog propagation, and
+structural checks. A domain owns resource-specific error codes, accepted fields,
+query ordering, cursor construction, effect classification, read-back, and
+recovery. Interactive loops and child-process lifecycle callbacks remain owned
+by their commands until their domain migration.
+
+## Safety metadata
+
+The public `effectClass` vocabulary is:
+
+- `none` for reads;
+- `local-reversible` for immediate local writes with a defined inverse;
+- `external` for communication, publication, sharing, or provider state;
+- `destructive` for irreversible removal or secret rotation;
+- `authority-expansion` for added permission or exposure;
+- `triggered-work` for work that continues independently;
+- `containment` for immediate authority reduction or emergency stop;
+- `cost-threshold` when a trustworthy estimate reaches a configured limit;
+- `conditional` when the invocation determines whether an effect is material;
+- `unclassified` for legacy mutations awaiting domain review.
+
+`unclassified` MUST remain visible and MUST NOT be interpreted as safe. At this
+draft stage, real legacy mutations are expected to remain unclassified; domain
+pull requests replace that value with a declared class and prove their actual
+brake. `classificationSource` reports whether the value was declared, inferred
+for a read, or retained as a legacy unknown.
+
+## Acceptance criteria
+
+- A native process test receives a valid JSON payload larger than 64 KiB through
+  a pipe with no truncation and exit code `0`.
+- Expected safe messages remain visible; unexpected internal messages do not
+  leak.
+- Unknown `--fields` values fail before projection with `acceptedFields` and
+  exit code `2` for the migrated `agents list` surface; each domain adds the
+  same proof when it migrates its own field sets.
+- Invalid shared pagination inputs use `USAGE_ERROR` and exit code `2`.
+- Exported command definitions contain effect, risk, and confirmation metadata.
+- A synthetic structural confirmation test proves the shared brake mechanism
+  stops before its first effect. Every real mutation remains subject to a
+  domain-owned no-effect proof before its classification can leave
+  `unclassified`.

--- a/.ravi/specs/cli/foundation/WHY.md
+++ b/.ravi/specs/cli/foundation/WHY.md
@@ -1,0 +1,29 @@
+# Agent-first CLI foundation / WHY
+
+The same defects were found across multiple domain dossiers. Output integrity,
+error taxonomy, field validation, pagination validation, and risk discovery are
+transport concerns, so fixing them independently in every domain would create
+different meanings for the same CLI behavior.
+
+The foundation is deliberately narrow. It does not decide whether a domain
+operation is safe, reversible, external, destructive, or authority-bearing. It
+provides the language and enforcement points; each domain supplies the facts.
+
+Large-output validation stays in the repository's native process tests. This
+exercises the real pipe and termination path without introducing a separate
+test-bench methodology or committed bench artifacts.
+
+Backward compatibility is preserved for existing pagination envelopes during
+the migration. Cursor pagination is preferred for mutable datasets, but each
+domain must define a stable ordering and cursor before switching its public
+contract.
+
+Shared numeric pagination no longer clamps values above the declared maximum.
+It returns a usage error so callers cannot mistake a different page size for
+the one they requested. This is a deliberate public behavior change; response
+envelopes and valid values remain compatible.
+
+The foundation starts as `draft`. Reads can be inferred as no-effect, while
+legacy mutations remain visibly `unclassified`. Promotion to `active` happens
+only after the official gates pass and domain PRs have supplied the real effect
+classification and no-effect proofs they own.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1439,3 +1439,21 @@ reproduzidas na `dev` no Windows. O pacote instalavel local tem SHA-256
 Este GO autoriza commit, push e abertura da PR. A spec permanece `draft` e
 qualquer merge ou uso na VPS continua condicionado a CI Linux verde no commit
 exato e a autorizacao humana de implantacao.
+
+### Correcao da espera de saida sem limite
+
+A auditoria posterior ao primeiro commit encontrou uma espera sem prazo quando
+o Bun mantinha o indicador de buffer ativo. A fundacao passou a verificar o
+progresso em intervalos curtos, interromper a espera depois de cinco segundos,
+garantir a terminacao em `finally` e remover a segunda descarga no encerramento
+global.
+
+O teste nativo agora cobre stream permanentemente preso e processo-filho que
+excede seu prazo, alem dos caminhos reais de JSON maior que 64 KiB, falha e
+versao. O recorte focado passou com 22 testes e 91 assercoes; metadados,
+paginacao e runtime passaram com 27 testes e 107 assercoes; `test:sdk` passou
+com 75 testes e 297 assercoes, seguido de `sdk:check`. Typecheck, build, quality
+gate dos 34 caminhos e lint documental tambem passaram.
+
+O GO anterior fica superado pela mudanca de codigo. Novo commit, pacote e
+revisao independente do SHA exato sao obrigatorios antes de push e PR.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1457,3 +1457,30 @@ gate dos 34 caminhos e lint documental tambem passaram.
 
 O GO anterior fica superado pela mudanca de codigo. Novo commit, pacote e
 revisao independente do SHA exato sao obrigatorios antes de push e PR.
+
+### Primeira CI Linux da PR 426
+
+O run Linux `32450827025` do SHA
+`677cd83857fe6b6d2f92e66b3fd2dd61d4928f3c` passou pela suite de canais e
+avancou ate os testes da CLI, mas falhou ao carregar sincronamente o bundle do
+daemon. O top-level await adicionado pela fronteira de saida tornou o bundle
+incompativel com o `require` usado pelo PM2, embora a execucao direta local
+continuasse funcional.
+
+O caminho de versao foi movido para `bootstrapCli` e a promessa raiz voltou a
+ser iniciada sem top-level await. A CI vermelha invalida o GO e o pacote do SHA
+anterior. Nova validacao integral, pacote, revisao independente e CI Linux sao
+obrigatorios.
+
+Na revalidacao local, uma selecao ampliada incluiu indevidamente
+`src/runtime/codex-provider.test.ts`: 20 casos de scripts `.mjs` temporarios
+falharam com `ENOENT` no Windows e 50 passaram. O recorte correto da fundacao,
+sem esse arquivo alheio, passou com 27 testes e 107 assercoes. A suite integral
+permanece sob autoridade da CI Linux do novo SHA.
+
+O bundle corrigido foi carregado sincronamente por `require` e `daemon status`
+terminou com codigo 0. O recorte de saida e erros passou com 23 testes e 93
+assercoes; o SDK completo passou com 75 testes e 297 assercoes, seguido de
+`sdk:check`. Typecheck, build integral, quality gate dos 34 caminhos e lint
+documental tambem passaram. O fechamento ainda depende de commit exato, revisao
+independente, novo pacote e CI Linux verde no mesmo SHA.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1388,3 +1388,54 @@ TypeScript/Swift foram alinhados em commit dedicado, com `GIT_SHA` preservado.
 Por instrucao explicita do operador, nenhum Bun foi executado localmente. O
 head final com este registro e os snapshots atualizados ainda precisa passar a
 CI completa antes de restaurar o veredito **APPROVE**.
+
+---
+
+## FASE 9 - fundacao compartilhada de CLI agent-first (2026-08-21)
+
+Esta fase inicia em estado **DRAFT**. Ela adiciona a fronteira comum de saida,
+erros publicos tipados, validadores de campos e paginacao e metadados
+descobríveis de operacao, efeito, risco e confirmacao. As regras de negocio e a
+prova de ausencia de efeito de cada mutacao continuam pertencendo aos PRs de
+dominio.
+
+A primeira candidata foi classificada como **NO-GO** pela revisao independente:
+os gates `test:agent-contract` e `test:sdk` excederam limites de tempo, os dois
+testes centrais novos nao estavam listados em `CHECKS.md` e a spec prometia
+rigidez de campos e classificacao real alem do recorte migrado. O ocorrido esta
+registrado em `docs/postmortems/0001-cli-foundation-gates-no-go.md`.
+
+O recorte factual desta fase e:
+
+- `agents list` e o primeiro comando com campos estritos; os demais permanecem
+  legados ate o PR de seu dominio;
+- leituras sao projetadas como `none`, enquanto mutacoes sem revisao permanecem
+  visivelmente `unclassified`;
+- a prova sintetica valida o mecanismo comum de freio, nao substitui a prova de
+  uma mutacao real;
+- a fronteira de flush cobre comandos registrados de execucao unica; loops
+  interativos e callbacks de ciclo de vida permanecem excecoes declaradas;
+- o limite maximo de paginacao deixa de ser reduzido silenciosamente e passa a
+  falhar como erro de uso.
+
+Promocao para `active`, commit, push e PR ficam condicionados aos gates oficiais
+aplicaveis e a uma nova revisao independente do SHA exato.
+
+### Terceira revisao independente e liberacao para PR
+
+A terceira revisao independente classificou a candidata local como
+**CLOSABILITY_READY · INDEPENDENTLY_VERIFIED · LIVE_UNAUTHORIZED**. Ela
+confirmou a supressao NATS em chamadas permitidas e negadas, a mascara restrita
+ao literal de `GIT_SHA`, a taxonomia de exit e a coerencia entre codigo, Ravi
+Spec, ADR, runbook e postmortem.
+
+No estado aprovado, `test:sdk` passou com 75 testes e 297 assercoes,
+`tools-export` com 14 testes e 65 assercoes, typecheck, build, quality gate
+sobre 34 caminhos e lint documental passaram. O `test:agent-contract` passou
+fora das mesmas duas falhas de portabilidade de `artifacts/store.test.ts`
+reproduzidas na `dev` no Windows. O pacote instalavel local tem SHA-256
+`581CA4862028E0A91C5025B9AE575188F8E16C1AA857731088F13DE436DF4B75`.
+
+Este GO autoriza commit, push e abertura da PR. A spec permanece `draft` e
+qualquer merge ou uso na VPS continua condicionado a CI Linux verde no commit
+exato e a autorizacao humana de implantacao.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1450,7 +1450,7 @@ global.
 
 O teste nativo agora cobre stream permanentemente preso e processo-filho que
 excede seu prazo, alem dos caminhos reais de JSON maior que 64 KiB, falha e
-versao. O recorte focado passou com 22 testes e 91 assercoes; metadados,
+versao. O recorte focado passou com 23 testes e 93 assercoes; metadados,
 paginacao e runtime passaram com 27 testes e 107 assercoes; `test:sdk` passou
 com 75 testes e 297 assercoes, seguido de `sdk:check`. Typecheck, build, quality
 gate dos 34 caminhos e lint documental tambem passaram.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1484,3 +1484,28 @@ assercoes; o SDK completo passou com 75 testes e 297 assercoes, seguido de
 `sdk:check`. Typecheck, build integral, quality gate dos 34 caminhos e lint
 documental tambem passaram. O fechamento ainda depende de commit exato, revisao
 independente, novo pacote e CI Linux verde no mesmo SHA.
+
+A segunda CI Linux, run `32451955010` no SHA
+`ec6d13ccdcbcdb90b7b8a224c90a4f8892e2af16`, passou build, typecheck e o teste
+sincrono do daemon, mas falhou em dois casos de `sdk.test.ts`. Catches antigos
+do SDK recapturavam o sinal privado de termino de `fail()` e substituiam a
+mensagem publica por `CLI termination requested.`.
+
+A correcao relanca a mesma instancia privada antes de qualquer conversao de
+erro e concentra todos os catches externos do SDK nesse funil. Os dois testes
+agora exigem codigo 1, exatamente uma mensagem publica e ausencia do texto
+interno. O recorte afetado passou com 26 testes e 74 assercoes. Os testes de
+comandos posteriores ao SDK tambem passaram; somente o cleanup de
+`tasks-profiles.test.ts` repetiu os tres `EBUSY` ja conhecidos da base Windows.
+O NO-GO permanece ate novo commit, pacote, revisao independente e CI Linux.
+
+Na revalidacao final da segunda correcao, contexto, sinal, saida nativa, SDK,
+ferramentas e gateway passaram com 86 testes e 310 assercoes. O processo real
+passou com 11 testes e 63 assercoes; o SDK completo passou com 75 testes e 297
+assercoes, seguido de `sdk:check`. Typecheck, build integral e quality gate dos
+36 caminhos passaram.
+
+O primeiro `biome check` apontou apenas finais de linha misturados nos dois
+arquivos SDK editados no Windows. A formatacao oficial corrigiu o problema; o
+check e os 20 testes dos arquivos formatados passaram. Novo SHA, pacote, revisao
+independente e CI Linux verde continuam obrigatorios.

--- a/docs/adr/0001-agent-first-cli-foundation.md
+++ b/docs/adr/0001-agent-first-cli-foundation.md
@@ -1,0 +1,76 @@
+# ADR 0001: Establish an agent-first CLI foundation before domain facades
+
+**Date:** 2026-08-21  
+**Status:** accepted
+
+## Context
+
+The domain audits found the same unresolved failures in multiple CLI surfaces:
+large JSON output can be lost during immediate process exit, known validation
+errors can become generic `COMMAND_FAILED` responses, unknown `--fields` values
+can succeed with empty objects, pagination contracts diverge, and effect risk is
+not consistently discoverable or enforced.
+
+Implementing these concerns independently in every domain would duplicate
+policy, create conflicting contracts, and make later domain pull requests depend
+on accidental merge order. The program also requires one pull request per
+domain, native repository tests, and no external test-bench artifacts.
+
+## Decision
+
+Create one prerequisite `cli/foundation` pull request before the 21 domain pull
+requests. It owns only shared transport and contract primitives:
+
+- reliable stdout and stderr completion before process termination;
+- typed public errors and the common exit taxonomy;
+- strict field-selection validation;
+- the common pagination envelope and validation rules;
+- discoverable effect, risk, and confirmation metadata with global consistency
+  checks.
+
+Each domain remains responsible for its public error codes, accepted fields,
+stable query ordering, effect classification, and facade behavior. A domain
+facade follows `plan -> apply -> verify -> recover` when the operation has
+effects that require confirmation or recovery; the foundation does not invent a
+single universal business facade.
+
+The foundation pull request is a prerequisite, not a second pull request for
+any domain. Every domain still receives exactly one domain pull request. Tests
+are added to the repository's native suites; no `tests/bench` structure is part
+of this program.
+
+## Alternatives considered
+
+- **Implement the shared behavior inside the first domain pull request.**
+  Rejected because unrelated domains would inherit a hidden dependency from a
+  domain-owned change, and review scope would mix shared policy with business
+  behavior.
+- **Repeat the helpers in each domain.** Rejected because contracts and fixes
+  would drift, and parallel pull requests would conflict in shared CLI files.
+- **Build one universal facade before any domain work.** Rejected because read,
+  local reversible writes, external effects, destructive operations, and
+  authority changes need different safeguards. Only the lifecycle vocabulary
+  is shared.
+- **Proceed without the foundation and reconcile later.** Rejected because the
+  known output and error defects would invalidate evidence produced by domain
+  CLIs.
+
+## Consequences
+
+- **Positive:** domain pull requests start from one explicit contract, reuse the
+  same safety primitives, and can be reviewed with comparable evidence.
+- **Positive:** large-output, error, pagination, and risk behavior is verified
+  once at the common boundary and then specialized by each domain.
+- **Cost:** the first domain pull request waits for the foundation to merge or
+  become a stable dependency branch.
+- **Cost:** domain branches must be rebased in controlled waves as prerequisite
+  pull requests merge.
+- **Cost:** the foundation needs a narrow review to prevent it from absorbing
+  business rules that belong to domains.
+
+## Notes
+
+This decision is based on the 2026-08-21 audit of `origin/dev` at
+`b6046936fce0b08add2253ca52974d4cde5f3e9f`. Deployment to the VPS remains a
+separate, serial operation that requires explicit approval and evidence from the
+exact package commit.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -129,3 +129,19 @@ A publicação deve usar o commit já aprovado pelos gates focados e pela revis�
 independente, com o hook local explicitamente dispensado apenas para acionar a
 CI Linux. Merge, pacote promovido e VPS continuam bloqueados até a CI do SHA
 exato concluir todos os jobs obrigatórios.
+
+## Nota de revisão — 2026-08-21 (espera de saída sem limite)
+
+A investigação independente do congelamento descartou regressão no Slack, mas
+encontrou um bloqueador real na nova fronteira de saída: enquanto o Bun
+mantivesse `writableLength` ou `writableNeedDrain`, o código repetia
+`setImmediate` sem prazo máximo. Um indicador preso poderia consumir CPU e
+impedir o encerramento indefinidamente. A descarga adicional no `finally` da
+CLI repetia a mesma exposição.
+
+A correção troca a repetição por verificações espaçadas, com limite de cinco
+segundos, remove a segunda descarga e garante `process.exit` em `finally`. O
+teste nativo agora prova o limite com um stream permanentemente preso e mata,
+observa e rejeita um processo-filho que ultrapassa seu próprio prazo. Assim, o
+caminho normal continua comprovando saída integral, enquanto uma anomalia do
+stream não cria laço de CPU nem processo órfão.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -106,3 +106,26 @@ Na primeira normalização, o Biome também identificou a constante antiga
 `GIT_SHA_MASK` sem uso depois que a máscara passou a preservar prefixo e
 sufixo da declaração. A constante foi removida; o algoritmo e sua prova
 permanecem inalterados.
+
+## Nota de revisão — 2026-08-21 (pré-envio no Windows)
+
+O primeiro `git push` foi interrompido porque o hook completo permaneceu sem
+progresso visível em `bun test src/channels/`. A interrupção encerrou o processo
+Git, mas deixou dois processos Bun filhos órfãos, que continuaram consumindo CPU
+e disputando os bancos temporários das reproduções seguintes. Os dois processos
+foram identificados pelo comando e horário de criação e encerrados de forma
+direcionada; nenhum arquivo ou estado do produto foi removido.
+
+Em ambiente limpo, o teste filtrado de timeout do `auth.test` terminou da mesma
+forma na candidata e na `dev`: o setup isolado excedeu o limite de 5 segundos.
+A suíte completa também demonstrou flutuação na própria `dev`: uma execução
+terminou em 57 segundos com somente a falha Windows de separador no caminho de
+áudio; outra permaneceu no teste de timeout sem avançar. A candidata terminou
+quando executada sem os processos órfãos, mas acumulou timeouts de setup sob a
+carga local. O comportamento não foi atribuído à fundação e o hook local não é
+registrado como aprovado.
+
+A publicação deve usar o commit já aprovado pelos gates focados e pela revisão
+independente, com o hook local explicitamente dispensado apenas para acionar a
+CI Linux. Merge, pacote promovido e VPS continuam bloqueados até a CI do SHA
+exato concluir todos os jobs obrigatórios.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -145,3 +145,18 @@ teste nativo agora prova o limite com um stream permanentemente preso e mata,
 observa e rejeita um processo-filho que ultrapassa seu próprio prazo. Assim, o
 caminho normal continua comprovando saída integral, enquanto uma anomalia do
 stream não cria laço de CPU nem processo órfão.
+
+## Nota de revisão — 2026-08-21 (observação do processo-filho)
+
+A revisão independente da correção manteve **NO-GO** porque o helper nativo
+rejeitava imediatamente quando o primeiro `child.kill()` retornava falso, sem
+aguardar o evento `close`. Isso contrariava a exigência recém-documentada de
+matar e observar o filho antes de concluir. O ledger também permanecia na prova
+anterior de 22 testes e 91 asserções, embora o HEAD já contivesse 23 testes e 93
+asserções.
+
+O helper agora solicita encerramento no prazo principal, escala para `SIGKILL`
+depois de 250 ms e só resolve ou rejeita o timeout quando observa `close`.
+Erros de sinalização após o timeout também aguardam esse fechamento. O ledger
+foi alinhado à evidência final; nova execução e nova revisão do SHA exato
+continuam obrigatórias.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -1,0 +1,108 @@
+# Postmortem 0001: fundação CLI bloqueada pelos gates finais
+
+**Data:** 2026-08-21  
+**Severidade:** média  
+**Status:** aberto  
+**Projeto:** Ravi
+
+## Resumo
+
+A primeira candidata da fundação agent-first passou nos testes focados, mas foi
+corretamente classificada como NO-GO pela revisão independente. Gates oficiais
+excederam limites de tempo e a Ravi Spec declarava cobertura mais ampla do que a
+migração realmente entregava.
+
+## Hipótese / Expectativa
+
+Esperávamos que os testes focados, build, typecheck e quality gate fossem
+suficientes para apresentar a candidata aos gates oficiais sem nova regressão.
+
+## O que aconteceu de fato
+
+O gate `test:agent-contract` ficou instável ao carregar o catálogo completo em
+um teste pequeno. O gate do SDK também excedeu seu limite de tempo. A auditoria
+ainda encontrou campos estritos migrados somente em `agents`, mutações reais
+ainda não classificadas e caminhos de encerramento fora da nova fronteira.
+
+## Causa-raiz
+
+O recorte foi validado por mecanismo, mas a declaração normativa foi escrita
+como estado final do programa. Além disso, o custo de inicialização global não
+foi medido nos gates que executam o catálogo completo em máquina sem aquecimento.
+
+## O que foi bem
+
+O revisor foi independente, executou os gates oficiais e bloqueou a candidata
+antes de commit, push, PR ou VPS. O empacotamento e os testes de saída também
+produziram evidência útil sem criar bancada externa.
+
+## O que foi mal
+
+Os dois testes centrais novos não estavam listados em `CHECKS.md`, a spec foi
+marcada como ativa cedo demais e a execução local inicial não incluiu o gate do
+SDK.
+
+## Lições aprendidas
+
+Uma fundação de migração deve declarar explicitamente o que já é obrigatório e
+o que ainda é legado. Testes pequenos não devem pagar inicialização global
+desnecessária, e os gates oficiais precisam rodar antes da promoção documental.
+
+## Ações
+
+- [ ] Remover inicialização global desnecessária dos testes e repetir os gates oficiais — Codex — imediato
+- [ ] Tornar a Ravi Spec fiel ao recorte migrado e adicionar os testes centrais ao `CHECKS.md` — Codex — imediato
+- [ ] Documentar exceções de encerramento e a quebra deliberada de paginação — Codex — antes do PR
+- [ ] Reexecutar revisão independente após todos os gates aplicáveis — Codex — antes de commit e push
+
+## Nota de revisão — 2026-08-21
+
+O `sdk:check` não possuía cinco diferenças de conteúdo: quatro arquivos eram
+idênticos após normalizar CRLF/LF, e o quinto diferia adicionalmente apenas no
+`GIT_SHA`, que o comparador já trata como informativo. O check comparava bytes
+de checkout e foi corrigido para ignorar somente finais de linha, mantendo uma
+prova explícita de que qualquer mudança real de fonte continua falhando.
+
+## Nota de revisão — 2026-08-21 (portão local)
+
+A primeira repetição local do quality gate usou a base padrão `main`, embora o
+PR tenha `dev` como base, e foi descartada. A segunda tentativa também foi
+descartada porque o PowerShell agrupou a lista de arquivos como dois objetos.
+A execução aceita passou a fornecer uma lista plana do estado de trabalho,
+removeu o cabeçalho informativo do `rtk` e mostrou nominalmente os 34 caminhos
+reais antes de aprovar spec e cobertura. Quality gates que sincronizam o índice
+de specs também não devem rodar em paralelo no mesmo estado local.
+
+## Nota de revisão — 2026-08-21 (segunda revisão independente)
+
+A segunda revisão manteve o estado **NO-GO** ao encontrar uma emissão NATS sem
+a guarda de supressão no caminho de permissão negada, uma máscara de
+`GIT_SHA` ampla o bastante para ocultar conteúdo adicional na mesma linha e
+duas divergências entre a Ravi Spec e o comportamento implementado. A correção
+passou a guardar também a negação, adicionou prova de zero emissão para chamadas
+permitidas e negadas, restringiu a máscara ao literal JSON da constante e
+incluiu uma prova de drift na própria linha. A taxonomia reserva exit `3` para
+bloqueios seguros e o runbook deixou de prometer `acceptedFields` no manifesto.
+Uma terceira revisão independente continua obrigatória antes de qualquer
+commit, push ou PR.
+
+## Nota de revisão — 2026-08-21 (terceira revisão independente)
+
+A terceira revisão emitiu **GO** para commit e abertura da PR. Foram confirmadas
+as guardas NATS nos dois caminhos, a prova de drift na linha de `GIT_SHA`, a
+taxonomia normativa e a propagação dos metadados de segurança até o runtime. O
+pacote aprovado tem SHA-256
+`581CA4862028E0A91C5025B9AE575188F8E16C1AA857731088F13DE436DF4B75` e
+foi instalado em diretório vazio. As duas falhas de artifacts no Windows
+continuam registradas como dívida reproduzida igualmente na base; CI Linux no
+commit exato permanece obrigatória antes de merge ou VPS.
+
+O primeiro commit foi bloqueado pelo hook porque 18 arquivos TypeScript
+mantinham CRLF no worktree do Windows e o Biome exige LF. Nenhum commit foi
+criado. A correção é mecânica e limitada aos arquivos TypeScript já revisados;
+o hook, typecheck e os testes focados devem ser repetidos após a normalização.
+
+Na primeira normalização, o Biome também identificou a constante antiga
+`GIT_SHA_MASK` sem uso depois que a máscara passou a preservar prefixo e
+sufixo da declaração. A constante foi removida; o algoritmo e sua prova
+permanecem inalterados.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -160,3 +160,44 @@ depois de 250 ms e só resolve ou rejeita o timeout quando observa `close`.
 Erros de sinalização após o timeout também aguardam esse fechamento. O ledger
 foi alinhado à evidência final; nova execução e nova revisão do SHA exato
 continuam obrigatórias.
+
+## Nota de revisão — 2026-08-21 (primeira CI Linux da PR 426)
+
+A CI Linux do SHA `677cd83857fe6b6d2f92e66b3fd2dd61d4928f3c` falhou no
+teste nativo do daemon que carrega o bundle da CLI de forma síncrona. A nova
+fronteira havia introduzido `await` no nível principal para a versão e para o
+bootstrap. O bundle continuava executável diretamente, mas deixou de poder ser
+carregado por `require`, retornando status 1 no contrato usado pelo PM2.
+
+A correção move o caminho de versão para dentro de `bootstrapCli` e inicia a
+promessa com `void`, mantendo toda espera de saída dentro da cadeia assíncrona
+sem criar top-level await. O resultado vermelho permanece como evidência
+histórica; o GO, pacote e SHA anteriores estão superados. Testes do daemon,
+saída, build, pacote e revisão independente devem ser repetidos antes de novo
+push.
+
+## Nota de revisão — 2026-08-21 (recorte local ampliado no Windows)
+
+Uma tentativa local incluiu por engano todo o arquivo
+`src/runtime/codex-provider.test.ts` junto dos quatro testes da fundação. Nesse
+arquivo, 20 casos que iniciam scripts temporários falharam com `ENOENT` porque o
+Windows não executa diretamente os arquivos `.mjs` usados como falsos binários.
+Os 50 casos restantes passaram. Esse arquivo não pertence ao recorte de 27
+testes da fundação e a falha não toca o código corrigido do bootstrap.
+
+O comando correto, sem `codex-provider.test.ts`, passou com 27 testes e 107
+asserções. A CI Linux continua sendo a autoridade para a suíte integral e deve
+passar no SHA corrigido antes de qualquer novo GO.
+
+## Nota de revisão — 2026-08-21 (correção revalidada localmente)
+
+O bundle corrigido foi carregado de forma síncrona por `require` e executou
+`daemon status` com código 0. Os testes focados de saída e erros passaram com 23
+casos e 93 asserções; segurança, paginação e projeção de runtime passaram com 27
+casos e 107 asserções; a suíte completa do SDK passou com 75 casos e 297
+asserções, seguida de `sdk:check`.
+
+Typecheck, build integral, quality gate dos 34 caminhos e lint dos documentos
+alterados também passaram. Isso fecha a revalidação local, mas não restaura o
+GO: ainda são obrigatórios commit exato, revisão independente, novo pacote e CI
+Linux verde no mesmo SHA.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -201,3 +201,37 @@ Typecheck, build integral, quality gate dos 34 caminhos e lint dos documentos
 alterados também passaram. Isso fecha a revalidação local, mas não restaura o
 GO: ainda são obrigatórios commit exato, revisão independente, novo pacote e CI
 Linux verde no mesmo SHA.
+
+## Nota de revisão — 2026-08-21 (segunda CI Linux da PR 426)
+
+A CI Linux `32451955010` do SHA
+`ec6d13ccdcbcdb90b7b8a224c90a4f8892e2af16` confirmou build, typecheck e o
+carregamento síncrono do daemon, mas encontrou duas falhas em
+`src/cli/commands/sdk.test.ts`. Chamadas diretas legadas recebiam a mensagem
+privada `CLI termination requested.` no lugar da mensagem pública original.
+
+O sinal de término lançado por `fail()` estava sendo capturado pelos blocos de
+tratamento do SDK e convertido em uma segunda falha. A correção adiciona um
+helper compartilhado que relança exatamente a mesma instância privada, faz
+todos os tratamentos externos do SDK usarem esse helper e reforça os testes
+para exigir código 1, uma única mensagem pública e nenhum vazamento do sinal.
+
+O recorte diretamente afetado passou com 26 testes e 74 asserções. Todos os
+arquivos de comandos posteriores ao SDK na sequência da CI também passaram,
+exceto `tasks-profiles.test.ts`: suas três verificações chegaram ao cleanup e
+falharam apenas com o `EBUSY` de pastas temporárias já reproduzido e documentado
+na base Windows. O resultado da CI mantém o NO-GO; novo commit, pacote, revisão
+independente e CI Linux continuam obrigatórios.
+
+## Nota de revisão — 2026-08-21 (segunda correção revalidada localmente)
+
+O recorte de contexto, sinal, saída nativa, SDK, ferramentas e gateway passou
+com 86 testes e 310 asserções. O smoke no processo real passou com 11 testes e
+63 asserções; o SDK completo passou com 75 testes e 297 asserções, seguido de
+`sdk:check`. Typecheck, build integral e quality gate dos 36 caminhos passaram.
+
+O primeiro `biome check` detectou somente finais de linha misturados nos dois
+arquivos do SDK editados no Windows. O formatador oficial corrigiu os arquivos;
+a repetição passou, assim como os 20 testes dos dois arquivos formatados. O lint
+documental também deve passar antes do commit. Esses resultados não restauram o
+GO sem novo SHA, pacote, revisão independente e CI Linux verde.

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, spyOn } from "bun:test";
 import { expectedErrorToContractError, pickFields, unexpectedErrorToContractError } from "./agent-contract.js";
 import { fail } from "./context.js";
 import { CliExpectedError } from "./expected-error.js";
-import { CliTerminationRequest } from "./process-output.js";
+import { CliTerminationRequest, rethrowCliTermination } from "./process-output.js";
 
 describe("agent-first CLI foundation contract", () => {
   it("preserves explicitly public expected failures with their typed metadata", () => {
@@ -103,5 +103,18 @@ describe("agent-first CLI foundation contract", () => {
 
     expect(failure).toBeInstanceOf(CliTerminationRequest);
     expect((failure as CliTerminationRequest).exitCode).toBe(1);
+  });
+
+  it("preserves the exact private termination signal through legacy catches", () => {
+    const signal = new CliTerminationRequest(3);
+    let observed: unknown;
+
+    try {
+      rethrowCliTermination(signal);
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBe(signal);
   });
 });

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { expectedErrorToContractError, pickFields, unexpectedErrorToContractError } from "./agent-contract.js";
+import { fail } from "./context.js";
+import { CliExpectedError } from "./expected-error.js";
+import { CliTerminationRequest } from "./process-output.js";
+
+describe("agent-first CLI foundation contract", () => {
+  it("preserves explicitly public expected failures with their typed metadata", () => {
+    const expected = new CliExpectedError("The requested agent was not found.", "AGENT_NOT_FOUND", 1, {
+      publicMessage: true,
+      retryable: false,
+      suggestedAction: "List agents and retry with an existing id",
+      details: { suggestions: ["main"] },
+    });
+
+    expect(expectedErrorToContractError("agents show", expected)?.envelope()).toEqual({
+      success: false,
+      op: "agents show",
+      error: {
+        code: "AGENT_NOT_FOUND",
+        message: "The requested agent was not found.",
+        retryable: false,
+        suggestedAction: "List agents and retry with an existing id",
+        suggestions: ["main"],
+      },
+    });
+  });
+
+  it("keeps legacy expected and unexpected internal messages redacted", () => {
+    const legacy = expectedErrorToContractError(
+      "agents show",
+      new CliExpectedError("PRIVATE_LEGACY_DETAIL", "COMMAND_FAILED", 1),
+    );
+    const unexpected = unexpectedErrorToContractError("agents show");
+
+    expect(legacy?.envelope().error.message).toBe("Command could not be completed.");
+    expect(JSON.stringify(legacy?.envelope())).not.toContain("PRIVATE_LEGACY_DETAIL");
+    expect(unexpected.envelope().error).toMatchObject({
+      code: "UNHANDLED_ERROR",
+      message: "Command failed unexpectedly.",
+    });
+  });
+
+  it("rejects mixed valid and unknown fields before projecting records", () => {
+    let ownKeysCalls = 0;
+    const row = new Proxy(
+      { id: "main", name: "Main" },
+      {
+        ownKeys(target) {
+          ownKeysCalls += 1;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+
+    let failure: unknown;
+    try {
+      pickFields([row], "id,unknown", { acceptedFields: ["id", "name"] });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(ownKeysCalls).toBe(0);
+    const contract = expectedErrorToContractError("agents list", failure);
+    expect(contract?.exitCode).toBe(2);
+    expect(contract?.envelope().error).toMatchObject({
+      code: "USAGE_ERROR",
+      message: "--fields contains one or more unknown fields.",
+      retryable: false,
+      acceptedFields: ["id", "name"],
+    });
+  });
+
+  it("validates fields against the declared set when the result is empty", () => {
+    let failure: unknown;
+    try {
+      pickFields([], "unknown", { acceptedFields: ["id", "name"] });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(expectedErrorToContractError("agents list", failure)?.envelope().error).toMatchObject({
+      code: "USAGE_ERROR",
+      acceptedFields: ["id", "name"],
+    });
+  });
+
+  it("keeps the projection API compatible for callers not migrated yet", () => {
+    const rows = pickFields([{ id: "main", name: "Main" }], "id");
+    expect(Object.keys(rows[0] ?? {})).toEqual(["id"]);
+  });
+
+  it("routes direct legacy fail termination through the top-level flush boundary", () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    let failure: unknown;
+    try {
+      fail("safe direct failure");
+    } catch (error) {
+      failure = error;
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect((failure as CliTerminationRequest).exitCode).toBe(1);
+  });
+});

--- a/src/cli/agent-contract.ts
+++ b/src/cli/agent-contract.ts
@@ -19,7 +19,8 @@
  */
 import type { Command as CommanderCommand, CommanderError } from "commander";
 import { getContext } from "./context.js";
-import { CliExpectedError } from "./expected-error.js";
+import { CliExpectedError, cliUsageError } from "./expected-error.js";
+import { requestCliTermination } from "./process-output.js";
 import { sanitizePublicValue } from "./redaction.js";
 
 export const CONTRACT_EXIT_ERROR = 1;
@@ -34,6 +35,7 @@ export interface ContractErrorDetails {
   suggestedAction?: string;
   suggestions?: string[];
   acceptedFlags?: string[];
+  acceptedFields?: string[];
   [key: string]: unknown;
 }
 
@@ -99,8 +101,77 @@ export function contractFailureOutcome(error: Pick<ContractError, "code" | "exit
 
 export function expectedErrorToContractError(op: string, error: unknown): ContractError | null {
   if (!(error instanceof CliExpectedError)) return null;
-  return new ContractError(op, error.code, "Command could not be completed.", error.exitCode, {
-    suggestedAction: `Inspect the command input and retry '${op}'`,
+  return new ContractError(
+    op,
+    error.code,
+    error.publicMessage ? error.message : "Command could not be completed.",
+    error.exitCode,
+    {
+      ...error.details,
+      retryable: error.retryable,
+      suggestedAction: error.suggestedAction ?? `Inspect the command input and retry '${op}'`,
+    },
+  );
+}
+
+export interface PickFieldsOptions {
+  /** Stable public field set supplied by the owning domain. */
+  acceptedFields: readonly string[];
+}
+
+function parseRequestedFields(fields?: string): string[] {
+  return [
+    ...new Set(
+      (fields ?? "")
+        .split(",")
+        .map((key) => key.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function validateRequestedFields(keys: readonly string[], acceptedFields: readonly string[]): string[] {
+  const stableAcceptedFields = [...new Set(acceptedFields)];
+  const accepted = new Set(stableAcceptedFields);
+  if (keys.some((key) => !accepted.has(key))) {
+    throw cliUsageError("--fields contains one or more unknown fields.", {
+      suggestedAction: "Retry with only fields listed in acceptedFields",
+      details: { acceptedFields: stableAcceptedFields },
+    });
+  }
+  return stableAcceptedFields;
+}
+
+/**
+ * Compact mode (7.9): keep only the requested top-level fields of each item.
+ * Migrated callers supply a stable public field set so validation does not
+ * depend on the first result row and also works for empty result sets.
+ */
+export function pickFields<T>(items: T[], fields?: string, options?: PickFieldsOptions): T[] {
+  const keys = parseRequestedFields(fields);
+  if (keys.length === 0) return items;
+  if (options) validateRequestedFields(keys, options.acceptedFields);
+  return items.map((item) => {
+    const record = item as Record<string, unknown>;
+    const picked: Record<string, unknown> = {};
+    const requested = new Set(keys);
+    for (const key of Object.keys(record)) {
+      if (requested.has(key)) {
+        picked[key] = record[key];
+        continue;
+      }
+
+      // Keep the complete row available to @Returns validation while exposing
+      // only requested fields through JSON/Object.keys. The gateway validates
+      // handlers before serializing their original return value.
+      Object.defineProperty(picked, key, {
+        value: record[key],
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      });
+    }
+    return picked as T;
   });
 }
 
@@ -270,7 +341,7 @@ function commandTree(root: CommanderCommand): CommanderCommand[] {
 }
 
 function failUsage(command: CommanderCommand, error: CommanderError): never {
-  if (COMMANDER_PASSTHROUGH_CODES.has(error.code)) process.exit(error.exitCode);
+  if (COMMANDER_PASSTHROUGH_CODES.has(error.code)) requestCliTermination(error.exitCode);
   const commandPath = opPath(command);
   const op = commandPath || "cli";
   const usage = `ravi ${commandPath ? `${commandPath} ` : ""}${command.usage()}`.trim();
@@ -373,38 +444,4 @@ export function suggestSimilar(query: string, candidates: Array<string | null | 
     .sort((a, b) => b.score - a.score)
     .slice(0, max)
     .map((entry) => entry.candidate);
-}
-
-/**
- * Compact mode (7.9): keep only the requested top-level fields of each item.
- * Unknown fields are ignored; without `fields` the list passes through.
- */
-export function pickFields<T>(items: T[], fields?: string): T[] {
-  const keys = (fields ?? "")
-    .split(",")
-    .map((key) => key.trim())
-    .filter(Boolean);
-  if (keys.length === 0) return items;
-  return items.map((item) => {
-    const record = item as Record<string, unknown>;
-    const picked: Record<string, unknown> = {};
-    const requested = new Set(keys);
-    for (const key of Object.keys(record)) {
-      if (requested.has(key)) {
-        picked[key] = record[key];
-        continue;
-      }
-
-      // Keep the complete row available to @Returns validation while exposing
-      // only requested fields through JSON/Object.keys. The gateway validates
-      // handlers before serializing their original return value.
-      Object.defineProperty(picked, key, {
-        value: record[key],
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      });
-    }
-    return picked as T;
-  });
 }

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -172,6 +172,37 @@ type AgentJsonSummary = Omit<AgentConfig, "modelPresetId"> & {
   tags: TagBinding[];
 };
 
+const AGENT_LIST_FIELDS = [
+  "id",
+  "name",
+  "cwd",
+  "model",
+  "effort",
+  "provider",
+  "modelPresetId",
+  "dmScope",
+  "systemPromptAppend",
+  "debounceMs",
+  "groupDebounceMs",
+  "matrixAccount",
+  "heartbeat",
+  "settingSources",
+  "memoryModel",
+  "specMode",
+  "contactScope",
+  "allowedSessions",
+  "mode",
+  "remote",
+  "remoteUser",
+  "defaults",
+  "isDefault",
+  "effectiveProvider",
+  "effectiveModel",
+  "modelSource",
+  "modelPresetVersion",
+  "tags",
+] as const satisfies ReadonlyArray<keyof AgentJsonSummary>;
+
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
 }
@@ -560,7 +591,7 @@ export class AgentsCommands {
       total: page.total,
       options: ["--tag", tagSlug?.trim() || null],
     });
-    const projectedRows = pickFields(agentRows, fields);
+    const projectedRows = pickFields(agentRows, fields, { acceptedFields: AGENT_LIST_FIELDS });
     const payload = {
       total: page.total,
       pagination,

--- a/src/cli/commands/sdk.test.ts
+++ b/src/cli/commands/sdk.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { emitJson } from "../../sdk/openapi/index.js";
 import { ContractError } from "../agent-contract.js";
 import { runWithContext } from "../context.js";
+import { CliTerminationRequest } from "../process-output.js";
 import { getRegistry } from "../registry-snapshot.js";
 import { SdkClientCommands, SdkOpenApiCommands, SdkSwiftCommands } from "./sdk.js";
 
@@ -105,18 +106,18 @@ describe("SdkOpenApiCommands.emit", () => {
 
   it("rejects --out and --stdout together", () => {
     const capture = captureConsole();
-    const original = process.exit;
-    process.exit = (() => {
-      throw new Error("__exit_called__");
-    }) as typeof process.exit;
+    let failure: unknown;
     try {
-      expect(() => new SdkOpenApiCommands().emit("foo.json", true)).toThrow(
-        /Pick exactly one destination|__exit_called__/,
-      );
+      new SdkOpenApiCommands().emit("foo.json", true);
+    } catch (error) {
+      failure = error;
     } finally {
-      process.exit = original;
       capture.restore();
     }
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect(failure).toMatchObject({ exitCode: 1 });
+    expect(capture.errors).toEqual(["Pick exactly one destination: --out <path> or --stdout."]);
+    expect(capture.errors.join("\n")).not.toContain("CLI termination requested.");
   });
 });
 
@@ -163,16 +164,18 @@ describe("SdkOpenApiCommands.check", () => {
 
   it("requires --against", () => {
     const capture = captureConsole();
-    const original = process.exit;
-    process.exit = (() => {
-      throw new Error("__exit_called__");
-    }) as typeof process.exit;
+    let failure: unknown;
     try {
-      expect(() => new SdkOpenApiCommands().check()).toThrow(/--against|__exit_called__/);
+      new SdkOpenApiCommands().check();
+    } catch (error) {
+      failure = error;
     } finally {
-      process.exit = original;
       capture.restore();
     }
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect(failure).toMatchObject({ exitCode: 1 });
+    expect(capture.errors).toEqual(["--against <path> is required."]);
+    expect(capture.errors.join("\n")).not.toContain("CLI termination requested.");
   });
 });
 

--- a/src/cli/commands/sdk.ts
+++ b/src/cli/commands/sdk.ts
@@ -7,6 +7,7 @@ import { Command, CommandAccess, Group, Option, Returns } from "../decorators.js
 import { fail } from "../context.js";
 import { getRegistry } from "../registry-snapshot.js";
 import { ContractError, contractFail } from "../agent-contract.js";
+import { rethrowCliTermination } from "../process-output.js";
 import { emitJson } from "../../sdk/openapi/index.js";
 import { emitAll, computeRegistryHash, compareSdkSource, type EmittedSdk } from "../../sdk/client-codegen/index.js";
 import {
@@ -28,6 +29,7 @@ function writeFileSafe(target: string, body: string): string {
 }
 
 function failSdkCommand(error: unknown): never {
+  rethrowCliTermination(error);
   if (error instanceof ContractError) throw error;
   fail(error instanceof Error ? error.message : String(error));
 }
@@ -187,7 +189,7 @@ export class SdkOpenApiCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 
@@ -285,7 +287,7 @@ export class SdkClientCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 
@@ -404,7 +406,7 @@ export class SdkSwiftCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 

--- a/src/cli/commands/usage-exit.smoke.test.ts
+++ b/src/cli/commands/usage-exit.smoke.test.ts
@@ -106,6 +106,43 @@ describe("usage exit taxonomy smoke", () => {
     });
   });
 
+  it("rejects unknown fields with the stable agents field set even when state is empty", () => {
+    const result = runCli(["agents", "list", "--fields", "id,unknown", "--json"], {
+      RAVI_AGENT_ID: undefined,
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      op: "agents list",
+      error: {
+        code: "USAGE_ERROR",
+        message: "--fields contains one or more unknown fields.",
+        acceptedFields: expect.arrayContaining(["id", "cwd", "effectiveModel"]),
+      },
+    });
+  });
+
+  it("returns usage exit 2 for invalid shared pagination values", () => {
+    const cases = [
+      ["agents", "list", "--limit", "many", "--json"],
+      ["agents", "list", "--limit", "501", "--json"],
+      ["agents", "list", "--offset", "-1", "--json"],
+    ];
+
+    for (const args of cases) {
+      const result = runCli(args, { RAVI_AGENT_ID: undefined });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        success: false,
+        op: "agents list",
+        error: { code: "USAGE_ERROR", retryable: false },
+      });
+    }
+  });
+
   it("renders migrated handler failures as canonical JSON at the real process boundary", () => {
     const cases = [
       {

--- a/src/cli/confirmation-policy.test.ts
+++ b/src/cli/confirmation-policy.test.ts
@@ -1,7 +1,21 @@
 import "reflect-metadata";
 import { describe, expect, it } from "bun:test";
 
-import { getRegistry } from "./registry-snapshot.js";
+import { Command, CommandAccess, Group } from "./decorators.js";
+import { buildRegistry, getRegistry } from "./registry-snapshot.js";
+
+@Group({ name: "invalid-effect", description: "Invalid effect fixture", scope: "open" })
+class InvalidEffectCommands {
+  @Command({ name: "send", description: "Missing required confirmation" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "invalid-effect",
+    action: "send",
+    risk: "high",
+    effectClass: "external",
+  })
+  send() {}
+}
 
 function executeOption(command: ReturnType<typeof getRegistry>["commands"][number]) {
   return command.options.find((option) => option.name === "execute" || option.flags.includes("--execute"));
@@ -9,6 +23,36 @@ function executeOption(command: ReturnType<typeof getRegistry>["commands"][numbe
 
 describe("global confirmation policy metadata", () => {
   const commands = getRegistry().commands;
+
+  it("publishes complete safety metadata matching every registered access declaration", () => {
+    const invalid = commands
+      .filter((command) => {
+        const access = command.access;
+        if (!access) return true;
+        const expectedEffect = access.effectClass ?? (access.kind === "read" ? "none" : "unclassified");
+        const expectedSource = access.effectClass
+          ? "declared"
+          : access.kind === "read"
+            ? "inferred-read"
+            : "legacy-unclassified";
+        return (
+          command.safety.operationKind !== access.kind ||
+          command.safety.effectClass !== expectedEffect ||
+          command.safety.risk !== access.risk ||
+          command.safety.requiresConfirmation !== (access.requiresConfirmation === true) ||
+          command.safety.classificationSource !== expectedSource
+        );
+      })
+      .map((command) => ({ command: command.fullName, access: command.access, safety: command.safety }));
+
+    expect(invalid).toEqual([]);
+  });
+
+  it("fails closed when a precise consequential effect omits confirmation", () => {
+    expect(() => buildRegistry([InvalidEffectCommands])).toThrow(
+      'Invalid safety metadata for invalid-effect.send: effectClass "external" requires confirmation.',
+    );
+  });
 
   it("authorizes every command exposing --execute as a mutation", () => {
     const invalid = commands

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -11,6 +11,7 @@ import { getRuntimeContextFromEnv, resolveRuntimeContext, RAVI_CONTEXT_KEY_ENV }
 import type { ContextRecord } from "../router/router-db.js";
 import { readCredentialsFile, selectDefaultCredentialsKey } from "../runtime/credentials-store.js";
 import { CliExpectedError } from "./expected-error.js";
+import { requestCliTermination } from "./process-output.js";
 
 /**
  * Context available to CLI tools during execution
@@ -218,5 +219,5 @@ export function fail(message: string): never {
     throw new CliExpectedError(message);
   }
   console.error(message);
-  process.exit(1);
+  requestCliTermination(1);
 }

--- a/src/cli/decorators.ts
+++ b/src/cli/decorators.ts
@@ -36,11 +36,43 @@ export type CommandAccessKind = "read" | "mutate";
 export type CommandAccessRisk = "low" | "medium" | "high" | "destructive";
 export type CommandAccessContextRequirement = "actor" | "surface" | "session" | "executorAgent" | "resource";
 
+/**
+ * State-effect classification exposed to agent consumers.
+ *
+ * `unclassified` is a fail-visible migration value for legacy mutations. It
+ * must not be interpreted as safe; domain PRs replace it with the actual
+ * effect class once their operation contracts are proven.
+ */
+export type CommandEffectClass =
+  | "none"
+  | "local-reversible"
+  | "external"
+  | "destructive"
+  | "authority-expansion"
+  | "triggered-work"
+  | "containment"
+  | "cost-threshold"
+  | "conditional"
+  | "unclassified";
+
+export type CommandSafetyClassificationSource = "declared" | "inferred-read" | "legacy-unclassified" | "missing";
+
+/** Stable, agent-discoverable projection of the command safety contract. */
+export interface CommandSafetyMetadata {
+  operationKind: CommandAccessKind | "unknown";
+  effectClass: CommandEffectClass;
+  risk: CommandAccessRisk | "unknown";
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyClassificationSource;
+}
+
 export interface CommandAccessOptions {
   kind: CommandAccessKind;
   resource: string;
   action: string;
   risk: CommandAccessRisk;
+  /** Actual state effect. Domain migrations should declare this explicitly. */
+  effectClass?: CommandEffectClass;
   requiresContext?: CommandAccessContextRequirement[];
   resourceId?: string;
   /** Require the concrete resource candidate; semantic and legacy command grants cannot substitute for it. */
@@ -52,6 +84,68 @@ export interface CommandAccessOptions {
   localOperator?: boolean;
   requiresConfirmation?: boolean;
   notes?: string;
+}
+
+const ALWAYS_CONFIRMED_EFFECTS = new Set<CommandEffectClass>([
+  "external",
+  "destructive",
+  "authority-expansion",
+  "triggered-work",
+  "cost-threshold",
+]);
+
+const IMMEDIATE_EFFECTS = new Set<CommandEffectClass>(["none", "local-reversible", "containment"]);
+
+/**
+ * Resolve the public safety metadata without silently classifying legacy
+ * mutations. Invalid explicit declarations fail during registry/tool export,
+ * before consumers can receive a contradictory manifest.
+ */
+export function resolveCommandSafetyMetadata(
+  access: CommandAccessOptions | undefined,
+  commandName = "command",
+): CommandSafetyMetadata {
+  if (!access) {
+    return {
+      operationKind: "unknown",
+      effectClass: "unclassified",
+      risk: "unknown",
+      requiresConfirmation: false,
+      classificationSource: "missing",
+    };
+  }
+
+  const effectClass = access.effectClass ?? (access.kind === "read" ? "none" : "unclassified");
+  const classificationSource: CommandSafetyClassificationSource = access.effectClass
+    ? "declared"
+    : access.kind === "read"
+      ? "inferred-read"
+      : "legacy-unclassified";
+  const requiresConfirmation = access.requiresConfirmation === true;
+
+  if (access.kind === "read" && effectClass !== "none") {
+    throw new Error(`Invalid safety metadata for ${commandName}: read operations must declare effectClass "none".`);
+  }
+  if (access.kind === "read" && requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: read operations cannot require effect confirmation.`);
+  }
+  if (access.kind === "mutate" && effectClass === "none") {
+    throw new Error(`Invalid safety metadata for ${commandName}: mutations cannot declare effectClass "none".`);
+  }
+  if (classificationSource === "declared" && ALWAYS_CONFIRMED_EFFECTS.has(effectClass) && !requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: effectClass "${effectClass}" requires confirmation.`);
+  }
+  if (classificationSource === "declared" && IMMEDIATE_EFFECTS.has(effectClass) && requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: effectClass "${effectClass}" must remain immediate.`);
+  }
+
+  return {
+    operationKind: access.kind,
+    effectClass,
+    risk: access.risk,
+    requiresConfirmation,
+    classificationSource,
+  };
 }
 
 export interface GroupOptions {

--- a/src/cli/expected-error.ts
+++ b/src/cli/expected-error.ts
@@ -1,11 +1,37 @@
+export interface CliExpectedErrorOptions {
+  /** The message is deliberately safe to expose to CLI, tool, and gateway consumers. */
+  publicMessage?: boolean;
+  retryable?: boolean;
+  suggestedAction?: string;
+  details?: Record<string, unknown>;
+}
+
 export class CliExpectedError extends Error {
   readonly code: string;
   readonly exitCode: number;
+  readonly publicMessage: boolean;
+  readonly retryable: boolean;
+  readonly suggestedAction?: string;
+  readonly details: Record<string, unknown>;
 
-  constructor(message: string, code = "COMMAND_FAILED", exitCode = 1) {
+  constructor(message: string, code = "COMMAND_FAILED", exitCode = 1, options: CliExpectedErrorOptions = {}) {
     super(message);
     this.name = "CliExpectedError";
     this.code = code;
     this.exitCode = exitCode;
+    this.publicMessage = options.publicMessage ?? false;
+    this.retryable = options.retryable ?? false;
+    this.suggestedAction = options.suggestedAction;
+    this.details = options.details ?? {};
   }
+}
+
+export function cliUsageError(
+  message: string,
+  options: Omit<CliExpectedErrorOptions, "publicMessage"> = {},
+): CliExpectedError {
+  return new CliExpectedError(message, "USAGE_ERROR", 2, {
+    ...options,
+    publicMessage: true,
+  });
 }

--- a/src/cli/exports.ts
+++ b/src/cli/exports.ts
@@ -59,4 +59,11 @@ export {
   type InferredOptionSchema,
 } from "./schema-inference.js";
 
-export { Returns, getReturnsMetadata } from "./decorators.js";
+export {
+  Returns,
+  getReturnsMetadata,
+  resolveCommandSafetyMetadata,
+  type CommandEffectClass,
+  type CommandSafetyClassificationSource,
+  type CommandSafetyMetadata,
+} from "./decorators.js";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,12 @@ import { configureCliLogging } from "./logging.js";
 import { spawnDirectTui } from "./tui-launcher.js";
 import { maybeRunAppAliasRoute } from "../apps/router.js";
 import { buildRootOperationalHelp } from "../runtime/runtime-operational-context.js";
+import {
+  CliTerminationRequest,
+  flushProcessOutput,
+  terminateCliProcess,
+  writeProcessStdout,
+} from "./process-output.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
@@ -50,8 +56,8 @@ function isRootVersionRequest(args: string[]): boolean {
 }
 
 if (isRootVersionRequest(process.argv.slice(2))) {
-  console.log(pkg.version);
-  process.exit(0);
+  await writeProcessStdout(`${pkg.version}\n`);
+  await terminateCliProcess(0);
 }
 
 program
@@ -320,40 +326,44 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-void bootstrapCli().catch(async (error: unknown) => {
-  if (error instanceof ContractError) {
-    // Contract helpers render once and throw. Audit the semantic outcome before
-    // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
-    if (!wasContractErrorAudited(error)) {
-      const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
-      await emitCliAuditEvent({
-        group,
-        name: operationParts.join("_") || "root",
-        tool: error.op.replace(/\s+/g, "_"),
-        outcome: contractFailureOutcome(error),
-        exitCode: error.exitCode,
-        errorCode: error.code,
-        status: "completed",
-        closeLazyConnection: true,
-      });
+await bootstrapCli()
+  .catch(async (error: unknown) => {
+    if (error instanceof CliTerminationRequest) {
+      return terminateCliProcess(error.exitCode);
     }
-    process.exitCode = error.exitCode;
-    return;
-  }
-  const contractError = unexpectedErrorToContractError("cli bootstrap");
-  renderContractError(contractError, process.argv.includes("--json"));
-  await emitCliAuditEvent({
-    group: "cli",
-    name: "bootstrap",
-    tool: "cli_bootstrap",
-    outcome: contractFailureOutcome(contractError),
-    exitCode: contractError.exitCode,
-    errorCode: contractError.code,
-    status: "completed",
-    closeLazyConnection: true,
-  });
-  process.exitCode = contractError.exitCode;
-});
+    if (error instanceof ContractError) {
+      // Contract helpers render once and throw. Audit the semantic outcome before
+      // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
+      if (!wasContractErrorAudited(error)) {
+        const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
+        await emitCliAuditEvent({
+          group,
+          name: operationParts.join("_") || "root",
+          tool: error.op.replace(/\s+/g, "_"),
+          outcome: contractFailureOutcome(error),
+          exitCode: error.exitCode,
+          errorCode: error.code,
+          status: "completed",
+          closeLazyConnection: true,
+        });
+      }
+      return terminateCliProcess(error.exitCode);
+    }
+    const contractError = unexpectedErrorToContractError("cli bootstrap");
+    renderContractError(contractError, process.argv.includes("--json"));
+    await emitCliAuditEvent({
+      group: "cli",
+      name: "bootstrap",
+      tool: "cli_bootstrap",
+      outcome: contractFailureOutcome(contractError),
+      exitCode: contractError.exitCode,
+      errorCode: contractError.code,
+      status: "completed",
+      closeLazyConnection: true,
+    });
+    return terminateCliProcess(contractError.exitCode);
+  })
+  .finally(() => flushProcessOutput());
 
 async function bootstrapCli(): Promise<void> {
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;
@@ -362,7 +372,7 @@ async function bootstrapCli(): Promise<void> {
     staticRootCommands: rootCommandNames(program),
   });
   if (handledByAppAlias) {
-    process.exit(process.exitCode ?? 0);
+    return terminateCliProcess(process.exitCode ?? 0);
   }
 
   await program.parseAsync();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,11 +50,6 @@ function isRootVersionRequest(args: string[]): boolean {
   return args.length === 1 && (args[0] === "--version" || args[0] === "-V");
 }
 
-if (isRootVersionRequest(process.argv.slice(2))) {
-  await writeProcessStdout(`${pkg.version}\n`);
-  await terminateCliProcess(0);
-}
-
 program
   .name("ravi")
   .description("Ravi Bot CLI - Claude-powered bot management")
@@ -321,7 +316,7 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-await bootstrapCli().catch(async (error: unknown) => {
+void bootstrapCli().catch(async (error: unknown) => {
   if (error instanceof CliTerminationRequest) {
     return terminateCliProcess(error.exitCode);
   }
@@ -359,6 +354,11 @@ await bootstrapCli().catch(async (error: unknown) => {
 });
 
 async function bootstrapCli(): Promise<void> {
+  if (isRootVersionRequest(process.argv.slice(2))) {
+    await writeProcessStdout(`${pkg.version}\n`);
+    return terminateCliProcess(0);
+  }
+
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;
 
   const handledByAppAlias = await maybeRunAppAliasRoute(process.argv.slice(2), {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,12 +36,7 @@ import { configureCliLogging } from "./logging.js";
 import { spawnDirectTui } from "./tui-launcher.js";
 import { maybeRunAppAliasRoute } from "../apps/router.js";
 import { buildRootOperationalHelp } from "../runtime/runtime-operational-context.js";
-import {
-  CliTerminationRequest,
-  flushProcessOutput,
-  terminateCliProcess,
-  writeProcessStdout,
-} from "./process-output.js";
+import { CliTerminationRequest, terminateCliProcess, writeProcessStdout } from "./process-output.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
@@ -326,44 +321,42 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-await bootstrapCli()
-  .catch(async (error: unknown) => {
-    if (error instanceof CliTerminationRequest) {
-      return terminateCliProcess(error.exitCode);
+await bootstrapCli().catch(async (error: unknown) => {
+  if (error instanceof CliTerminationRequest) {
+    return terminateCliProcess(error.exitCode);
+  }
+  if (error instanceof ContractError) {
+    // Contract helpers render once and throw. Audit the semantic outcome before
+    // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
+    if (!wasContractErrorAudited(error)) {
+      const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
+      await emitCliAuditEvent({
+        group,
+        name: operationParts.join("_") || "root",
+        tool: error.op.replace(/\s+/g, "_"),
+        outcome: contractFailureOutcome(error),
+        exitCode: error.exitCode,
+        errorCode: error.code,
+        status: "completed",
+        closeLazyConnection: true,
+      });
     }
-    if (error instanceof ContractError) {
-      // Contract helpers render once and throw. Audit the semantic outcome before
-      // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
-      if (!wasContractErrorAudited(error)) {
-        const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
-        await emitCliAuditEvent({
-          group,
-          name: operationParts.join("_") || "root",
-          tool: error.op.replace(/\s+/g, "_"),
-          outcome: contractFailureOutcome(error),
-          exitCode: error.exitCode,
-          errorCode: error.code,
-          status: "completed",
-          closeLazyConnection: true,
-        });
-      }
-      return terminateCliProcess(error.exitCode);
-    }
-    const contractError = unexpectedErrorToContractError("cli bootstrap");
-    renderContractError(contractError, process.argv.includes("--json"));
-    await emitCliAuditEvent({
-      group: "cli",
-      name: "bootstrap",
-      tool: "cli_bootstrap",
-      outcome: contractFailureOutcome(contractError),
-      exitCode: contractError.exitCode,
-      errorCode: contractError.code,
-      status: "completed",
-      closeLazyConnection: true,
-    });
-    return terminateCliProcess(contractError.exitCode);
-  })
-  .finally(() => flushProcessOutput());
+    return terminateCliProcess(error.exitCode);
+  }
+  const contractError = unexpectedErrorToContractError("cli bootstrap");
+  renderContractError(contractError, process.argv.includes("--json"));
+  await emitCliAuditEvent({
+    group: "cli",
+    name: "bootstrap",
+    tool: "cli_bootstrap",
+    outcome: contractFailureOutcome(contractError),
+    exitCode: contractError.exitCode,
+    errorCode: contractError.code,
+    status: "completed",
+    closeLazyConnection: true,
+  });
+  return terminateCliProcess(contractError.exitCode);
+});
 
 async function bootstrapCli(): Promise<void> {
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;

--- a/src/cli/pagination.test.ts
+++ b/src/cli/pagination.test.ts
@@ -1,12 +1,41 @@
 import { describe, expect, it } from "bun:test";
+import { expectedErrorToContractError } from "./agent-contract.js";
+import { CliExpectedError } from "./expected-error.js";
 import { buildCliOffsetPagination, paginateCliItems, parseCliListLimit, parseCliListOffset } from "./pagination.js";
 
 describe("CLI pagination helpers", () => {
   it("parses standard list limit and offset options", () => {
     expect(parseCliListLimit(undefined)).toBe(50);
-    expect(parseCliListLimit("999", { maxLimit: 100 })).toBe(100);
+    expect(parseCliListLimit("100", { maxLimit: 100 })).toBe(100);
     expect(parseCliListOffset(undefined)).toBe(0);
     expect(parseCliListOffset("25")).toBe(25);
+  });
+
+  it("classifies invalid limit and offset values as public usage errors", () => {
+    const cases = [
+      () => parseCliListLimit("many"),
+      () => parseCliListLimit("0"),
+      () => parseCliListLimit("501"),
+      () => parseCliListOffset("-1"),
+      () => parseCliListOffset("1.5"),
+    ];
+
+    for (const attempt of cases) {
+      let failure: unknown;
+      try {
+        attempt();
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(CliExpectedError);
+      const contract = expectedErrorToContractError("agents list", failure);
+      expect(contract).toMatchObject({ code: "USAGE_ERROR", exitCode: 2 });
+      expect(contract?.envelope().error).toMatchObject({
+        code: "USAGE_ERROR",
+        retryable: false,
+      });
+      expect(contract?.envelope().error.message).not.toBe("Command could not be completed.");
+    }
   });
 
   it("paginates finite command lists", () => {

--- a/src/cli/pagination.ts
+++ b/src/cli/pagination.ts
@@ -1,4 +1,4 @@
-import { fail } from "./context.js";
+import { cliUsageError } from "./expected-error.js";
 import {
   buildCommand,
   buildOffsetPagination,
@@ -87,10 +87,22 @@ function parseBoundedIntegerOption(
   if (value === undefined || value === null || value === "") return options.defaultValue;
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
-    fail(`${label} must be an integer.`);
+    throw cliUsageError(`${label} must be an integer.`, {
+      suggestedAction: `Retry with an integer value for ${label}`,
+      details: { option: label, minimum: options.min, ...(options.max === undefined ? {} : { maximum: options.max }) },
+    });
   }
   if (parsed < options.min) {
-    fail(`${label} must be greater than or equal to ${options.min}.`);
+    throw cliUsageError(`${label} must be greater than or equal to ${options.min}.`, {
+      suggestedAction: `Retry with ${label} greater than or equal to ${options.min}`,
+      details: { option: label, minimum: options.min, ...(options.max === undefined ? {} : { maximum: options.max }) },
+    });
   }
-  return Math.min(options.max ?? parsed, parsed);
+  if (options.max !== undefined && parsed > options.max) {
+    throw cliUsageError(`${label} must be less than or equal to ${options.max}.`, {
+      suggestedAction: `Retry with ${label} less than or equal to ${options.max}`,
+      details: { option: label, minimum: options.min, maximum: options.max },
+    });
+  }
+  return parsed;
 }

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+setDefaultTimeout(90_000);
+
+const stateDir = mkdtempSync(join(tmpdir(), "ravi-cli-output-native-"));
+const packageVersion = (JSON.parse(readFileSync("package.json", "utf8")) as { version: string }).version;
+
+afterAll(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+interface CliProcessResult {
+  status: number | null;
+  stdout: Buffer;
+  stderr: Buffer;
+}
+
+function isolatedCliEnv(): NodeJS.ProcessEnv {
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("RAVI_")));
+  return {
+    ...env,
+    RAVI_STATE_DIR: stateDir,
+    RAVI_NO_AUDIT: "1",
+    RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+  };
+}
+
+function runNativeCli(args: string[]): Promise<CliProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["src/cli/index.ts", ...args], {
+      cwd: process.cwd(),
+      env: isolatedCliEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("close", (status) => {
+      resolve({
+        status,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      });
+    });
+  });
+}
+
+describe("native CLI process output integrity", () => {
+  it("delivers a complete piped JSON document larger than 64 KiB", async () => {
+    const result = await runNativeCli(["tools", "list", "--json", "--limit", "500"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr.byteLength).toBe(0);
+    expect(result.stdout.byteLength).toBeGreaterThan(64 * 1024);
+
+    const payload = JSON.parse(result.stdout.toString("utf8")) as {
+      total: number;
+      items: unknown[];
+      tools: unknown[];
+    };
+    expect(payload.total).toBeGreaterThan(0);
+    expect(payload.items.length).toBeGreaterThan(0);
+    expect(payload.tools).toEqual(payload.items);
+  });
+
+  it("flushes failure output before preserving exit code 1", async () => {
+    const result = await runNativeCli(["audio", "blob", "__missing_output_integrity_probe__"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout.byteLength).toBe(0);
+    expect(result.stderr.toString("utf8")).toBe("Binary resource was not found.\n");
+  });
+
+  it("preserves the root version output and exit code 0", async () => {
+    const result = await runNativeCli(["--version"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).toBe(`${packageVersion}\n`);
+    expect(result.stderr.byteLength).toBe(0);
+  });
+});

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { waitUntilProcessOutputFlushed, type ProcessOutputStream } from "./process-output.js";
 
 setDefaultTimeout(90_000);
 
@@ -29,9 +30,9 @@ function isolatedCliEnv(): NodeJS.ProcessEnv {
   };
 }
 
-function runNativeCli(args: string[]): Promise<CliProcessResult> {
+function runNativeProcess(args: string[], timeoutMs: number): Promise<CliProcessResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["src/cli/index.ts", ...args], {
+    const child = spawn(process.execPath, args, {
       cwd: process.cwd(),
       env: isolatedCliEnv(),
       stdio: ["ignore", "pipe", "pipe"],
@@ -39,11 +40,32 @@ function runNativeCli(args: string[]): Promise<CliProcessResult> {
     });
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
+    let settled = false;
+    let timeoutError: Error | null = null;
+    const timeout = setTimeout(() => {
+      timeoutError = new Error(`Native process did not exit within ${timeoutMs}ms: ${args.join(" ")}`);
+      if (!child.kill()) {
+        settled = true;
+        reject(timeoutError);
+      }
+    }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.once("error", reject);
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
     child.once("close", (status) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (timeoutError) {
+        reject(timeoutError);
+        return;
+      }
       resolve({
         status,
         stdout: Buffer.concat(stdout),
@@ -53,7 +75,54 @@ function runNativeCli(args: string[]): Promise<CliProcessResult> {
   });
 }
 
+function runNativeCli(args: string[]): Promise<CliProcessResult> {
+  return runNativeProcess(["src/cli/index.ts", ...args], 30_000);
+}
+
 describe("native CLI process output integrity", () => {
+  it("bounds a permanently stuck output stream without busy-spinning", async () => {
+    const stuckStream: ProcessOutputStream = {
+      destroyed: false,
+      writableEnded: false,
+      writableLength: 1,
+      writableNeedDrain: true,
+      write: () => false,
+    };
+    const startedAt = performance.now();
+
+    await expect(waitUntilProcessOutputFlushed(stuckStream, 20)).rejects.toThrow(
+      "CLI output did not flush within 20ms.",
+    );
+
+    const elapsedMs = performance.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(15);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("kills and observes a child process that exceeds its native timeout", async () => {
+    const startedAt = performance.now();
+
+    await expect(runNativeProcess(["-e", "setInterval(() => {}, 1000)"], 100)).rejects.toThrow(
+      "Native process did not exit within 100ms",
+    );
+
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("preserves termination when a native process stream never reports progress", async () => {
+    const script = [
+      'Object.defineProperty(process.stdout, "writableLength", { get: () => 1 });',
+      'Object.defineProperty(process.stdout, "writableNeedDrain", { get: () => true });',
+      'const { terminateCliProcess } = await import("./src/cli/process-output.ts");',
+      "await terminateCliProcess(7, 20);",
+    ].join("\n");
+
+    const result = await runNativeProcess(["-e", script], 2_000);
+
+    expect(result.status).toBe(7);
+    expect(result.stderr.byteLength).toBe(0);
+  });
+
   it("delivers a complete piped JSON document larger than 64 KiB", async () => {
     const result = await runNativeCli(["tools", "list", "--json", "--limit", "500"]);
 

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -42,26 +42,30 @@ function runNativeProcess(args: string[], timeoutMs: number): Promise<CliProcess
     const stderr: Buffer[] = [];
     let settled = false;
     let timeoutError: Error | null = null;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
     const timeout = setTimeout(() => {
       timeoutError = new Error(`Native process did not exit within ${timeoutMs}ms: ${args.join(" ")}`);
-      if (!child.kill()) {
-        settled = true;
-        reject(timeoutError);
-      }
+      child.kill();
+      forceKillTimeout = setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 250);
     }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
     child.once("error", (error) => {
       if (settled) return;
+      if (timeoutError && child.pid !== undefined) return;
       settled = true;
       clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       reject(error);
     });
     child.once("close", (status) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       if (timeoutError) {
         reject(timeoutError);
         return;

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -22,6 +22,10 @@ export function requestCliTermination(code: CliExitCode): never {
   throw new CliTerminationRequest(code);
 }
 
+export function rethrowCliTermination(error: unknown): void {
+  if (error instanceof CliTerminationRequest) throw error;
+}
+
 export type ProcessOutputStream = Pick<
   NodeJS.WriteStream,
   "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -1,0 +1,70 @@
+type ProcessOutputChunk = string | Uint8Array;
+type CliExitCode = number | string;
+
+export class CliTerminationRequest extends Error {
+  readonly exitCode: CliExitCode;
+
+  constructor(exitCode: CliExitCode) {
+    super("CLI termination requested.");
+    this.name = "CliTerminationRequest";
+    this.exitCode = exitCode;
+  }
+}
+
+/**
+ * Synchronous adapters such as Commander exit hooks cannot await output. They
+ * throw this private control-flow signal so the top-level CLI boundary can
+ * flush output and terminate with the requested code.
+ */
+export function requestCliTermination(code: CliExitCode): never {
+  throw new CliTerminationRequest(code);
+}
+
+type ProcessOutputStream = Pick<
+  NodeJS.WriteStream,
+  "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"
+>;
+
+function nextEventLoopTurn(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function waitUntilFlushed(stream: ProcessOutputStream): Promise<void> {
+  while (stream.writableLength > 0 || stream.writableNeedDrain) {
+    if (stream.destroyed || stream.writableEnded) {
+      throw new Error("CLI output stream became unavailable before pending output completed.");
+    }
+    await nextEventLoopTurn();
+  }
+}
+
+async function writeAndWait(stream: ProcessOutputStream, chunk: ProcessOutputChunk): Promise<void> {
+  if (stream.destroyed || stream.writableEnded) {
+    throw new Error("CLI output stream is unavailable.");
+  }
+
+  stream.write(chunk);
+  await waitUntilFlushed(stream);
+}
+
+export function writeProcessStdout(chunk: ProcessOutputChunk): Promise<void> {
+  return writeAndWait(process.stdout, chunk);
+}
+
+export function writeProcessStderr(chunk: ProcessOutputChunk): Promise<void> {
+  return writeAndWait(process.stderr, chunk);
+}
+
+/**
+ * Wait until both process output buffers are empty. This keeps console output
+ * complete when stdout or stderr is connected to a pipe without relying on
+ * write callbacks, which Bun does not consistently invoke for process streams.
+ */
+export async function flushProcessOutput(): Promise<void> {
+  await Promise.all([waitUntilFlushed(process.stdout), waitUntilFlushed(process.stderr)]);
+}
+
+export async function terminateCliProcess(code: CliExitCode): Promise<never> {
+  await flushProcessOutput();
+  process.exit(code);
+}

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -1,5 +1,7 @@
 type ProcessOutputChunk = string | Uint8Array;
 type CliExitCode = number | string;
+const DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS = 5_000;
+const OUTPUT_FLUSH_POLL_INTERVAL_MS = 4;
 
 export class CliTerminationRequest extends Error {
   readonly exitCode: CliExitCode;
@@ -20,21 +22,29 @@ export function requestCliTermination(code: CliExitCode): never {
   throw new CliTerminationRequest(code);
 }
 
-type ProcessOutputStream = Pick<
+export type ProcessOutputStream = Pick<
   NodeJS.WriteStream,
   "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"
 >;
 
-function nextEventLoopTurn(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
+function waitForOutputProgress(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
-async function waitUntilFlushed(stream: ProcessOutputStream): Promise<void> {
+export async function waitUntilProcessOutputFlushed(
+  stream: ProcessOutputStream,
+  timeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS,
+): Promise<void> {
+  const startedAt = performance.now();
   while (stream.writableLength > 0 || stream.writableNeedDrain) {
     if (stream.destroyed || stream.writableEnded) {
       throw new Error("CLI output stream became unavailable before pending output completed.");
     }
-    await nextEventLoopTurn();
+    const remainingMs = timeoutMs - (performance.now() - startedAt);
+    if (remainingMs <= 0) {
+      throw new Error(`CLI output did not flush within ${timeoutMs}ms.`);
+    }
+    await waitForOutputProgress(Math.min(OUTPUT_FLUSH_POLL_INTERVAL_MS, remainingMs));
   }
 }
 
@@ -44,7 +54,7 @@ async function writeAndWait(stream: ProcessOutputStream, chunk: ProcessOutputChu
   }
 
   stream.write(chunk);
-  await waitUntilFlushed(stream);
+  await waitUntilProcessOutputFlushed(stream);
 }
 
 export function writeProcessStdout(chunk: ProcessOutputChunk): Promise<void> {
@@ -60,11 +70,20 @@ export function writeProcessStderr(chunk: ProcessOutputChunk): Promise<void> {
  * complete when stdout or stderr is connected to a pipe without relying on
  * write callbacks, which Bun does not consistently invoke for process streams.
  */
-export async function flushProcessOutput(): Promise<void> {
-  await Promise.all([waitUntilFlushed(process.stdout), waitUntilFlushed(process.stderr)]);
+export async function flushProcessOutput(timeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS): Promise<void> {
+  await Promise.all([
+    waitUntilProcessOutputFlushed(process.stdout, timeoutMs),
+    waitUntilProcessOutputFlushed(process.stderr, timeoutMs),
+  ]);
 }
 
-export async function terminateCliProcess(code: CliExitCode): Promise<never> {
-  await flushProcessOutput();
-  process.exit(code);
+export async function terminateCliProcess(
+  code: CliExitCode,
+  flushTimeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS,
+): Promise<never> {
+  try {
+    await flushProcessOutput(flushTimeoutMs);
+  } finally {
+    process.exit(code);
+  }
 }

--- a/src/cli/registry-snapshot.ts
+++ b/src/cli/registry-snapshot.ts
@@ -22,7 +22,9 @@ import {
   getReturnsBinaryMetadata,
   getReturnsMetadata,
   getScopeMetadata,
+  resolveCommandSafetyMetadata,
   type CommandAccessOptions,
+  type CommandSafetyMetadata,
   type ScopeType,
 } from "./decorators.js";
 import { inferArgSchema, inferOptionSchema, type ParsedOptionFlags } from "./schema-inference.js";
@@ -117,6 +119,8 @@ export interface CommandRegistryEntry {
   skillGate?: SkillGateMetadata;
   /** Semantic operation contract used by the Permission Provider Runtime. */
   access?: CommandAccessOptions;
+  /** Stable operation/effect/risk/confirmation projection for agent consumers. */
+  safety: CommandSafetyMetadata;
 }
 
 export interface RegistrySnapshot {
@@ -199,6 +203,8 @@ export function buildRegistry(classes: CommandClass[]): RegistrySnapshot {
 
       const effectiveScope: ScopeType = scopeMap.get(cmdMeta.method) ?? groupMeta.scope ?? "admin";
       const fullName = `${groupMeta.name}.${cmdMeta.name}`;
+      const access = commandAccessMap.get(cmdMeta.method);
+      const safety = resolveCommandSafetyMetadata(access, fullName);
       const skillGate = resolveCommandSkillGate({
         groupPath: groupMeta.name,
         command: cmdMeta.name,
@@ -221,7 +227,8 @@ export function buildRegistry(classes: CommandClass[]): RegistrySnapshot {
         ...(binaryReturnsSet.has(cmdMeta.method) ? { binary: true } : {}),
         ...(cliOnlySet.has(cmdMeta.method) ? { cliOnly: true } : {}),
         ...(skillGate ? { skillGate } : {}),
-        ...(commandAccessMap.get(cmdMeta.method) ? { access: commandAccessMap.get(cmdMeta.method)! } : {}),
+        ...(access ? { access } : {}),
+        safety,
       };
 
       const existing = commandsByFullName.get(fullName);

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -41,6 +41,7 @@ import {
   type RemoteDispatchResult,
   type RemoteGatewayConfig,
 } from "./remote-gateway.js";
+import { terminateCliProcess, writeProcessStdout } from "./process-output.js";
 
 type CommandClass = new () => object;
 
@@ -230,7 +231,7 @@ function registerCommand(
     } catch (error) {
       if (!(error instanceof ContractError)) throw error;
       renderContractError(error, input.json === true);
-      process.exit(error.exitCode);
+      return terminateCliProcess(error.exitCode);
     }
 
     // The target gateway owns authorization for its context key. Performing a
@@ -293,7 +294,7 @@ function registerCommand(
           renderContractError(error, input.json === true);
           throw error;
         }
-        process.stdout.write(new Uint8Array(await returnValue.arrayBuffer()));
+        await writeProcessStdout(new Uint8Array(await returnValue.arrayBuffer()));
       }
     } catch (err) {
       const op = commandOperation(groupName, cmdMeta.name);
@@ -328,7 +329,7 @@ function registerCommand(
       closeLazyConnection: true,
     });
 
-    if (contractExitCode !== null) process.exit(contractExitCode);
+    if (contractExitCode !== null) return terminateCliProcess(contractExitCode);
   });
 }
 
@@ -383,7 +384,7 @@ async function dispatchRemoteCommand(input: DispatchRemoteCommandInput): Promise
       },
     );
     renderContractError(error, input.input.json === true);
-    process.exit(error.exitCode);
+    return terminateCliProcess(error.exitCode);
   }
 
   let result;
@@ -401,21 +402,21 @@ async function dispatchRemoteCommand(input: DispatchRemoteCommandInput): Promise
       suggestedAction: "Check gateway availability and retry",
     });
     renderContractError(error, input.input.json === true);
-    process.exit(error.exitCode);
+    return terminateCliProcess(error.exitCode);
   }
 
   const remoteError = remoteGatewayErrorToContractError(op, result);
   if (remoteError) {
     renderContractError(remoteError, input.input.json === true);
-    process.exit(remoteError.exitCode);
+    return terminateCliProcess(remoteError.exitCode);
   }
-  printRemoteResponse(result);
+  await printRemoteResponse(result);
   if (!result.ok) {
-    process.exit(remoteGatewayExitCode(result));
+    return terminateCliProcess(remoteGatewayExitCode(result));
   }
 }
 
-function printRemoteResponse(result: RemoteDispatchResult): void {
+async function printRemoteResponse(result: RemoteDispatchResult): Promise<void> {
   const output = remoteDispatchOutput(result);
-  if (output.value.length > 0) process.stdout.write(output.value);
+  if (output.value.length > 0) await writeProcessStdout(output.value);
 }

--- a/src/cli/tool-definitions.ts
+++ b/src/cli/tool-definitions.ts
@@ -3,6 +3,7 @@
  */
 
 import { extractTools, type ExportedTool } from "./tools-export.js";
+import type { CommandSafetyMetadata } from "./decorators.js";
 import { setCliToolsInitializer } from "./tool-registry.js";
 import { extractOptionName, isBooleanOption } from "./utils.js";
 
@@ -15,6 +16,11 @@ type CommandClass = new () => object;
 export interface SdkToolDefinition {
   name: string;
   description: string;
+  operationKind: CommandSafetyMetadata["operationKind"];
+  effectClass: CommandSafetyMetadata["effectClass"];
+  risk: CommandSafetyMetadata["risk"];
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyMetadata["classificationSource"];
   inputSchema: {
     type: "object";
     properties: Record<string, { type: string; description?: string }>;
@@ -97,9 +103,11 @@ export function getCliToolsByGroup(): Record<string, string[]> {
 export function createSdkTools(classes: CommandClass[], options: CreateSdkToolsOptions = {}): SdkToolDefinition[] {
   const { filter } = options;
 
-  // Use cache if using all classes, otherwise extract fresh
-  const allClasses = getAllCommandClasses();
-  let tools = classes === allClasses ? getCachedTools() : extractTools(classes);
+  // Do not initialize the complete command catalog merely to compare array
+  // identity. Focused callers and tests must remain proportional to the command
+  // classes they supplied. The cache is used only after getAllCommandClasses()
+  // has already established the canonical array.
+  let tools = _commandClasses !== null && classes === _commandClasses ? getCachedTools() : extractTools(classes);
 
   if (filter) {
     const regex = typeof filter === "string" ? new RegExp(filter) : filter;
@@ -147,6 +155,11 @@ function toSdkDefinition(tool: ExportedTool): SdkToolDefinition {
   return {
     name: tool.name,
     description: tool.description,
+    operationKind: tool.metadata.safety.operationKind,
+    effectClass: tool.metadata.safety.effectClass,
+    risk: tool.metadata.safety.risk,
+    requiresConfirmation: tool.metadata.safety.requiresConfirmation,
+    classificationSource: tool.metadata.safety.classificationSource,
     inputSchema: { type: "object", properties, required },
   };
 }

--- a/src/cli/tools-export.test.ts
+++ b/src/cli/tools-export.test.ts
@@ -1,11 +1,24 @@
 import "reflect-metadata";
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { AppsCommands } from "./commands/apps.js";
 import type { ContextRecord } from "../router/router-db.js";
 import { ContractError, contractDryRun, contractFail } from "./agent-contract.js";
 import { fail, runWithContext } from "./context.js";
 import { CliOnly, Command, CommandAccess, Group, Option, Returns } from "./decorators.js";
-import { extractTools } from "./tools-export.js";
+import { createSdkTools } from "./tool-definitions.js";
+import { extractTools, generateManifest, manifestToJSON } from "./tools-export.js";
+import { nats } from "../nats.js";
+
+const previousSuppressAuditEvents = process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+
+beforeAll(() => {
+  process.env.RAVI_SUPPRESS_AUDIT_EVENTS = "1";
+});
+
+afterAll(() => {
+  if (previousSuppressAuditEvents === undefined) delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+  else process.env.RAVI_SUPPRESS_AUDIT_EVENTS = previousSuppressAuditEvents;
+});
 
 @Group({ name: "negated", description: "Negated option fixture", scope: "open" })
 class NegatedToolCommands {
@@ -112,6 +125,28 @@ class CliOnlyToolCommands {
   }
 }
 
+let confirmedEffectCount = 0;
+
+@Group({ name: "effect-metadata", description: "Effect metadata fixture", scope: "open" })
+class EffectMetadataCommands {
+  @Command({ name: "apply", description: "Apply one externally visible effect" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "effect-metadata",
+    action: "apply",
+    risk: "high",
+    effectClass: "external",
+    requiresConfirmation: true,
+  })
+  apply(@Option({ flags: "--execute", description: "Apply the external effect" }) execute = false) {
+    if (!execute) {
+      contractDryRun("effect-metadata apply", { effect: "external" }, { asJson: true });
+    }
+    confirmedEffectCount += 1;
+    console.log(JSON.stringify({ applied: true }));
+  }
+}
+
 const mediaContext: ContextRecord = {
   contextId: "ctx_media_authorization_test",
   contextKey: "rctx_media_authorization_test",
@@ -150,6 +185,15 @@ const appsContext: ContextRecord = {
   createdAt: Date.now(),
 };
 
+const effectMetadataContext: ContextRecord = {
+  contextId: "ctx_effect_metadata_test",
+  contextKey: "rctx_effect_metadata_test",
+  kind: "test-runtime",
+  agentId: "effect-metadata-test",
+  capabilities: [{ permission: "mutate", objectType: "effect-metadata", objectId: "apply", source: "test" }],
+  createdAt: Date.now(),
+};
+
 describe("tools export negated options", () => {
   it("uses one semantic grant and the same no-prefixed logical contract as CLI and gateway calls", async () => {
     const tool = extractTools([NegatedToolCommands]).find((candidate) => candidate.name === "negated_run");
@@ -166,6 +210,74 @@ describe("tools export negated options", () => {
 describe("tools export surface", () => {
   it("never exports commands marked @CliOnly", () => {
     expect(extractTools([CliOnlyToolCommands]).map((tool) => tool.name)).toEqual(["terminal_status"]);
+  });
+
+  it("exports operation, effect, risk, and confirmation metadata to every agent manifest", () => {
+    const tool = extractTools([EffectMetadataCommands])[0];
+    expect(tool?.metadata.safety).toEqual({
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+    });
+
+    const expected = {
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+    };
+    expect(generateManifest([tool!])[0]).toMatchObject(expected);
+    expect(JSON.parse(manifestToJSON([tool!]))[0]).toMatchObject(expected);
+    expect(createSdkTools([EffectMetadataCommands])[0]).toMatchObject(expected);
+  });
+
+  it("does not contact the global audit transport for allowed or denied calls when suppressed", async () => {
+    const originalEmit = nats.emit;
+    let emits = 0;
+    nats.emit = async () => {
+      emits += 1;
+    };
+    try {
+      const tool = extractTools([NegatedToolCommands])[0];
+      await runWithContext({ agentId: context.agentId, context }, () => tool!.handler({}));
+
+      const deniedTool = extractTools([MediaAuthorizationCommands]).find(
+        (candidate) => candidate.name === "media_remove",
+      );
+      const denied = await runWithContext({ agentId: mediaContext.agentId, context: mediaContext }, () =>
+        deniedTool!.handler({}),
+      );
+      expect(denied).toMatchObject({ outcome: "denied", exitCode: 1 });
+      expect(emits).toBe(0);
+    } finally {
+      nats.emit = originalEmit;
+    }
+  });
+
+  it("blocks a declared confirmation path before its first effect", async () => {
+    confirmedEffectCount = 0;
+    const tool = extractTools([EffectMetadataCommands])[0];
+
+    const blocked = await runWithContext(
+      { agentId: effectMetadataContext.agentId, context: effectMetadataContext },
+      () => tool!.handler({}),
+    );
+    expect(blocked).toMatchObject({ isError: false, outcome: "blocked", exitCode: 3 });
+    expect(JSON.parse(blocked.content[0]?.text ?? "{}")).toMatchObject({
+      success: false,
+      error: { code: "WRITE_REQUIRES_EXECUTE", dryRun: true },
+    });
+    expect(confirmedEffectCount).toBe(0);
+
+    const applied = await runWithContext(
+      { agentId: effectMetadataContext.agentId, context: effectMetadataContext },
+      () => tool!.handler({ execute: true }),
+    );
+    expect(applied).toMatchObject({ isError: false, outcome: "succeeded" });
+    expect(confirmedEffectCount).toBe(1);
   });
 });
 

--- a/src/cli/tools-export.ts
+++ b/src/cli/tools-export.ts
@@ -10,8 +10,10 @@ import {
   getArgsMetadata,
   getOptionsMetadata,
   getScopeMetadata,
+  resolveCommandSafetyMetadata,
   type ArgMetadata,
   type CommandAccessOptions,
+  type CommandSafetyMetadata,
   type OptionMetadata,
   type ScopeType,
 } from "./decorators.js";
@@ -52,6 +54,7 @@ export interface ExportedTool {
     scope?: ScopeType;
     skillGate?: SkillGateMetadata;
     access?: CommandAccessOptions;
+    safety: CommandSafetyMetadata;
   };
 }
 
@@ -68,6 +71,11 @@ export interface ToolResult {
 export interface ToolManifestEntry {
   name: string;
   description: string;
+  operationKind: CommandSafetyMetadata["operationKind"];
+  effectClass: CommandSafetyMetadata["effectClass"];
+  risk: CommandSafetyMetadata["risk"];
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyMetadata["classificationSource"];
   parameters: Array<{
     name: string;
     type: string;
@@ -116,6 +124,7 @@ export function extractTools(classes: CommandClass[]): ExportedTool[] {
         method: cmdMeta.method,
       });
       const access = commandAccessMap.get(cmdMeta.method);
+      const safety = resolveCommandSafetyMetadata(access, `${groupMeta.name}.${cmdMeta.name}`);
 
       tools.push({
         name: `${normalizedGroup}_${cmdMeta.name}`,
@@ -140,6 +149,7 @@ export function extractTools(classes: CommandClass[]): ExportedTool[] {
           scope: effectiveScope,
           ...(skillGate ? { skillGate } : {}),
           ...(access ? { access } : {}),
+          safety,
         },
       });
     }
@@ -155,6 +165,11 @@ export function generateManifest(tools: ExportedTool[]): ToolManifestEntry[] {
   return tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
+    operationKind: tool.metadata.safety.operationKind,
+    effectClass: tool.metadata.safety.effectClass,
+    risk: tool.metadata.safety.risk,
+    requiresConfirmation: tool.metadata.safety.requiresConfirmation,
+    classificationSource: tool.metadata.safety.classificationSource,
     parameters: [
       ...tool.metadata.args.map((arg) => ({
         name: arg.name,
@@ -236,21 +251,23 @@ function buildHandler(
         accessResult.errorMessage,
       );
       const envelope = JSON.stringify(contractError.envelope());
-      nats
-        .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
-          tool: toolName,
-          input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
-          output: sanitizeCliAuditValue(accessResult.errorMessage, "output"),
-          isError: true,
-          outcome: "denied",
-          exitCode: 1,
-          errorCode: "PERMISSION_DENIED",
-          durationMs: Date.now() - startTime,
-          timestamp: new Date().toISOString(),
-          sessionKey,
-          agentId,
-        })
-        .catch(() => {});
+      if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+        nats
+          .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
+            tool: toolName,
+            input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
+            output: sanitizeCliAuditValue(accessResult.errorMessage, "output"),
+            isError: true,
+            outcome: "denied",
+            exitCode: 1,
+            errorCode: "PERMISSION_DENIED",
+            durationMs: Date.now() - startTime,
+            timestamp: new Date().toISOString(),
+            sessionKey,
+            agentId,
+          })
+          .catch(() => {});
+      }
       return {
         content: [{ type: "text", text: envelope }],
         isError: true,
@@ -343,23 +360,25 @@ function buildHandler(
 
     const text = output.join("\n").trim() || "(no output)";
 
-    nats
-      .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
-        tool: toolName,
-        input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
-        // Tool output may contain message bodies or provider payloads. Audit
-        // the semantic outcome, never the full returned content.
-        output: truncateForEvent(sanitizeCliAuditValue(text, "output")),
-        isError,
-        outcome,
-        ...(contractExitCode !== undefined ? { exitCode: contractExitCode } : {}),
-        ...(contractErrorCode !== undefined ? { errorCode: contractErrorCode } : {}),
-        durationMs: Date.now() - startTime,
-        timestamp: new Date().toISOString(),
-        sessionKey,
-        agentId,
-      })
-      .catch(() => {});
+    if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+      nats
+        .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
+          tool: toolName,
+          input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
+          // Tool output may contain message bodies or provider payloads. Audit
+          // the semantic outcome, never the full returned content.
+          output: truncateForEvent(sanitizeCliAuditValue(text, "output")),
+          isError,
+          outcome,
+          ...(contractExitCode !== undefined ? { exitCode: contractExitCode } : {}),
+          ...(contractErrorCode !== undefined ? { errorCode: contractErrorCode } : {}),
+          durationMs: Date.now() - startTime,
+          timestamp: new Date().toISOString(),
+          sessionKey,
+          agentId,
+        })
+        .catch(() => {});
+    }
 
     return {
       content: [{ type: "text", text }],

--- a/src/permissions/scope.ts
+++ b/src/permissions/scope.ts
@@ -13,6 +13,7 @@ import { closeNats } from "../nats.js";
 import type { ContextRecord, ContextSource } from "../router/router-db.js";
 import type { SessionEntry } from "../router/types.js";
 import type { ScopeType } from "../cli/decorators.js";
+import { terminateCliProcess } from "../cli/process-output.js";
 
 /**
  * Flush pending audit events and exit the process.
@@ -21,7 +22,7 @@ import type { ScopeType } from "../cli/decorators.js";
 export async function flushAuditAndExit(code: number): Promise<never> {
   await flushPermissionAuditEvents();
   await closeNats();
-  process.exit(code);
+  return terminateCliProcess(code);
 }
 
 interface ScopeDenialDiagnosis {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -263,6 +263,13 @@ describe("createCodexRuntimeProvider", () => {
       name: "tools_list",
       description: "List tools",
       inputSchema: { type: "object" },
+      safety: {
+        operationKind: "read" as const,
+        effectClass: "none" as const,
+        risk: "low" as const,
+        requiresConfirmation: false,
+        classificationSource: "declared" as const,
+      },
     };
 
     writeFileSync(

--- a/src/runtime/host-services.foundation.test.ts
+++ b/src/runtime/host-services.foundation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import type { SdkToolDefinition } from "../cli/tool-definitions.js";
+import { projectRuntimeDynamicToolSpec } from "./host-services.js";
+
+describe("runtime host agent-first tool catalog", () => {
+  it("preserves command safety metadata at the runtime boundary", () => {
+    const tool: SdkToolDefinition = {
+      name: "demo_apply",
+      description: "Apply a demo change",
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    };
+
+    expect(projectRuntimeDynamicToolSpec(tool)).toEqual({
+      name: "demo_apply",
+      description: "Apply a demo change",
+      inputSchema: { type: "object", properties: {}, required: [] },
+      safety: {
+        operationKind: "mutate",
+        effectClass: "external",
+        risk: "high",
+        requiresConfirmation: true,
+        classificationSource: "declared",
+      },
+    });
+  });
+});

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -1,5 +1,5 @@
 import { runWithContext } from "../cli/context.js";
-import { getAllCommandClasses, createSdkTools } from "../cli/tool-definitions.js";
+import { getAllCommandClasses, createSdkTools, type SdkToolDefinition } from "../cli/tool-definitions.js";
 import { extractTools, type ExportedTool, type ToolResult } from "../cli/tools-export.js";
 import { logger } from "../utils/logger.js";
 
@@ -89,13 +89,24 @@ function getRuntimeDynamicToolDefinitions(): ExportedTool[] {
 
 function getRuntimeDynamicToolSpecs(): RuntimeDynamicToolSpec[] {
   if (!cachedRuntimeDynamicToolSpecs) {
-    cachedRuntimeDynamicToolSpecs = createSdkTools(getAllCommandClasses()).map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-    }));
+    cachedRuntimeDynamicToolSpecs = createSdkTools(getAllCommandClasses()).map(projectRuntimeDynamicToolSpec);
   }
   return cachedRuntimeDynamicToolSpecs;
+}
+
+export function projectRuntimeDynamicToolSpec(tool: SdkToolDefinition): RuntimeDynamicToolSpec {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    safety: {
+      operationKind: tool.operationKind,
+      effectClass: tool.effectClass,
+      risk: tool.risk,
+      requiresConfirmation: tool.requiresConfirmation,
+      classificationSource: tool.classificationSource,
+    },
+  };
 }
 
 function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDynamicToolSpec[] {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,5 +1,6 @@
 import type { RuntimeEffort } from "./effort.js";
 import type { RuntimeModelBrokerBinding, RuntimeModelBrokerCapabilities } from "./model-broker.js";
+import type { CommandSafetyMetadata } from "../cli/decorators.js";
 
 export type { RuntimeEffort } from "./effort.js";
 
@@ -177,6 +178,7 @@ export interface RuntimeDynamicToolSpec {
   name: string;
   description: string;
   inputSchema: unknown;
+  safety: CommandSafetyMetadata;
   deferLoading?: boolean;
 }
 

--- a/src/sdk/client-codegen/codegen.test.ts
+++ b/src/sdk/client-codegen/codegen.test.ts
@@ -219,7 +219,7 @@ describe("client-codegen :: compareSdkSource", () => {
     expect(result.equal).toBe(false);
   });
 
-  it("requires byte equality for client.ts / schemas.ts / types.ts", () => {
+  it("requires source equality for client.ts / schemas.ts / types.ts", () => {
     const a = emitWith({});
     expect(compareSdkSource("client.ts", a.client, a.client).equal).toBe(true);
     expect(compareSdkSource("schemas.ts", a.schemas, a.schemas).equal).toBe(true);
@@ -228,7 +228,7 @@ describe("client-codegen :: compareSdkSource", () => {
     const mutatedClient = `${a.client}// drift\n`;
     const clientResult = compareSdkSource("client.ts", mutatedClient, a.client);
     expect(clientResult.equal).toBe(false);
-    expect(clientResult.reason).toMatch(/byte mismatch/);
+    expect(clientResult.reason).toMatch(/source mismatch/);
     expect(clientResult.reason).not.toMatch(/GIT_SHA/);
 
     const mutatedSchemas = a.schemas.replace("export const", "export  const");
@@ -238,10 +238,32 @@ describe("client-codegen :: compareSdkSource", () => {
     expect(compareSdkSource("types.ts", mutatedTypes, a.types).equal).toBe(false);
   });
 
+  it("ignores checkout line-ending conversion without hiding source drift", () => {
+    const a = emitWith({});
+    const crlfClient = a.client.replace(/\n/g, "\r\n");
+    const crlfVersion = a.version.replace(/\n/g, "\r\n");
+
+    expect(compareSdkSource("client.ts", crlfClient, a.client).equal).toBe(true);
+    expect(compareSdkSource("version.ts", crlfVersion, a.version).equal).toBe(true);
+    expect(compareSdkSource("client.ts", `${crlfClient}// real drift\r\n`, a.client).equal).toBe(false);
+  });
+
   it("ignores GIT_SHA even when stored has the literal `unknown` placeholder", () => {
     const a = emitWith({ gitSha: "unknown" });
     const b = emitWith({ gitSha: "5e17fe5608f7" });
     expect(compareSdkSource("version.ts", a.version, b.version).equal).toBe(true);
+  });
+
+  it("rejects source appended to the GIT_SHA declaration line", () => {
+    const generated = emitWith({});
+    const storedWithAppendedSource = generated.version.replace(
+      /^(export const GIT_SHA = .*;)$/m,
+      "$1 void globalThis;",
+    );
+
+    const result = compareSdkSource("version.ts", storedWithAppendedSource, generated.version);
+    expect(result.equal).toBe(false);
+    expect(result.reason).toMatch(/source mismatch/);
   });
 });
 

--- a/src/sdk/client-codegen/emit-files.ts
+++ b/src/sdk/client-codegen/emit-files.ts
@@ -381,8 +381,7 @@ export function emitVersion(input: EmitVersionInput): string {
  * the generated SDK surface is byte-stable. Mask the value before comparison
  * so drift detection reflects real registry/codegen changes.
  */
-const GIT_SHA_LINE_RE = /^export const GIT_SHA = .*$/m;
-const GIT_SHA_MASK = 'export const GIT_SHA = "<masked-for-drift-check>";';
+const GIT_SHA_VALUE_RE = /^(export const GIT_SHA = )"(?:\\.|[^"\\])*"([ \t]*;[ \t]*)$/m;
 
 export type GeneratedSdkFile = "client.ts" | "schemas.ts" | "types.ts" | "version.ts" | "streaming.generated.ts";
 
@@ -392,24 +391,32 @@ export interface SdkSourceComparison {
 }
 
 export function compareSdkSource(file: GeneratedSdkFile, stored: string, generated: string): SdkSourceComparison {
+  const canonicalStored = normalizeLineEndings(stored);
+  const canonicalGenerated = normalizeLineEndings(generated);
   if (file === "version.ts") {
-    const a = maskGitSha(stored);
-    const b = maskGitSha(generated);
+    const a = maskGitSha(canonicalStored);
+    const b = maskGitSha(canonicalGenerated);
     if (a === b) return { equal: true };
     return {
       equal: false,
-      reason: `byte mismatch ignoring GIT_SHA (stored=${stored.length}, live=${generated.length})`,
+      reason: `source mismatch ignoring GIT_SHA and line endings (stored=${stored.length}, live=${generated.length})`,
     };
   }
-  if (stored === generated) return { equal: true };
+  if (canonicalStored === canonicalGenerated) return { equal: true };
   return {
     equal: false,
-    reason: `byte mismatch (stored=${stored.length}, live=${generated.length})`,
+    reason: `source mismatch ignoring line endings (stored=${stored.length}, live=${generated.length})`,
   };
 }
 
+function normalizeLineEndings(source: string): string {
+  return source.replace(/\r\n/g, "\n");
+}
+
 function maskGitSha(source: string): string {
-  return source.replace(GIT_SHA_LINE_RE, GIT_SHA_MASK);
+  return source.replace(GIT_SHA_VALUE_RE, (_match, prefix: string, suffix: string) => {
+    return `${prefix}"<masked-for-drift-check>"${suffix}`;
+  });
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/sdk/client-codegen/return-schema-coverage.test.ts
+++ b/src/sdk/client-codegen/return-schema-coverage.test.ts
@@ -1,10 +1,15 @@
 import "reflect-metadata";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
 
 import { getRegistry } from "../../cli/registry-snapshot.js";
 import { UNTYPED_PUBLIC_RETURN_COMMANDS_BASELINE } from "./return-schema-baseline.js";
 import { WEAK_PUBLIC_RETURN_COMMANDS_BASELINE } from "./return-schema-quality-baseline.js";
 import { currentWeakPublicReturnCommands } from "./return-schema-quality.js";
+
+// A cold registry snapshot imports the complete CLI catalog. Five seconds is
+// below observed Windows startup time and made this deterministic coverage
+// assertion fail before it could compare the registry with its baseline.
+setDefaultTimeout(15_000);
 
 function currentUntypedPublicReturnCommands(): string[] {
   return getRegistry()


### PR DESCRIPTION
## Objective

Establish the shared CLI foundation required to migrate Ravi domains to an
agent-first contract without duplicating behavior across each domain PR.

## Problem

The CLI already exposes broad command coverage, but shared guarantees were
incomplete: process output could be lost at exit boundaries, public failures
were not consistently typed, tool metadata did not describe mutation safety,
pagination accepted unsafe limits, and generated SDK drift checks were
sensitive to platform line endings and build metadata.

## Solution

- add an explicit process-output flush boundary for success and failure exits;
- bound output flushing to five seconds, avoid busy-spinning, guarantee process
  termination, and kill and observe timed-out native test children;
- keep the bundled entrypoint synchronously loadable by PM2 while all output
  waits remain inside the asynchronous bootstrap chain;
- standardize typed public CLI errors and preserve clean JSON output;
- add shared mutation-safety metadata to the registry, manifests, exported
  tools, SDK and host runtime;
- add opt-in strict field validation, initially enabled only for `agents list`;
- reject pagination limits above the documented maximum instead of silently
  coercing them;
- make SDK drift checks platform-stable while still detecting meaningful
  generated-code changes;
- suppress NATS side effects during isolated tool-contract tests;
- document the change through the Ravi Spec quartet, ADR, migration ledger and
  revision-preserving postmortem.

## Practical impact

Agents can discover whether an operation is read-only, mutating or not yet
classified before execution. CLI output is flushed deterministically,
structured errors remain machine-readable, and subsequent domain facades can
reuse one tested safety contract.

## What does not change

- Existing command names and legacy command behavior remain available.
- Strict unknown-field rejection is not enabled globally.
- Domain mutations are not automatically reclassified by this PR; each domain
  PR owns that decision.
- There is no database migration and no VPS deployment in this PR.

## Validation

- `bun run typecheck` - passed.
- `bun run build` - passed.
- repository quality gate for the 36 changed paths - passed.
- focused output and error tests - 23 passed, 93 assertions.
- safety metadata, pagination and runtime projection tests - 27 passed, 107
  assertions.
- full SDK suite - 75 passed, 297 assertions; `bun run sdk:check` passed.
- context, private termination signal, native output, SDK command, tool and
  gateway tests - 86 passed, 310 assertions.
- real-process usage and error smoke tests - 11 passed, 63 assertions.
- Markdown lint for the changed ledger and postmortem - passed.
- the package was installed in an empty directory; its installed bundle passed
  `--version`, `--help`, and synchronous `require(...)` followed by
  `daemon status`.
- commit quality hook - passed.

The first Linux CI run (`32450827025`) tested superseded commit
`677cd83857fe6b6d2f92e66b3fd2dd61d4928f3c` and failed the native PM2 loading
test because that commit introduced top-level await. The second Linux CI run
(`32451955010`) tested superseded commit
`ec6d13ccdcbcdb90b7b8a224c90a4f8892e2af16`; it passed build, typecheck and the
PM2 loading test, then found two legacy direct-call SDK cases that recaptured
the private termination signal and replaced the public error message.

Commit `560517a43248c3798f82e3da98c088df0743016e` preserves the private signal's
identity through every external SDK catch. The strengthened tests require exit
code 1, exactly one public message and no private-signal leakage. Both failed
runs remain documented. Linux CI run `32453644867` passed build, typecheck, the
complete test suite, Swift SDK tests, and the spec and coverage quality gate on
this exact commit.

The repository pre-push hook was attempted on Windows but is not recorded as
passed. Both this branch and baseline `dev` reproduce existing Windows-only
instability in channel and artifact-store tests. The push bypasses only that
local hook so mandatory Linux CI can provide the merge result.

The package's existing `bin/ravi` launcher is a Bash script. Invoking that shim
directly on this Windows host therefore reports that Bash is unavailable; the
installed bundle tests above use Bun directly. The target VPS and Linux CI
provide Bash and remain the authority for the packaged launcher.

## Release evidence

- candidate commit: `560517a43248c3798f82e3da98c088df0743016e`;
- package: `ravi.bot-3.260817.2.tgz`;
- package SHA-256:
  `34A95BFD91C08C446E1ED372854059454CF8490001712240C156F301799E573E`;
- package version is intentionally unchanged; the candidate is identified by
  commit and SHA-256.

## Risks

- Pagination requests above 500 now return a usage error instead of being
  silently reduced.
- Safety metadata remains `unclassified` until each domain explicitly declares
  its operations.
- Interactive lifecycle commands continue to use their existing output
  lifecycle where required.
- If an output stream remains stuck, the CLI prioritizes bounded termination
  after five seconds; output already blocked by the operating system may be
  incomplete.
- VPS rollout remains intentionally out of scope and requires a separate,
  explicit approval after merge.

## Rollback

Revert the foundation commits and reinstall the previous package. No database
or persistent-state rollback is required.

## Follow-ups

- Migrate the 21 scoped domains through one Ravi Spec-backed PR per domain.
- Rebase the existing CRM candidate onto this foundation before final CRM
  review.
- Address the pre-existing Windows artifact-store portability debt separately
  from this foundation.
