### PR TITLE
feat(commands): add agent-first discovery contract

### DIFF
--- a/.ravi/specs/cli/commands/CHECKS.md
+++ b/.ravi/specs/cli/commands/CHECKS.md
@@ -11,7 +11,8 @@
   discovery, after command-name validation where applicable.
 - Invalid `limit` and `offset` MUST exit 2 with `USAGE_ERROR`, never exit 1
   with `COMMAND_FAILED`.
-- Valid `--fields` MUST project equal `items` and `commands` rows.
+- Valid `--fields` MUST project equal `items` and `commands` rows, and the
+  serialized partial rows MUST validate against the published return schema.
 - One unknown field, alone or mixed with valid fields, MUST exit 2 with the
   stable `acceptedFields` set, including when no commands are discovered. It
   MUST never produce `{}` rows with exit 0.
@@ -26,8 +27,11 @@
   and ordering.
 - Repeating a paginated list MUST preserve `pagination.nextCommand`.
 - Repeating a render MUST preserve `metadata.renderedPromptSha256`.
-- `list`, `show`, `validate`, and `run` MUST leave command files, config,
-  sessions, and runtime transport unchanged.
+- `list`, `show`, `validate`, and `run` MUST leave command files, every SQLite
+  table, every runtime state file, and runtime transport unchanged without a
+  test-only audit suppression variable.
+- Agent resolution MUST use read-only SQLite access and MUST NOT initialize
+  schema, enable writable WAL behavior, or create missing state.
 - `run` MUST remain a pure renderer and MUST NOT publish to a session.
 - No COMMANDS operation may exit 3.
 - `validate` MUST preserve its exit-1 file verdict when validation errors
@@ -39,6 +43,10 @@
   Ravi Spec, and shipped COMMANDS skill MUST remain coherent.
 - The skill MUST document name validation, pagination, strict fields, exit
   taxonomy, and the absence of write effects.
+- CLI, exported-tool, and gateway paths MUST all honor the declared
+  transport-free policy for COMMANDS.
+- The shared audit policy MUST reject opt-out declarations on mutations,
+  effectful reads, and reads above low risk.
 - `bun test src/cli/commands/commands.test.ts` SHOULD pass after every change
   to this surface.
 - SDK generation/check, typecheck, build, quality gate, and documentation lint

--- a/.ravi/specs/cli/commands/CHECKS.md
+++ b/.ravi/specs/cli/commands/CHECKS.md
@@ -1,22 +1,45 @@
 # Ravi Commands agent-first CLI contract / CHECKS
 
-## Checks
+## Contract Checks
 
-- `commands show <unknown> --json` and `commands run <unknown> --json` MUST
-  exit 1 with the `COMMAND_NOT_FOUND` envelope and up to three `suggestions`
-  of real command ids from the same registry the lookup used.
-- Any commands op given an unknown `--agent` MUST exit 1 with
-  `AGENT_NOT_FOUND` and suggestions from the local agent config, before any
-  filesystem discovery runs.
-- `commands list --fields a,b,c --json` MUST return `items` (and `commands`)
-  containing only the requested fields.
-- `commands run` MUST remain a pure renderer: it returns the composed prompt
-  and MUST NOT publish to any session or emit runtime side effects.
-- No commands op may exit 3 — the domain is declared brake-free.
-- `commands validate` MUST keep its pre-existing exit-1 verdict when command
-  files carry validation errors; that exit is not renamed to a contract code.
-- The shipped `commands` skill MUST document the contract (envelope, exits,
-  `--fields`, absence of brakes) in its `## Contrato Do CLI` section.
-- An invalid flag on any `commands` op SHOULD exit 2 with `acceptedFlags`.
-- `bun test src/cli/commands/commands.test.ts` SHOULD pass after any change
-  to the commands contract surface.
+- `show` and `run` with a valid unknown name MUST exit 1 with
+  `COMMAND_NOT_FOUND` and suggestions from the lookup registry.
+- Empty and invalid names on `show` and `run` MUST exit 2 with
+  `INVALID_COMMAND_NAME` before agent resolution and MUST never surface as
+  `UNHANDLED_ERROR`.
+- An unknown agent MUST exit 1 with `AGENT_NOT_FOUND` before command
+  discovery, after command-name validation where applicable.
+- Invalid `limit` and `offset` MUST exit 2 with `USAGE_ERROR`, never exit 1
+  with `COMMAND_FAILED`.
+- Valid `--fields` MUST project equal `items` and `commands` rows.
+- One unknown field, alone or mixed with valid fields, MUST exit 2 with the
+  stable `acceptedFields` set, including when no commands are discovered. It
+  MUST never produce `{}` rows with exit 0.
+- Every success payload MUST validate against its declared return schema.
+- Parser-level invalid flags and arguments SHOULD exit 2 with accepted usage
+  metadata.
+- Bare `ravi commands` MUST print operation help and exit 0.
+
+## Read-Only and Determinism Checks
+
+- Repeating each operation against unchanged input MUST preserve JSON values
+  and ordering.
+- Repeating a paginated list MUST preserve `pagination.nextCommand`.
+- Repeating a render MUST preserve `metadata.renderedPromptSha256`.
+- `list`, `show`, `validate`, and `run` MUST leave command files, config,
+  sessions, and runtime transport unchanged.
+- `run` MUST remain a pure renderer and MUST NOT publish to a session.
+- No COMMANDS operation may exit 3.
+- `validate` MUST preserve its exit-1 file verdict when validation errors
+  exist.
+
+## Surface Checks
+
+- The handler's stable list fields, return schema, generated tool surface,
+  Ravi Spec, and shipped COMMANDS skill MUST remain coherent.
+- The skill MUST document name validation, pagination, strict fields, exit
+  taxonomy, and the absence of write effects.
+- `bun test src/cli/commands/commands.test.ts` SHOULD pass after every change
+  to this surface.
+- SDK generation/check, typecheck, build, quality gate, and documentation lint
+  SHOULD pass before the increment is considered ready.

--- a/.ravi/specs/cli/commands/RUNBOOK.md
+++ b/.ravi/specs/cli/commands/RUNBOOK.md
@@ -43,8 +43,11 @@ Expected results, in order:
 - a rendered prompt preview with no session publication.
 
 For a zero-effect check, hash the configured agent and global command
-directories, every runtime state file (including SQLite WAL/SHM files), and a
-stable dump of every SQLite table before and after every call. Run without
+directories, every durable runtime state file (including SQLite DB/WAL files),
+and a stable dump of every SQLite table before and after every call. Keep a WAL
+writer connection open in one native check. SQLite's `-shm` file is an
+ephemeral coordination index and may change during a concurrency-safe read;
+it is not durable command state. Run without
 `RAVI_SUPPRESS_AUDIT_EVENTS`; COMMANDS declares transport-free inspection and
 must not contact the audit transport. Repeating unchanged calls must retain
 values, ordering, `pagination.nextCommand`, and

--- a/.ravi/specs/cli/commands/RUNBOOK.md
+++ b/.ravi/specs/cli/commands/RUNBOOK.md
@@ -1,34 +1,66 @@
 # Ravi Commands agent-first CLI contract / RUNBOOK
 
-## Debug Flow
+## Diagnose a Call
 
-1. Read the rules: `ravi specs get cli/commands --mode rules --json`.
-2. Reproduce the failing call with `--json` and read `error.code` first.
-3. Exit `1` + `COMMAND_NOT_FOUND`: read `error.suggestions` — real command
-   ids from the same registry (agent + global dirs). Retry with one, or list
-   with `ravi commands list --json`.
-4. Exit `1` + `AGENT_NOT_FOUND`: the `--agent` id does not exist in the local
-   config; `error.suggestions` carries similar agent ids.
-5. Exit `1` from `commands validate` WITHOUT an envelope: that is the
-   pre-existing verdict "validation errors exist in command files" — inspect
-   the printed issues, fix the Markdown files.
-6. There is NO exit 3 in this domain — `run` only renders; if a commands op
-   ever returns 3, someone added a brake without updating this spec.
-7. To check whether a command expanded in a real message, use
-   `ravi sessions trace <session> --message <id> --explain --json` (see the
-   commands skill).
+1. Read the rules with `ravi specs get cli/commands --mode rules --json`.
+2. Reproduce the call with `--json` and inspect `error.code` before the text.
+3. For exit 2 plus `INVALID_COMMAND_NAME`, use a non-empty name matching
+   `[A-Za-z0-9][A-Za-z0-9-]{0,63}`. No registry lookup occurred.
+4. For exit 2 plus pagination `USAGE_ERROR`, use `limit` from 1 through 500
+   and `offset` of zero or greater; both must be integers.
+5. For exit 2 plus fields `USAGE_ERROR`, read `error.acceptedFields` and retry
+   using only that set. One unknown field invalidates the whole request.
+6. For exit 1 plus `COMMAND_NOT_FOUND`, inspect `error.suggestions`; they are
+   real ids from the same registry used by lookup.
+7. For exit 1 plus `AGENT_NOT_FOUND`, inspect the suggested local agent ids.
+8. Exit 1 from `commands validate` without an envelope is the preserved
+   verdict that command files contain errors.
+9. COMMANDS has no valid exit-3 path. `run` only renders.
+10. Bare `ravi commands` is successful discovery help and must exit 0.
 
-## Validation
+## Read-Only Checks
+
+```bash
+ravi commands
+ravi commands show nope --json
+ravi commands show "" --json
+ravi commands list --agent ghost --json
+ravi commands list --fields id,scope --json
+ravi commands list --fields id,unknown --json
+ravi commands list --limit 0 --json
+ravi commands run restart --json -- "motivo"
+```
+
+Expected results, in order:
+
+- group help, exit 0;
+- `COMMAND_NOT_FOUND`, exit 1, with suggestions;
+- `INVALID_COMMAND_NAME`, exit 2;
+- `AGENT_NOT_FOUND`, exit 1, with suggestions;
+- compact and equal `items`/`commands` rows;
+- `USAGE_ERROR`, exit 2, with `acceptedFields`;
+- `USAGE_ERROR`, exit 2;
+- a rendered prompt preview with no session publication.
+
+For a zero-write check, hash the configured agent and global command
+directories before and after every call. Repeating unchanged calls must retain
+values, ordering, `pagination.nextCommand`, and
+`metadata.renderedPromptSha256`. In an isolated test process, set
+`RAVI_SUPPRESS_AUDIT_EVENTS=1` so transport evidence does not alter the state
+being inspected; suppression does not change command semantics.
+
+## Repository Validation
 
 ```bash
 bun test src/cli/commands/commands.test.ts
+bun test src/commands/index.test.ts
+bun run sdk:generate
+bun run sdk:check
+bun run typecheck
+bun run build
+bun src/ci/run-quality-gate.ts
+bun run lint:docs
 ```
 
-Live checks against the local CLI (read-only):
-
-```bash
-ravi commands show nope --json                  # expect exit 1 + COMMAND_NOT_FOUND + suggestions
-ravi commands list --agent ghost --json         # expect exit 1 + AGENT_NOT_FOUND + suggestions
-ravi commands list --fields id,scope --json     # expect compact items
-ravi commands run restart --json -- "motivo"    # renders the prompt; no session publish
-```
+Do not use a benchmark or external test bench for this domain increment. Its
+evidence belongs in native operation tests and normal repository gates.

--- a/.ravi/specs/cli/commands/RUNBOOK.md
+++ b/.ravi/specs/cli/commands/RUNBOOK.md
@@ -42,18 +42,22 @@ Expected results, in order:
 - `USAGE_ERROR`, exit 2;
 - a rendered prompt preview with no session publication.
 
-For a zero-write check, hash the configured agent and global command
-directories before and after every call. Repeating unchanged calls must retain
+For a zero-effect check, hash the configured agent and global command
+directories, every runtime state file (including SQLite WAL/SHM files), and a
+stable dump of every SQLite table before and after every call. Run without
+`RAVI_SUPPRESS_AUDIT_EVENTS`; COMMANDS declares transport-free inspection and
+must not contact the audit transport. Repeating unchanged calls must retain
 values, ordering, `pagination.nextCommand`, and
-`metadata.renderedPromptSha256`. In an isolated test process, set
-`RAVI_SUPPRESS_AUDIT_EVENTS=1` so transport evidence does not alter the state
-being inspected; suppression does not change command semantics.
+`metadata.renderedPromptSha256`.
 
 ## Repository Validation
 
 ```bash
 bun test src/cli/commands/commands.test.ts
+bun test src/cli/commands/commands.process.test.ts
 bun test src/commands/index.test.ts
+bun test src/cli/tools-export.test.ts
+bun test src/sdk/gateway/dispatcher.test.ts
 bun run sdk:generate
 bun run sdk:check
 bun run typecheck

--- a/.ravi/specs/cli/commands/SPEC.md
+++ b/.ravi/specs/cli/commands/SPEC.md
@@ -13,6 +13,7 @@ tags:
   - exit-taxonomy
 applies_to:
   - src/cli/commands/commands.ts
+  - src/cli/commands/operational-return-schemas.ts
   - src/cli/agent-contract.ts
   - src/plugins/internal/ravi-system/skills/commands/SKILL.md
 owners:
@@ -20,81 +21,127 @@ owners:
 status: active
 normative: true
 ---
-# Ravi Commands agent-first CLI contract
-
 ## Intent
 
-Make `ravi commands` (prompt-command management: list, show, validate, run)
-reliable for agent consumers under the agent-first contract defined by
-`cli`: typed error envelopes, the 0/1/2/3 exit taxonomy, and compact
-discovery. The domain is READ-ONLY — `run` only RENDERS the composed prompt
-and never publishes to a session — so this migration ships WITHOUT a write
-brake.
+Make `ravi commands` reliable for agent consumers across `list`, `show`,
+`validate`, and `run`. The surface uses typed error envelopes, the 0/1/2/3
+exit taxonomy, bounded pagination, strict compact fields, and declared return
+schemas.
+
+The whole domain is read-only. `run` only renders a composed prompt preview;
+it never publishes to a session or starts runtime execution. Therefore no
+COMMANDS operation has a write brake or a valid exit-3 path.
 
 ## Invariants
 
-1. With `--json`, every failure on a migrated op MUST return the envelope
-   `{success:false, op, error:{code, message, retryable, suggestedAction, suggestions?|acceptedFlags?}}`.
-2. Exit codes MUST follow the taxonomy: `0` success · `1` error (not-found)
-   · `2` usage error · `3` blocked by policy (no commands op uses 3).
-3. `commands show` and `commands run` on an unknown command MUST exit 1 with
-   `COMMAND_NOT_FOUND` and up to 3 `suggestions` built from the ids of the
-   SAME registry the lookup used (zero extra cost).
-4. Any op given an unknown `--agent` MUST exit 1 with `AGENT_NOT_FOUND` and
-   suggestions from the local agent config, BEFORE any filesystem discovery
-   runs.
-5. `commands list` MUST accept `--fields a,b,c` for compact output (applied
-   to both the `items` and `commands` arrays, which carry the same rows).
-6. `commands validate` keeps its pre-existing semantics: exit 1 via
-   `process.exitCode` when validation errors exist — that is a validation
-   verdict, not a contract envelope, and is NOT renamed or re-coded.
-7. When invoked from an agent context (`RAVI_*` envs present), a thrown
-   `ContractError` MUST preserve its exit code through the registry
-   dispatcher.
+1. With `--json`, every failure MUST return
+   `{success:false, op, error:{code, message, retryable, suggestedAction, suggestions?|acceptedFlags?|acceptedFields?}}`.
+2. Exit codes MUST follow the shared taxonomy: `0` success, `1` execution or
+   lookup failure, `2` usage failure, and `3` policy block. COMMANDS MUST NOT
+   emit exit 3.
+3. `show` and `run` with a valid but absent name MUST exit 1 with
+   `COMMAND_NOT_FOUND` and suggestions from the same registry used by lookup.
+4. `show` and `run` with an empty or syntactically invalid name MUST fail
+   before agent resolution with `INVALID_COMMAND_NAME`, exit 2, and a safe
+   correction hint. They MUST NOT become `UNHANDLED_ERROR`.
+5. After name validation, an unknown `--agent` MUST exit 1 with
+   `AGENT_NOT_FOUND` and suggestions from local config before command
+   discovery starts.
+6. `list` MUST reject non-integer, zero, negative, fractional, or over-limit
+   pagination as `USAGE_ERROR`, exit 2. `limit` is 1 through 500; `offset` is
+   an integer of zero or greater.
+7. `list --fields` MUST project the same rows into both `items` and `commands`.
+   One unknown field invalidates the complete request as `USAGE_ERROR`, exit
+   2, with stable `acceptedFields`, including when the result is empty. It
+   MUST NOT return `{}` rows with exit 0.
+8. The stable list fields are `id`, `token`, `title`, `description`,
+   `argumentHint`, `arguments`, `disabled`, `scope`, `path`, `relativePath`,
+   `shadowedBy`, `shadows`, and `issues`. Handler, return schema, generated
+   surface, and this spec MUST remain coherent with this set.
+9. `validate` keeps its pre-existing exit-1 verdict through
+   `process.exitCode` when command files contain errors. That is a validation
+   result, not a contract error envelope.
+10. Repeating an operation against unchanged files and config MUST preserve
+    JSON values, ordering, pagination continuation, and rendered prompt hash.
+11. `list`, `show`, `validate`, and `run` MUST leave command files, config,
+    sessions, and runtime transport unchanged.
+12. A thrown `ContractError` MUST preserve its exit code through CLI, tool,
+    gateway, and agent-context dispatchers.
+13. Invoking bare `ravi commands` MUST print the group help and exit 0. It is
+    discovery, not a failed operation.
 
-## Write classification (no new brakes — rationale)
+## Operation Contract
 
-| op | class | brake |
+| operation | behavior | effect class |
 |---|---|---|
-| list / show / validate | read (filesystem discovery only) | n/a |
-| run | read — renders the composed prompt for preview; publishes nothing | not braked (declared) |
+| bare group | print operation discovery help | read |
+| `list` | discover, filter, paginate, and project command summaries | read |
+| `show` | resolve and return one command, including its body | read |
+| `validate` | classify registry issues and return a verdict | read |
+| `run` | render and return a composed prompt preview | read |
 
-`run` looks like execution but is explicitly a renderer (see the commands
-skill: "Ele nao publica em sessao e nao executa runtime"). Verdict: "sem
-freios novos".
+`run` is a renderer despite its name. It does not publish to
+`SESSION_PROMPTS`, dispatch a provider request, mutate a session, or execute
+Markdown content.
 
-## Official error cases
+## Official Error Cases
 
 | case | code | exit |
 |---|---|---|
-| command not found | `COMMAND_NOT_FOUND` + suggestions | 1 |
-| agent not found | `AGENT_NOT_FOUND` + suggestions | 1 |
-| invalid flag/arg | `USAGE_ERROR` + acceptedFlags | 2 |
-| validation errors present (`validate`) | pre-existing exit 1 verdict | 1 |
+| command not found | `COMMAND_NOT_FOUND` plus suggestions | 1 |
+| agent not found | `AGENT_NOT_FOUND` plus suggestions | 1 |
+| empty or invalid command name | `INVALID_COMMAND_NAME` | 2 |
+| invalid `--limit` or `--offset` | `USAGE_ERROR` | 2 |
+| unknown `--fields` value | `USAGE_ERROR` plus `acceptedFields` | 2 |
+| invalid flag or positional argument | `USAGE_ERROR` plus parser metadata | 2 |
+| validation errors present | pre-existing validation verdict | 1 |
 
-## Internal consumers
+## Compatibility
+
+The following behavior is deliberately preserved:
+
+- command names remain case-insensitive and accept an optional leading `#`;
+- `items` and `commands` remain redundant aliases with equal rows;
+- valid `--fields` projections remain compact;
+- `validate` keeps its exit-1 file verdict;
+- `run` keeps `renderedPromptSha256` and remains preview-only.
+- bare `ravi commands` now returns successful discovery help instead of the
+  legacy exit 1.
+
+Strict fields are a deliberate hardening. Legacy COMMANDS silently ignored an
+unknown field, which could return partial data or `{}` with success. The whole
+request now fails so a typo cannot masquerade as valid empty data.
+
+## Boundary
+
+This contract owns the existing four CLI operations. The conversational
+facade proposed in the domain dossier remains deferred until registry
+revision, envelope integrity, engine routing, real shadowing, and
+material-change contracts are decided.
+
+## Internal Consumer
 
 `src/plugins/internal/ravi-system/skills/commands/SKILL.md` teaches this
-surface and carries the `## Contrato Do CLI` section (envelope, exits,
-`--fields`, declared absence of brakes). No other doc teaches braked commands
-syntax (there is none).
+surface. It MUST describe name validation, pagination, strict fields, exit
+taxonomy, and the absence of write effects.
 
 ## Validation
 
-- `bun test src/cli/commands/commands.test.ts` green (contract suite), no new
-  failures vs the `dev` baseline.
-- Live checks on the local CLI: `commands show nope --json` →
-  `COMMAND_NOT_FOUND`, exit 1; `commands list --fields id,scope --json`
-  narrows items; `commands run <name> --json -- args` renders without side
-  effects.
+- `bun test src/cli/commands/commands.test.ts` covers every operation, typed
+  usage failures, schema acceptance, determinism, and unchanged source state.
+- `bun test src/commands/index.test.ts` covers registry and renderer behavior.
+- SDK generation/check, typecheck, build, quality gate, and documentation lint
+  are proportional release gates for a surface or schema change.
 
 ## Known Failure Modes
 
-- `resolveRaviCommand` returns null (it does not throw); the not-found branch
-  must build suggestions from `registry.commands` BEFORE bailing, or the
-  registry work is discarded and re-done.
-- `--agent` failures after discovery would waste a filesystem scan; agent
-  resolution happens first and fails with `AGENT_NOT_FOUND` from the local
-  config only.
-- Parser-level usage errors use the global exit-2 `USAGE_ERROR` envelope with
-  `acceptedFlags`.
+- A raw `RaviCommandError("invalid_command_name")` is an engine detail. The
+  CLI boundary must translate it before the unexpected-error fallback.
+- COMMANDS must not catch and recode the shared pagination
+  `CliExpectedError`.
+- Omitting the stable field set from `pickFields` restores legacy silent
+  projection behavior.
+- Return schema changes without regenerated surfaces create tool and SDK
+  drift even when direct CLI calls still work.
+- Bare-help behavior is opt-in through group metadata; enabling it globally
+  would change unrelated domains and is outside this contract.

--- a/.ravi/specs/cli/commands/SPEC.md
+++ b/.ravi/specs/cli/commands/SPEC.md
@@ -67,9 +67,12 @@ COMMANDS operation has a write brake or a valid exit-3 path.
 10. Repeating an operation against unchanged files and config MUST preserve
     JSON values, ordering, pagination continuation, and rendered prompt hash.
 11. `list`, `show`, `validate`, and `run` MUST leave command files, every
-    SQLite table, every runtime state file, and runtime transport unchanged.
-    They MUST resolve agents without schema initialization or writable SQLite
-    access and MUST NOT emit command audit transport events.
+    SQLite table, every durable runtime state file (including `ravi.db` and its
+    WAL), and runtime transport unchanged. A read MAY update SQLite's ephemeral
+    `-shm` coordination index while a writer is active; that index is not
+    durable command or route state. Reads MUST remain current under concurrent
+    WAL writers, MUST resolve agents without schema initialization or writable
+    SQLite access, and MUST NOT emit command audit transport events.
     The audit opt-out policy MUST reject any operation that is not a low-risk
     read with resolved effect class `none`.
 12. A thrown `ContractError` MUST preserve its exit code through CLI, tool,

--- a/.ravi/specs/cli/commands/SPEC.md
+++ b/.ravi/specs/cli/commands/SPEC.md
@@ -45,8 +45,8 @@ COMMANDS operation has a write brake or a valid exit-3 path.
    before agent resolution with `INVALID_COMMAND_NAME`, exit 2, and a safe
    correction hint. They MUST NOT become `UNHANDLED_ERROR`.
 5. After name validation, an unknown `--agent` MUST exit 1 with
-   `AGENT_NOT_FOUND` and suggestions from local config before command
-   discovery starts.
+   `AGENT_NOT_FOUND` and suggestions from the read-only agent directory
+   snapshot before command discovery starts.
 6. `list` MUST reject non-integer, zero, negative, fractional, or over-limit
    pagination as `USAGE_ERROR`, exit 2. `limit` is 1 through 500; `offset` is
    an integer of zero or greater.
@@ -58,13 +58,20 @@ COMMANDS operation has a write brake or a valid exit-3 path.
    `argumentHint`, `arguments`, `disabled`, `scope`, `path`, `relativePath`,
    `shadowedBy`, `shadows`, and `issues`. Handler, return schema, generated
    surface, and this spec MUST remain coherent with this set.
+   A compact projection MUST serialize as exactly the requested non-empty
+   subset and its published schema MUST accept that JSON without hidden
+   properties.
 9. `validate` keeps its pre-existing exit-1 verdict through
    `process.exitCode` when command files contain errors. That is a validation
    result, not a contract error envelope.
 10. Repeating an operation against unchanged files and config MUST preserve
     JSON values, ordering, pagination continuation, and rendered prompt hash.
-11. `list`, `show`, `validate`, and `run` MUST leave command files, config,
-    sessions, and runtime transport unchanged.
+11. `list`, `show`, `validate`, and `run` MUST leave command files, every
+    SQLite table, every runtime state file, and runtime transport unchanged.
+    They MUST resolve agents without schema initialization or writable SQLite
+    access and MUST NOT emit command audit transport events.
+    The audit opt-out policy MUST reject any operation that is not a low-risk
+    read with resolved effect class `none`.
 12. A thrown `ContractError` MUST preserve its exit code through CLI, tool,
     gateway, and agent-context dispatchers.
 13. Invoking bare `ravi commands` MUST print the group help and exit 0. It is
@@ -143,5 +150,9 @@ taxonomy, and the absence of write effects.
   projection behavior.
 - Return schema changes without regenerated surfaces create tool and SDK
   drift even when direct CLI calls still work.
+- A return schema that validates complete non-enumerable properties before
+  JSON serialization is invalid; only the serialized public projection counts.
+- Opening the normal config store for discovery can initialize SQLite or alter
+  WAL/SHM files even when table rows are unchanged.
 - Bare-help behavior is opt-in through group metadata; enabling it globally
   would change unrelated domains and is outside this contract.

--- a/.ravi/specs/cli/commands/WHY.md
+++ b/.ravi/specs/cli/commands/WHY.md
@@ -1,23 +1,50 @@
 # Ravi Commands agent-first CLI contract / WHY
 
-`ravi commands` is the management surface for `#name` prompt shortcuts. Its
-one deceptive op is `run`: the name suggests execution, but the implementation
-only renders the composed prompt for preview — it never publishes to
-`SESSION_PROMPTS` and never touches the runtime. That fact (already
-documented in the commands skill) is what makes this a brake-free domain:
-there is nothing destructive, irreversible or execution-dispatching to gate.
-The migration's value here is the envelope and suggestions.
+`ravi commands` is the management surface for file-backed `#name` prompt
+shortcuts. Agents need more than output that happens to be JSON: they need to
+distinguish a typo from an absent command, continue a list without guessing,
+request compact fields safely, and know whether a call changed anything.
 
-The not-found path is unusually cheap: `commands show`/`run` already built
-the full registry (`discoverRaviCommands`) before the lookup failed, so
-`COMMAND_NOT_FOUND` suggestions reuse `registry.commands` ids with zero extra
-I/O. Agent resolution deliberately happens BEFORE discovery — an unknown
-`--agent` fails from the in-memory config with `AGENT_NOT_FOUND` (same code
-and shape as the `agents` and `skills` domains) without paying for a
-filesystem scan whose result would be discarded.
+## Why the Domain Has No Write Brake
 
-One pre-existing behavior is intentionally preserved: `commands validate`
-sets exit 1 when command files carry validation errors. That exit is a
-verdict about the FILES, not an invocation failure, and renaming it to a
-contract code would break the "validate in CI, non-zero on bad files"
-pattern. The contract table lists it as-is.
+The deceptive operation is `run`. Its name suggests execution, but the
+implementation only renders a composed prompt preview. It does not publish to
+`SESSION_PROMPTS`, touch a runtime session, call a provider, or execute content
+from Markdown. All four operations are reads, so exit 3 would be a contract
+violation rather than protection.
+
+## Why Validation Order Matters
+
+Malformed command names are usage errors regardless of the requested agent.
+Validating the name before agent resolution gives stable taxonomy and avoids
+unnecessary config-dependent behavior. Once a name is valid, an unknown agent
+still fails before filesystem discovery. A valid but absent command reaches
+the registry so `COMMAND_NOT_FOUND` can reuse real ids as suggestions without
+extra I/O.
+
+## Why Fields Are Strict
+
+Legacy COMMANDS silently ignored unknown field names. A mixed request such as
+`id,unknown` returned only `id`, while `unknown` alone produced `{}` rows with
+exit 0. For an agent, both cases make a typo look like trustworthy data.
+
+The domain now opts into the shared strict-fields foundation. One unknown
+field rejects the whole request and returns the stable accepted set, even when
+no commands exist. Valid projections and the redundant `items`/`commands`
+arrays remain compatible.
+
+## Preserved Verdict
+
+`commands validate` still sets exit 1 when command files contain validation
+errors. That status is a verdict about the files, not an invocation failure.
+Changing it to a typed contract error would break the established CI pattern
+of using a non-zero result for invalid command definitions.
+
+## Why the Proposed Facade Is Deferred
+
+The natural-language facade in the domain dossier depends on unresolved
+contracts: immutable registry revision, envelope integrity, real shadowing,
+material-change classification, and engine routing. Implementing those choices
+implicitly would weaken the read-only guarantee. This increment completes the
+existing four-operation surface and leaves the future facade as an explicit
+decision.

--- a/.ravi/specs/cli/foundation/CHECKS.md
+++ b/.ravi/specs/cli/foundation/CHECKS.md
@@ -1,0 +1,66 @@
+# Agent-first CLI foundation / CHECKS
+
+## Output integrity
+
+- A native process test MUST parse a piped JSON response larger than 64 KiB.
+- Success and failure paths MUST complete pending output before process exit.
+- The test MUST exercise the real CLI process boundary.
+- Direct `fail()` termination MUST route through the top-level flush boundary.
+- Native isolated tool tests with `RAVI_SUPPRESS_AUDIT_EVENTS=1` MUST NOT contact
+  the global NATS audit transport.
+- Interactive loops and child-process lifecycle callbacks listed in
+  `RUNBOOK.md` MUST NOT be represented as migrated one-shot command exits.
+
+## Public errors
+
+- Expected safe failures MUST preserve their public code, message, retryability,
+  suggested action, and exit code.
+- Unexpected failures MUST NOT expose stack traces, SQL, paths, tokens, provider
+  bodies, or internal exception messages.
+- Invalid shared pagination values MUST return `USAGE_ERROR` with exit code `2`.
+
+## Field selection
+
+- One unknown field among valid fields MUST fail with `acceptedFields`.
+- Only unknown fields MUST fail instead of returning empty objects.
+- An empty result set MUST still validate requested fields.
+- These checks apply to `agents list` in this foundation PR and to each command
+  only after its domain declares a stable accepted field set.
+
+## Effect metadata and brakes
+
+- Agent-discoverable command manifests MUST include operation kind, effect
+  class, risk, and confirmation requirement.
+- The host runtime dynamic-tool catalog MUST preserve the same safety metadata
+  instead of stripping it during projection.
+- Legacy mutations without a reviewed effect class MUST be exported as
+  `unclassified` with `classificationSource: legacy-unclassified`; they MUST NOT
+  default to a safe class.
+- The shared brake MUST have a native synthetic proof. Each real command
+  requiring confirmation MUST add a domain-owned proof that its unconfirmed
+  path performs no effect before leaving `unclassified`.
+- A command's exported metadata MUST match its registered decorators and actual
+  brake behavior.
+
+## SDK drift portability
+
+- Generated SDK comparison MUST accept only line-ending conversion and the
+  already-informational `GIT_SHA` difference.
+- Added, removed, or changed source content MUST continue to fail the drift
+  check on every platform.
+
+## Commands
+
+- `bun test src/cli/commands/usage-exit.smoke.test.ts`
+- `bun test src/cli/process-output.native.test.ts`
+- `bun test src/cli/agent-contract.foundation.test.ts`
+- `bun test src/runtime/host-services.foundation.test.ts`
+- `bun test src/cli/pagination.test.ts`
+- `bun test src/cli/tools-export.test.ts`
+- `bun test src/cli/confirmation-policy.test.ts`
+- `bun run test:agent-contract`
+- `bun run test:sdk`
+- `bun test src/sdk/client-codegen/codegen.test.ts`
+- `bun run sdk:check`
+- `bun run build`
+- `bun run typecheck`

--- a/.ravi/specs/cli/foundation/CHECKS.md
+++ b/.ravi/specs/cli/foundation/CHECKS.md
@@ -4,6 +4,10 @@
 
 - A native process test MUST parse a piped JSON response larger than 64 KiB.
 - Success and failure paths MUST complete pending output before process exit.
+- A permanently stuck stream MUST hit a bounded flush timeout without a busy
+  loop, and termination MUST still complete.
+- Native child-process checks MUST kill and observe a timed-out child before
+  returning, so a failed check cannot leave an orphan process.
 - The test MUST exercise the real CLI process boundary.
 - Direct `fail()` termination MUST route through the top-level flush boundary.
 - Native isolated tool tests with `RAVI_SUPPRESS_AUDIT_EVENTS=1` MUST NOT contact

--- a/.ravi/specs/cli/foundation/RUNBOOK.md
+++ b/.ravi/specs/cli/foundation/RUNBOOK.md
@@ -7,6 +7,9 @@
    parsed.
 3. If the payload is incomplete, inspect the common output writer and all
    immediate `process.exit()` paths before changing a domain command.
+4. If a process remains alive with no output progress, confirm that the common
+   writer reaches its five-second flush bound and that termination runs from the
+   guaranteed cleanup path. Never replace the bound with an unbounded poll.
 
 The migrated boundary covers registered one-shot CLI commands. The remaining
 direct exits are explicit lifecycle exceptions: daemon log/follow callbacks,

--- a/.ravi/specs/cli/foundation/RUNBOOK.md
+++ b/.ravi/specs/cli/foundation/RUNBOOK.md
@@ -1,0 +1,46 @@
+# Agent-first CLI foundation / RUNBOOK
+
+## Diagnose an incomplete response
+
+1. Re-run the command with `--json` and stdout redirected through a pipe.
+2. Confirm that the process exits only after the complete JSON document can be
+   parsed.
+3. If the payload is incomplete, inspect the common output writer and all
+   immediate `process.exit()` paths before changing a domain command.
+
+The migrated boundary covers registered one-shot CLI commands. The remaining
+direct exits are explicit lifecycle exceptions: daemon log/follow callbacks,
+interactive setup/session loops, instance connection listeners, and spawned
+service callbacks. They do not establish the output guarantee for structured
+one-shot responses and must be migrated and tested in their owning domain PRs.
+
+## Diagnose a generic error
+
+1. Decide whether the failure is expected and safe to disclose.
+2. Expected validation failures use a typed public error with a domain code.
+3. Caller mistakes use `USAGE_ERROR` and exit code `2`.
+4. Unexpected exceptions keep a generic public message; inspect protected logs
+   for internal details.
+
+## Diagnose field selection
+
+1. Read `acceptedFields` from the command's usage-error envelope.
+2. Retry with only declared public fields.
+3. If unknown fields succeed on an empty result set, validation is occurring too
+   late and the foundation contract has regressed.
+
+## Diagnose a confirmation mismatch
+
+1. Inspect the exported effect, risk, and confirmation metadata.
+2. Run the command without confirmation against an isolated native test state.
+3. Verify that no database write, event, provider call, child process, or remote
+   request occurred.
+4. Treat a metadata-only pass as a failed safety check.
+
+## Diagnose catalog drift
+
+1. Compare `ravi tools ... --json` with the host runtime dynamic-tool catalog.
+2. Confirm both surfaces carry operation kind, effect class, risk,
+   confirmation requirement, and classification source.
+3. Treat `unclassified` as an unresolved migration state, never as permission
+   to execute without the command's existing authorization and brake.

--- a/.ravi/specs/cli/foundation/SPEC.md
+++ b/.ravi/specs/cli/foundation/SPEC.md
@@ -41,6 +41,9 @@ belongs to this capability; business rules remain in domain specs.
   boundary before pending stdout, stderr, audit, and required transport work has
   completed or failed explicitly. Interactive loops and child-process lifecycle
   callbacks remain explicit migration exceptions listed in `RUNBOOK.md`.
+- Output flushing MUST be bounded. A stream that never reports progress MUST
+  time out without busy-spinning, and the requested process termination MUST
+  still occur so a broken pipe cannot hold the CLI indefinitely.
 - Large JSON responses MUST be emitted as one complete document when stdout is
   a pipe.
 - Expected failures MUST carry a public, typed, non-secret message. Unexpected
@@ -104,6 +107,9 @@ for a read, or retained as a legacy unknown.
 
 - A native process test receives a valid JSON payload larger than 64 KiB through
   a pipe with no truncation and exit code `0`.
+- A synthetic stuck stream reaches its bounded timeout without holding the
+  process, and a native timed-out child is killed and observed before the test
+  returns.
 - Expected safe messages remain visible; unexpected internal messages do not
   leak.
 - Unknown `--fields` values fail before projection with `acceptedFields` and

--- a/.ravi/specs/cli/foundation/SPEC.md
+++ b/.ravi/specs/cli/foundation/SPEC.md
@@ -1,0 +1,117 @@
+---
+id: cli/foundation
+title: Agent-first CLI foundation
+kind: capability
+domain: cli
+capabilities:
+  - output-integrity
+  - public-errors
+  - field-selection
+  - pagination
+  - effect-metadata
+tags:
+  - cli
+  - agent-first
+  - safety
+applies_to:
+  - src/cli
+  - src/permissions/scope.ts
+  - src/runtime/host-services.ts
+  - src/runtime/types.ts
+  - src/sdk/client-codegen
+owners:
+  - ravi-dev
+status: draft
+normative: true
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# Agent-first CLI foundation
+
+## Intent
+
+Agent consumers must be able to trust that a completed CLI process delivered a
+complete response with a stable meaning. Shared transport and contract behavior
+belongs to this capability; business rules remain in domain specs.
+
+## Invariants
+
+- A registered one-shot CLI command MUST NOT terminate at its top-level command
+  boundary before pending stdout, stderr, audit, and required transport work has
+  completed or failed explicitly. Interactive loops and child-process lifecycle
+  callbacks remain explicit migration exceptions listed in `RUNBOOK.md`.
+- Large JSON responses MUST be emitted as one complete document when stdout is
+  a pipe.
+- Expected failures MUST carry a public, typed, non-secret message. Unexpected
+  failures MUST retain a generic public message and keep internal details out of
+  the response.
+- Caller mistakes MUST use `USAGE_ERROR` and exit code `2`. Operational or
+  domain failures, including unavailable retryable dependencies, MUST use exit
+  code `1`; retryability is carried separately in the envelope. Exit code `3`
+  is reserved for policy or confirmation blocks that prevent an effect safely.
+- A domain command migrated to strict field selection MUST validate against a
+  stable public field set before projecting records. For those migrated
+  commands, any unknown field MUST fail with `USAGE_ERROR`, exit code `2`, and
+  `acceptedFields`, including when the result set is empty. Legacy callers of
+  `pickFields` remain permissive until their domain pull request supplies the
+  accepted field set.
+- Pagination inputs MUST be validated before querying. Invalid limits, offsets,
+  or cursors MUST fail as usage errors rather than operational failures.
+- SDK drift checks MUST ignore checkout-only CRLF/LF conversion while still
+  rejecting any source-content difference.
+- Existing offset pagination responses MUST remain backward compatible while a
+  domain is migrated. Mutable operational datasets SHOULD adopt cursor-based
+  continuation in their domain pull request.
+- Every public command MUST expose its operation kind, effect class, risk, and
+  confirmation requirement through agent-discoverable command manifests and
+  the host runtime's dynamic-tool catalog. Unreviewed mutations MUST remain
+  visibly `unclassified`.
+- A command that declares confirmation MUST be proven to stop before its first
+  effect when confirmation is absent. Metadata alone MUST NOT count as a brake.
+
+## Ownership boundary
+
+The foundation owns one-shot command writers and termination, public error
+types, shared validators, manifest fields, runtime catalog propagation, and
+structural checks. A domain owns resource-specific error codes, accepted fields,
+query ordering, cursor construction, effect classification, read-back, and
+recovery. Interactive loops and child-process lifecycle callbacks remain owned
+by their commands until their domain migration.
+
+## Safety metadata
+
+The public `effectClass` vocabulary is:
+
+- `none` for reads;
+- `local-reversible` for immediate local writes with a defined inverse;
+- `external` for communication, publication, sharing, or provider state;
+- `destructive` for irreversible removal or secret rotation;
+- `authority-expansion` for added permission or exposure;
+- `triggered-work` for work that continues independently;
+- `containment` for immediate authority reduction or emergency stop;
+- `cost-threshold` when a trustworthy estimate reaches a configured limit;
+- `conditional` when the invocation determines whether an effect is material;
+- `unclassified` for legacy mutations awaiting domain review.
+
+`unclassified` MUST remain visible and MUST NOT be interpreted as safe. At this
+draft stage, real legacy mutations are expected to remain unclassified; domain
+pull requests replace that value with a declared class and prove their actual
+brake. `classificationSource` reports whether the value was declared, inferred
+for a read, or retained as a legacy unknown.
+
+## Acceptance criteria
+
+- A native process test receives a valid JSON payload larger than 64 KiB through
+  a pipe with no truncation and exit code `0`.
+- Expected safe messages remain visible; unexpected internal messages do not
+  leak.
+- Unknown `--fields` values fail before projection with `acceptedFields` and
+  exit code `2` for the migrated `agents list` surface; each domain adds the
+  same proof when it migrates its own field sets.
+- Invalid shared pagination inputs use `USAGE_ERROR` and exit code `2`.
+- Exported command definitions contain effect, risk, and confirmation metadata.
+- A synthetic structural confirmation test proves the shared brake mechanism
+  stops before its first effect. Every real mutation remains subject to a
+  domain-owned no-effect proof before its classification can leave
+  `unclassified`.

--- a/.ravi/specs/cli/foundation/WHY.md
+++ b/.ravi/specs/cli/foundation/WHY.md
@@ -1,0 +1,29 @@
+# Agent-first CLI foundation / WHY
+
+The same defects were found across multiple domain dossiers. Output integrity,
+error taxonomy, field validation, pagination validation, and risk discovery are
+transport concerns, so fixing them independently in every domain would create
+different meanings for the same CLI behavior.
+
+The foundation is deliberately narrow. It does not decide whether a domain
+operation is safe, reversible, external, destructive, or authority-bearing. It
+provides the language and enforcement points; each domain supplies the facts.
+
+Large-output validation stays in the repository's native process tests. This
+exercises the real pipe and termination path without introducing a separate
+test-bench methodology or committed bench artifacts.
+
+Backward compatibility is preserved for existing pagination envelopes during
+the migration. Cursor pagination is preferred for mutable datasets, but each
+domain must define a stable ordering and cursor before switching its public
+contract.
+
+Shared numeric pagination no longer clamps values above the declared maximum.
+It returns a usage error so callers cannot mistake a different page size for
+the one they requested. This is a deliberate public behavior change; response
+envelopes and valid values remain compatible.
+
+The foundation starts as `draft`. Reads can be inferred as no-effect, while
+legacy mutations remain visibly `unclassified`. Promotion to `active` happens
+only after the official gates pass and domain PRs have supplied the real effect
+classification and no-effect proofs they own.

--- a/.ravi/specs/commands/CHECKS.md
+++ b/.ravi/specs/commands/CHECKS.md
@@ -7,8 +7,6 @@ status: draft
 normative: false
 ---
 
-# Ravi Commands Checks
-
 ## Unit Coverage
 
 - Parser accepts `#abc`, `#abc-123`, mixed-case input, and trailing arguments.
@@ -27,6 +25,11 @@ normative: false
 - Channel message `#command args` dispatches one composed prompt to the resolved session.
 - CLI/session message `#command args` follows the same path as channel messages.
 - `ravi commands run <name> -- <args>` returns the composed prompt preview and does not dispatch to a session.
+- Every operator operation is deterministic against unchanged files and does
+  not write command, config, session, or runtime state.
+- Empty/invalid operator names and invalid pagination are typed usage errors;
+  unknown fields never produce `{}` with exit 0.
+- Bare `ravi commands` prints operation discovery help and exits 0.
 - Unknown command passes through as ordinary chat without command expansion.
 - Invalid command name fails before provider handoff.
 - Disabled command fails before provider handoff.

--- a/.ravi/specs/commands/RUNBOOK.md
+++ b/.ravi/specs/commands/RUNBOOK.md
@@ -7,8 +7,6 @@ status: draft
 normative: false
 ---
 
-# Ravi Commands Runbook
-
 ## Add a Global Command
 
 ```bash
@@ -38,13 +36,16 @@ If the same command exists globally, the agent command shadows it.
 ## Inspect Resolution
 
 ```bash
+ravi commands
 ravi commands list --agent <agent> --json
+ravi commands list --agent <agent> --limit 50 --offset 0 --fields id,scope --json
 ravi commands show review-pr --agent <agent> --json
-ravi commands run review-pr --agent <agent> -- 123 high
+ravi commands run review-pr --agent <agent> --json -- 123 high
 ```
 
 Check:
 
+- bare group help exits 0 and lists the four operations;
 - selected source scope;
 - source path;
 - whether another command is shadowed;
@@ -64,7 +65,7 @@ Unknown commands are passed through as ordinary chat text. If a `#name` did not 
 
 ## Debug a Bad Prompt
 
-1. Run `ravi commands show <name> --agent <agent> --json` and inspect the rendered preview.
+1. Run `ravi commands run <name> --agent <agent> --json -- <args>` and inspect the rendered preview.
 2. Check placeholder spelling: `$ARGUMENTS`, `$ARGUMENTS[0]`, `$0`, or named args declared in `arguments`.
 3. Inspect `ravi sessions trace <session> --json` for command metadata.
 4. Confirm the composed prompt, not the raw command text, was dispatched.

--- a/.ravi/specs/commands/SPEC.md
+++ b/.ravi/specs/commands/SPEC.md
@@ -24,8 +24,6 @@ status: draft
 normative: true
 ---
 
-# Ravi Commands
-
 ## Intent
 
 Ravi Commands are user-invoked prompt templates. A command expands a Markdown file into a composed prompt and sends that prompt to the resolved Ravi agent through the normal session runtime.
@@ -153,7 +151,7 @@ The durable user message and session trace MUST retain command metadata so the e
 The operator CLI SHOULD expose:
 
 ```bash
-ravi commands list [--agent <agent>] [--json]
+ravi commands list [--agent <agent>] [--limit <n>] [--offset <n>] [--fields <a,b,c>] [--json]
 ravi commands show <name> [--agent <agent>] [--json]
 ravi commands validate [--agent <agent>] [--json]
 ravi commands run <name> [--agent <agent>] [--json] -- <arguments>
@@ -162,6 +160,14 @@ ravi commands run <name> [--agent <agent>] [--json] -- <arguments>
 `ravi commands run` MUST render and return the composed prompt only. It MUST NOT publish to a session or start runtime execution.
 
 All machine-consumed outputs MUST support `--json`.
+
+The operator surface is a pure read boundary. Name and pagination mistakes
+MUST use the typed usage taxonomy, and unknown compact fields MUST fail rather
+than return empty objects with success. The normative CLI details and stable
+field set live in `cli/commands`.
+
+Bare `ravi commands` MUST act as successful operation discovery: print group
+help and exit 0.
 
 ## Non-Goals
 
@@ -179,6 +185,8 @@ All machine-consumed outputs MUST support `--json`.
 - `#review-pr 123 high` renders `$ARGUMENTS`, `$ARGUMENTS[0]`, `$0`, and named placeholders correctly.
 - Unknown commands are ordinary chat and dispatch without command expansion.
 - Invalid command names return structured errors without dispatching to the model.
+- Repeating an unchanged operator call returns deterministic values and does
+  not modify command files, config, sessions, or runtime transport.
 - Unsupported frontmatter cannot grant tools or change runtime settings.
 - Editing a command file is visible without daemon restart.
 - The session trace can show which command produced a prompt and where the Markdown came from.

--- a/.ravi/specs/commands/WHY.md
+++ b/.ravi/specs/commands/WHY.md
@@ -7,8 +7,6 @@ status: draft
 normative: false
 ---
 
-# Why Ravi Commands Exist
-
 Ravi already has CLIs, skills, task profiles, hooks, triggers, and cron. Commands fill a narrower gap: a human wants to type a short token in a chat or session and expand it into a known prompt for the same agent.
 
 The design intentionally follows the file-backed Markdown pattern used by coding agents:
@@ -31,6 +29,12 @@ Ravi should not copy the risky parts by default:
 - Commands do not auto-load like skills.
 - Commands do not change provider model or runtime settings.
 
+The operator CLI is intentionally narrower than channel execution. Its `run`
+operation is a read-only preview, and its agent-first contract is normative in
+`cli/commands`. The future conversational facade remains deferred until its
+revision, integrity, shadowing, materiality, and engine-routing decisions are
+explicit.
+
 ## Why `#` Instead of `/`
 
 Ravi runs in channels where `/` can collide with platform UX, provider-native slash commands, or ordinary text. `#name` gives Ravi its own command namespace while still being quick to type on mobile.
@@ -48,6 +52,6 @@ This lets `#review` mean one thing for a dev agent and another for a support age
 
 ## References
 
-- Claude Code skills/commands docs: https://code.claude.com/docs/en/slash-commands
-- OpenAI Codex CLI slash commands docs: https://developers.openai.com/codex/cli/slash-commands
-- Codex custom prompt issue example: https://github.com/openai/codex/issues/15941
+- [Claude Code skills and commands](https://code.claude.com/docs/en/slash-commands)
+- [OpenAI Codex CLI slash commands](https://developers.openai.com/codex/cli/slash-commands)
+- [Codex custom prompt issue example](https://github.com/openai/codex/issues/15941)

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1439,3 +1439,21 @@ reproduzidas na `dev` no Windows. O pacote instalavel local tem SHA-256
 Este GO autoriza commit, push e abertura da PR. A spec permanece `draft` e
 qualquer merge ou uso na VPS continua condicionado a CI Linux verde no commit
 exato e a autorizacao humana de implantacao.
+
+### Correcao da espera de saida sem limite
+
+A auditoria posterior ao primeiro commit encontrou uma espera sem prazo quando
+o Bun mantinha o indicador de buffer ativo. A fundacao passou a verificar o
+progresso em intervalos curtos, interromper a espera depois de cinco segundos,
+garantir a terminacao em `finally` e remover a segunda descarga no encerramento
+global.
+
+O teste nativo agora cobre stream permanentemente preso e processo-filho que
+excede seu prazo, alem dos caminhos reais de JSON maior que 64 KiB, falha e
+versao. O recorte focado passou com 22 testes e 91 assercoes; metadados,
+paginacao e runtime passaram com 27 testes e 107 assercoes; `test:sdk` passou
+com 75 testes e 297 assercoes, seguido de `sdk:check`. Typecheck, build, quality
+gate dos 34 caminhos e lint documental tambem passaram.
+
+O GO anterior fica superado pela mudanca de codigo. Novo commit, pacote e
+revisao independente do SHA exato sao obrigatorios antes de push e PR.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1509,3 +1509,80 @@ O primeiro `biome check` apontou apenas finais de linha misturados nos dois
 arquivos SDK editados no Windows. A formatacao oficial corrigiu o problema; o
 check e os 20 testes dos arquivos formatados passaram. Novo SHA, pacote, revisao
 independente e CI Linux verde continuam obrigatorios.
+
+### COMMANDS read-only agent-first - incremento local
+
+**Base:** `560517a43248c3798f82e3da98c088df0743016e`. O slice cobre
+`commands list`, `show`, `validate` e `run`; nenhuma operacao escreve e `run`
+continua sendo somente preview do prompt. A fachada conversacional proposta no
+dossie foi adiada porque revisao do registry, integridade do envelope,
+sombreamento real, materialidade e roteamento de engine ainda exigem decisao.
+
+**Contrato implementado:** nome vazio/invalido vira
+`INVALID_COMMAND_NAME`, exit 2, antes da resolucao do agente; paginacao invalida
+preserva o `USAGE_ERROR`, exit 2, da fundacao; `--fields` usa um conjunto
+estavel de 13 campos e rejeita qualquer desconhecido, inclusive misturado ou
+com lista vazia. Permanecem compativeis nomes sem distincao de caixa e com `#`,
+`items` igual a `commands`, veredito exit 1 de `validate` e
+`renderedPromptSha256`.
+
+**Evidencia nativa:** contrato do handler 24/24, 93 assercoes; registro e
+renderer 7/7, 24 assercoes; processo real isolado 9/9, 33 assercoes. O grupo
+sem subcomando imprimiu help com exit 0. As quatro
+operacoes preservaram hashes dos command files e o digest logico final de
+agente, rotas e sessoes; auditoria NATS ficou suprimida no processo isolado.
+Os testes proporcionais da fundacao de registry passaram 27/27, com 76
+assercoes. Codegen e `sdk:check`, typecheck, build integral, Biome dos seis
+arquivos TS, markdownlint dos dez documentos e quality gate explicito dos 18
+caminhos passaram. A geracao atualizou a descricao de `--fields` no schema SDK
+e o hash de registry/versionamento derivado.
+
+**Estado:** implementacao local pronta para revisao, sem commit, push, PR ou
+VPS. A fachada futura e as decisoes acima permanecem fora deste incremento.
+
+### Correcao da divergencia dos contratos gerados
+
+A verificacao independente do handoff encontrou os dois snapshots OpenAPI e
+cinco artefatos Swift divergentes do registry vivo, apesar do relato anterior
+de que estavam atuais. O TypeScript SDK estava sincronizado, mas isso nao prova
+as outras superficies. A candidata voltou para **NO-GO** sem commit, pacote,
+push, PR ou acesso remoto.
+
+Os dois OpenAPI e todos os arquivos Swift foram regenerados pelos comandos
+oficiais. O incidente esta em
+`docs/postmortems/0002-commands-generated-contract-drift.md`. Checks de drift,
+SDK e gates finais devem ser repetidos antes de qualquer promocao.
+
+### Fechamento local da divergencia gerada de COMMANDS
+
+Depois da regeneracao oficial, os dois checks OpenAPI e o check deterministico
+do SDK Swift passaram separadamente. O SDK completo passou 75 testes com 297
+assercoes e `sdk:check` verde. O recorte de commands foi repetido e passou 40
+testes com 150 assercoes, incluindo nove casos de processo real isolado.
+
+Typecheck, build integral, Biome focado, lint dos nove documentos aplicaveis e
+quality gate dos 23 caminhos com 274 specs indexadas tambem passaram. Isso
+fecha apenas a correcao local do drift. Commit exato, pacote, nova auditoria
+independente e CI Linux ainda sao obrigatorios antes de push ou PR; merge e VPS
+continuam fora deste checkpoint.
+
+Uma recaptura posterior do Biome encontrou finais de linha Windows no arquivo
+compartilhado de schemas depois da geracao. O formatador oficial normalizou
+somente esse arquivo, sem mudanca semantica. O Biome focado e os 40 testes de
+commands foram repetidos; as 150 assercoes passaram. A evidencia de estilo e
+teste anterior a essa normalizacao nao e usada como captura final.
+
+### Recaptura final do coordenador para COMMANDS
+
+O recorte final passou 40 testes com 150 assercoes e typecheck. A primeira
+execucao do SDK sob carga paralela teve timeout em dois hooks inalterados de
+cinco segundos e foi descartada; a repeticao isolada passou os 75 testes com
+297 assercoes e `sdk:check`.
+
+Passaram tambem os dois checks OpenAPI, o check deterministico Swift, build
+integral, Biome dos seis fontes de commands/framework, lint dos 11 documentos
+alterados localmente, `git diff --check`, os 40 testes nativos do quality gate e
+o runner sobre 56 caminhos acumulados da foundation e do dominio. Foram
+indexadas 274 specs, com aprovacao de `cli/commands`, `cli/foundation` e
+`commands`. O drift gerado esta fechado localmente. Ainda faltam commit exato,
+pacote, auditoria independente e CI Linux; nao houve push, PR, merge ou VPS.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1457,3 +1457,30 @@ gate dos 34 caminhos e lint documental tambem passaram.
 
 O GO anterior fica superado pela mudanca de codigo. Novo commit, pacote e
 revisao independente do SHA exato sao obrigatorios antes de push e PR.
+
+### Primeira CI Linux da PR 426
+
+O run Linux `32450827025` do SHA
+`677cd83857fe6b6d2f92e66b3fd2dd61d4928f3c` passou pela suite de canais e
+avancou ate os testes da CLI, mas falhou ao carregar sincronamente o bundle do
+daemon. O top-level await adicionado pela fronteira de saida tornou o bundle
+incompativel com o `require` usado pelo PM2, embora a execucao direta local
+continuasse funcional.
+
+O caminho de versao foi movido para `bootstrapCli` e a promessa raiz voltou a
+ser iniciada sem top-level await. A CI vermelha invalida o GO e o pacote do SHA
+anterior. Nova validacao integral, pacote, revisao independente e CI Linux sao
+obrigatorios.
+
+Na revalidacao local, uma selecao ampliada incluiu indevidamente
+`src/runtime/codex-provider.test.ts`: 20 casos de scripts `.mjs` temporarios
+falharam com `ENOENT` no Windows e 50 passaram. O recorte correto da fundacao,
+sem esse arquivo alheio, passou com 27 testes e 107 assercoes. A suite integral
+permanece sob autoridade da CI Linux do novo SHA.
+
+O bundle corrigido foi carregado sincronamente por `require` e `daemon status`
+terminou com codigo 0. O recorte de saida e erros passou com 23 testes e 93
+assercoes; o SDK completo passou com 75 testes e 297 assercoes, seguido de
+`sdk:check`. Typecheck, build integral, quality gate dos 34 caminhos e lint
+documental tambem passaram. O fechamento ainda depende de commit exato, revisao
+independente, novo pacote e CI Linux verde no mesmo SHA.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1606,3 +1606,20 @@ de configuracao sem inicializacao ou escrita, impedir auditoria por politica
 declarada do dominio, comparar todos os arquivos e tabelas relevantes, testar o
 help compartilhado e regenerar todos os contratos. O candidato rejeitado fica
 em NO-GO definitivo.
+
+### Recaptura do substituto de COMMANDS
+
+O substituto removeu campos ocultos, publicou schema de projecao parcial
+estrito, passou o retorno por round-trip JSON e usa leitura SQLite dedicada sem
+inicializacao ou escrita. CLI, tool e gateway compartilham `audit: none`; a
+politica agora recusa esse opt-out fora de leituras de baixo risco e efeito
+`none`.
+
+Passaram nove testes de processo com 51 assercoes sem supressao de auditoria,
+41 testes isolados de gateway com 171 assercoes, 12 testes do router com 60
+assercoes, 75 testes SDK com 297 assercoes, build, typecheck, Biome, Markdown e
+todos os checks gerados. Uma captura paralela do gateway teve dois timeouts e
+foi descartada; a repeticao isolada passou. O primeiro quality gate bloqueou a
+falta do teste aprovado de router; depois dos dois casos nativos, o runner
+passou sobre 35 caminhos e indexou 274 specs. Commit, pacote, auditoria
+independente e CI Linux ainda sao obrigatorios; segue NO-GO para push ou PR.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1388,3 +1388,54 @@ TypeScript/Swift foram alinhados em commit dedicado, com `GIT_SHA` preservado.
 Por instrucao explicita do operador, nenhum Bun foi executado localmente. O
 head final com este registro e os snapshots atualizados ainda precisa passar a
 CI completa antes de restaurar o veredito **APPROVE**.
+
+---
+
+## FASE 9 - fundacao compartilhada de CLI agent-first (2026-08-21)
+
+Esta fase inicia em estado **DRAFT**. Ela adiciona a fronteira comum de saida,
+erros publicos tipados, validadores de campos e paginacao e metadados
+descobríveis de operacao, efeito, risco e confirmacao. As regras de negocio e a
+prova de ausencia de efeito de cada mutacao continuam pertencendo aos PRs de
+dominio.
+
+A primeira candidata foi classificada como **NO-GO** pela revisao independente:
+os gates `test:agent-contract` e `test:sdk` excederam limites de tempo, os dois
+testes centrais novos nao estavam listados em `CHECKS.md` e a spec prometia
+rigidez de campos e classificacao real alem do recorte migrado. O ocorrido esta
+registrado em `docs/postmortems/0001-cli-foundation-gates-no-go.md`.
+
+O recorte factual desta fase e:
+
+- `agents list` e o primeiro comando com campos estritos; os demais permanecem
+  legados ate o PR de seu dominio;
+- leituras sao projetadas como `none`, enquanto mutacoes sem revisao permanecem
+  visivelmente `unclassified`;
+- a prova sintetica valida o mecanismo comum de freio, nao substitui a prova de
+  uma mutacao real;
+- a fronteira de flush cobre comandos registrados de execucao unica; loops
+  interativos e callbacks de ciclo de vida permanecem excecoes declaradas;
+- o limite maximo de paginacao deixa de ser reduzido silenciosamente e passa a
+  falhar como erro de uso.
+
+Promocao para `active`, commit, push e PR ficam condicionados aos gates oficiais
+aplicaveis e a uma nova revisao independente do SHA exato.
+
+### Terceira revisao independente e liberacao para PR
+
+A terceira revisao independente classificou a candidata local como
+**CLOSABILITY_READY · INDEPENDENTLY_VERIFIED · LIVE_UNAUTHORIZED**. Ela
+confirmou a supressao NATS em chamadas permitidas e negadas, a mascara restrita
+ao literal de `GIT_SHA`, a taxonomia de exit e a coerencia entre codigo, Ravi
+Spec, ADR, runbook e postmortem.
+
+No estado aprovado, `test:sdk` passou com 75 testes e 297 assercoes,
+`tools-export` com 14 testes e 65 assercoes, typecheck, build, quality gate
+sobre 34 caminhos e lint documental passaram. O `test:agent-contract` passou
+fora das mesmas duas falhas de portabilidade de `artifacts/store.test.ts`
+reproduzidas na `dev` no Windows. O pacote instalavel local tem SHA-256
+`581CA4862028E0A91C5025B9AE575188F8E16C1AA857731088F13DE436DF4B75`.
+
+Este GO autoriza commit, push e abertura da PR. A spec permanece `draft` e
+qualquer merge ou uso na VPS continua condicionado a CI Linux verde no commit
+exato e a autorizacao humana de implantacao.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1666,3 +1666,47 @@ nao possui o executavel Swift, entao compilacao Swift local nao foi declarada;
 o teste nativo do gerador passou. Nao houve pacote, push, PR ou VPS. O novo
 commit continuara NO-GO ate auditoria independente, novo pacote e validacao
 posterior autorizada.
+
+### NO-GO independente do candidato `aec8c019`
+
+A nova auditoria confirmou que os bloqueadores de projecao, auditoria e
+contratos gerados foram corrigidos, mas rejeitou o commit
+`aec8c0196aab68b15f283092e1a9119db90b38da` por dois gaps de prova. O contrato
+exigia identidade de bytes do `ravi.db-shm`, embora esse arquivo seja indice
+efemero de coordenacao do SQLite e possa mudar durante leitura segura com o
+daemon escrevendo em WAL. O teste tambem abria uma leitora logica antes de
+capturar os hashes, o que podia mascarar a primeira coordenacao.
+
+A fronteira corrigida protege fontes de comandos, todas as linhas logicas e
+todos os arquivos duraveis, incluindo DB e WAL. O `-shm` fica explicitamente
+fora da identidade de estado duravel, e uma prova nativa mantem uma conexao
+escritora WAL aberta enquanto o processo real executa. O teste OpenAPI do
+registro vivo, que estourava o timeout padrao de cinco segundos neste host,
+agora declara 30 segundos nos dois casos pesados e passa pelo comando normal.
+
+A primeira fixture WAL falhou porque inseriu uma configuracao sem o campo
+obrigatorio `updated_at`; essa captura foi descartada. Com a fixture corrigida,
+o arquivo de processo passou 11 testes/57 assercoes e o OpenAPI normal passou
+22 testes/61 assercoes. Ainda nao existe novo commit candidato. Gates integrais,
+nova revisao independente, pacote e CI Linux continuam obrigatorios; nao houve
+push, PR ou VPS.
+
+### Recaptura dos gates apos a correcao concorrente
+
+Passaram 93 testes focados de COMMANDS, AGENTS, renderer e fundacao com 303
+assercoes; 11 testes de processo com 57 assercoes; 12 do router com 60; 41 do
+gateway com 171; seis de saida nativa com 19; e 22 do OpenAPI normal com 61.
+O SDK passou 76 testes/305 assercoes. Os dois snapshots OpenAPI, o check Swift,
+typecheck, build, Biome, Markdown e `git diff --check` tambem passaram.
+
+A primeira chamada local do quality runner foi invalida porque o fallback
+procura `origin/main`, referencia ausente neste worktree. Com os 43 caminhos
+exatos fornecidos por `CHANGED_FILES`, o runner passou e indexou 274 specs; os
+40 testes nativos do proprio gate passaram com 90 assercoes.
+
+O encadeamento `test:agent-contract` passou todos os arquivos anteriores e
+parou em dois casos Windows do artifact store: uma expectativa de blob e a
+criacao de symlink negada por `EPERM`. O mesmo arquivo no commit exato da
+fundacao `560517a4` reproduziu as duas falhas. A suite ampla nao e declarada
+verde, mas a comparacao demonstra que essas duas falhas nao foram introduzidas
+por COMMANDS. A compilacao Swift segue reservada a CI Linux.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1638,3 +1638,31 @@ emitiram stderr, nao criaram arquivo de estado e nao alteraram o fixture. Como
 este registro muda o commit, o primeiro arquivo fica apenas como diagnostico;
 o pacote final deve ser reconstruido, rehashado, reinstalado e auditado no novo
 SHA antes de push ou PR.
+
+### NO-GO independente do candidato `d67ad42a`
+
+A auditoria read-only rejeitou o commit
+`d67ad42acbb3fe33c1c89d413f1c5f691a37b7a0` e o pacote herdado. A projecao
+honesta havia sido aplicada no helper compartilhado e quebrou a validacao
+estrita anterior ao JSON de AGENTS e de outros dominios compactos ainda nao
+migrados. O teste de processo tambem herdava
+`RAVI_SUPPRESS_AUDIT_EVENTS=1` do helper de estado, portanto nao provava
+transporte zero por `audit: none`. O refinamento de linha nao vazia funcionava
+em Returns, mas desaparecia do TypeScript e do OpenAPI gerados; Swift publicava
+o item como `RaviJSON`.
+
+A rodada corretiva restaura a compatibilidade do helper por padrao e ativa a
+projecao serializada somente em COMMANDS. Um teste nativo de AGENTS exige, ao
+mesmo tempo, Returns estrito valido antes da serializacao e JSON contendo apenas
+os campos pedidos. COMMANDS agora representa qualquer subconjunto nao vazio dos
+13 campos como uniao estrita; TypeScript e OpenAPI preservam cada alternativa,
+e Swift gera modelos tipados com rejeicao de linha vazia e campo desconhecido.
+
+O processo filho remove explicitamente `RAVI_SUPPRESS_AUDIT_EVENTS` e
+`RAVI_NO_AUDIT`. Os dez casos nativos passaram mantendo fontes, todos os
+arquivos de estado e todas as tabelas SQLite sem alteracao. Os artefatos SDK e
+OpenAPI foram regenerados e seus checks deterministas passaram. O host Windows
+nao possui o executavel Swift, entao compilacao Swift local nao foi declarada;
+o teste nativo do gerador passou. Nao houve pacote, push, PR ou VPS. O novo
+commit continuara NO-GO ate auditoria independente, novo pacote e validacao
+posterior autorizada.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1623,3 +1623,18 @@ foi descartada; a repeticao isolada passou. O primeiro quality gate bloqueou a
 falta do teste aprovado de router; depois dos dois casos nativos, o runner
 passou sobre 35 caminhos e indexou 274 specs. Commit, pacote, auditoria
 independente e CI Linux ainda sao obrigatorios; segue NO-GO para push ou PR.
+
+### Captura do pacote substituto de COMMANDS
+
+O commit `e78e106c5b63df66d16ecccec2f70e29ccfdc844` gerou pacote de
+4.945.479 bytes com SHA-256
+`C763E1991CDED3A0E2BD50A237FE2F0C6D8BEEB3C018A5239AC140BBB7D42845`.
+Uma instalacao vazia resolveu 367 pacotes; o Bun bloqueou dois postinstalls de
+dependencias pela politica padrao, mas instalou o binario e o bundle do Ravi.
+
+O bundle instalado passou help, list compacto, show, validate, preview de run,
+erro `COMMAND_NOT_FOUND` exit 1 e fields invalido exit 2. Os sete processos nao
+emitiram stderr, nao criaram arquivo de estado e nao alteraram o fixture. Como
+este registro muda o commit, o primeiro arquivo fica apenas como diagnostico;
+o pacote final deve ser reconstruido, rehashado, reinstalado e auditado no novo
+SHA antes de push ou PR.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1586,3 +1586,23 @@ o runner sobre 56 caminhos acumulados da foundation e do dominio. Foram
 indexadas 274 specs, com aprovacao de `cli/commands`, `cli/foundation` e
 `commands`. O drift gerado esta fechado localmente. Ainda faltam commit exato,
 pacote, auditoria independente e CI Linux; nao houve push, PR, merge ou VPS.
+
+### NO-GO independente do pacote COMMANDS
+
+A auditoria independente rejeitou o commit
+`d648b40691300af98818331313a7445b93ab1e90` e o pacote de 4.944.320 bytes com
+SHA-256
+`206A02D753F590AEF798A74DA80C93D93A0963EF0F0ED721A1E9B253A4C2F4AB`.
+Nada foi enviado ou usado para abrir PR.
+
+O `--fields` produzia registros parciais que os schemas publicados ainda
+tratavam como completos; propriedades nao enumeraveis mascaravam o erro antes
+do JSON real. As operacoes chamadas read-only tambem abriam SQLite gravavel,
+alteravam WAL/SHM e tentavam auditoria NATS. O teste de processo suprimia esses
+eventos e observava apenas parte do estado, deixando os efeitos escaparem.
+
+Novo candidato deve tornar a projecao honesta depois de serializar, usar leitura
+de configuracao sem inicializacao ou escrita, impedir auditoria por politica
+declarada do dominio, comparar todos os arquivos e tabelas relevantes, testar o
+help compartilhado e regenerar todos os contratos. O candidato rejeitado fica
+em NO-GO definitivo.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1450,7 +1450,7 @@ global.
 
 O teste nativo agora cobre stream permanentemente preso e processo-filho que
 excede seu prazo, alem dos caminhos reais de JSON maior que 64 KiB, falha e
-versao. O recorte focado passou com 22 testes e 91 assercoes; metadados,
+versao. O recorte focado passou com 23 testes e 93 assercoes; metadados,
 paginacao e runtime passaram com 27 testes e 107 assercoes; `test:sdk` passou
 com 75 testes e 297 assercoes, seguido de `sdk:check`. Typecheck, build, quality
 gate dos 34 caminhos e lint documental tambem passaram.

--- a/MIGRACAO-LEDGER.md
+++ b/MIGRACAO-LEDGER.md
@@ -1484,3 +1484,28 @@ assercoes; o SDK completo passou com 75 testes e 297 assercoes, seguido de
 `sdk:check`. Typecheck, build integral, quality gate dos 34 caminhos e lint
 documental tambem passaram. O fechamento ainda depende de commit exato, revisao
 independente, novo pacote e CI Linux verde no mesmo SHA.
+
+A segunda CI Linux, run `32451955010` no SHA
+`ec6d13ccdcbcdb90b7b8a224c90a4f8892e2af16`, passou build, typecheck e o teste
+sincrono do daemon, mas falhou em dois casos de `sdk.test.ts`. Catches antigos
+do SDK recapturavam o sinal privado de termino de `fail()` e substituiam a
+mensagem publica por `CLI termination requested.`.
+
+A correcao relanca a mesma instancia privada antes de qualquer conversao de
+erro e concentra todos os catches externos do SDK nesse funil. Os dois testes
+agora exigem codigo 1, exatamente uma mensagem publica e ausencia do texto
+interno. O recorte afetado passou com 26 testes e 74 assercoes. Os testes de
+comandos posteriores ao SDK tambem passaram; somente o cleanup de
+`tasks-profiles.test.ts` repetiu os tres `EBUSY` ja conhecidos da base Windows.
+O NO-GO permanece ate novo commit, pacote, revisao independente e CI Linux.
+
+Na revalidacao final da segunda correcao, contexto, sinal, saida nativa, SDK,
+ferramentas e gateway passaram com 86 testes e 310 assercoes. O processo real
+passou com 11 testes e 63 assercoes; o SDK completo passou com 75 testes e 297
+assercoes, seguido de `sdk:check`. Typecheck, build integral e quality gate dos
+36 caminhos passaram.
+
+O primeiro `biome check` apontou apenas finais de linha misturados nos dois
+arquivos SDK editados no Windows. A formatacao oficial corrigiu o problema; o
+check e os 20 testes dos arquivos formatados passaram. Novo SHA, pacote, revisao
+independente e CI Linux verde continuam obrigatorios.

--- a/docs/adr/0001-agent-first-cli-foundation.md
+++ b/docs/adr/0001-agent-first-cli-foundation.md
@@ -1,0 +1,76 @@
+# ADR 0001: Establish an agent-first CLI foundation before domain facades
+
+**Date:** 2026-08-21  
+**Status:** accepted
+
+## Context
+
+The domain audits found the same unresolved failures in multiple CLI surfaces:
+large JSON output can be lost during immediate process exit, known validation
+errors can become generic `COMMAND_FAILED` responses, unknown `--fields` values
+can succeed with empty objects, pagination contracts diverge, and effect risk is
+not consistently discoverable or enforced.
+
+Implementing these concerns independently in every domain would duplicate
+policy, create conflicting contracts, and make later domain pull requests depend
+on accidental merge order. The program also requires one pull request per
+domain, native repository tests, and no external test-bench artifacts.
+
+## Decision
+
+Create one prerequisite `cli/foundation` pull request before the 21 domain pull
+requests. It owns only shared transport and contract primitives:
+
+- reliable stdout and stderr completion before process termination;
+- typed public errors and the common exit taxonomy;
+- strict field-selection validation;
+- the common pagination envelope and validation rules;
+- discoverable effect, risk, and confirmation metadata with global consistency
+  checks.
+
+Each domain remains responsible for its public error codes, accepted fields,
+stable query ordering, effect classification, and facade behavior. A domain
+facade follows `plan -> apply -> verify -> recover` when the operation has
+effects that require confirmation or recovery; the foundation does not invent a
+single universal business facade.
+
+The foundation pull request is a prerequisite, not a second pull request for
+any domain. Every domain still receives exactly one domain pull request. Tests
+are added to the repository's native suites; no `tests/bench` structure is part
+of this program.
+
+## Alternatives considered
+
+- **Implement the shared behavior inside the first domain pull request.**
+  Rejected because unrelated domains would inherit a hidden dependency from a
+  domain-owned change, and review scope would mix shared policy with business
+  behavior.
+- **Repeat the helpers in each domain.** Rejected because contracts and fixes
+  would drift, and parallel pull requests would conflict in shared CLI files.
+- **Build one universal facade before any domain work.** Rejected because read,
+  local reversible writes, external effects, destructive operations, and
+  authority changes need different safeguards. Only the lifecycle vocabulary
+  is shared.
+- **Proceed without the foundation and reconcile later.** Rejected because the
+  known output and error defects would invalidate evidence produced by domain
+  CLIs.
+
+## Consequences
+
+- **Positive:** domain pull requests start from one explicit contract, reuse the
+  same safety primitives, and can be reviewed with comparable evidence.
+- **Positive:** large-output, error, pagination, and risk behavior is verified
+  once at the common boundary and then specialized by each domain.
+- **Cost:** the first domain pull request waits for the foundation to merge or
+  become a stable dependency branch.
+- **Cost:** domain branches must be rebased in controlled waves as prerequisite
+  pull requests merge.
+- **Cost:** the foundation needs a narrow review to prevent it from absorbing
+  business rules that belong to domains.
+
+## Notes
+
+This decision is based on the 2026-08-21 audit of `origin/dev` at
+`b6046936fce0b08add2253ca52974d4cde5f3e9f`. Deployment to the VPS remains a
+separate, serial operation that requires explicit approval and evidence from the
+exact package commit.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "2370946ba69718e6"
+    "version": "e2a5418c6acb56f9"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24142,7 +24142,7 @@
                     },
                     "commands": {
                       "items": {
-                        "additionalProperties": {},
+                        "additionalProperties": false,
                         "properties": {
                           "argumentHint": {
                             "anyOf": [
@@ -24269,21 +24269,6 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "token",
-                          "title",
-                          "description",
-                          "argumentHint",
-                          "arguments",
-                          "disabled",
-                          "scope",
-                          "path",
-                          "relativePath",
-                          "shadowedBy",
-                          "shadows",
-                          "issues"
-                        ],
                         "type": "object"
                       },
                       "type": "array"
@@ -24346,8 +24331,133 @@
                     },
                     "items": {
                       "items": {
-                        "additionalProperties": {},
-                        "properties": {},
+                        "additionalProperties": false,
+                        "properties": {
+                          "argumentHint": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "arguments": {
+                            "items": {},
+                            "type": "array"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "issues": {
+                            "items": {
+                              "additionalProperties": {},
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "level": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "scope": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "level",
+                                "code",
+                                "message",
+                                "id",
+                                "scope",
+                                "path"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "relativePath": {
+                            "type": "string"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "shadowedBy": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "shadows": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "title": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "token": {
+                            "type": "string"
+                          }
+                        },
                         "type": "object"
                       },
                       "type": "array"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "035eb8a0686f51ec"
+    "version": "2370946ba69718e6"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24106,7 +24106,7 @@
                     "type": "string"
                   },
                   "fields": {
-                    "description": "Compact mode: keep only these fields of each item",
+                    "description": "Compact fields: id,token,title,description,argumentHint,arguments,disabled,scope,path,relativePath,shadowedBy,shadows,issues",
                     "type": "string"
                   },
                   "limit": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "e2a5418c6acb56f9"
+    "version": "5b018e7b6d1479b9"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24133,149 +24133,438 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {},
+                  "additionalProperties": false,
                   "properties": {
                     "agent": {
-                      "additionalProperties": {},
-                      "properties": {},
+                      "additionalProperties": false,
+                      "properties": {
+                        "cwd": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "cwd"
+                      ],
+                      "title": "CommandsListAgent",
                       "type": "object"
                     },
                     "commands": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "argumentHint": {
-                            "anyOf": [
-                              {
+                        "allOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "argumentHint": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "arguments": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "disabled": {
+                                "type": "boolean"
+                              },
+                              "id": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "arguments": {
-                            "items": {},
-                            "type": "array"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
+                              "issues": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "level": {
+                                      "enum": [
+                                        "error",
+                                        "warning"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "scope": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "level",
+                                    "code",
+                                    "message",
+                                    "id",
+                                    "scope",
+                                    "path"
+                                  ],
+                                  "title": "CommandsListIssue",
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "disabled": {
-                            "type": "boolean"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "issues": {
-                            "items": {
-                              "additionalProperties": {},
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "id": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "level": {
-                                  "type": "string"
-                                },
-                                "message": {
-                                  "type": "string"
-                                },
-                                "path": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "scope": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                }
+                              "relativePath": {
+                                "type": "string"
                               },
-                              "required": [
-                                "level",
-                                "code",
-                                "message",
-                                "id",
-                                "scope",
-                                "path"
-                              ],
-                              "type": "object"
+                              "scope": {
+                                "type": "string"
+                              },
+                              "shadowedBy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "shadows": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "title": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "token": {
+                                "type": "string"
+                              }
                             },
-                            "type": "array"
+                            "type": "object"
                           },
-                          "path": {
-                            "type": "string"
-                          },
-                          "relativePath": {
-                            "type": "string"
-                          },
-                          "scope": {
-                            "type": "string"
-                          },
-                          "shadowedBy": {
+                          {
                             "anyOf": [
                               {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "shadows": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "title": {
-                            "anyOf": [
-                              {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "token": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "title": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "title"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "description": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "description"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "argumentHint": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "argumentHint"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "arguments": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "arguments"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "disabled"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "scope": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "scope"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "relativePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "relativePath"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadowedBy": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "shadowedBy"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadows": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "shadows"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "issues": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "level": {
+                                          "enum": [
+                                            "error",
+                                            "warning"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "message": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "scope": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "level",
+                                        "code",
+                                        "message",
+                                        "id",
+                                        "scope",
+                                        "path"
+                                      ],
+                                      "title": "CommandsListIssue",
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "issues"
+                                ],
+                                "type": "object"
                               }
                             ]
-                          },
-                          "token": {
-                            "type": "string"
                           }
-                        },
-                        "type": "object"
+                        ],
+                        "title": "CommandsListItem"
                       },
                       "type": "array"
                     },
+                    "filters": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "tag": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "tag"
+                      ],
+                      "title": "CommandsListFilters",
+                      "type": "object"
+                    },
                     "issues": {
                       "items": {
-                        "additionalProperties": {},
+                        "additionalProperties": false,
                         "properties": {
                           "code": {
                             "type": "string"
@@ -24291,6 +24580,10 @@
                             ]
                           },
                           "level": {
+                            "enum": [
+                              "error",
+                              "warning"
+                            ],
                             "type": "string"
                           },
                           "message": {
@@ -24325,150 +24618,434 @@
                           "scope",
                           "path"
                         ],
+                        "title": "CommandsListIssue",
                         "type": "object"
                       },
                       "type": "array"
                     },
                     "items": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "argumentHint": {
-                            "anyOf": [
-                              {
+                        "allOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "argumentHint": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "arguments": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "disabled": {
+                                "type": "boolean"
+                              },
+                              "id": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "arguments": {
-                            "items": {},
-                            "type": "array"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
+                              "issues": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "level": {
+                                      "enum": [
+                                        "error",
+                                        "warning"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "scope": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "level",
+                                    "code",
+                                    "message",
+                                    "id",
+                                    "scope",
+                                    "path"
+                                  ],
+                                  "title": "CommandsListIssue",
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "disabled": {
-                            "type": "boolean"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "issues": {
-                            "items": {
-                              "additionalProperties": {},
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "id": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "level": {
-                                  "type": "string"
-                                },
-                                "message": {
-                                  "type": "string"
-                                },
-                                "path": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "scope": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                }
+                              "relativePath": {
+                                "type": "string"
                               },
-                              "required": [
-                                "level",
-                                "code",
-                                "message",
-                                "id",
-                                "scope",
-                                "path"
-                              ],
-                              "type": "object"
+                              "scope": {
+                                "type": "string"
+                              },
+                              "shadowedBy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "shadows": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "title": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "token": {
+                                "type": "string"
+                              }
                             },
-                            "type": "array"
+                            "type": "object"
                           },
-                          "path": {
-                            "type": "string"
-                          },
-                          "relativePath": {
-                            "type": "string"
-                          },
-                          "scope": {
-                            "type": "string"
-                          },
-                          "shadowedBy": {
+                          {
                             "anyOf": [
                               {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "shadows": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "title": {
-                            "anyOf": [
-                              {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "token": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "title": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "title"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "description": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "description"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "argumentHint": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "argumentHint"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "arguments": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "arguments"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "disabled"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "scope": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "scope"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "relativePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "relativePath"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadowedBy": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "shadowedBy"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadows": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "shadows"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "issues": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "level": {
+                                          "enum": [
+                                            "error",
+                                            "warning"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "message": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "scope": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "level",
+                                        "code",
+                                        "message",
+                                        "id",
+                                        "scope",
+                                        "path"
+                                      ],
+                                      "title": "CommandsListIssue",
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "issues"
+                                ],
+                                "type": "object"
                               }
                             ]
-                          },
-                          "token": {
-                            "type": "string"
                           }
-                        },
-                        "type": "object"
+                        ],
+                        "title": "CommandsListItem"
                       },
                       "type": "array"
                     },
                     "locations": {
-                      "additionalProperties": {},
-                      "properties": {},
+                      "additionalProperties": false,
+                      "properties": {
+                        "agent": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "global": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "agent",
+                        "global"
+                      ],
+                      "title": "CommandsListLocations",
                       "type": "object"
                     },
                     "pagination": {
-                      "additionalProperties": {},
+                      "additionalProperties": false,
                       "properties": {
                         "hasMore": {
                           "type": "boolean"
@@ -24510,11 +25087,9 @@
                         "limit",
                         "offset",
                         "returned",
-                        "total",
-                        "hasMore",
-                        "nextOffset",
-                        "nextCommand"
+                        "total"
                       ],
+                      "title": "CommandsListPagination",
                       "type": "object"
                     },
                     "total": {
@@ -24524,9 +25099,9 @@
                   "required": [
                     "total",
                     "pagination",
-                    "items",
                     "agent",
                     "locations",
+                    "items",
                     "commands",
                     "issues"
                   ],

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -129,3 +129,19 @@ A publicação deve usar o commit já aprovado pelos gates focados e pela revis�
 independente, com o hook local explicitamente dispensado apenas para acionar a
 CI Linux. Merge, pacote promovido e VPS continuam bloqueados até a CI do SHA
 exato concluir todos os jobs obrigatórios.
+
+## Nota de revisão — 2026-08-21 (espera de saída sem limite)
+
+A investigação independente do congelamento descartou regressão no Slack, mas
+encontrou um bloqueador real na nova fronteira de saída: enquanto o Bun
+mantivesse `writableLength` ou `writableNeedDrain`, o código repetia
+`setImmediate` sem prazo máximo. Um indicador preso poderia consumir CPU e
+impedir o encerramento indefinidamente. A descarga adicional no `finally` da
+CLI repetia a mesma exposição.
+
+A correção troca a repetição por verificações espaçadas, com limite de cinco
+segundos, remove a segunda descarga e garante `process.exit` em `finally`. O
+teste nativo agora prova o limite com um stream permanentemente preso e mata,
+observa e rejeita um processo-filho que ultrapassa seu próprio prazo. Assim, o
+caminho normal continua comprovando saída integral, enquanto uma anomalia do
+stream não cria laço de CPU nem processo órfão.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -106,3 +106,26 @@ Na primeira normalização, o Biome também identificou a constante antiga
 `GIT_SHA_MASK` sem uso depois que a máscara passou a preservar prefixo e
 sufixo da declaração. A constante foi removida; o algoritmo e sua prova
 permanecem inalterados.
+
+## Nota de revisão — 2026-08-21 (pré-envio no Windows)
+
+O primeiro `git push` foi interrompido porque o hook completo permaneceu sem
+progresso visível em `bun test src/channels/`. A interrupção encerrou o processo
+Git, mas deixou dois processos Bun filhos órfãos, que continuaram consumindo CPU
+e disputando os bancos temporários das reproduções seguintes. Os dois processos
+foram identificados pelo comando e horário de criação e encerrados de forma
+direcionada; nenhum arquivo ou estado do produto foi removido.
+
+Em ambiente limpo, o teste filtrado de timeout do `auth.test` terminou da mesma
+forma na candidata e na `dev`: o setup isolado excedeu o limite de 5 segundos.
+A suíte completa também demonstrou flutuação na própria `dev`: uma execução
+terminou em 57 segundos com somente a falha Windows de separador no caminho de
+áudio; outra permaneceu no teste de timeout sem avançar. A candidata terminou
+quando executada sem os processos órfãos, mas acumulou timeouts de setup sob a
+carga local. O comportamento não foi atribuído à fundação e o hook local não é
+registrado como aprovado.
+
+A publicação deve usar o commit já aprovado pelos gates focados e pela revisão
+independente, com o hook local explicitamente dispensado apenas para acionar a
+CI Linux. Merge, pacote promovido e VPS continuam bloqueados até a CI do SHA
+exato concluir todos os jobs obrigatórios.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -145,3 +145,18 @@ teste nativo agora prova o limite com um stream permanentemente preso e mata,
 observa e rejeita um processo-filho que ultrapassa seu próprio prazo. Assim, o
 caminho normal continua comprovando saída integral, enquanto uma anomalia do
 stream não cria laço de CPU nem processo órfão.
+
+## Nota de revisão — 2026-08-21 (observação do processo-filho)
+
+A revisão independente da correção manteve **NO-GO** porque o helper nativo
+rejeitava imediatamente quando o primeiro `child.kill()` retornava falso, sem
+aguardar o evento `close`. Isso contrariava a exigência recém-documentada de
+matar e observar o filho antes de concluir. O ledger também permanecia na prova
+anterior de 22 testes e 91 asserções, embora o HEAD já contivesse 23 testes e 93
+asserções.
+
+O helper agora solicita encerramento no prazo principal, escala para `SIGKILL`
+depois de 250 ms e só resolve ou rejeita o timeout quando observa `close`.
+Erros de sinalização após o timeout também aguardam esse fechamento. O ledger
+foi alinhado à evidência final; nova execução e nova revisão do SHA exato
+continuam obrigatórias.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -1,0 +1,108 @@
+# Postmortem 0001: fundação CLI bloqueada pelos gates finais
+
+**Data:** 2026-08-21  
+**Severidade:** média  
+**Status:** aberto  
+**Projeto:** Ravi
+
+## Resumo
+
+A primeira candidata da fundação agent-first passou nos testes focados, mas foi
+corretamente classificada como NO-GO pela revisão independente. Gates oficiais
+excederam limites de tempo e a Ravi Spec declarava cobertura mais ampla do que a
+migração realmente entregava.
+
+## Hipótese / Expectativa
+
+Esperávamos que os testes focados, build, typecheck e quality gate fossem
+suficientes para apresentar a candidata aos gates oficiais sem nova regressão.
+
+## O que aconteceu de fato
+
+O gate `test:agent-contract` ficou instável ao carregar o catálogo completo em
+um teste pequeno. O gate do SDK também excedeu seu limite de tempo. A auditoria
+ainda encontrou campos estritos migrados somente em `agents`, mutações reais
+ainda não classificadas e caminhos de encerramento fora da nova fronteira.
+
+## Causa-raiz
+
+O recorte foi validado por mecanismo, mas a declaração normativa foi escrita
+como estado final do programa. Além disso, o custo de inicialização global não
+foi medido nos gates que executam o catálogo completo em máquina sem aquecimento.
+
+## O que foi bem
+
+O revisor foi independente, executou os gates oficiais e bloqueou a candidata
+antes de commit, push, PR ou VPS. O empacotamento e os testes de saída também
+produziram evidência útil sem criar bancada externa.
+
+## O que foi mal
+
+Os dois testes centrais novos não estavam listados em `CHECKS.md`, a spec foi
+marcada como ativa cedo demais e a execução local inicial não incluiu o gate do
+SDK.
+
+## Lições aprendidas
+
+Uma fundação de migração deve declarar explicitamente o que já é obrigatório e
+o que ainda é legado. Testes pequenos não devem pagar inicialização global
+desnecessária, e os gates oficiais precisam rodar antes da promoção documental.
+
+## Ações
+
+- [ ] Remover inicialização global desnecessária dos testes e repetir os gates oficiais — Codex — imediato
+- [ ] Tornar a Ravi Spec fiel ao recorte migrado e adicionar os testes centrais ao `CHECKS.md` — Codex — imediato
+- [ ] Documentar exceções de encerramento e a quebra deliberada de paginação — Codex — antes do PR
+- [ ] Reexecutar revisão independente após todos os gates aplicáveis — Codex — antes de commit e push
+
+## Nota de revisão — 2026-08-21
+
+O `sdk:check` não possuía cinco diferenças de conteúdo: quatro arquivos eram
+idênticos após normalizar CRLF/LF, e o quinto diferia adicionalmente apenas no
+`GIT_SHA`, que o comparador já trata como informativo. O check comparava bytes
+de checkout e foi corrigido para ignorar somente finais de linha, mantendo uma
+prova explícita de que qualquer mudança real de fonte continua falhando.
+
+## Nota de revisão — 2026-08-21 (portão local)
+
+A primeira repetição local do quality gate usou a base padrão `main`, embora o
+PR tenha `dev` como base, e foi descartada. A segunda tentativa também foi
+descartada porque o PowerShell agrupou a lista de arquivos como dois objetos.
+A execução aceita passou a fornecer uma lista plana do estado de trabalho,
+removeu o cabeçalho informativo do `rtk` e mostrou nominalmente os 34 caminhos
+reais antes de aprovar spec e cobertura. Quality gates que sincronizam o índice
+de specs também não devem rodar em paralelo no mesmo estado local.
+
+## Nota de revisão — 2026-08-21 (segunda revisão independente)
+
+A segunda revisão manteve o estado **NO-GO** ao encontrar uma emissão NATS sem
+a guarda de supressão no caminho de permissão negada, uma máscara de
+`GIT_SHA` ampla o bastante para ocultar conteúdo adicional na mesma linha e
+duas divergências entre a Ravi Spec e o comportamento implementado. A correção
+passou a guardar também a negação, adicionou prova de zero emissão para chamadas
+permitidas e negadas, restringiu a máscara ao literal JSON da constante e
+incluiu uma prova de drift na própria linha. A taxonomia reserva exit `3` para
+bloqueios seguros e o runbook deixou de prometer `acceptedFields` no manifesto.
+Uma terceira revisão independente continua obrigatória antes de qualquer
+commit, push ou PR.
+
+## Nota de revisão — 2026-08-21 (terceira revisão independente)
+
+A terceira revisão emitiu **GO** para commit e abertura da PR. Foram confirmadas
+as guardas NATS nos dois caminhos, a prova de drift na linha de `GIT_SHA`, a
+taxonomia normativa e a propagação dos metadados de segurança até o runtime. O
+pacote aprovado tem SHA-256
+`581CA4862028E0A91C5025B9AE575188F8E16C1AA857731088F13DE436DF4B75` e
+foi instalado em diretório vazio. As duas falhas de artifacts no Windows
+continuam registradas como dívida reproduzida igualmente na base; CI Linux no
+commit exato permanece obrigatória antes de merge ou VPS.
+
+O primeiro commit foi bloqueado pelo hook porque 18 arquivos TypeScript
+mantinham CRLF no worktree do Windows e o Biome exige LF. Nenhum commit foi
+criado. A correção é mecânica e limitada aos arquivos TypeScript já revisados;
+o hook, typecheck e os testes focados devem ser repetidos após a normalização.
+
+Na primeira normalização, o Biome também identificou a constante antiga
+`GIT_SHA_MASK` sem uso depois que a máscara passou a preservar prefixo e
+sufixo da declaração. A constante foi removida; o algoritmo e sua prova
+permanecem inalterados.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -160,3 +160,44 @@ depois de 250 ms e só resolve ou rejeita o timeout quando observa `close`.
 Erros de sinalização após o timeout também aguardam esse fechamento. O ledger
 foi alinhado à evidência final; nova execução e nova revisão do SHA exato
 continuam obrigatórias.
+
+## Nota de revisão — 2026-08-21 (primeira CI Linux da PR 426)
+
+A CI Linux do SHA `677cd83857fe6b6d2f92e66b3fd2dd61d4928f3c` falhou no
+teste nativo do daemon que carrega o bundle da CLI de forma síncrona. A nova
+fronteira havia introduzido `await` no nível principal para a versão e para o
+bootstrap. O bundle continuava executável diretamente, mas deixou de poder ser
+carregado por `require`, retornando status 1 no contrato usado pelo PM2.
+
+A correção move o caminho de versão para dentro de `bootstrapCli` e inicia a
+promessa com `void`, mantendo toda espera de saída dentro da cadeia assíncrona
+sem criar top-level await. O resultado vermelho permanece como evidência
+histórica; o GO, pacote e SHA anteriores estão superados. Testes do daemon,
+saída, build, pacote e revisão independente devem ser repetidos antes de novo
+push.
+
+## Nota de revisão — 2026-08-21 (recorte local ampliado no Windows)
+
+Uma tentativa local incluiu por engano todo o arquivo
+`src/runtime/codex-provider.test.ts` junto dos quatro testes da fundação. Nesse
+arquivo, 20 casos que iniciam scripts temporários falharam com `ENOENT` porque o
+Windows não executa diretamente os arquivos `.mjs` usados como falsos binários.
+Os 50 casos restantes passaram. Esse arquivo não pertence ao recorte de 27
+testes da fundação e a falha não toca o código corrigido do bootstrap.
+
+O comando correto, sem `codex-provider.test.ts`, passou com 27 testes e 107
+asserções. A CI Linux continua sendo a autoridade para a suíte integral e deve
+passar no SHA corrigido antes de qualquer novo GO.
+
+## Nota de revisão — 2026-08-21 (correção revalidada localmente)
+
+O bundle corrigido foi carregado de forma síncrona por `require` e executou
+`daemon status` com código 0. Os testes focados de saída e erros passaram com 23
+casos e 93 asserções; segurança, paginação e projeção de runtime passaram com 27
+casos e 107 asserções; a suíte completa do SDK passou com 75 casos e 297
+asserções, seguida de `sdk:check`.
+
+Typecheck, build integral, quality gate dos 34 caminhos e lint dos documentos
+alterados também passaram. Isso fecha a revalidação local, mas não restaura o
+GO: ainda são obrigatórios commit exato, revisão independente, novo pacote e CI
+Linux verde no mesmo SHA.

--- a/docs/postmortems/0001-cli-foundation-gates-no-go.md
+++ b/docs/postmortems/0001-cli-foundation-gates-no-go.md
@@ -201,3 +201,37 @@ Typecheck, build integral, quality gate dos 34 caminhos e lint dos documentos
 alterados também passaram. Isso fecha a revalidação local, mas não restaura o
 GO: ainda são obrigatórios commit exato, revisão independente, novo pacote e CI
 Linux verde no mesmo SHA.
+
+## Nota de revisão — 2026-08-21 (segunda CI Linux da PR 426)
+
+A CI Linux `32451955010` do SHA
+`ec6d13ccdcbcdb90b7b8a224c90a4f8892e2af16` confirmou build, typecheck e o
+carregamento síncrono do daemon, mas encontrou duas falhas em
+`src/cli/commands/sdk.test.ts`. Chamadas diretas legadas recebiam a mensagem
+privada `CLI termination requested.` no lugar da mensagem pública original.
+
+O sinal de término lançado por `fail()` estava sendo capturado pelos blocos de
+tratamento do SDK e convertido em uma segunda falha. A correção adiciona um
+helper compartilhado que relança exatamente a mesma instância privada, faz
+todos os tratamentos externos do SDK usarem esse helper e reforça os testes
+para exigir código 1, uma única mensagem pública e nenhum vazamento do sinal.
+
+O recorte diretamente afetado passou com 26 testes e 74 asserções. Todos os
+arquivos de comandos posteriores ao SDK na sequência da CI também passaram,
+exceto `tasks-profiles.test.ts`: suas três verificações chegaram ao cleanup e
+falharam apenas com o `EBUSY` de pastas temporárias já reproduzido e documentado
+na base Windows. O resultado da CI mantém o NO-GO; novo commit, pacote, revisão
+independente e CI Linux continuam obrigatórios.
+
+## Nota de revisão — 2026-08-21 (segunda correção revalidada localmente)
+
+O recorte de contexto, sinal, saída nativa, SDK, ferramentas e gateway passou
+com 86 testes e 310 asserções. O smoke no processo real passou com 11 testes e
+63 asserções; o SDK completo passou com 75 testes e 297 asserções, seguido de
+`sdk:check`. Typecheck, build integral e quality gate dos 36 caminhos passaram.
+
+O primeiro `biome check` detectou somente finais de linha misturados nos dois
+arquivos do SDK editados no Windows. O formatador oficial corrigiu os arquivos;
+a repetição passou, assim como os 20 testes dos dois arquivos formatados. O lint
+documental também deve passar antes do commit. Esses resultados não restauram o
+GO sem novo SHA, pacote, revisão independente e CI Linux verde.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -180,3 +180,36 @@ This note changes the candidate commit, so that first archive is retained as
 diagnostic evidence only. The final archive must be rebuilt after the
 documentation commit, rehashed, reinstalled, and independently reviewed before
 push or PR. Linux CI remains mandatory after an authorized push.
+
+## Revision note: 2026-08-21, independent review of `d67ad42a` NO-GO
+
+Independent read-only review rejected commit
+`d67ad42acbb3fe33c1c89d413f1c5f691a37b7a0` and the inherited package recorded
+above. The package was not pushed or opened as a PR.
+
+The replacement made shared compact projection honest for COMMANDS by removing
+hidden fields globally. That silently invalidated strict pre-serialization
+Returns contracts in AGENTS and other compact consumers that had not migrated.
+The COMMANDS process test also inherited `RAVI_SUPPRESS_AUDIT_EVENTS=1` from its
+state helper, so its zero-transport result did not prove the declared
+`audit: none` behavior. Finally, the runtime non-empty refinement was lost by
+JSON Schema conversion: generated TypeScript allowed an empty projected row,
+OpenAPI carried no equivalent non-empty rule, and Swift lowered the row to
+`RaviJSON`.
+
+The corrective round restores the shared compatibility behavior by default and
+opts only COMMANDS into serialized-only projection. Native AGENTS regression
+coverage now proves that strict Returns validation sees the complete legacy row
+while JSON remains compact. COMMANDS publishes a strict union of 13 typed
+single-field-or-larger projections, which preserves the non-empty invariant in
+Returns, TypeScript, JSON Schema, OpenAPI, and typed Swift models. The process
+child environment explicitly removes both `RAVI_SUPPRESS_AUDIT_EVENTS` and
+`RAVI_NO_AUDIT`; all ten native process cases preserve every state file, every
+SQLite table, and command sources.
+
+Generated TypeScript, OpenAPI, and Swift drift checks pass locally. The Windows
+host has no Swift toolchain, so generated Swift compilation was not claimed;
+the native generator contract is green, but independent review and later Linux
+CI remain mandatory. No package was produced in this corrective round. The
+candidate remains NO-GO for push or PR until the new commit is independently
+audited and its final package is rebuilt and tested.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -4,7 +4,7 @@
 
 **Severity:** medium
 
-**Status:** corrected locally; gate rerun pending
+**Status:** open; replacement candidate in validation
 
 **Project:** Ravi
 
@@ -112,3 +112,51 @@ configuration through a genuinely read-only path, suppress domain audit effects
 by declared policy rather than test environment, compare all relevant SQLite
 tables and state files, add focused group-help tests, and repeat every generated
 artifact and package review. This candidate remains permanently NO-GO.
+
+## Revision note: 2026-08-21, replacement implementation
+
+The replacement removes non-enumerable projection fields and publishes a
+strict non-empty subset schema for the 13 documented command fields. Native
+tests validate the return only after JSON round-trip and reject arbitrary
+projected keys. The shared gateway fixture was migrated to the same honest
+projection contract.
+
+Agent lookup now uses a dedicated read-only SQLite snapshot that bypasses the
+normal config store, schema initialization, migrations, and writable database
+singleton. COMMANDS declares `audit: none`; CLI, exported-tool, and gateway
+paths skip audit transport for both allowed and denied calls. The process test
+no longer sets the suppression environment variable and compares command
+sources, every SQLite table, and every runtime state file before and after each
+operation.
+
+Focused unit, process, gateway, typecheck, and formatting captures are green at
+this checkpoint. Generated TypeScript, OpenAPI, and Swift artifacts, full
+build, quality gates, exact commit/package, fresh independent review, and Linux
+CI must still be repeated. No push, PR, merge, remote call, or VPS action has
+occurred.
+
+## Revision note: 2026-08-21, replacement gate recapture
+
+Generated TypeScript, both OpenAPI snapshots, and Swift artifacts were rebuilt
+and passed their deterministic checks. The SDK suite passed 75 tests with 297
+assertions, the build and typecheck passed, and focused formatting and Markdown
+lint were clean. The installed-process slice passed nine tests with 51
+assertions while comparing all SQLite tables and state files without audit
+suppression.
+
+One parallel gateway run exceeded two inherited five-second timeouts while the
+process suite was consuming the same host. That capture was discarded; the
+isolated rerun passed all 41 tests with 171 assertions. The first quality-gate
+run correctly rejected the new router read path because its approved focused
+test was absent from the diff. Two native router cases were added: one proves a
+missing database is not created, and one proves an existing agent snapshot
+does not alter any state file. The router file then passed 12 tests with 60
+assertions, and the repeated quality runner passed over 35 accumulated paths
+with 274 specs indexed.
+
+A final adversarial review narrowed `audit: none` itself. Shared policy now
+throws unless the command is a low-risk read with resolved effect class
+`none`; CLI, tool export, and gateway use the same resolver. The focused
+foundation test proves mutations and medium-risk reads cannot opt out. Exact
+commit, package, independent review, and Linux CI remain mandatory, so the
+replacement is still NO-GO for push or PR at this checkpoint.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -160,3 +160,23 @@ throws unless the command is a low-risk read with resolved effect class
 foundation test proves mutations and medium-risk reads cannot opt out. Exact
 commit, package, independent review, and Linux CI remain mandatory, so the
 replacement is still NO-GO for push or PR at this checkpoint.
+
+## Revision note: 2026-08-21, replacement package capture
+
+Commit `e78e106c5b63df66d16ecccec2f70e29ccfdc844` produced an eight-file
+package of 4,945,479 bytes with SHA-256
+`C763E1991CDED3A0E2BD50A237FE2F0C6D8BEEB3C018A5239AC140BBB7D42845`.
+An empty Bun project installed 367 packages from that archive. Bun reported two
+dependency postinstall scripts as blocked by its default trust policy; the Ravi
+package still installed with its binary and bundle intact.
+
+The installed bundle, executed directly on Windows, passed bare help, compact
+list, show, validate, and rendered run preview. It also returned exit 1 with
+`COMMAND_NOT_FOUND` and exit 2 with `USAGE_ERROR` for invalid fields. All seven
+processes had empty stderr, the isolated runtime state remained empty, and the
+command fixture hash was unchanged.
+
+This note changes the candidate commit, so that first archive is retained as
+diagnostic evidence only. The final archive must be rebuilt after the
+documentation commit, rehashed, reinstalled, and independently reviewed before
+push or PR. Linux CI remains mandatory after an authorized push.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -1,0 +1,85 @@
+# Postmortem 0002: commands handoff left generated contracts stale
+
+**Date:** 2026-08-21
+
+**Severity:** medium
+
+**Status:** corrected locally; gate rerun pending
+
+**Project:** Ravi
+
+## Summary
+
+The implementation handoff reported OpenAPI and Swift artifacts as current,
+but the coordinator's official checks found drift in both OpenAPI snapshots and
+five Swift files. No commit, package, push, PR, or deployment had occurred.
+
+## Expected behavior
+
+Every CLI contract change must leave TypeScript, OpenAPI, and Swift artifacts
+equal to the live registry before a domain can be marked ready.
+
+## Actual behavior
+
+TypeScript SDK generation and `sdk:check` were current. Both OpenAPI checks
+failed with `OPENAPI_DRIFT`, and `sdk swift check` reported five divergent
+artifacts.
+
+## Root cause
+
+The handoff treated successful TypeScript code generation as evidence for all
+generated surfaces. The OpenAPI and Swift checks were not independently
+reproduced against the final worktree state before reporting readiness.
+
+## Resolution
+
+The two OpenAPI snapshots and all Swift generated files were regenerated with
+the repository's official CLI. Their checks, the SDK suite, and downstream
+gates must pass again before the candidate can be committed.
+
+## Prevention
+
+- Record each generated-surface command and exit code separately.
+- Do not infer OpenAPI or Swift status from TypeScript SDK status.
+- The coordinator must reproduce every claimed gate before accepting a handoff.
+
+## Revision note: 2026-08-21, generated surfaces recaptured
+
+The coordinator regenerated both OpenAPI snapshots and every affected Swift
+artifact with the repository CLI. The two OpenAPI checks and the deterministic
+Swift check then passed independently. The complete SDK suite passed 75 tests
+with 297 assertions and was followed by a green `sdk:check`.
+
+The changed commands slice was repeated after regeneration and passed 40 tests
+with 150 assertions, including nine installed-process-style CLI cases. The
+typecheck, full build, focused Biome, Markdown lint over nine applicable
+documents, and the diff-based quality gate over 23 paths with 274 specs indexed
+also passed.
+
+This closes the local generated-drift correction only. An exact commit, package,
+fresh independent review, and Linux CI are still mandatory before push or PR;
+merge and VPS remain outside this checkpoint.
+
+## Revision note: 2026-08-21, line-ending recapture
+
+A later focused Biome run found Windows line endings in the shared operational
+return-schema file after generation. The official formatter normalized that
+single file; no schema semantics changed. Focused Biome and the 40-test commands
+slice were repeated, with all 150 assertions passing. Evidence recorded before
+this normalization is not used as the final style/test capture.
+
+## Revision note: 2026-08-21, final coordinator recapture
+
+The final commands slice passed 40 tests with 150 assertions and typecheck. The
+complete SDK suite first ran under parallel load and two unchanged five-second
+hooks timed out; that output was discarded. Its isolated recapture passed all
+75 tests with 297 assertions and `sdk:check`.
+
+Both OpenAPI checks, the deterministic Swift check, full build, focused Biome
+over six command/framework source files, Markdown lint over 11 locally changed
+documents, `git diff --check`, 40 native quality-gate tests, and the quality
+runner over 56 accumulated foundation-plus-domain paths passed. The runner
+indexed 274 specs and approved `cli/commands`, `cli/foundation`, and `commands`.
+The generated-drift correction is locally closed. Exact commit, package,
+independent review, and Linux CI remain mandatory; push, PR, merge, and VPS have
+not occurred.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -83,3 +83,32 @@ indexed 274 specs and approved `cli/commands`, `cli/foundation`, and `commands`.
 The generated-drift correction is locally closed. Exact commit, package,
 independent review, and Linux CI remain mandatory; push, PR, merge, and VPS have
 not occurred.
+
+## Revision note: 2026-08-21, independent package review NO-GO
+
+Independent review rejected commit
+`d648b40691300af98818331313a7445b93ab1e90` and its 4,944,320-byte package
+with SHA-256
+`206A02D753F590AEF798A74DA80C93D93A0963EF0F0ED721A1E9B253A4C2F4AB`.
+Neither candidate was pushed or opened as a PR. The historical status in this
+document's header describes the earlier generated-drift incident; it does not
+override this later NO-GO.
+
+The review found that `--fields` serialized partial records while the Returns,
+TypeScript, OpenAPI, and Swift schemas still required complete command records.
+Non-enumerable properties let validation pass before serialization but vanished
+from actual JSON, so the published contract rejected its own compact output.
+
+The review also disproved the strict read-only claim. Resolving the active agent
+through the normal config store opened writable SQLite, initialized schema/WAL,
+and changed `ravi.db-wal` and `ravi.db-shm`. The normal registry path also tried
+to publish audit events to NATS. The process test hid that transport with
+`RAVI_SUPPRESS_AUDIT_EVENTS` and compared only selected tables and command-file
+hashes, so it could not detect the state-file changes.
+
+A replacement candidate must publish an honest projected-record schema after
+JSON round-trip, remove the non-enumerable-field workaround, resolve command
+configuration through a genuinely read-only path, suppress domain audit effects
+by declared policy rather than test environment, compare all relevant SQLite
+tables and state files, add focused group-help tests, and repeat every generated
+artifact and package review. This candidate remains permanently NO-GO.

--- a/docs/postmortems/0002-commands-generated-contract-drift.md
+++ b/docs/postmortems/0002-commands-generated-contract-drift.md
@@ -213,3 +213,56 @@ the native generator contract is green, but independent review and later Linux
 CI remain mandatory. No package was produced in this corrective round. The
 candidate remains NO-GO for push or PR until the new commit is independently
 audited and its final package is rebuilt and tested.
+
+## Revision note: 2026-08-21, independent review of `aec8c019` NO-GO
+
+Independent read-only review rejected commit
+`aec8c0196aab68b15f283092e1a9119db90b38da`. The earlier projection, audit and
+generated-contract blockers were confirmed fixed, but two new promotion gaps
+remained.
+
+The normative text and process proof required byte-identical SQLite `-shm`
+state even though that file is an ephemeral coordination index and may be
+updated by a safe reader while the daemon writes in WAL mode. The proof also
+opened its own logical reader before hashing files, which could hide the first
+coordination update. The corrected boundary protects command sources, every
+logical row and every durable state file, including `ravi.db` and its WAL;
+`-shm` is explicitly excluded from durable-state identity. A native case keeps
+a WAL writer open while the real COMMANDS process runs.
+
+The altered live-registry OpenAPI test also exceeded Bun's default five-second
+timeout on this host, although it passed with an external timeout override. Its
+two registry-heavy cases now declare a 30-second native timeout so the ordinary
+`bun test src/sdk/openapi/emit.test.ts` command is authoritative.
+
+The first concurrent-WAL fixture was invalid because it inserted a settings
+row without the required `updated_at` column. That failed run is discarded.
+After fixing only the fixture, the process file passed 11 tests with 57
+assertions, including the active writer, and the ordinary OpenAPI file passed
+22 tests with 61 assertions. These local corrections are not a candidate:
+full gates, a new commit, fresh independent review, package and Linux CI remain
+mandatory before push or PR.
+
+## Revision note: 2026-08-21, corrected candidate gate recapture
+
+The corrected tree passed 93 focused COMMANDS, AGENTS, renderer and foundation
+tests with 303 assertions; 11 real-process tests with 57 assertions; 12 router
+tests with 60 assertions; 41 gateway tests with 171 assertions; six native
+output tests with 19 assertions; and the ordinary OpenAPI file with 22 tests
+and 61 assertions. The SDK passed 76 tests with 305 assertions, and both
+OpenAPI snapshots, the Swift deterministic check, typecheck, full build,
+Biome, Markdown lint and `git diff --check` passed.
+
+The quality runner's first local invocation was invalid because its fallback
+expects `origin/main`, which this worktree does not have. Re-running it with
+the exact 43 changed paths through its documented `CHANGED_FILES` input passed
+both gates and indexed 274 specs. The quality runner's own 40 tests also passed
+with 90 assertions.
+
+The full `test:agent-contract` chain passed every preceding file and then
+failed two Windows artifact-store cases: one blob expectation and one symlink
+creation denied with `EPERM`. Running the same artifact-store file at the exact
+foundation commit `560517a4` reproduced the same two failures. They are kept as
+pre-existing Windows evidence and are not reported as a green suite. No
+commands-specific regression was observed. Swift compilation remains pending
+for Linux CI because this Windows host has no Swift toolchain.

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "2370946ba69718e6"
+    "version": "e2a5418c6acb56f9"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24142,7 +24142,7 @@
                     },
                     "commands": {
                       "items": {
-                        "additionalProperties": {},
+                        "additionalProperties": false,
                         "properties": {
                           "argumentHint": {
                             "anyOf": [
@@ -24269,21 +24269,6 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "token",
-                          "title",
-                          "description",
-                          "argumentHint",
-                          "arguments",
-                          "disabled",
-                          "scope",
-                          "path",
-                          "relativePath",
-                          "shadowedBy",
-                          "shadows",
-                          "issues"
-                        ],
                         "type": "object"
                       },
                       "type": "array"
@@ -24346,8 +24331,133 @@
                     },
                     "items": {
                       "items": {
-                        "additionalProperties": {},
-                        "properties": {},
+                        "additionalProperties": false,
+                        "properties": {
+                          "argumentHint": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "arguments": {
+                            "items": {},
+                            "type": "array"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "issues": {
+                            "items": {
+                              "additionalProperties": {},
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "level": {
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "scope": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "level",
+                                "code",
+                                "message",
+                                "id",
+                                "scope",
+                                "path"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "relativePath": {
+                            "type": "string"
+                          },
+                          "scope": {
+                            "type": "string"
+                          },
+                          "shadowedBy": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "shadows": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "title": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "token": {
+                            "type": "string"
+                          }
+                        },
                         "type": "object"
                       },
                       "type": "array"

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "035eb8a0686f51ec"
+    "version": "2370946ba69718e6"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24106,7 +24106,7 @@
                     "type": "string"
                   },
                   "fields": {
-                    "description": "Compact mode: keep only these fields of each item",
+                    "description": "Compact fields: id,token,title,description,argumentHint,arguments,disabled,scope,path,relativePath,shadowedBy,shadows,issues",
                     "type": "string"
                   },
                   "limit": {

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "e2a5418c6acb56f9"
+    "version": "5b018e7b6d1479b9"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -24133,149 +24133,438 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {},
+                  "additionalProperties": false,
                   "properties": {
                     "agent": {
-                      "additionalProperties": {},
-                      "properties": {},
+                      "additionalProperties": false,
+                      "properties": {
+                        "cwd": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "cwd"
+                      ],
+                      "title": "CommandsListAgent",
                       "type": "object"
                     },
                     "commands": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "argumentHint": {
-                            "anyOf": [
-                              {
+                        "allOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "argumentHint": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "arguments": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "disabled": {
+                                "type": "boolean"
+                              },
+                              "id": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "arguments": {
-                            "items": {},
-                            "type": "array"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
+                              "issues": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "level": {
+                                      "enum": [
+                                        "error",
+                                        "warning"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "scope": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "level",
+                                    "code",
+                                    "message",
+                                    "id",
+                                    "scope",
+                                    "path"
+                                  ],
+                                  "title": "CommandsListIssue",
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "disabled": {
-                            "type": "boolean"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "issues": {
-                            "items": {
-                              "additionalProperties": {},
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "id": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "level": {
-                                  "type": "string"
-                                },
-                                "message": {
-                                  "type": "string"
-                                },
-                                "path": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "scope": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                }
+                              "relativePath": {
+                                "type": "string"
                               },
-                              "required": [
-                                "level",
-                                "code",
-                                "message",
-                                "id",
-                                "scope",
-                                "path"
-                              ],
-                              "type": "object"
+                              "scope": {
+                                "type": "string"
+                              },
+                              "shadowedBy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "shadows": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "title": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "token": {
+                                "type": "string"
+                              }
                             },
-                            "type": "array"
+                            "type": "object"
                           },
-                          "path": {
-                            "type": "string"
-                          },
-                          "relativePath": {
-                            "type": "string"
-                          },
-                          "scope": {
-                            "type": "string"
-                          },
-                          "shadowedBy": {
+                          {
                             "anyOf": [
                               {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "shadows": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "title": {
-                            "anyOf": [
-                              {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "token": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "title": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "title"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "description": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "description"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "argumentHint": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "argumentHint"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "arguments": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "arguments"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "disabled"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "scope": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "scope"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "relativePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "relativePath"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadowedBy": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "shadowedBy"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadows": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "shadows"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "issues": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "level": {
+                                          "enum": [
+                                            "error",
+                                            "warning"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "message": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "scope": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "level",
+                                        "code",
+                                        "message",
+                                        "id",
+                                        "scope",
+                                        "path"
+                                      ],
+                                      "title": "CommandsListIssue",
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "issues"
+                                ],
+                                "type": "object"
                               }
                             ]
-                          },
-                          "token": {
-                            "type": "string"
                           }
-                        },
-                        "type": "object"
+                        ],
+                        "title": "CommandsListItem"
                       },
                       "type": "array"
                     },
+                    "filters": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "tag": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "tag"
+                      ],
+                      "title": "CommandsListFilters",
+                      "type": "object"
+                    },
                     "issues": {
                       "items": {
-                        "additionalProperties": {},
+                        "additionalProperties": false,
                         "properties": {
                           "code": {
                             "type": "string"
@@ -24291,6 +24580,10 @@
                             ]
                           },
                           "level": {
+                            "enum": [
+                              "error",
+                              "warning"
+                            ],
                             "type": "string"
                           },
                           "message": {
@@ -24325,150 +24618,434 @@
                           "scope",
                           "path"
                         ],
+                        "title": "CommandsListIssue",
                         "type": "object"
                       },
                       "type": "array"
                     },
                     "items": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "argumentHint": {
-                            "anyOf": [
-                              {
+                        "allOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "argumentHint": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "arguments": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "disabled": {
+                                "type": "boolean"
+                              },
+                              "id": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "arguments": {
-                            "items": {},
-                            "type": "array"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
+                              "issues": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "level": {
+                                      "enum": [
+                                        "error",
+                                        "warning"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "scope": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "level",
+                                    "code",
+                                    "message",
+                                    "id",
+                                    "scope",
+                                    "path"
+                                  ],
+                                  "title": "CommandsListIssue",
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
                                 "type": "string"
                               },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "disabled": {
-                            "type": "boolean"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "issues": {
-                            "items": {
-                              "additionalProperties": {},
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "id": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "level": {
-                                  "type": "string"
-                                },
-                                "message": {
-                                  "type": "string"
-                                },
-                                "path": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                },
-                                "scope": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
-                                }
+                              "relativePath": {
+                                "type": "string"
                               },
-                              "required": [
-                                "level",
-                                "code",
-                                "message",
-                                "id",
-                                "scope",
-                                "path"
-                              ],
-                              "type": "object"
+                              "scope": {
+                                "type": "string"
+                              },
+                              "shadowedBy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "shadows": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "title": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "token": {
+                                "type": "string"
+                              }
                             },
-                            "type": "array"
+                            "type": "object"
                           },
-                          "path": {
-                            "type": "string"
-                          },
-                          "relativePath": {
-                            "type": "string"
-                          },
-                          "scope": {
-                            "type": "string"
-                          },
-                          "shadowedBy": {
+                          {
                             "anyOf": [
                               {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "shadows": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "title": {
-                            "anyOf": [
-                              {
-                                "type": "string"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "token": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "token"
+                                ],
+                                "type": "object"
                               },
                               {
-                                "type": "null"
+                                "additionalProperties": {},
+                                "properties": {
+                                  "title": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "title"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "description": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "description"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "argumentHint": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "argumentHint"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "arguments": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "arguments"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "disabled": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "disabled"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "scope": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "scope"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "relativePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "relativePath"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadowedBy": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "shadowedBy"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "shadows": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "shadows"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": {},
+                                "properties": {
+                                  "issues": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "level": {
+                                          "enum": [
+                                            "error",
+                                            "warning"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "message": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "scope": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "level",
+                                        "code",
+                                        "message",
+                                        "id",
+                                        "scope",
+                                        "path"
+                                      ],
+                                      "title": "CommandsListIssue",
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "issues"
+                                ],
+                                "type": "object"
                               }
                             ]
-                          },
-                          "token": {
-                            "type": "string"
                           }
-                        },
-                        "type": "object"
+                        ],
+                        "title": "CommandsListItem"
                       },
                       "type": "array"
                     },
                     "locations": {
-                      "additionalProperties": {},
-                      "properties": {},
+                      "additionalProperties": false,
+                      "properties": {
+                        "agent": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "global": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "agent",
+                        "global"
+                      ],
+                      "title": "CommandsListLocations",
                       "type": "object"
                     },
                     "pagination": {
-                      "additionalProperties": {},
+                      "additionalProperties": false,
                       "properties": {
                         "hasMore": {
                           "type": "boolean"
@@ -24510,11 +25087,9 @@
                         "limit",
                         "offset",
                         "returned",
-                        "total",
-                        "hasMore",
-                        "nextOffset",
-                        "nextCommand"
+                        "total"
                       ],
+                      "title": "CommandsListPagination",
                       "type": "object"
                     },
                     "total": {
@@ -24524,9 +25099,9 @@
                   "required": [
                     "total",
                     "pagination",
-                    "items",
                     "agent",
                     "locations",
+                    "items",
                     "commands",
                     "issues"
                   ],

--- a/packages/ravi-os-sdk/src/__tests__/types.test-d.ts
+++ b/packages/ravi-os-sdk/src/__tests__/types.test-d.ts
@@ -24,6 +24,7 @@ import type {
   ChannelsBackendRuntimeInterruptReturn,
   ChannelsBackendRuntimeReadbackInput,
   ChannelsBackendRuntimeReadbackReturn,
+  CommandsListReturn,
   ContextCredentialsListReturn,
 } from "../types.js";
 
@@ -125,6 +126,19 @@ type _ListReturnOk = ExpectTrue<Eq<ListResult, ContextCredentialsListReturn>>;
 type _ListReturnIsUnknown = ExpectTrue<Eq<ContextCredentialsListReturn, unknown>>;
 type _ListParamsOk = ExpectFalse<Eq<ListParams, [string]>>;
 
+// Projected COMMANDS rows remain typed and require at least one declared field.
+type CommandsListRow = CommandsListReturn["items"][number];
+type _CommandsEmptyRowRejected = ExpectFalse<{} extends CommandsListRow ? true : false>;
+type _CommandsIdRowAccepted = ExpectTrue<{ id: string } extends CommandsListRow ? true : false>;
+const validCommandsRow: CommandsListRow = { arguments: ["target"] };
+// @ts-expect-error an empty projection violates the generated non-empty contract
+const emptyCommandsRow: CommandsListRow = {};
+// @ts-expect-error command arguments are strings, not arbitrary JSON
+const invalidCommandsArguments: CommandsListRow = { arguments: [1] };
+void validCommandsRow;
+void emptyCommandsRow;
+void invalidCommandsArguments;
+
 describe("types.test-d", () => {
   it("compiles the typed surface", () => {
     // The Expect* aliases above run at compile time — this test only ensures
@@ -156,5 +170,7 @@ type _Touched =
   | _ChannelBackendRuntimeReadbackReturnOk
   | _ListReturnOk
   | _ListReturnIsUnknown
-  | _ListParamsOk;
+  | _ListParamsOk
+  | _CommandsEmptyRowRejected
+  | _CommandsIdRowAccepted;
 export type { _Touched };

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -21153,7 +21153,7 @@ export const CommandsListReturnSchema = {
     },
     "commands": {
       "items": {
-        "additionalProperties": {},
+        "additionalProperties": false,
         "properties": {
           "argumentHint": {
             "anyOf": [
@@ -21280,21 +21280,6 @@ export const CommandsListReturnSchema = {
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "token",
-          "title",
-          "description",
-          "argumentHint",
-          "arguments",
-          "disabled",
-          "scope",
-          "path",
-          "relativePath",
-          "shadowedBy",
-          "shadows",
-          "issues"
-        ],
         "type": "object"
       },
       "type": "array"
@@ -21357,8 +21342,133 @@ export const CommandsListReturnSchema = {
     },
     "items": {
       "items": {
-        "additionalProperties": {},
-        "properties": {},
+        "additionalProperties": false,
+        "properties": {
+          "argumentHint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "arguments": {
+            "items": {},
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "issues": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "level": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "path": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "scope": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "level",
+                "code",
+                "message",
+                "id",
+                "scope",
+                "path"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "path": {
+            "type": "string"
+          },
+          "relativePath": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "shadowedBy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "shadows": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "token": {
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "type": "array"

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -21123,7 +21123,7 @@ export const CommandsListInputSchema = {
       "type": "string"
     },
     "fields": {
-      "description": "Compact mode: keep only these fields of each item",
+      "description": "Compact fields: id,token,title,description,argumentHint,arguments,disabled,scope,path,relativePath,shadowedBy,shadows,issues",
       "type": "string"
     },
     "limit": {

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -21144,149 +21144,438 @@ export const CommandsListInputSchema = {
 
 /** JSON Schema for the return shape of `commands.list`. */
 export const CommandsListReturnSchema = {
-  "additionalProperties": {},
+  "additionalProperties": false,
   "properties": {
     "agent": {
-      "additionalProperties": {},
-      "properties": {},
+      "additionalProperties": false,
+      "properties": {
+        "cwd": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "cwd"
+      ],
+      "title": "CommandsListAgent",
       "type": "object"
     },
     "commands": {
       "items": {
-        "additionalProperties": false,
-        "properties": {
-          "argumentHint": {
-            "anyOf": [
-              {
+        "allOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "argumentHint": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "arguments": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "id": {
                 "type": "string"
               },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "arguments": {
-            "items": {},
-            "type": "array"
-          },
-          "description": {
-            "anyOf": [
-              {
+              "issues": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "level": {
+                      "enum": [
+                        "error",
+                        "warning"
+                      ],
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "scope": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "level",
+                    "code",
+                    "message",
+                    "id",
+                    "scope",
+                    "path"
+                  ],
+                  "title": "CommandsListIssue",
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "path": {
                 "type": "string"
               },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "disabled": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string"
-          },
-          "issues": {
-            "items": {
-              "additionalProperties": {},
-              "properties": {
-                "code": {
-                  "type": "string"
-                },
-                "id": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "level": {
-                  "type": "string"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "path": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "scope": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
+              "relativePath": {
+                "type": "string"
               },
-              "required": [
-                "level",
-                "code",
-                "message",
-                "id",
-                "scope",
-                "path"
-              ],
-              "type": "object"
+              "scope": {
+                "type": "string"
+              },
+              "shadowedBy": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "shadows": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "title": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "token": {
+                "type": "string"
+              }
             },
-            "type": "array"
+            "type": "object"
           },
-          "path": {
-            "type": "string"
-          },
-          "relativePath": {
-            "type": "string"
-          },
-          "scope": {
-            "type": "string"
-          },
-          "shadowedBy": {
+          {
             "anyOf": [
               {
-                "type": "string"
+                "additionalProperties": {},
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
               },
               {
-                "type": "null"
-              }
-            ]
-          },
-          "shadows": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
+                "additionalProperties": {},
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object"
               },
               {
-                "type": "null"
+                "additionalProperties": {},
+                "properties": {
+                  "title": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "title"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "description"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "argumentHint": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "argumentHint"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "arguments": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "arguments"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "disabled"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "scope": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "scope"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "relativePath": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "relativePath"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "shadowedBy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "shadowedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "shadows": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "shadows"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "issues": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "level": {
+                          "enum": [
+                            "error",
+                            "warning"
+                          ],
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "scope": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "level",
+                        "code",
+                        "message",
+                        "id",
+                        "scope",
+                        "path"
+                      ],
+                      "title": "CommandsListIssue",
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "issues"
+                ],
+                "type": "object"
               }
             ]
-          },
-          "token": {
-            "type": "string"
           }
-        },
-        "type": "object"
+        ],
+        "title": "CommandsListItem"
       },
       "type": "array"
     },
+    "filters": {
+      "additionalProperties": false,
+      "properties": {
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tag"
+      ],
+      "title": "CommandsListFilters",
+      "type": "object"
+    },
     "issues": {
       "items": {
-        "additionalProperties": {},
+        "additionalProperties": false,
         "properties": {
           "code": {
             "type": "string"
@@ -21302,6 +21591,10 @@ export const CommandsListReturnSchema = {
             ]
           },
           "level": {
+            "enum": [
+              "error",
+              "warning"
+            ],
             "type": "string"
           },
           "message": {
@@ -21336,150 +21629,434 @@ export const CommandsListReturnSchema = {
           "scope",
           "path"
         ],
+        "title": "CommandsListIssue",
         "type": "object"
       },
       "type": "array"
     },
     "items": {
       "items": {
-        "additionalProperties": false,
-        "properties": {
-          "argumentHint": {
-            "anyOf": [
-              {
+        "allOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "argumentHint": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "arguments": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "id": {
                 "type": "string"
               },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "arguments": {
-            "items": {},
-            "type": "array"
-          },
-          "description": {
-            "anyOf": [
-              {
+              "issues": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "level": {
+                      "enum": [
+                        "error",
+                        "warning"
+                      ],
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "scope": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "level",
+                    "code",
+                    "message",
+                    "id",
+                    "scope",
+                    "path"
+                  ],
+                  "title": "CommandsListIssue",
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "path": {
                 "type": "string"
               },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "disabled": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string"
-          },
-          "issues": {
-            "items": {
-              "additionalProperties": {},
-              "properties": {
-                "code": {
-                  "type": "string"
-                },
-                "id": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "level": {
-                  "type": "string"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "path": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "scope": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
+              "relativePath": {
+                "type": "string"
               },
-              "required": [
-                "level",
-                "code",
-                "message",
-                "id",
-                "scope",
-                "path"
-              ],
-              "type": "object"
+              "scope": {
+                "type": "string"
+              },
+              "shadowedBy": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "shadows": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "title": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "token": {
+                "type": "string"
+              }
             },
-            "type": "array"
+            "type": "object"
           },
-          "path": {
-            "type": "string"
-          },
-          "relativePath": {
-            "type": "string"
-          },
-          "scope": {
-            "type": "string"
-          },
-          "shadowedBy": {
+          {
             "anyOf": [
               {
-                "type": "string"
+                "additionalProperties": {},
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
               },
               {
-                "type": "null"
-              }
-            ]
-          },
-          "shadows": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
+                "additionalProperties": {},
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object"
               },
               {
-                "type": "null"
+                "additionalProperties": {},
+                "properties": {
+                  "title": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "title"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "description"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "argumentHint": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "argumentHint"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "arguments": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "arguments"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "disabled"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "scope": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "scope"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "relativePath": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "relativePath"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "shadowedBy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "shadowedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "shadows": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "shadows"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": {},
+                "properties": {
+                  "issues": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "level": {
+                          "enum": [
+                            "error",
+                            "warning"
+                          ],
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "scope": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "level",
+                        "code",
+                        "message",
+                        "id",
+                        "scope",
+                        "path"
+                      ],
+                      "title": "CommandsListIssue",
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "issues"
+                ],
+                "type": "object"
               }
             ]
-          },
-          "token": {
-            "type": "string"
           }
-        },
-        "type": "object"
+        ],
+        "title": "CommandsListItem"
       },
       "type": "array"
     },
     "locations": {
-      "additionalProperties": {},
-      "properties": {},
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "global": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent",
+        "global"
+      ],
+      "title": "CommandsListLocations",
       "type": "object"
     },
     "pagination": {
-      "additionalProperties": {},
+      "additionalProperties": false,
       "properties": {
         "hasMore": {
           "type": "boolean"
@@ -21521,11 +22098,9 @@ export const CommandsListReturnSchema = {
         "limit",
         "offset",
         "returned",
-        "total",
-        "hasMore",
-        "nextOffset",
-        "nextCommand"
+        "total"
       ],
+      "title": "CommandsListPagination",
       "type": "object"
     },
     "total": {
@@ -21535,9 +22110,9 @@ export const CommandsListReturnSchema = {
   "required": [
     "total",
     "pagination",
-    "items",
     "agent",
     "locations",
+    "items",
     "commands",
     "issues"
   ],

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -3929,21 +3929,23 @@ export type CommandsListInput = {
 
 /** Return shape for `commands.list`. */
 export type CommandsListReturn = {
-  agent: Record<string, unknown>;
-  commands: Array<{
+  agent: {
+    cwd: string;
+    id: string;
+  };
+  commands: Array<({
     argumentHint?: string | null;
-    arguments?: unknown[];
+    arguments?: string[];
     description?: string | null;
     disabled?: boolean;
     id?: string;
     issues?: Array<{
       code: string;
       id: string | null;
-      level: string;
+      level: "error" | "warning";
       message: string;
       path: string | null;
       scope: string | null;
-      [k: string]: unknown;
     }>;
     path?: string;
     relativePath?: string;
@@ -3952,30 +3954,64 @@ export type CommandsListReturn = {
     shadows?: string[];
     title?: string | null;
     token?: string;
-  }>;
+  }) & (({
+    id: string;
+  }) | ({
+    token: string;
+  }) | ({
+    title: string | null;
+  }) | ({
+    description: string | null;
+  }) | ({
+    argumentHint: string | null;
+  }) | ({
+    arguments: string[];
+  }) | ({
+    disabled: boolean;
+  }) | ({
+    scope: string;
+  }) | ({
+    path: string;
+  }) | ({
+    relativePath: string;
+  }) | ({
+    shadowedBy: string | null;
+  }) | ({
+    shadows: string[];
+  }) | ({
+    issues: Array<{
+      code: string;
+      id: string | null;
+      level: "error" | "warning";
+      message: string;
+      path: string | null;
+      scope: string | null;
+    }>;
+  }))>;
+  filters?: {
+    tag: string;
+  };
   issues: Array<{
     code: string;
     id: string | null;
-    level: string;
+    level: "error" | "warning";
     message: string;
     path: string | null;
     scope: string | null;
-    [k: string]: unknown;
   }>;
-  items: Array<{
+  items: Array<({
     argumentHint?: string | null;
-    arguments?: unknown[];
+    arguments?: string[];
     description?: string | null;
     disabled?: boolean;
     id?: string;
     issues?: Array<{
       code: string;
       id: string | null;
-      level: string;
+      level: "error" | "warning";
       message: string;
       path: string | null;
       scope: string | null;
-      [k: string]: unknown;
     }>;
     path?: string;
     relativePath?: string;
@@ -3984,20 +4020,54 @@ export type CommandsListReturn = {
     shadows?: string[];
     title?: string | null;
     token?: string;
-  }>;
-  locations: Record<string, unknown>;
+  }) & (({
+    id: string;
+  }) | ({
+    token: string;
+  }) | ({
+    title: string | null;
+  }) | ({
+    description: string | null;
+  }) | ({
+    argumentHint: string | null;
+  }) | ({
+    arguments: string[];
+  }) | ({
+    disabled: boolean;
+  }) | ({
+    scope: string;
+  }) | ({
+    path: string;
+  }) | ({
+    relativePath: string;
+  }) | ({
+    shadowedBy: string | null;
+  }) | ({
+    shadows: string[];
+  }) | ({
+    issues: Array<{
+      code: string;
+      id: string | null;
+      level: "error" | "warning";
+      message: string;
+      path: string | null;
+      scope: string | null;
+    }>;
+  }))>;
+  locations: {
+    agent: string | null;
+    global: string;
+  };
   pagination: {
-    hasMore: boolean;
+    hasMore?: boolean;
     limit: number;
-    nextCommand: string | null;
-    nextOffset: number | null;
+    nextCommand?: string | null;
+    nextOffset?: number | null;
     offset: number;
     returned: number;
     total: number;
-    [k: string]: unknown;
   };
   total: number;
-  [k: string]: unknown;
 };
 
 /** Input shape for `commands.run`. */

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -3931,12 +3931,12 @@ export type CommandsListInput = {
 export type CommandsListReturn = {
   agent: Record<string, unknown>;
   commands: Array<{
-    argumentHint: string | null;
-    arguments: unknown[];
-    description: string | null;
-    disabled: boolean;
-    id: string;
-    issues: Array<{
+    argumentHint?: string | null;
+    arguments?: unknown[];
+    description?: string | null;
+    disabled?: boolean;
+    id?: string;
+    issues?: Array<{
       code: string;
       id: string | null;
       level: string;
@@ -3945,14 +3945,13 @@ export type CommandsListReturn = {
       scope: string | null;
       [k: string]: unknown;
     }>;
-    path: string;
-    relativePath: string;
-    scope: string;
-    shadowedBy: string | null;
-    shadows: string[];
-    title: string | null;
-    token: string;
-    [k: string]: unknown;
+    path?: string;
+    relativePath?: string;
+    scope?: string;
+    shadowedBy?: string | null;
+    shadows?: string[];
+    title?: string | null;
+    token?: string;
   }>;
   issues: Array<{
     code: string;
@@ -3963,7 +3962,29 @@ export type CommandsListReturn = {
     scope: string | null;
     [k: string]: unknown;
   }>;
-  items: Array<Record<string, unknown>>;
+  items: Array<{
+    argumentHint?: string | null;
+    arguments?: unknown[];
+    description?: string | null;
+    disabled?: boolean;
+    id?: string;
+    issues?: Array<{
+      code: string;
+      id: string | null;
+      level: string;
+      message: string;
+      path: string | null;
+      scope: string | null;
+      [k: string]: unknown;
+    }>;
+    path?: string;
+    relativePath?: string;
+    scope?: string;
+    shadowedBy?: string | null;
+    shadows?: string[];
+    title?: string | null;
+    token?: string;
+  }>;
   locations: Record<string, unknown>;
   pagination: {
     hasMore: boolean;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:9f82fb5061db6b338fcadf002457ed7f59bcb8f22cc359a60fa31a9da2ac317e";
+export const REGISTRY_HASH = "sha256:c3cfd9e4a5d2e1ffec3943b9c597464ca93f536a7408908a634c4247db5f6c53";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "560517a43248";
+export const GIT_SHA = "e32efb03e8a2";

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:c3cfd9e4a5d2e1ffec3943b9c597464ca93f536a7408908a634c4247db5f6c53";
+export const REGISTRY_HASH = "sha256:57d0066106d961f35f553cb750378b46c85fb3d07bf5691cea44638324a13202";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "e32efb03e8a2";
+export const GIT_SHA = "d67ad42acbb3";

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:e34286d91e1da6bb4fd22f541e888ec37567b3efed4fa0fbb38d2ce76470340d";
+export const REGISTRY_HASH = "sha256:9f82fb5061db6b338fcadf002457ed7f59bcb8f22cc359a60fa31a9da2ac317e";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "571b155daf90";
+export const GIT_SHA = "560517a43248";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -21300,7 +21300,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "fields": {
-        "description": "Compact mode: keep only these fields of each item",
+        "description": "Compact fields: id,token,title,description,argumentHint,arguments,disabled,scope,path,relativePath,shadowedBy,shadows,issues",
         "type": "string"
       },
       "limit": {

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -21331,7 +21331,7 @@ public enum RaviSchemas {
       },
       "commands": {
         "items": {
-          "additionalProperties": {},
+          "additionalProperties": false,
           "properties": {
             "argumentHint": {
               "anyOf": [
@@ -21458,21 +21458,6 @@ public enum RaviSchemas {
               "type": "string"
             }
           },
-          "required": [
-            "id",
-            "token",
-            "title",
-            "description",
-            "argumentHint",
-            "arguments",
-            "disabled",
-            "scope",
-            "path",
-            "relativePath",
-            "shadowedBy",
-            "shadows",
-            "issues"
-          ],
           "type": "object"
         },
         "type": "array"
@@ -21535,8 +21520,133 @@ public enum RaviSchemas {
       },
       "items": {
         "items": {
-          "additionalProperties": {},
-          "properties": {},
+          "additionalProperties": false,
+          "properties": {
+            "argumentHint": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "arguments": {
+              "items": {},
+              "type": "array"
+            },
+            "description": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "disabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            },
+            "issues": {
+              "items": {
+                "additionalProperties": {},
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "level": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "scope": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "level",
+                  "code",
+                  "message",
+                  "id",
+                  "scope",
+                  "path"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "path": {
+              "type": "string"
+            },
+            "relativePath": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "string"
+            },
+            "shadowedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "shadows": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "token": {
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "type": "array"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -21322,149 +21322,438 @@ public enum RaviSchemas {
 
   public static let CommandsListReturnSchema = #"""
   {
-    "additionalProperties": {},
+    "additionalProperties": false,
     "properties": {
       "agent": {
-        "additionalProperties": {},
-        "properties": {},
+        "additionalProperties": false,
+        "properties": {
+          "cwd": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "cwd"
+        ],
+        "title": "CommandsListAgent",
         "type": "object"
       },
       "commands": {
         "items": {
-          "additionalProperties": false,
-          "properties": {
-            "argumentHint": {
-              "anyOf": [
-                {
+          "allOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "argumentHint": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "arguments": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "id": {
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "arguments": {
-              "items": {},
-              "type": "array"
-            },
-            "description": {
-              "anyOf": [
-                {
+                "issues": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "code": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "level": {
+                        "enum": [
+                          "error",
+                          "warning"
+                        ],
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "level",
+                      "code",
+                      "message",
+                      "id",
+                      "scope",
+                      "path"
+                    ],
+                    "title": "CommandsListIssue",
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "path": {
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "disabled": {
-              "type": "boolean"
-            },
-            "id": {
-              "type": "string"
-            },
-            "issues": {
-              "items": {
-                "additionalProperties": {},
-                "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "level": {
-                    "type": "string"
-                  },
-                  "message": {
-                    "type": "string"
-                  },
-                  "path": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "scope": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  }
+                "relativePath": {
+                  "type": "string"
                 },
-                "required": [
-                  "level",
-                  "code",
-                  "message",
-                  "id",
-                  "scope",
-                  "path"
-                ],
-                "type": "object"
+                "scope": {
+                  "type": "string"
+                },
+                "shadowedBy": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "shadows": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "token": {
+                  "type": "string"
+                }
               },
-              "type": "array"
+              "type": "object"
             },
-            "path": {
-              "type": "string"
-            },
-            "relativePath": {
-              "type": "string"
-            },
-            "scope": {
-              "type": "string"
-            },
-            "shadowedBy": {
+            {
               "anyOf": [
                 {
-                  "type": "string"
+                  "additionalProperties": {},
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "type": "object"
                 },
                 {
-                  "type": "null"
-                }
-              ]
-            },
-            "shadows": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "type": "string"
+                  "additionalProperties": {},
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ],
+                  "type": "object"
                 },
                 {
-                  "type": "null"
+                  "additionalProperties": {},
+                  "properties": {
+                    "title": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "title"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "description"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "argumentHint": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "argumentHint"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "arguments": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "arguments"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "disabled"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "scope": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "scope"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "relativePath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "relativePath"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "shadowedBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "shadowedBy"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "shadows": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "shadows"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "issues": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "level": {
+                            "enum": [
+                              "error",
+                              "warning"
+                            ],
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "scope": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "level",
+                          "code",
+                          "message",
+                          "id",
+                          "scope",
+                          "path"
+                        ],
+                        "title": "CommandsListIssue",
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "issues"
+                  ],
+                  "type": "object"
                 }
               ]
-            },
-            "token": {
-              "type": "string"
             }
-          },
-          "type": "object"
+          ],
+          "title": "CommandsListItem"
         },
         "type": "array"
       },
+      "filters": {
+        "additionalProperties": false,
+        "properties": {
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ],
+        "title": "CommandsListFilters",
+        "type": "object"
+      },
       "issues": {
         "items": {
-          "additionalProperties": {},
+          "additionalProperties": false,
           "properties": {
             "code": {
               "type": "string"
@@ -21480,6 +21769,10 @@ public enum RaviSchemas {
               ]
             },
             "level": {
+              "enum": [
+                "error",
+                "warning"
+              ],
               "type": "string"
             },
             "message": {
@@ -21514,150 +21807,434 @@ public enum RaviSchemas {
             "scope",
             "path"
           ],
+          "title": "CommandsListIssue",
           "type": "object"
         },
         "type": "array"
       },
       "items": {
         "items": {
-          "additionalProperties": false,
-          "properties": {
-            "argumentHint": {
-              "anyOf": [
-                {
+          "allOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "argumentHint": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "arguments": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "id": {
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "arguments": {
-              "items": {},
-              "type": "array"
-            },
-            "description": {
-              "anyOf": [
-                {
+                "issues": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "code": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "level": {
+                        "enum": [
+                          "error",
+                          "warning"
+                        ],
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "level",
+                      "code",
+                      "message",
+                      "id",
+                      "scope",
+                      "path"
+                    ],
+                    "title": "CommandsListIssue",
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "path": {
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "disabled": {
-              "type": "boolean"
-            },
-            "id": {
-              "type": "string"
-            },
-            "issues": {
-              "items": {
-                "additionalProperties": {},
-                "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "level": {
-                    "type": "string"
-                  },
-                  "message": {
-                    "type": "string"
-                  },
-                  "path": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "scope": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  }
+                "relativePath": {
+                  "type": "string"
                 },
-                "required": [
-                  "level",
-                  "code",
-                  "message",
-                  "id",
-                  "scope",
-                  "path"
-                ],
-                "type": "object"
+                "scope": {
+                  "type": "string"
+                },
+                "shadowedBy": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "shadows": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "token": {
+                  "type": "string"
+                }
               },
-              "type": "array"
+              "type": "object"
             },
-            "path": {
-              "type": "string"
-            },
-            "relativePath": {
-              "type": "string"
-            },
-            "scope": {
-              "type": "string"
-            },
-            "shadowedBy": {
+            {
               "anyOf": [
                 {
-                  "type": "string"
+                  "additionalProperties": {},
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "type": "object"
                 },
                 {
-                  "type": "null"
-                }
-              ]
-            },
-            "shadows": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "type": "string"
+                  "additionalProperties": {},
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ],
+                  "type": "object"
                 },
                 {
-                  "type": "null"
+                  "additionalProperties": {},
+                  "properties": {
+                    "title": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "title"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "description"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "argumentHint": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "argumentHint"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "arguments": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "arguments"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "disabled"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "scope": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "scope"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "relativePath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "relativePath"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "shadowedBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "shadowedBy"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "shadows": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "shadows"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": {},
+                  "properties": {
+                    "issues": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "level": {
+                            "enum": [
+                              "error",
+                              "warning"
+                            ],
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "scope": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "level",
+                          "code",
+                          "message",
+                          "id",
+                          "scope",
+                          "path"
+                        ],
+                        "title": "CommandsListIssue",
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "issues"
+                  ],
+                  "type": "object"
                 }
               ]
-            },
-            "token": {
-              "type": "string"
             }
-          },
-          "type": "object"
+          ],
+          "title": "CommandsListItem"
         },
         "type": "array"
       },
       "locations": {
-        "additionalProperties": {},
-        "properties": {},
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "global": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent",
+          "global"
+        ],
+        "title": "CommandsListLocations",
         "type": "object"
       },
       "pagination": {
-        "additionalProperties": {},
+        "additionalProperties": false,
         "properties": {
           "hasMore": {
             "type": "boolean"
@@ -21699,11 +22276,9 @@ public enum RaviSchemas {
           "limit",
           "offset",
           "returned",
-          "total",
-          "hasMore",
-          "nextOffset",
-          "nextCommand"
+          "total"
         ],
+        "title": "CommandsListPagination",
         "type": "object"
       },
       "total": {
@@ -21713,9 +22288,9 @@ public enum RaviSchemas {
     "required": [
       "total",
       "pagination",
-      "items",
       "agent",
       "locations",
+      "items",
       "commands",
       "issues"
     ],

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -4889,12 +4889,12 @@ public struct CommandsListReturn: Codable, Sendable {
   public var agent: [String: RaviJSON]
   public var commands: [RaviJSON]
   public var issues: [RaviJSON]
-  public var items: [[String: RaviJSON]]
+  public var items: [RaviJSON]
   public var locations: [String: RaviJSON]
   public var pagination: RaviJSON
   public var total: Double
 
-  public init(agent: [String: RaviJSON], commands: [RaviJSON], issues: [RaviJSON], items: [[String: RaviJSON]], locations: [String: RaviJSON], pagination: RaviJSON, total: Double) {
+  public init(agent: [String: RaviJSON], commands: [RaviJSON], issues: [RaviJSON], items: [RaviJSON], locations: [String: RaviJSON], pagination: RaviJSON, total: Double) {
     self.agent = agent
     self.commands = commands
     self.issues = issues

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -4,6 +4,274 @@
 
 import Foundation
 
+private struct RaviGeneratedCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init?(intValue: Int) {
+    self.stringValue = String(intValue)
+    self.intValue = intValue
+  }
+}
+
+public struct CommandsListAgent: Codable, Sendable {
+  public var cwd: String
+  public var id: String
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case cwd = "cwd"
+    case id = "id"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListAgent contains an unknown field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.cwd = try container.decode(String.self, forKey: .cwd)
+    self.id = try container.decode(String.self, forKey: .id)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.cwd, forKey: .cwd)
+    try container.encode(self.id, forKey: .id)
+  }
+}
+
+public struct CommandsListFilters: Codable, Sendable {
+  public var tag: String
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case tag = "tag"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListFilters contains an unknown field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.tag = try container.decode(String.self, forKey: .tag)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.tag, forKey: .tag)
+  }
+}
+
+public struct CommandsListIssue: Codable, Sendable {
+  public var code: String
+  public var id: String?
+  public var level: String
+  public var message: String
+  public var path: String?
+  public var scope: String?
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case code = "code"
+    case id = "id"
+    case level = "level"
+    case message = "message"
+    case path = "path"
+    case scope = "scope"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListIssue contains an unknown field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.code = try container.decode(String.self, forKey: .code)
+    guard container.contains(.id) else {
+      throw DecodingError.keyNotFound(CodingKeys.id, .init(codingPath: decoder.codingPath, debugDescription: "Missing required field id."))
+    }
+    self.id = try container.decodeIfPresent(String.self, forKey: .id)
+    self.level = try container.decode(String.self, forKey: .level)
+    self.message = try container.decode(String.self, forKey: .message)
+    guard container.contains(.path) else {
+      throw DecodingError.keyNotFound(CodingKeys.path, .init(codingPath: decoder.codingPath, debugDescription: "Missing required field path."))
+    }
+    self.path = try container.decodeIfPresent(String.self, forKey: .path)
+    guard container.contains(.scope) else {
+      throw DecodingError.keyNotFound(CodingKeys.scope, .init(codingPath: decoder.codingPath, debugDescription: "Missing required field scope."))
+    }
+    self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.code, forKey: .code)
+    try container.encode(self.id, forKey: .id)
+    try container.encode(self.level, forKey: .level)
+    try container.encode(self.message, forKey: .message)
+    try container.encode(self.path, forKey: .path)
+    try container.encode(self.scope, forKey: .scope)
+  }
+}
+
+public struct CommandsListItem: Codable, Sendable {
+  public var argumentHint: String?
+  public var arguments: [String]?
+  public var description: String?
+  public var disabled: Bool?
+  public var id: String?
+  public var issues: [CommandsListIssue]?
+  public var path: String?
+  public var relativePath: String?
+  public var scope: String?
+  public var shadowedBy: String?
+  public var shadows: [String]?
+  public var title: String?
+  public var token: String?
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case argumentHint = "argumentHint"
+    case arguments = "arguments"
+    case description = "description"
+    case disabled = "disabled"
+    case id = "id"
+    case issues = "issues"
+    case path = "path"
+    case relativePath = "relativePath"
+    case scope = "scope"
+    case shadowedBy = "shadowedBy"
+    case shadows = "shadows"
+    case title = "title"
+    case token = "token"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListItem contains an unknown field."))
+    }
+    guard !rawContainer.allKeys.isEmpty else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListItem requires at least one field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.argumentHint = try container.decodeIfPresent(String.self, forKey: .argumentHint)
+    self.arguments = try container.decodeIfPresent([String].self, forKey: .arguments)
+    self.description = try container.decodeIfPresent(String.self, forKey: .description)
+    self.disabled = try container.decodeIfPresent(Bool.self, forKey: .disabled)
+    self.id = try container.decodeIfPresent(String.self, forKey: .id)
+    self.issues = try container.decodeIfPresent([CommandsListIssue].self, forKey: .issues)
+    self.path = try container.decodeIfPresent(String.self, forKey: .path)
+    self.relativePath = try container.decodeIfPresent(String.self, forKey: .relativePath)
+    self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+    self.shadowedBy = try container.decodeIfPresent(String.self, forKey: .shadowedBy)
+    self.shadows = try container.decodeIfPresent([String].self, forKey: .shadows)
+    self.title = try container.decodeIfPresent(String.self, forKey: .title)
+    self.token = try container.decodeIfPresent(String.self, forKey: .token)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(self.argumentHint, forKey: .argumentHint)
+    try container.encodeIfPresent(self.arguments, forKey: .arguments)
+    try container.encodeIfPresent(self.description, forKey: .description)
+    try container.encodeIfPresent(self.disabled, forKey: .disabled)
+    try container.encodeIfPresent(self.id, forKey: .id)
+    try container.encodeIfPresent(self.issues, forKey: .issues)
+    try container.encodeIfPresent(self.path, forKey: .path)
+    try container.encodeIfPresent(self.relativePath, forKey: .relativePath)
+    try container.encodeIfPresent(self.scope, forKey: .scope)
+    try container.encodeIfPresent(self.shadowedBy, forKey: .shadowedBy)
+    try container.encodeIfPresent(self.shadows, forKey: .shadows)
+    try container.encodeIfPresent(self.title, forKey: .title)
+    try container.encodeIfPresent(self.token, forKey: .token)
+  }
+}
+
+public struct CommandsListLocations: Codable, Sendable {
+  public var agent: String?
+  public var global: String
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case agent = "agent"
+    case global = "global"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListLocations contains an unknown field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    guard container.contains(.agent) else {
+      throw DecodingError.keyNotFound(CodingKeys.agent, .init(codingPath: decoder.codingPath, debugDescription: "Missing required field agent."))
+    }
+    self.agent = try container.decodeIfPresent(String.self, forKey: .agent)
+    self.global = try container.decode(String.self, forKey: .global)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.agent, forKey: .agent)
+    try container.encode(self.global, forKey: .global)
+  }
+}
+
+public struct CommandsListPagination: Codable, Sendable {
+  public var hasMore: Bool?
+  public var limit: Double
+  public var nextCommand: String?
+  public var nextOffset: Double?
+  public var offset: Double
+  public var returned: Double
+  public var total: Double
+
+  enum CodingKeys: String, CodingKey, CaseIterable {
+    case hasMore = "hasMore"
+    case limit = "limit"
+    case nextCommand = "nextCommand"
+    case nextOffset = "nextOffset"
+    case offset = "offset"
+    case returned = "returned"
+    case total = "total"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)
+    let allowedKeys = Set(CodingKeys.allCases.map(\.rawValue))
+    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "CommandsListPagination contains an unknown field."))
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.hasMore = try container.decodeIfPresent(Bool.self, forKey: .hasMore)
+    self.limit = try container.decode(Double.self, forKey: .limit)
+    self.nextCommand = try container.decodeIfPresent(String.self, forKey: .nextCommand)
+    self.nextOffset = try container.decodeIfPresent(Double.self, forKey: .nextOffset)
+    self.offset = try container.decode(Double.self, forKey: .offset)
+    self.returned = try container.decode(Double.self, forKey: .returned)
+    self.total = try container.decode(Double.self, forKey: .total)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(self.hasMore, forKey: .hasMore)
+    try container.encode(self.limit, forKey: .limit)
+    try container.encodeIfPresent(self.nextCommand, forKey: .nextCommand)
+    try container.encodeIfPresent(self.nextOffset, forKey: .nextOffset)
+    try container.encode(self.offset, forKey: .offset)
+    try container.encode(self.returned, forKey: .returned)
+    try container.encode(self.total, forKey: .total)
+  }
+}
+
 public struct AdaptersListOptions: Codable, Sendable {
   public var limit: String?
   public var offset: String?
@@ -4886,17 +5154,19 @@ public struct CommandsListOptions: Codable, Sendable {
 }
 
 public struct CommandsListReturn: Codable, Sendable {
-  public var agent: [String: RaviJSON]
-  public var commands: [RaviJSON]
-  public var issues: [RaviJSON]
-  public var items: [RaviJSON]
-  public var locations: [String: RaviJSON]
-  public var pagination: RaviJSON
+  public var agent: CommandsListAgent
+  public var commands: [CommandsListItem]
+  public var filters: CommandsListFilters?
+  public var issues: [CommandsListIssue]
+  public var items: [CommandsListItem]
+  public var locations: CommandsListLocations
+  public var pagination: CommandsListPagination
   public var total: Double
 
-  public init(agent: [String: RaviJSON], commands: [RaviJSON], issues: [RaviJSON], items: [RaviJSON], locations: [String: RaviJSON], pagination: RaviJSON, total: Double) {
+  public init(agent: CommandsListAgent, commands: [CommandsListItem], filters: CommandsListFilters? = nil, issues: [CommandsListIssue], items: [CommandsListItem], locations: CommandsListLocations, pagination: CommandsListPagination, total: Double) {
     self.agent = agent
     self.commands = commands
+    self.filters = filters
     self.issues = issues
     self.items = items
     self.locations = locations
@@ -4907,6 +5177,7 @@ public struct CommandsListReturn: Codable, Sendable {
   enum CodingKeys: String, CodingKey {
     case agent = "agent"
     case commands = "commands"
+    case filters = "filters"
     case issues = "issues"
     case items = "items"
     case locations = "locations"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:e34286d91e1da6bb4fd22f541e888ec37567b3efed4fa0fbb38d2ce76470340d"
-public let RAVI_GIT_SHA = "571b155daf90"
+public let RAVI_REGISTRY_HASH = "sha256:9f82fb5061db6b338fcadf002457ed7f59bcb8f22cc359a60fa31a9da2ac317e"
+public let RAVI_GIT_SHA = "560517a43248"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:9f82fb5061db6b338fcadf002457ed7f59bcb8f22cc359a60fa31a9da2ac317e"
-public let RAVI_GIT_SHA = "560517a43248"
+public let RAVI_REGISTRY_HASH = "sha256:c3cfd9e4a5d2e1ffec3943b9c597464ca93f536a7408908a634c4247db5f6c53"
+public let RAVI_GIT_SHA = "e32efb03e8a2"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:c3cfd9e4a5d2e1ffec3943b9c597464ca93f536a7408908a634c4247db5f6c53"
-public let RAVI_GIT_SHA = "e32efb03e8a2"
+public let RAVI_REGISTRY_HASH = "sha256:57d0066106d961f35f553cb750378b46c85fb3d07bf5691cea44638324a13202"
+public let RAVI_GIT_SHA = "d67ad42acbb3"

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -111,8 +111,20 @@ describe("agent-first CLI foundation contract", () => {
   it("keeps the projection API compatible for callers not migrated yet", () => {
     const rows = pickFields([{ id: "main", name: "Main" }], "id");
     expect(Object.keys(rows[0] ?? {})).toEqual(["id"]);
-    expect(Object.getOwnPropertyNames(rows[0] ?? {})).toEqual(["id"]);
+    expect(Object.getOwnPropertyNames(rows[0] ?? {})).toEqual(["id", "name"]);
+    expect(Object.getOwnPropertyDescriptor(rows[0] ?? {}, "name")?.enumerable).toBe(false);
     expect(JSON.parse(JSON.stringify(rows))).toEqual([{ id: "main" }]);
+  });
+
+  it("allows a migrated domain to request an honest serialized-only projection", () => {
+    const rows = pickFields([{ id: "review", scope: "agent" }], "id", {
+      acceptedFields: ["id", "scope"],
+      projection: "serialized-only",
+    });
+
+    expect(Object.keys(rows[0] ?? {})).toEqual(["id"]);
+    expect(Object.getOwnPropertyNames(rows[0] ?? {})).toEqual(["id"]);
+    expect(JSON.parse(JSON.stringify(rows))).toEqual([{ id: "review" }]);
   });
 
   it("routes direct legacy fail termination through the top-level flush boundary", () => {

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, spyOn } from "bun:test";
 import { expectedErrorToContractError, pickFields, unexpectedErrorToContractError } from "./agent-contract.js";
 import { fail } from "./context.js";
 import { CliExpectedError } from "./expected-error.js";
-import { CliTerminationRequest } from "./process-output.js";
+import { CliTerminationRequest, rethrowCliTermination } from "./process-output.js";
 
 describe("agent-first CLI foundation contract", () => {
   it("preserves explicitly public expected failures with their typed metadata", () => {
@@ -103,5 +103,18 @@ describe("agent-first CLI foundation contract", () => {
 
     expect(failure).toBeInstanceOf(CliTerminationRequest);
     expect((failure as CliTerminationRequest).exitCode).toBe(1);
+  });
+
+  it("preserves the exact private termination signal through legacy catches", () => {
+    const signal = new CliTerminationRequest(3);
+    let observed: unknown;
+
+    try {
+      rethrowCliTermination(signal);
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBe(signal);
   });
 });

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -3,8 +3,31 @@ import { expectedErrorToContractError, pickFields, unexpectedErrorToContractErro
 import { fail } from "./context.js";
 import { CliExpectedError } from "./expected-error.js";
 import { CliTerminationRequest, rethrowCliTermination } from "./process-output.js";
+import { shouldEmitCommandAudit } from "./decorators.js";
 
 describe("agent-first CLI foundation contract", () => {
+  it("limits audit opt-out to low-risk effect-free reads", () => {
+    expect(shouldEmitCommandAudit(undefined, "missing")).toBe(true);
+    expect(
+      shouldEmitCommandAudit(
+        { kind: "read", resource: "commands", action: "list", risk: "low", effectClass: "none", audit: "none" },
+        "commands.list",
+      ),
+    ).toBe(false);
+    expect(() =>
+      shouldEmitCommandAudit(
+        { kind: "mutate", resource: "commands", action: "write", risk: "low", audit: "none" },
+        "commands.write",
+      ),
+    ).toThrow('audit "none" is limited to low-risk reads');
+    expect(() =>
+      shouldEmitCommandAudit(
+        { kind: "read", resource: "secrets", action: "show", risk: "medium", audit: "none" },
+        "secrets.show",
+      ),
+    ).toThrow('audit "none" is limited to low-risk reads');
+  });
+
   it("preserves explicitly public expected failures with their typed metadata", () => {
     const expected = new CliExpectedError("The requested agent was not found.", "AGENT_NOT_FOUND", 1, {
       publicMessage: true,
@@ -88,6 +111,8 @@ describe("agent-first CLI foundation contract", () => {
   it("keeps the projection API compatible for callers not migrated yet", () => {
     const rows = pickFields([{ id: "main", name: "Main" }], "id");
     expect(Object.keys(rows[0] ?? {})).toEqual(["id"]);
+    expect(Object.getOwnPropertyNames(rows[0] ?? {})).toEqual(["id"]);
+    expect(JSON.parse(JSON.stringify(rows))).toEqual([{ id: "main" }]);
   });
 
   it("routes direct legacy fail termination through the top-level flush boundary", () => {

--- a/src/cli/agent-contract.foundation.test.ts
+++ b/src/cli/agent-contract.foundation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { expectedErrorToContractError, pickFields, unexpectedErrorToContractError } from "./agent-contract.js";
+import { fail } from "./context.js";
+import { CliExpectedError } from "./expected-error.js";
+import { CliTerminationRequest } from "./process-output.js";
+
+describe("agent-first CLI foundation contract", () => {
+  it("preserves explicitly public expected failures with their typed metadata", () => {
+    const expected = new CliExpectedError("The requested agent was not found.", "AGENT_NOT_FOUND", 1, {
+      publicMessage: true,
+      retryable: false,
+      suggestedAction: "List agents and retry with an existing id",
+      details: { suggestions: ["main"] },
+    });
+
+    expect(expectedErrorToContractError("agents show", expected)?.envelope()).toEqual({
+      success: false,
+      op: "agents show",
+      error: {
+        code: "AGENT_NOT_FOUND",
+        message: "The requested agent was not found.",
+        retryable: false,
+        suggestedAction: "List agents and retry with an existing id",
+        suggestions: ["main"],
+      },
+    });
+  });
+
+  it("keeps legacy expected and unexpected internal messages redacted", () => {
+    const legacy = expectedErrorToContractError(
+      "agents show",
+      new CliExpectedError("PRIVATE_LEGACY_DETAIL", "COMMAND_FAILED", 1),
+    );
+    const unexpected = unexpectedErrorToContractError("agents show");
+
+    expect(legacy?.envelope().error.message).toBe("Command could not be completed.");
+    expect(JSON.stringify(legacy?.envelope())).not.toContain("PRIVATE_LEGACY_DETAIL");
+    expect(unexpected.envelope().error).toMatchObject({
+      code: "UNHANDLED_ERROR",
+      message: "Command failed unexpectedly.",
+    });
+  });
+
+  it("rejects mixed valid and unknown fields before projecting records", () => {
+    let ownKeysCalls = 0;
+    const row = new Proxy(
+      { id: "main", name: "Main" },
+      {
+        ownKeys(target) {
+          ownKeysCalls += 1;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+
+    let failure: unknown;
+    try {
+      pickFields([row], "id,unknown", { acceptedFields: ["id", "name"] });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(ownKeysCalls).toBe(0);
+    const contract = expectedErrorToContractError("agents list", failure);
+    expect(contract?.exitCode).toBe(2);
+    expect(contract?.envelope().error).toMatchObject({
+      code: "USAGE_ERROR",
+      message: "--fields contains one or more unknown fields.",
+      retryable: false,
+      acceptedFields: ["id", "name"],
+    });
+  });
+
+  it("validates fields against the declared set when the result is empty", () => {
+    let failure: unknown;
+    try {
+      pickFields([], "unknown", { acceptedFields: ["id", "name"] });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(expectedErrorToContractError("agents list", failure)?.envelope().error).toMatchObject({
+      code: "USAGE_ERROR",
+      acceptedFields: ["id", "name"],
+    });
+  });
+
+  it("keeps the projection API compatible for callers not migrated yet", () => {
+    const rows = pickFields([{ id: "main", name: "Main" }], "id");
+    expect(Object.keys(rows[0] ?? {})).toEqual(["id"]);
+  });
+
+  it("routes direct legacy fail termination through the top-level flush boundary", () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    let failure: unknown;
+    try {
+      fail("safe direct failure");
+    } catch (error) {
+      failure = error;
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect((failure as CliTerminationRequest).exitCode).toBe(1);
+  });
+});

--- a/src/cli/agent-contract.ts
+++ b/src/cli/agent-contract.ts
@@ -19,7 +19,8 @@
  */
 import type { Command as CommanderCommand, CommanderError } from "commander";
 import { getContext } from "./context.js";
-import { CliExpectedError } from "./expected-error.js";
+import { CliExpectedError, cliUsageError } from "./expected-error.js";
+import { requestCliTermination } from "./process-output.js";
 import { sanitizePublicValue } from "./redaction.js";
 
 export const CONTRACT_EXIT_ERROR = 1;
@@ -34,6 +35,7 @@ export interface ContractErrorDetails {
   suggestedAction?: string;
   suggestions?: string[];
   acceptedFlags?: string[];
+  acceptedFields?: string[];
   [key: string]: unknown;
 }
 
@@ -99,8 +101,77 @@ export function contractFailureOutcome(error: Pick<ContractError, "code" | "exit
 
 export function expectedErrorToContractError(op: string, error: unknown): ContractError | null {
   if (!(error instanceof CliExpectedError)) return null;
-  return new ContractError(op, error.code, "Command could not be completed.", error.exitCode, {
-    suggestedAction: `Inspect the command input and retry '${op}'`,
+  return new ContractError(
+    op,
+    error.code,
+    error.publicMessage ? error.message : "Command could not be completed.",
+    error.exitCode,
+    {
+      ...error.details,
+      retryable: error.retryable,
+      suggestedAction: error.suggestedAction ?? `Inspect the command input and retry '${op}'`,
+    },
+  );
+}
+
+export interface PickFieldsOptions {
+  /** Stable public field set supplied by the owning domain. */
+  acceptedFields: readonly string[];
+}
+
+function parseRequestedFields(fields?: string): string[] {
+  return [
+    ...new Set(
+      (fields ?? "")
+        .split(",")
+        .map((key) => key.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function validateRequestedFields(keys: readonly string[], acceptedFields: readonly string[]): string[] {
+  const stableAcceptedFields = [...new Set(acceptedFields)];
+  const accepted = new Set(stableAcceptedFields);
+  if (keys.some((key) => !accepted.has(key))) {
+    throw cliUsageError("--fields contains one or more unknown fields.", {
+      suggestedAction: "Retry with only fields listed in acceptedFields",
+      details: { acceptedFields: stableAcceptedFields },
+    });
+  }
+  return stableAcceptedFields;
+}
+
+/**
+ * Compact mode (7.9): keep only the requested top-level fields of each item.
+ * Migrated callers supply a stable public field set so validation does not
+ * depend on the first result row and also works for empty result sets.
+ */
+export function pickFields<T>(items: T[], fields?: string, options?: PickFieldsOptions): T[] {
+  const keys = parseRequestedFields(fields);
+  if (keys.length === 0) return items;
+  if (options) validateRequestedFields(keys, options.acceptedFields);
+  return items.map((item) => {
+    const record = item as Record<string, unknown>;
+    const picked: Record<string, unknown> = {};
+    const requested = new Set(keys);
+    for (const key of Object.keys(record)) {
+      if (requested.has(key)) {
+        picked[key] = record[key];
+        continue;
+      }
+
+      // Keep the complete row available to @Returns validation while exposing
+      // only requested fields through JSON/Object.keys. The gateway validates
+      // handlers before serializing their original return value.
+      Object.defineProperty(picked, key, {
+        value: record[key],
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      });
+    }
+    return picked as T;
   });
 }
 
@@ -270,7 +341,7 @@ function commandTree(root: CommanderCommand): CommanderCommand[] {
 }
 
 function failUsage(command: CommanderCommand, error: CommanderError): never {
-  if (COMMANDER_PASSTHROUGH_CODES.has(error.code)) process.exit(error.exitCode);
+  if (COMMANDER_PASSTHROUGH_CODES.has(error.code)) requestCliTermination(error.exitCode);
   const commandPath = opPath(command);
   const op = commandPath || "cli";
   const usage = `ravi ${commandPath ? `${commandPath} ` : ""}${command.usage()}`.trim();
@@ -373,38 +444,4 @@ export function suggestSimilar(query: string, candidates: Array<string | null | 
     .sort((a, b) => b.score - a.score)
     .slice(0, max)
     .map((entry) => entry.candidate);
-}
-
-/**
- * Compact mode (7.9): keep only the requested top-level fields of each item.
- * Unknown fields are ignored; without `fields` the list passes through.
- */
-export function pickFields<T>(items: T[], fields?: string): T[] {
-  const keys = (fields ?? "")
-    .split(",")
-    .map((key) => key.trim())
-    .filter(Boolean);
-  if (keys.length === 0) return items;
-  return items.map((item) => {
-    const record = item as Record<string, unknown>;
-    const picked: Record<string, unknown> = {};
-    const requested = new Set(keys);
-    for (const key of Object.keys(record)) {
-      if (requested.has(key)) {
-        picked[key] = record[key];
-        continue;
-      }
-
-      // Keep the complete row available to @Returns validation while exposing
-      // only requested fields through JSON/Object.keys. The gateway validates
-      // handlers before serializing their original return value.
-      Object.defineProperty(picked, key, {
-        value: record[key],
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      });
-    }
-    return picked as T;
-  });
 }

--- a/src/cli/agent-contract.ts
+++ b/src/cli/agent-contract.ts
@@ -154,22 +154,8 @@ export function pickFields<T>(items: T[], fields?: string, options?: PickFieldsO
   return items.map((item) => {
     const record = item as Record<string, unknown>;
     const picked: Record<string, unknown> = {};
-    const requested = new Set(keys);
-    for (const key of Object.keys(record)) {
-      if (requested.has(key)) {
-        picked[key] = record[key];
-        continue;
-      }
-
-      // Keep the complete row available to @Returns validation while exposing
-      // only requested fields through JSON/Object.keys. The gateway validates
-      // handlers before serializing their original return value.
-      Object.defineProperty(picked, key, {
-        value: record[key],
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      });
+    for (const key of keys) {
+      if (Object.hasOwn(record, key)) picked[key] = record[key];
     }
     return picked as T;
   });

--- a/src/cli/agent-contract.ts
+++ b/src/cli/agent-contract.ts
@@ -117,6 +117,13 @@ export function expectedErrorToContractError(op: string, error: unknown): Contra
 export interface PickFieldsOptions {
   /** Stable public field set supplied by the owning domain. */
   acceptedFields: readonly string[];
+  /**
+   * `legacy-compatible` keeps non-selected fields non-enumerable so strict
+   * pre-serialization @Returns validators used by older domains still see the
+   * complete record. Migrated domains may opt into an honest serialized-only
+   * record once their projected Returns contract is explicit.
+   */
+  projection?: "legacy-compatible" | "serialized-only";
 }
 
 function parseRequestedFields(fields?: string): string[] {
@@ -154,8 +161,20 @@ export function pickFields<T>(items: T[], fields?: string, options?: PickFieldsO
   return items.map((item) => {
     const record = item as Record<string, unknown>;
     const picked: Record<string, unknown> = {};
-    for (const key of keys) {
-      if (Object.hasOwn(record, key)) picked[key] = record[key];
+    const requested = new Set(keys);
+    for (const key of Object.keys(record)) {
+      if (requested.has(key)) {
+        picked[key] = record[key];
+        continue;
+      }
+      if (options?.projection === "serialized-only") continue;
+
+      Object.defineProperty(picked, key, {
+        value: record[key],
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      });
     }
     return picked as T;
   });

--- a/src/cli/commands/agents.test.ts
+++ b/src/cli/commands/agents.test.ts
@@ -290,6 +290,25 @@ describe("AgentsCommands public return contracts", () => {
       console.log = originalLog;
     }
   });
+
+  it("keeps compact agents JSON while preserving its strict pre-serialization Returns contract", () => {
+    const commands = new AgentsCommands();
+    const originalLog = console.log;
+    console.log = () => {};
+
+    try {
+      const payload = commands.list(true, undefined, undefined, undefined, "id,cwd");
+      const item = payload.items[0] as Record<string, unknown>;
+      const serialized = JSON.parse(JSON.stringify(payload));
+
+      expect(Object.keys(item).sort()).toEqual(["cwd", "id"]);
+      expect(Object.getOwnPropertyNames(item).length).toBeGreaterThan(2);
+      expect(agentsListReturnSchema.safeParse(payload).success).toBe(true);
+      expect(Object.keys(serialized.items[0]).sort()).toEqual(["cwd", "id"]);
+    } finally {
+      console.log = originalLog;
+    }
+  });
 });
 
 describe("AgentsCommands set model validation", () => {

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -172,6 +172,37 @@ type AgentJsonSummary = Omit<AgentConfig, "modelPresetId"> & {
   tags: TagBinding[];
 };
 
+const AGENT_LIST_FIELDS = [
+  "id",
+  "name",
+  "cwd",
+  "model",
+  "effort",
+  "provider",
+  "modelPresetId",
+  "dmScope",
+  "systemPromptAppend",
+  "debounceMs",
+  "groupDebounceMs",
+  "matrixAccount",
+  "heartbeat",
+  "settingSources",
+  "memoryModel",
+  "specMode",
+  "contactScope",
+  "allowedSessions",
+  "mode",
+  "remote",
+  "remoteUser",
+  "defaults",
+  "isDefault",
+  "effectiveProvider",
+  "effectiveModel",
+  "modelSource",
+  "modelPresetVersion",
+  "tags",
+] as const satisfies ReadonlyArray<keyof AgentJsonSummary>;
+
 function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
 }
@@ -560,7 +591,7 @@ export class AgentsCommands {
       total: page.total,
       options: ["--tag", tagSlug?.trim() || null],
     });
-    const projectedRows = pickFields(agentRows, fields);
+    const projectedRows = pickFields(agentRows, fields, { acceptedFields: AGENT_LIST_FIELDS });
     const payload = {
       total: page.total,
       pagination,

--- a/src/cli/commands/commands.process.test.ts
+++ b/src/cli/commands/commands.process.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { Database } from "bun:sqlite";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -35,7 +36,6 @@ function runCli(args: string[]): CliResult {
       ...withoutRaviRuntimeContextEnv(),
       RAVI_HOME: stateDir,
       RAVI_STATE_DIR: stateDir,
-      RAVI_SUPPRESS_AUDIT_EVENTS: "1",
     },
   });
   return {
@@ -67,25 +67,67 @@ function sourceDigest(): SourceFileDigest[] {
   return files.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-async function logicalStateDigest(): Promise<string> {
-  const { dbGetAgent, dbListRoutes, closeRouterDb } = await import("../../router/router-db.js");
-  const { listSessions, closeSessionStore } = await import("../../router/sessions.js");
-  const value = JSON.stringify({
-    agent: dbGetAgent("main"),
-    routes: dbListRoutes(),
-    sessions: listSessions(),
-  });
-  closeSessionStore();
-  closeRouterDb();
-  return createHash("sha256").update(value).digest("hex");
+function stateFileDigest(): SourceFileDigest[] {
+  const files: SourceFileDigest[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    )) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) visit(path);
+      else if (entry.isFile()) {
+        files.push({
+          path: relative(stateDir, path).replaceAll("\\", "/"),
+          sha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
+        });
+      }
+    }
+  };
+  visit(stateDir);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function logicalStateDigest(): string {
+  const path = join(stateDir, "ravi.db");
+  if (!existsSync(path)) return createHash("sha256").update("missing").digest("hex");
+  const database = new Database(path, { readonly: true, create: false });
+  try {
+    const tableNames = (
+      database
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    const snapshot = tableNames.map((table) => {
+      const escaped = table.replaceAll('"', '""');
+      const rows = (database.prepare(`SELECT * FROM "${escaped}"`).all() as Array<Record<string, unknown>>)
+        .map((row) => JSON.stringify(row))
+        .sort();
+      return { table, rows };
+    });
+    return createHash("sha256").update(JSON.stringify(snapshot)).digest("hex");
+  } finally {
+    database.close();
+  }
+}
+
+function captureState(): { sources: SourceFileDigest[]; files: SourceFileDigest[]; logical: string } {
+  const logical = logicalStateDigest();
+  return { sources: sourceDigest(), files: stateFileDigest(), logical };
+}
+
+function expectStateUnchanged(before: ReturnType<typeof captureState>): void {
+  const after = captureState();
+  expect(after.sources).toEqual(before.sources);
+  expect(after.logical).toBe(before.logical);
+  expect(after.files).toEqual(before.files);
 }
 
 function expectReadOnlySuccess(args: string[]): Record<string, unknown> {
-  const before = sourceDigest();
+  const before = captureState();
   const result = runCli(args);
 
   expect(result).toMatchObject({ status: 0, stderr: "" });
-  expect(sourceDigest()).toEqual(before);
+  expectStateUnchanged(before);
 
   return JSON.parse(result.stdout) as Record<string, unknown>;
 }
@@ -107,12 +149,12 @@ beforeAll(async () => {
   const { dbUpdateAgent, closeRouterDb } = await import("../../router/router-db.js");
   dbUpdateAgent("main", { cwd: agentCwd });
   closeRouterDb();
-  logicalStateBefore = await logicalStateDigest();
+  logicalStateBefore = logicalStateDigest();
 });
 
 afterAll(async () => {
   try {
-    expect(await logicalStateDigest()).toBe(logicalStateBefore);
+    expect(logicalStateDigest()).toBe(logicalStateBefore);
   } finally {
     await cleanupIsolatedRaviState(stateDir);
     rmSync(agentCwd, { recursive: true, force: true });
@@ -121,13 +163,13 @@ afterAll(async () => {
 
 describe("commands process contract", () => {
   it("prints group help with exit 0 when no operation is supplied", () => {
-    const before = sourceDigest();
+    const before = captureState();
     const result = runCli(["commands"]);
 
     expect(result).toMatchObject({ status: 0, stderr: "" });
     expect(result.stdout).toContain("Usage: ravi commands");
     expect(result.stdout).toContain("list [options]");
-    expect(sourceDigest()).toEqual(before);
+    expectStateUnchanged(before);
   });
 
   it("list is paginated, projected, and leaves command sources unchanged", () => {
@@ -178,7 +220,7 @@ describe("commands process contract", () => {
     },
   ] as const) {
     it(`returns one typed exit-2 envelope for ${testCase.name}`, () => {
-      const before = sourceDigest();
+      const before = captureState();
       const result = runCli([...testCase.args]);
 
       expect(result).toMatchObject({ status: 2, stderr: "" });
@@ -189,7 +231,7 @@ describe("commands process contract", () => {
       };
       expect(payload).toMatchObject({ success: false, error: { code: testCase.code } });
       if (testCase.acceptedFields) expect(payload.error.acceptedFields).toContain("id");
-      expect(sourceDigest()).toEqual(before);
+      expectStateUnchanged(before);
     });
   }
 });

--- a/src/cli/commands/commands.process.test.ts
+++ b/src/cli/commands/commands.process.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  cleanupIsolatedRaviState,
+  createIsolatedRaviState,
+  withoutRaviRuntimeContextEnv,
+} from "../../test/ravi-state.js";
+
+setDefaultTimeout(90_000);
+
+let stateDir = "";
+let agentCwd = "";
+let logicalStateBefore = "";
+
+interface CliResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface SourceFileDigest {
+  path: string;
+  sha256: string;
+}
+
+function runCli(args: string[]): CliResult {
+  const result = spawnSync("bun", ["src/cli/index.ts", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...withoutRaviRuntimeContextEnv(),
+      RAVI_HOME: stateDir,
+      RAVI_STATE_DIR: stateDir,
+      RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function sourceDigest(): SourceFileDigest[] {
+  const roots = [join(agentCwd, ".ravi", "commands"), join(stateDir, "commands")];
+  const files: SourceFileDigest[] = [];
+  const visit = (root: string, directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    )) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(root, path);
+      } else if (entry.isFile()) {
+        files.push({
+          path: `${relative(root, path).replaceAll("\\", "/")}:${root === roots[0] ? "agent" : "global"}`,
+          sha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
+        });
+      }
+    }
+  };
+  for (const root of roots) visit(root, root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function logicalStateDigest(): Promise<string> {
+  const { dbGetAgent, dbListRoutes, closeRouterDb } = await import("../../router/router-db.js");
+  const { listSessions, closeSessionStore } = await import("../../router/sessions.js");
+  const value = JSON.stringify({
+    agent: dbGetAgent("main"),
+    routes: dbListRoutes(),
+    sessions: listSessions(),
+  });
+  closeSessionStore();
+  closeRouterDb();
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function expectReadOnlySuccess(args: string[]): Record<string, unknown> {
+  const before = sourceDigest();
+  const result = runCli(args);
+
+  expect(result).toMatchObject({ status: 0, stderr: "" });
+  expect(sourceDigest()).toEqual(before);
+
+  return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  stateDir = await createIsolatedRaviState("ravi-commands-process-");
+  agentCwd = mkdtempSync(join(tmpdir(), "ravi-commands-agent-"));
+
+  const agentCommandsDir = join(agentCwd, ".ravi", "commands");
+  const globalCommandsDir = join(stateDir, "commands");
+  mkdirSync(agentCommandsDir, { recursive: true });
+  mkdirSync(globalCommandsDir, { recursive: true });
+  writeFileSync(
+    join(agentCommandsDir, "review.md"),
+    "---\ntitle: Review\ndescription: Review a change\n---\nReview $ARGUMENTS",
+  );
+  writeFileSync(join(globalCommandsDir, "notes.md"), "Summarize notes");
+
+  const { dbUpdateAgent, closeRouterDb } = await import("../../router/router-db.js");
+  dbUpdateAgent("main", { cwd: agentCwd });
+  closeRouterDb();
+  logicalStateBefore = await logicalStateDigest();
+});
+
+afterAll(async () => {
+  try {
+    expect(await logicalStateDigest()).toBe(logicalStateBefore);
+  } finally {
+    await cleanupIsolatedRaviState(stateDir);
+    rmSync(agentCwd, { recursive: true, force: true });
+  }
+});
+
+describe("commands process contract", () => {
+  it("prints group help with exit 0 when no operation is supplied", () => {
+    const before = sourceDigest();
+    const result = runCli(["commands"]);
+
+    expect(result).toMatchObject({ status: 0, stderr: "" });
+    expect(result.stdout).toContain("Usage: ravi commands");
+    expect(result.stdout).toContain("list [options]");
+    expect(sourceDigest()).toEqual(before);
+  });
+
+  it("list is paginated, projected, and leaves command sources unchanged", () => {
+    const payload = expectReadOnlySuccess(["commands", "list", "--limit", "1", "--fields", "id", "--json"]);
+    expect(payload.items).toEqual([{ id: "notes" }]);
+    expect(payload.commands).toEqual(payload.items);
+    expect(payload.pagination).toMatchObject({ limit: 1, offset: 0, returned: 1, total: 2, nextOffset: 1 });
+  });
+
+  it("show resolves case-insensitively and leaves command sources unchanged", () => {
+    const payload = expectReadOnlySuccess(["commands", "show", "#REVIEW", "--json"]);
+    expect(payload.command).toMatchObject({ id: "review", scope: "agent", body: "Review $ARGUMENTS" });
+  });
+
+  it("validate returns a verdict and leaves command sources unchanged", () => {
+    const payload = expectReadOnlySuccess(["commands", "validate", "--json"]);
+    expect(payload).toMatchObject({ valid: true, total: 2, effectiveTotal: 2, errors: [], warnings: [] });
+  });
+
+  it("run renders a preview and leaves command sources and runtime untouched", () => {
+    const payload = expectReadOnlySuccess(["commands", "run", "review", "--json", "--", "change-42"]);
+    expect(payload.prompt).toContain("Review change-42");
+    expect(payload.metadata).toMatchObject({ id: "review", scope: "agent" });
+    expect((payload.metadata as { renderedPromptSha256: string }).renderedPromptSha256).toHaveLength(64);
+  });
+
+  for (const testCase of [
+    {
+      name: "empty name",
+      args: ["commands", "show", "", "--json"],
+      code: "INVALID_COMMAND_NAME",
+    },
+    {
+      name: "invalid name",
+      args: ["commands", "run", "bad_name", "--json"],
+      code: "INVALID_COMMAND_NAME",
+    },
+    {
+      name: "invalid pagination",
+      args: ["commands", "list", "--limit", "0", "--json"],
+      code: "USAGE_ERROR",
+    },
+    {
+      name: "invalid fields",
+      args: ["commands", "list", "--fields", "id,unknown", "--json"],
+      code: "USAGE_ERROR",
+      acceptedFields: true,
+    },
+  ] as const) {
+    it(`returns one typed exit-2 envelope for ${testCase.name}`, () => {
+      const before = sourceDigest();
+      const result = runCli([...testCase.args]);
+
+      expect(result).toMatchObject({ status: 2, stderr: "" });
+      const payload = JSON.parse(result.stdout) as {
+        success: boolean;
+        op: string;
+        error: { code: string; acceptedFields?: string[] };
+      };
+      expect(payload).toMatchObject({ success: false, error: { code: testCase.code } });
+      if (testCase.acceptedFields) expect(payload.error.acceptedFields).toContain("id");
+      expect(sourceDigest()).toEqual(before);
+    });
+  }
+});

--- a/src/cli/commands/commands.process.test.ts
+++ b/src/cli/commands/commands.process.test.ts
@@ -78,7 +78,7 @@ function stateFileDigest(): SourceFileDigest[] {
     )) {
       const path = join(directory, entry.name);
       if (entry.isDirectory()) visit(path);
-      else if (entry.isFile()) {
+      else if (entry.isFile() && !entry.name.endsWith("-shm")) {
         files.push({
           path: relative(stateDir, path).replaceAll("\\", "/"),
           sha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
@@ -114,8 +114,14 @@ function logicalStateDigest(): string {
 }
 
 function captureState(): { sources: SourceFileDigest[]; files: SourceFileDigest[]; logical: string } {
+  // Capture durable bytes before opening the independent logical reader. A
+  // SQLite read may legitimately participate in WAL coordination through the
+  // ephemeral -shm index, but it must not alter ravi.db, its WAL, command
+  // sources, other state files, or any logical row.
+  const sources = sourceDigest();
+  const files = stateFileDigest();
   const logical = logicalStateDigest();
-  return { sources: sourceDigest(), files: stateFileDigest(), logical };
+  return { sources, files, logical };
 }
 
 function expectStateUnchanged(before: ReturnType<typeof captureState>): void {
@@ -206,6 +212,27 @@ describe("commands process contract", () => {
     expect(payload.prompt).toContain("Review change-42");
     expect(payload.metadata).toMatchObject({ id: "review", scope: "agent" });
     expect((payload.metadata as { renderedPromptSha256: string }).renderedPromptSha256).toHaveLength(64);
+  });
+
+  it("preserves durable state while a WAL writer connection remains active", () => {
+    const database = new Database(join(stateDir, "ravi.db"));
+    try {
+      database.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0");
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('commandsConcurrentProbe', 'active', ?)",
+        )
+        .run(Date.now());
+      const before = captureState();
+
+      const result = runCli(["commands", "list", "--json"]);
+
+      expect(result).toMatchObject({ status: 0, stderr: "" });
+      expectStateUnchanged(before);
+    } finally {
+      database.prepare("DELETE FROM settings WHERE key = 'commandsConcurrentProbe'").run();
+      database.close();
+    }
   });
 
   for (const testCase of [

--- a/src/cli/commands/commands.process.test.ts
+++ b/src/cli/commands/commands.process.test.ts
@@ -29,11 +29,14 @@ interface SourceFileDigest {
 }
 
 function runCli(args: string[]): CliResult {
+  const childEnv = withoutRaviRuntimeContextEnv();
+  delete childEnv.RAVI_SUPPRESS_AUDIT_EVENTS;
+  delete childEnv.RAVI_NO_AUDIT;
   const result = spawnSync("bun", ["src/cli/index.ts", ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: {
-      ...withoutRaviRuntimeContextEnv(),
+      ...childEnv,
       RAVI_HOME: stateDir,
       RAVI_STATE_DIR: stateDir,
     },
@@ -162,6 +165,15 @@ afterAll(async () => {
 });
 
 describe("commands process contract", () => {
+  it("does not inherit test-only audit suppression into native CLI processes", () => {
+    const childEnv = withoutRaviRuntimeContextEnv();
+    delete childEnv.RAVI_SUPPRESS_AUDIT_EVENTS;
+    delete childEnv.RAVI_NO_AUDIT;
+
+    expect(childEnv.RAVI_SUPPRESS_AUDIT_EVENTS).toBeUndefined();
+    expect(childEnv.RAVI_NO_AUDIT).toBeUndefined();
+  });
+
   it("prints group help with exit 0 when no operation is supplied", () => {
     const before = captureState();
     const result = runCli(["commands"]);

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -41,6 +41,16 @@ function buildCommandFixture(id: string, overrides: Record<string, unknown> = {}
 
 let registryFixture: Record<string, unknown> = {};
 
+class MockRaviCommandError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+  ) {
+    super(message);
+    this.name = "RaviCommandError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Module mocks (must be installed before importing the module under test)
 // ---------------------------------------------------------------------------
@@ -79,11 +89,21 @@ mock.module("../../config-store.js", () => ({
 }));
 
 mock.module("../../commands/index.js", () => ({
+  RaviCommandError: MockRaviCommandError,
   discoverRaviCommands: (input: Record<string, unknown>) => {
     discoverCalls.push(input);
     return registryFixture;
   },
-  normalizeRaviCommandId: (name: string) => name.replace(/^#/, "").trim().toLowerCase(),
+  normalizeRaviCommandId: (name: string) => {
+    const normalized = name.trim().replace(/^#/, "");
+    if (!normalized) {
+      throw new MockRaviCommandError("Command name is required.", "invalid_command_name");
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9-]{0,63}$/.test(normalized)) {
+      throw new MockRaviCommandError(`Invalid command name "${name}".`, "invalid_command_name");
+    }
+    return normalized.toLowerCase();
+  },
   resolveRaviCommand: (registry: { commands: Array<{ id: string }> }, id: string) =>
     registry.commands.find((command) => command.id === id) ?? null,
   renderRaviCommand: (command: { id: string }, invocation: { rawArguments: string }, args: string[]) => {
@@ -101,7 +121,9 @@ mock.module("../../tags/helpers.js", () => ({
 }));
 
 const { RaviCommandsCommands } = await import("./commands.js");
-const { ContractError } = await import("../agent-contract.js");
+const { ContractError, expectedErrorToContractError } = await import("../agent-contract.js");
+const { commandRunReturnSchema, commandShowReturnSchema, commandValidateReturnSchema, commandsListReturnSchema } =
+  await import("./operational-return-schemas.js");
 
 type ContractErrorInstance = InstanceType<typeof ContractError>;
 
@@ -140,6 +162,20 @@ async function expectContractError(
   expect(contractError.code).toBe(code);
   expect(contractError.exitCode).toBe(exitCode);
   return contractError;
+}
+
+async function expectUsageError(run: () => Promise<unknown> | unknown): Promise<ContractErrorInstance> {
+  let caught: unknown;
+  await silenced(async () => {
+    try {
+      await run();
+    } catch (error) {
+      caught = error;
+    }
+  });
+  const contractError = expectedErrorToContractError("commands list", caught);
+  expect(contractError).toMatchObject({ code: "USAGE_ERROR", exitCode: 2 });
+  return contractError!;
 }
 
 beforeEach(() => {
@@ -185,6 +221,75 @@ describe("commands not-found envelopes", () => {
   });
 });
 
+describe("commands typed usage failures", () => {
+  for (const [operation, invoke] of [
+    ["show", (commands: InstanceType<typeof RaviCommandsCommands>, name: string) => commands.show(name, "ghost", true)],
+    [
+      "run",
+      (commands: InstanceType<typeof RaviCommandsCommands>, name: string) => commands.run(name, [], "ghost", true),
+    ],
+  ] as const) {
+    for (const name of ["", "#", "bad_name", "a".repeat(65)]) {
+      it(`${operation} rejects ${JSON.stringify(name)} as INVALID_COMMAND_NAME before agent lookup`, async () => {
+        const commands = new RaviCommandsCommands();
+        const error = await expectContractError(() => invoke(commands, name), "INVALID_COMMAND_NAME", 2);
+
+        expect(error.details.suggestedAction).toContain("[A-Za-z0-9]");
+        expect(discoverCalls).toHaveLength(0);
+      });
+    }
+  }
+
+  for (const [limit, offset] of [
+    ["many", undefined],
+    ["0", undefined],
+    ["501", undefined],
+    [undefined, "-1"],
+    [undefined, "1.5"],
+  ] as const) {
+    it(`list classifies invalid pagination limit=${limit ?? "default"} offset=${offset ?? "default"} as usage`, async () => {
+      const commands = new RaviCommandsCommands();
+      const error = await expectUsageError(() => commands.list(undefined, true, undefined, limit, offset));
+
+      expect(error.envelope().error.message).not.toBe("Command could not be completed.");
+    });
+  }
+
+  it("list rejects an unknown field in a mixed projection with the stable accepted set", async () => {
+    const commands = new RaviCommandsCommands();
+    const error = await expectUsageError(() =>
+      commands.list(undefined, true, undefined, undefined, undefined, "id,unknown"),
+    );
+
+    expect(error.details.acceptedFields).toContain("id");
+    expect(error.details.acceptedFields).not.toContain("unknown");
+  });
+
+  it("list rejects an unknown field even when the registry is empty", async () => {
+    registryFixture = { ...registryFixture, commands: [], entries: [] };
+    const commands = new RaviCommandsCommands();
+    const error = await expectUsageError(() =>
+      commands.list(undefined, true, undefined, undefined, undefined, "unknown"),
+    );
+
+    expect(error.details.acceptedFields).toEqual([
+      "id",
+      "token",
+      "title",
+      "description",
+      "argumentHint",
+      "arguments",
+      "disabled",
+      "scope",
+      "path",
+      "relativePath",
+      "shadowedBy",
+      "shadows",
+      "issues",
+    ]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Read-only surface + compact mode
 // ---------------------------------------------------------------------------
@@ -208,5 +313,52 @@ describe("commands read-only surface and compact mode", () => {
       expect(Object.keys(item).sort()).toEqual(["id", "scope"]);
     }
     expect(payload.commands).toEqual(payload.items);
+    expect(commandsListReturnSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it("list paginates deterministically and emits a reproducible next command", async () => {
+    const before = JSON.stringify(registryFixture);
+    const commands = new RaviCommandsCommands();
+    const first = await silenced(() => commands.list(undefined, true, undefined, "1", "0", "id"));
+    const repeated = await silenced(() => commands.list(undefined, true, undefined, "1", "0", "id"));
+
+    expect(first).toEqual(repeated);
+    expect(first.items).toEqual([{ id: "review-pr" }]);
+    expect(first.pagination).toMatchObject({ limit: 1, offset: 0, returned: 1, total: 2, nextOffset: 1 });
+    expect(first.pagination.nextCommand).toContain("ravi commands list --json --limit 1 --offset 1 --fields id");
+    expect(JSON.stringify(registryFixture)).toBe(before);
+  });
+
+  it("show is deterministic, schema-valid, and does not mutate discovered state", async () => {
+    const before = JSON.stringify(registryFixture);
+    const commands = new RaviCommandsCommands();
+    const first = await silenced(() => commands.show("review-pr", undefined, true));
+    const repeated = await silenced(() => commands.show("#REVIEW-PR", undefined, true));
+
+    expect(first).toEqual(repeated);
+    expect(commandShowReturnSchema.safeParse(first).success).toBe(true);
+    expect(JSON.stringify(registryFixture)).toBe(before);
+  });
+
+  it("validate is deterministic, schema-valid, and does not mutate discovered state", async () => {
+    const before = JSON.stringify(registryFixture);
+    const commands = new RaviCommandsCommands();
+    const first = await silenced(() => commands.validate(undefined, true));
+    const repeated = await silenced(() => commands.validate(undefined, true));
+
+    expect(first).toEqual(repeated);
+    expect(commandValidateReturnSchema.safeParse(first).success).toBe(true);
+    expect(JSON.stringify(registryFixture)).toBe(before);
+  });
+
+  it("run is deterministic, schema-valid, and does not mutate discovered state", async () => {
+    const before = JSON.stringify(registryFixture);
+    const commands = new RaviCommandsCommands();
+    const first = await silenced(() => commands.run("restart", ["ativar", "commands"], undefined, true));
+    const repeated = await silenced(() => commands.run("#RESTART", ["ativar", "commands"], undefined, true));
+
+    expect(first).toEqual(repeated);
+    expect(commandRunReturnSchema.safeParse(first).success).toBe(true);
+    expect(JSON.stringify(registryFixture)).toBe(before);
   });
 });

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -76,16 +76,14 @@ mock.module("../context.js", () => ({
   },
 }));
 
-mock.module("../../config-store.js", () => ({
-  configStore: {
-    getConfig: () => ({
-      defaultAgent: "main",
-      agents: {
-        main: { id: "main", cwd: "/tmp/agents/main" },
-        vendas: { id: "vendas", cwd: "/tmp/agents/vendas" },
-      },
-    }),
-  },
+mock.module("../../router/router-db.js", () => ({
+  dbReadAgentDirectorySnapshot: () => ({
+    defaultAgent: "main",
+    agents: [
+      { id: "main", cwd: "/tmp/agents/main" },
+      { id: "vendas", cwd: "/tmp/agents/vendas" },
+    ],
+  }),
 }));
 
 mock.module("../../commands/index.js", () => ({
@@ -304,16 +302,35 @@ describe("commands read-only surface and compact mode", () => {
     expect(payload).toMatchObject({ prompt: "rendered:restart:ativar commands" });
   });
 
-  it("list --fields narrows each item to the requested fields", async () => {
+  it("list --fields survives JSON round-trip under the published Returns schema", async () => {
     const commands = new RaviCommandsCommands();
     const payload = await silenced(() => commands.list(undefined, true, undefined, undefined, undefined, "id,scope"));
+    const serializedPayload = JSON.parse(JSON.stringify(payload));
 
     expect(payload.items).toHaveLength(2);
     for (const item of payload.items as Array<Record<string, unknown>>) {
       expect(Object.keys(item).sort()).toEqual(["id", "scope"]);
+      expect(Object.getOwnPropertyNames(item).sort()).toEqual(["id", "scope"]);
     }
+    expect(payload.items).toBe(payload.commands);
     expect(payload.commands).toEqual(payload.items);
-    expect(commandsListReturnSchema.safeParse(payload).success).toBe(true);
+    expect(serializedPayload.items).toEqual(payload.items);
+    expect(serializedPayload.commands).toEqual(serializedPayload.items);
+    expect(commandsListReturnSchema.safeParse(serializedPayload).success).toBe(true);
+  });
+
+  it("list Returns accepts complete records and rejects arbitrary projected fields", async () => {
+    const commands = new RaviCommandsCommands();
+    const completePayload = await silenced(() => commands.list(undefined, true));
+    const projectedPayload = await silenced(() =>
+      commands.list(undefined, true, undefined, undefined, undefined, "id"),
+    );
+    const invalidPayload = JSON.parse(JSON.stringify(projectedPayload));
+    invalidPayload.items[0].unknown = "not-public";
+    invalidPayload.commands[0].unknown = "not-public";
+
+    expect(commandsListReturnSchema.safeParse(JSON.parse(JSON.stringify(completePayload))).success).toBe(true);
+    expect(commandsListReturnSchema.safeParse(invalidPayload).success).toBe(false);
   });
 
   it("list paginates deterministically and emits a reproducible next command", async () => {

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -319,6 +319,35 @@ describe("commands read-only surface and compact mode", () => {
     expect(commandsListReturnSchema.safeParse(serializedPayload).success).toBe(true);
   });
 
+  it("list Returns rejects empty projected rows and accepts every declared singleton field", async () => {
+    const commands = new RaviCommandsCommands();
+    const emptyProjection = await silenced(() => commands.list(undefined, true, undefined, undefined, undefined, "id"));
+    const serialized = JSON.parse(JSON.stringify(emptyProjection));
+    serialized.items[0] = {};
+    serialized.commands[0] = {};
+
+    expect(commandsListReturnSchema.safeParse(serialized).success).toBe(false);
+
+    for (const field of [
+      "id",
+      "token",
+      "title",
+      "description",
+      "argumentHint",
+      "arguments",
+      "disabled",
+      "scope",
+      "path",
+      "relativePath",
+      "shadowedBy",
+      "shadows",
+      "issues",
+    ]) {
+      const payload = await silenced(() => commands.list(undefined, true, undefined, undefined, undefined, field));
+      expect(commandsListReturnSchema.safeParse(JSON.parse(JSON.stringify(payload))).success).toBe(true);
+    }
+  });
+
   it("list Returns accepts complete records and rejects arbitrary projected fields", async () => {
     const commands = new RaviCommandsCommands();
     const completePayload = await silenced(() => commands.list(undefined, true));

--- a/src/cli/commands/commands.ts
+++ b/src/cli/commands/commands.ts
@@ -1,11 +1,12 @@
 import "reflect-metadata";
 import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
-import { contractFail, pickFields, suggestSimilar } from "../agent-contract.js";
+import { CONTRACT_EXIT_USAGE, contractFail, pickFields, suggestSimilar } from "../agent-contract.js";
 import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
 import { configStore } from "../../config-store.js";
 import {
   discoverRaviCommands,
   normalizeRaviCommandId,
+  RaviCommandError,
   renderRaviCommand,
   resolveRaviCommand,
   type RaviCommandIssue,
@@ -37,6 +38,23 @@ function printJson(payload: unknown): void {
 interface ContractCallSite {
   op: string;
   asJson?: boolean;
+}
+
+function normalizeCommandName(name: string, site: ContractCallSite): string {
+  try {
+    return normalizeRaviCommandId(typeof name === "string" ? name : "");
+  } catch (error) {
+    if (error instanceof RaviCommandError && error.code === "invalid_command_name") {
+      contractFail(site.op, "INVALID_COMMAND_NAME", error.message, {
+        asJson: site.asJson,
+        exitCode: CONTRACT_EXIT_USAGE,
+        details: {
+          suggestedAction: "Retry with a non-empty command name matching [A-Za-z0-9][A-Za-z0-9-]{0,63}",
+        },
+      });
+    }
+    throw error;
+  }
 }
 
 /**
@@ -110,6 +128,22 @@ function serializeCommand(
   };
 }
 
+const COMMAND_LIST_FIELDS = [
+  "id",
+  "token",
+  "title",
+  "description",
+  "argumentHint",
+  "arguments",
+  "disabled",
+  "scope",
+  "path",
+  "relativePath",
+  "shadowedBy",
+  "shadows",
+  "issues",
+] as const satisfies ReadonlyArray<keyof ReturnType<typeof serializeCommand>>;
+
 function printCommandSummary(command: RaviCommandRecord): void {
   const disabled = command.disabled ? " disabled" : "";
   const shadow = command.shadows?.length ? " shadows global" : command.shadowedBy ? " shadowed" : "";
@@ -138,6 +172,7 @@ function normalizeRestArgs(rest?: string[]): string[] {
   name: "commands",
   description: "Manage Ravi prompt commands",
   scope: "open",
+  showHelpOnBare: true,
 })
 export class RaviCommandsCommands {
   @Command({ name: "list", description: "List Ravi commands" })
@@ -149,7 +184,11 @@ export class RaviCommandsCommands {
     @Option({ flags: "--tag <slug>", description: "Filter by canonical command tag" }) tagSlug?: string,
     @Option({ flags: "--limit <n>", description: "Page size (default: 50, max: 500)" }) limit?: string,
     @Option({ flags: "--offset <n>", description: "Number of matching commands to skip (default: 0)" }) offset?: string,
-    @Option({ flags: "--fields <a,b,c>", description: "Compact mode: keep only these fields of each item" })
+    @Option({
+      flags: "--fields <a,b,c>",
+      description:
+        "Compact fields: id,token,title,description,argumentHint,arguments,disabled,scope,path,relativePath,shadowedBy,shadows,issues",
+    })
     fields?: string,
   ) {
     const agent = resolveAgent(agentId, { op: "commands list", asJson });
@@ -175,6 +214,7 @@ export class RaviCommandsCommands {
     const commandRows = pickFields(
       pageCommands.map((command) => serializeCommand(command)),
       fields,
+      { acceptedFields: COMMAND_LIST_FIELDS },
     );
     const payload = {
       total: page.total,
@@ -224,8 +264,9 @@ export class RaviCommandsCommands {
     @Option({ flags: "--agent <id>", description: "Resolve agent-scoped commands for this agent" }) agentId?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
-    const agent = resolveAgent(agentId, { op: "commands show", asJson });
-    const id = normalizeRaviCommandId(name);
+    const site = { op: "commands show", asJson };
+    const id = normalizeCommandName(name, site);
+    const agent = resolveAgent(agentId, site);
     const registry = discoverRaviCommands({ agentCwd: agent.cwd });
     const command = resolveRaviCommand(registry, id);
     if (!command) {
@@ -289,8 +330,9 @@ export class RaviCommandsCommands {
     @Option({ flags: "--agent <id>", description: "Resolve agent-scoped commands for this agent" }) agentId?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
-    const agent = resolveAgent(agentId, { op: "commands run", asJson });
-    const id = normalizeRaviCommandId(name);
+    const site = { op: "commands run", asJson };
+    const id = normalizeCommandName(name, site);
+    const agent = resolveAgent(agentId, site);
     const args = normalizeRestArgs(rest);
     const rawArguments = args.join(" ");
     const registry = discoverRaviCommands({ agentCwd: agent.cwd });

--- a/src/cli/commands/commands.ts
+++ b/src/cli/commands/commands.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { Arg, Command, CommandAccess, Group, Option, Returns } from "../decorators.js";
 import { CONTRACT_EXIT_USAGE, contractFail, pickFields, suggestSimilar } from "../agent-contract.js";
 import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
-import { configStore } from "../../config-store.js";
+import { dbReadAgentDirectorySnapshot } from "../../router/router-db.js";
 import {
   discoverRaviCommands,
   normalizeRaviCommandId,
@@ -62,15 +62,19 @@ function normalizeCommandName(name: string, site: ContractCallSite): string {
  * envelope with real similar ids from the local config.
  */
 function resolveAgent(agentId: string | undefined, site: ContractCallSite): AgentConfig {
-  const config = configStore.getConfig();
-  const resolvedAgentId = agentId?.trim() || config.defaultAgent;
-  const agent = config.agents[resolvedAgentId];
+  const snapshot = dbReadAgentDirectorySnapshot();
+  const agents = Object.fromEntries(snapshot.agents.map((agent) => [agent.id, agent]));
+  if (snapshot.agents.length === 0) {
+    agents.main = { id: "main", cwd: process.cwd() };
+  }
+  const resolvedAgentId = agentId?.trim() || (snapshot.agents.length === 0 ? "main" : snapshot.defaultAgent);
+  const agent = agents[resolvedAgentId];
   if (!agent) {
     contractFail(site.op, "AGENT_NOT_FOUND", `Agent not found: ${resolvedAgentId}`, {
       asJson: site.asJson,
       details: {
         suggestedAction: "Check the agent id (see suggestions; list with: ravi agents list --json)",
-        suggestions: suggestSimilar(resolvedAgentId, Object.keys(config.agents)),
+        suggestions: suggestSimilar(resolvedAgentId, Object.keys(agents)),
       },
     });
   }
@@ -176,7 +180,7 @@ function normalizeRestArgs(rest?: string[]): string[] {
 })
 export class RaviCommandsCommands {
   @Command({ name: "list", description: "List Ravi commands" })
-  @CommandAccess({ kind: "read", resource: "commands", action: "list", risk: "low" })
+  @CommandAccess({ kind: "read", resource: "commands", action: "list", risk: "low", audit: "none" })
   @Returns(commandsListReturnSchema)
   list(
     @Option({ flags: "--agent <id>", description: "Resolve agent-scoped commands for this agent" }) agentId?: string,
@@ -257,7 +261,7 @@ export class RaviCommandsCommands {
   }
 
   @Command({ name: "show", description: "Show one Ravi command" })
-  @CommandAccess({ kind: "read", resource: "commands", action: "show", risk: "low" })
+  @CommandAccess({ kind: "read", resource: "commands", action: "show", risk: "low", audit: "none" })
   @Returns(commandShowReturnSchema)
   show(
     @Arg("name", { description: "Command name, with or without #" }) name: string,
@@ -288,7 +292,7 @@ export class RaviCommandsCommands {
   }
 
   @Command({ name: "validate", description: "Validate Ravi command files" })
-  @CommandAccess({ kind: "read", resource: "commands", action: "validate", risk: "low" })
+  @CommandAccess({ kind: "read", resource: "commands", action: "validate", risk: "low", audit: "none" })
   @Returns(commandValidateReturnSchema)
   validate(
     @Option({ flags: "--agent <id>", description: "Resolve agent-scoped commands for this agent" }) agentId?: string,
@@ -322,7 +326,7 @@ export class RaviCommandsCommands {
   }
 
   @Command({ name: "run", description: "Render a Ravi command into its composed prompt" })
-  @CommandAccess({ kind: "read", resource: "commands", action: "render", risk: "low" })
+  @CommandAccess({ kind: "read", resource: "commands", action: "render", risk: "low", audit: "none" })
   @Returns(commandRunReturnSchema)
   run(
     @Arg("name", { description: "Command name, with or without #" }) name: string,

--- a/src/cli/commands/commands.ts
+++ b/src/cli/commands/commands.ts
@@ -218,7 +218,7 @@ export class RaviCommandsCommands {
     const commandRows = pickFields(
       pageCommands.map((command) => serializeCommand(command)),
       fields,
-      { acceptedFields: COMMAND_LIST_FIELDS },
+      { acceptedFields: COMMAND_LIST_FIELDS, projection: "serialized-only" },
     );
     const payload = {
       total: page.total,

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -1056,23 +1056,80 @@ const commandRecordReturnShape = {
 
 export const commandRecordReturnSchema = z.object(commandRecordReturnShape).passthrough();
 
-const projectedCommandRecordReturnSchema = z
-  .object(commandRecordReturnShape)
-  .partial()
+const commandsListIssueReturnSchema = z
+  .object({
+    level: z.enum(["error", "warning"]),
+    code: z.string(),
+    message: z.string(),
+    id: z.string().nullable(),
+    scope: z.string().nullable(),
+    path: z.string().nullable(),
+  })
   .strict()
-  .refine((record) => Object.keys(record).length > 0, {
-    message: "A projected command must contain at least one field.",
-  });
+  .meta({ title: "CommandsListIssue" });
 
-export const commandsListReturnSchema = pagedItemsReturnSchema
-  .extend({
-    agent: looseObjectSchema,
-    locations: looseObjectSchema,
+const commandsListItemShape = {
+  id: z.string(),
+  token: z.string(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  argumentHint: z.string().nullable(),
+  arguments: z.array(z.string()),
+  disabled: z.boolean(),
+  scope: z.string(),
+  path: z.string(),
+  relativePath: z.string(),
+  shadowedBy: z.string().nullable(),
+  shadows: z.array(z.string()),
+  issues: z.array(commandsListIssueReturnSchema),
+};
+
+const commandsListItemSubsetSchema = z.object(commandsListItemShape).partial().strict();
+const commandsListItemFields = new Set(Object.keys(commandsListItemShape));
+const projectedCommandRecordVariants = Object.entries(commandsListItemShape).map(([requiredKey, schema]) =>
+  z.object({ [requiredKey]: schema }).passthrough(),
+);
+const projectedCommandRecordReturnSchema = z
+  .intersection(
+    commandsListItemSubsetSchema,
+    z.union(projectedCommandRecordVariants as unknown as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]),
+  )
+  .superRefine((record, context) => {
+    const unknownFields = Object.keys(record).filter((field) => !commandsListItemFields.has(field));
+    if (unknownFields.length > 0) {
+      context.addIssue({
+        code: "custom",
+        message: `Unrecognized projected command fields: ${unknownFields.join(", ")}`,
+      });
+    }
+  })
+  .meta({ title: "CommandsListItem" });
+
+const commandsListAgentReturnSchema = z
+  .object({ id: z.string(), cwd: z.string() })
+  .strict()
+  .meta({ title: "CommandsListAgent" });
+const commandsListLocationsReturnSchema = z
+  .object({ agent: z.string().nullable(), global: z.string() })
+  .strict()
+  .meta({ title: "CommandsListLocations" });
+const commandsListFiltersReturnSchema = z.object({ tag: z.string() }).strict().meta({ title: "CommandsListFilters" });
+const commandsListPaginationReturnSchema = strictCliOffsetPaginationSchema
+  .strict()
+  .meta({ title: "CommandsListPagination" });
+
+export const commandsListReturnSchema = z
+  .object({
+    total: z.number(),
+    pagination: commandsListPaginationReturnSchema,
+    filters: commandsListFiltersReturnSchema.optional(),
+    agent: commandsListAgentReturnSchema,
+    locations: commandsListLocationsReturnSchema,
     items: z.array(projectedCommandRecordReturnSchema),
     commands: z.array(projectedCommandRecordReturnSchema),
-    issues: z.array(commandIssueReturnSchema),
+    issues: z.array(commandsListIssueReturnSchema),
   })
-  .passthrough();
+  .strict();
 
 export const commandShowReturnSchema = z
   .object({

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -1038,29 +1038,38 @@ export const commandIssueReturnSchema = z
   })
   .passthrough();
 
-export const commandRecordReturnSchema = z
-  .object({
-    id: z.string(),
-    token: z.string(),
-    title: z.string().nullable(),
-    description: z.string().nullable(),
-    argumentHint: z.string().nullable(),
-    arguments: z.array(z.unknown()),
-    disabled: z.boolean(),
-    scope: z.string(),
-    path: z.string(),
-    relativePath: z.string(),
-    shadowedBy: z.string().nullable(),
-    shadows: z.array(z.string()),
-    issues: z.array(commandIssueReturnSchema),
-  })
-  .passthrough();
+const commandRecordReturnShape = {
+  id: z.string(),
+  token: z.string(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  argumentHint: z.string().nullable(),
+  arguments: z.array(z.unknown()),
+  disabled: z.boolean(),
+  scope: z.string(),
+  path: z.string(),
+  relativePath: z.string(),
+  shadowedBy: z.string().nullable(),
+  shadows: z.array(z.string()),
+  issues: z.array(commandIssueReturnSchema),
+};
+
+export const commandRecordReturnSchema = z.object(commandRecordReturnShape).passthrough();
+
+const projectedCommandRecordReturnSchema = z
+  .object(commandRecordReturnShape)
+  .partial()
+  .strict()
+  .refine((record) => Object.keys(record).length > 0, {
+    message: "A projected command must contain at least one field.",
+  });
 
 export const commandsListReturnSchema = pagedItemsReturnSchema
   .extend({
     agent: looseObjectSchema,
     locations: looseObjectSchema,
-    commands: z.array(commandRecordReturnSchema),
+    items: z.array(projectedCommandRecordReturnSchema),
+    commands: z.array(projectedCommandRecordReturnSchema),
     issues: z.array(commandIssueReturnSchema),
   })
   .passthrough();

--- a/src/cli/commands/sdk.test.ts
+++ b/src/cli/commands/sdk.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { emitJson } from "../../sdk/openapi/index.js";
 import { ContractError } from "../agent-contract.js";
 import { runWithContext } from "../context.js";
+import { CliTerminationRequest } from "../process-output.js";
 import { getRegistry } from "../registry-snapshot.js";
 import { SdkClientCommands, SdkOpenApiCommands, SdkSwiftCommands } from "./sdk.js";
 
@@ -105,18 +106,18 @@ describe("SdkOpenApiCommands.emit", () => {
 
   it("rejects --out and --stdout together", () => {
     const capture = captureConsole();
-    const original = process.exit;
-    process.exit = (() => {
-      throw new Error("__exit_called__");
-    }) as typeof process.exit;
+    let failure: unknown;
     try {
-      expect(() => new SdkOpenApiCommands().emit("foo.json", true)).toThrow(
-        /Pick exactly one destination|__exit_called__/,
-      );
+      new SdkOpenApiCommands().emit("foo.json", true);
+    } catch (error) {
+      failure = error;
     } finally {
-      process.exit = original;
       capture.restore();
     }
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect(failure).toMatchObject({ exitCode: 1 });
+    expect(capture.errors).toEqual(["Pick exactly one destination: --out <path> or --stdout."]);
+    expect(capture.errors.join("\n")).not.toContain("CLI termination requested.");
   });
 });
 
@@ -163,16 +164,18 @@ describe("SdkOpenApiCommands.check", () => {
 
   it("requires --against", () => {
     const capture = captureConsole();
-    const original = process.exit;
-    process.exit = (() => {
-      throw new Error("__exit_called__");
-    }) as typeof process.exit;
+    let failure: unknown;
     try {
-      expect(() => new SdkOpenApiCommands().check()).toThrow(/--against|__exit_called__/);
+      new SdkOpenApiCommands().check();
+    } catch (error) {
+      failure = error;
     } finally {
-      process.exit = original;
       capture.restore();
     }
+    expect(failure).toBeInstanceOf(CliTerminationRequest);
+    expect(failure).toMatchObject({ exitCode: 1 });
+    expect(capture.errors).toEqual(["--against <path> is required."]);
+    expect(capture.errors.join("\n")).not.toContain("CLI termination requested.");
   });
 });
 

--- a/src/cli/commands/sdk.ts
+++ b/src/cli/commands/sdk.ts
@@ -7,6 +7,7 @@ import { Command, CommandAccess, Group, Option, Returns } from "../decorators.js
 import { fail } from "../context.js";
 import { getRegistry } from "../registry-snapshot.js";
 import { ContractError, contractFail } from "../agent-contract.js";
+import { rethrowCliTermination } from "../process-output.js";
 import { emitJson } from "../../sdk/openapi/index.js";
 import { emitAll, computeRegistryHash, compareSdkSource, type EmittedSdk } from "../../sdk/client-codegen/index.js";
 import {
@@ -28,6 +29,7 @@ function writeFileSafe(target: string, body: string): string {
 }
 
 function failSdkCommand(error: unknown): never {
+  rethrowCliTermination(error);
   if (error instanceof ContractError) throw error;
   fail(error instanceof Error ? error.message : String(error));
 }
@@ -187,7 +189,7 @@ export class SdkOpenApiCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 
@@ -285,7 +287,7 @@ export class SdkClientCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 
@@ -404,7 +406,7 @@ export class SdkSwiftCommands {
       }
       return payload;
     } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+      failSdkCommand(error);
     }
   }
 

--- a/src/cli/commands/usage-exit.smoke.test.ts
+++ b/src/cli/commands/usage-exit.smoke.test.ts
@@ -106,6 +106,43 @@ describe("usage exit taxonomy smoke", () => {
     });
   });
 
+  it("rejects unknown fields with the stable agents field set even when state is empty", () => {
+    const result = runCli(["agents", "list", "--fields", "id,unknown", "--json"], {
+      RAVI_AGENT_ID: undefined,
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      op: "agents list",
+      error: {
+        code: "USAGE_ERROR",
+        message: "--fields contains one or more unknown fields.",
+        acceptedFields: expect.arrayContaining(["id", "cwd", "effectiveModel"]),
+      },
+    });
+  });
+
+  it("returns usage exit 2 for invalid shared pagination values", () => {
+    const cases = [
+      ["agents", "list", "--limit", "many", "--json"],
+      ["agents", "list", "--limit", "501", "--json"],
+      ["agents", "list", "--offset", "-1", "--json"],
+    ];
+
+    for (const args of cases) {
+      const result = runCli(args, { RAVI_AGENT_ID: undefined });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        success: false,
+        op: "agents list",
+        error: { code: "USAGE_ERROR", retryable: false },
+      });
+    }
+  });
+
   it("renders migrated handler failures as canonical JSON at the real process boundary", () => {
     const cases = [
       {

--- a/src/cli/confirmation-policy.test.ts
+++ b/src/cli/confirmation-policy.test.ts
@@ -1,7 +1,21 @@
 import "reflect-metadata";
 import { describe, expect, it } from "bun:test";
 
-import { getRegistry } from "./registry-snapshot.js";
+import { Command, CommandAccess, Group } from "./decorators.js";
+import { buildRegistry, getRegistry } from "./registry-snapshot.js";
+
+@Group({ name: "invalid-effect", description: "Invalid effect fixture", scope: "open" })
+class InvalidEffectCommands {
+  @Command({ name: "send", description: "Missing required confirmation" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "invalid-effect",
+    action: "send",
+    risk: "high",
+    effectClass: "external",
+  })
+  send() {}
+}
 
 function executeOption(command: ReturnType<typeof getRegistry>["commands"][number]) {
   return command.options.find((option) => option.name === "execute" || option.flags.includes("--execute"));
@@ -9,6 +23,36 @@ function executeOption(command: ReturnType<typeof getRegistry>["commands"][numbe
 
 describe("global confirmation policy metadata", () => {
   const commands = getRegistry().commands;
+
+  it("publishes complete safety metadata matching every registered access declaration", () => {
+    const invalid = commands
+      .filter((command) => {
+        const access = command.access;
+        if (!access) return true;
+        const expectedEffect = access.effectClass ?? (access.kind === "read" ? "none" : "unclassified");
+        const expectedSource = access.effectClass
+          ? "declared"
+          : access.kind === "read"
+            ? "inferred-read"
+            : "legacy-unclassified";
+        return (
+          command.safety.operationKind !== access.kind ||
+          command.safety.effectClass !== expectedEffect ||
+          command.safety.risk !== access.risk ||
+          command.safety.requiresConfirmation !== (access.requiresConfirmation === true) ||
+          command.safety.classificationSource !== expectedSource
+        );
+      })
+      .map((command) => ({ command: command.fullName, access: command.access, safety: command.safety }));
+
+    expect(invalid).toEqual([]);
+  });
+
+  it("fails closed when a precise consequential effect omits confirmation", () => {
+    expect(() => buildRegistry([InvalidEffectCommands])).toThrow(
+      'Invalid safety metadata for invalid-effect.send: effectClass "external" requires confirmation.',
+    );
+  });
 
   it("authorizes every command exposing --execute as a mutation", () => {
     const invalid = commands

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -11,6 +11,7 @@ import { getRuntimeContextFromEnv, resolveRuntimeContext, RAVI_CONTEXT_KEY_ENV }
 import type { ContextRecord } from "../router/router-db.js";
 import { readCredentialsFile, selectDefaultCredentialsKey } from "../runtime/credentials-store.js";
 import { CliExpectedError } from "./expected-error.js";
+import { requestCliTermination } from "./process-output.js";
 
 /**
  * Context available to CLI tools during execution
@@ -218,5 +219,5 @@ export function fail(message: string): never {
     throw new CliExpectedError(message);
   }
   console.error(message);
-  process.exit(1);
+  requestCliTermination(1);
 }

--- a/src/cli/decorators.ts
+++ b/src/cli/decorators.ts
@@ -36,11 +36,43 @@ export type CommandAccessKind = "read" | "mutate";
 export type CommandAccessRisk = "low" | "medium" | "high" | "destructive";
 export type CommandAccessContextRequirement = "actor" | "surface" | "session" | "executorAgent" | "resource";
 
+/**
+ * State-effect classification exposed to agent consumers.
+ *
+ * `unclassified` is a fail-visible migration value for legacy mutations. It
+ * must not be interpreted as safe; domain PRs replace it with the actual
+ * effect class once their operation contracts are proven.
+ */
+export type CommandEffectClass =
+  | "none"
+  | "local-reversible"
+  | "external"
+  | "destructive"
+  | "authority-expansion"
+  | "triggered-work"
+  | "containment"
+  | "cost-threshold"
+  | "conditional"
+  | "unclassified";
+
+export type CommandSafetyClassificationSource = "declared" | "inferred-read" | "legacy-unclassified" | "missing";
+
+/** Stable, agent-discoverable projection of the command safety contract. */
+export interface CommandSafetyMetadata {
+  operationKind: CommandAccessKind | "unknown";
+  effectClass: CommandEffectClass;
+  risk: CommandAccessRisk | "unknown";
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyClassificationSource;
+}
+
 export interface CommandAccessOptions {
   kind: CommandAccessKind;
   resource: string;
   action: string;
   risk: CommandAccessRisk;
+  /** Actual state effect. Domain migrations should declare this explicitly. */
+  effectClass?: CommandEffectClass;
   requiresContext?: CommandAccessContextRequirement[];
   resourceId?: string;
   /** Require the concrete resource candidate; semantic and legacy command grants cannot substitute for it. */
@@ -52,6 +84,68 @@ export interface CommandAccessOptions {
   localOperator?: boolean;
   requiresConfirmation?: boolean;
   notes?: string;
+}
+
+const ALWAYS_CONFIRMED_EFFECTS = new Set<CommandEffectClass>([
+  "external",
+  "destructive",
+  "authority-expansion",
+  "triggered-work",
+  "cost-threshold",
+]);
+
+const IMMEDIATE_EFFECTS = new Set<CommandEffectClass>(["none", "local-reversible", "containment"]);
+
+/**
+ * Resolve the public safety metadata without silently classifying legacy
+ * mutations. Invalid explicit declarations fail during registry/tool export,
+ * before consumers can receive a contradictory manifest.
+ */
+export function resolveCommandSafetyMetadata(
+  access: CommandAccessOptions | undefined,
+  commandName = "command",
+): CommandSafetyMetadata {
+  if (!access) {
+    return {
+      operationKind: "unknown",
+      effectClass: "unclassified",
+      risk: "unknown",
+      requiresConfirmation: false,
+      classificationSource: "missing",
+    };
+  }
+
+  const effectClass = access.effectClass ?? (access.kind === "read" ? "none" : "unclassified");
+  const classificationSource: CommandSafetyClassificationSource = access.effectClass
+    ? "declared"
+    : access.kind === "read"
+      ? "inferred-read"
+      : "legacy-unclassified";
+  const requiresConfirmation = access.requiresConfirmation === true;
+
+  if (access.kind === "read" && effectClass !== "none") {
+    throw new Error(`Invalid safety metadata for ${commandName}: read operations must declare effectClass "none".`);
+  }
+  if (access.kind === "read" && requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: read operations cannot require effect confirmation.`);
+  }
+  if (access.kind === "mutate" && effectClass === "none") {
+    throw new Error(`Invalid safety metadata for ${commandName}: mutations cannot declare effectClass "none".`);
+  }
+  if (classificationSource === "declared" && ALWAYS_CONFIRMED_EFFECTS.has(effectClass) && !requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: effectClass "${effectClass}" requires confirmation.`);
+  }
+  if (classificationSource === "declared" && IMMEDIATE_EFFECTS.has(effectClass) && requiresConfirmation) {
+    throw new Error(`Invalid safety metadata for ${commandName}: effectClass "${effectClass}" must remain immediate.`);
+  }
+
+  return {
+    operationKind: access.kind,
+    effectClass,
+    risk: access.risk,
+    requiresConfirmation,
+    classificationSource,
+  };
 }
 
 export interface GroupOptions {

--- a/src/cli/decorators.ts
+++ b/src/cli/decorators.ts
@@ -154,6 +154,8 @@ export interface GroupOptions {
   scope?: ScopeType;
   aliases?: string[];
   hidden?: boolean;
+  /** Print group help and succeed when the group is invoked without a subcommand. */
+  showHelpOnBare?: boolean;
 }
 
 export interface CommandOptions {

--- a/src/cli/decorators.ts
+++ b/src/cli/decorators.ts
@@ -83,6 +83,8 @@ export interface CommandAccessOptions {
   redactions?: string[];
   localOperator?: boolean;
   requiresConfirmation?: boolean;
+  /** Audit transport policy. `none` is reserved for proven effect-free inspection domains. */
+  audit?: "emit" | "none";
   notes?: string;
 }
 
@@ -146,6 +148,24 @@ export function resolveCommandSafetyMetadata(
     requiresConfirmation,
     classificationSource,
   };
+}
+
+/**
+ * Resolve whether a command may emit audit transport.
+ *
+ * Opting out is intentionally narrow: only low-risk reads whose resolved
+ * effect is `none` may do so. Invalid declarations fail before execution
+ * rather than silently creating an unaudited mutation path.
+ */
+export function shouldEmitCommandAudit(access: CommandAccessOptions | undefined, commandName = "command"): boolean {
+  if (access?.audit !== "none") return true;
+  const safety = resolveCommandSafetyMetadata(access, commandName);
+  if (safety.operationKind !== "read" || safety.effectClass !== "none" || safety.risk !== "low") {
+    throw new Error(
+      `Invalid audit metadata for ${commandName}: audit "none" is limited to low-risk reads with effectClass "none".`,
+    );
+  }
+  return false;
 }
 
 export interface GroupOptions {

--- a/src/cli/expected-error.ts
+++ b/src/cli/expected-error.ts
@@ -1,11 +1,37 @@
+export interface CliExpectedErrorOptions {
+  /** The message is deliberately safe to expose to CLI, tool, and gateway consumers. */
+  publicMessage?: boolean;
+  retryable?: boolean;
+  suggestedAction?: string;
+  details?: Record<string, unknown>;
+}
+
 export class CliExpectedError extends Error {
   readonly code: string;
   readonly exitCode: number;
+  readonly publicMessage: boolean;
+  readonly retryable: boolean;
+  readonly suggestedAction?: string;
+  readonly details: Record<string, unknown>;
 
-  constructor(message: string, code = "COMMAND_FAILED", exitCode = 1) {
+  constructor(message: string, code = "COMMAND_FAILED", exitCode = 1, options: CliExpectedErrorOptions = {}) {
     super(message);
     this.name = "CliExpectedError";
     this.code = code;
     this.exitCode = exitCode;
+    this.publicMessage = options.publicMessage ?? false;
+    this.retryable = options.retryable ?? false;
+    this.suggestedAction = options.suggestedAction;
+    this.details = options.details ?? {};
   }
+}
+
+export function cliUsageError(
+  message: string,
+  options: Omit<CliExpectedErrorOptions, "publicMessage"> = {},
+): CliExpectedError {
+  return new CliExpectedError(message, "USAGE_ERROR", 2, {
+    ...options,
+    publicMessage: true,
+  });
 }

--- a/src/cli/exports.ts
+++ b/src/cli/exports.ts
@@ -59,4 +59,11 @@ export {
   type InferredOptionSchema,
 } from "./schema-inference.js";
 
-export { Returns, getReturnsMetadata } from "./decorators.js";
+export {
+  Returns,
+  getReturnsMetadata,
+  resolveCommandSafetyMetadata,
+  type CommandEffectClass,
+  type CommandSafetyClassificationSource,
+  type CommandSafetyMetadata,
+} from "./decorators.js";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,12 @@ import { configureCliLogging } from "./logging.js";
 import { spawnDirectTui } from "./tui-launcher.js";
 import { maybeRunAppAliasRoute } from "../apps/router.js";
 import { buildRootOperationalHelp } from "../runtime/runtime-operational-context.js";
+import {
+  CliTerminationRequest,
+  flushProcessOutput,
+  terminateCliProcess,
+  writeProcessStdout,
+} from "./process-output.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
@@ -50,8 +56,8 @@ function isRootVersionRequest(args: string[]): boolean {
 }
 
 if (isRootVersionRequest(process.argv.slice(2))) {
-  console.log(pkg.version);
-  process.exit(0);
+  await writeProcessStdout(`${pkg.version}\n`);
+  await terminateCliProcess(0);
 }
 
 program
@@ -320,40 +326,44 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-void bootstrapCli().catch(async (error: unknown) => {
-  if (error instanceof ContractError) {
-    // Contract helpers render once and throw. Audit the semantic outcome before
-    // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
-    if (!wasContractErrorAudited(error)) {
-      const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
-      await emitCliAuditEvent({
-        group,
-        name: operationParts.join("_") || "root",
-        tool: error.op.replace(/\s+/g, "_"),
-        outcome: contractFailureOutcome(error),
-        exitCode: error.exitCode,
-        errorCode: error.code,
-        status: "completed",
-        closeLazyConnection: true,
-      });
+await bootstrapCli()
+  .catch(async (error: unknown) => {
+    if (error instanceof CliTerminationRequest) {
+      return terminateCliProcess(error.exitCode);
     }
-    process.exitCode = error.exitCode;
-    return;
-  }
-  const contractError = unexpectedErrorToContractError("cli bootstrap");
-  renderContractError(contractError, process.argv.includes("--json"));
-  await emitCliAuditEvent({
-    group: "cli",
-    name: "bootstrap",
-    tool: "cli_bootstrap",
-    outcome: contractFailureOutcome(contractError),
-    exitCode: contractError.exitCode,
-    errorCode: contractError.code,
-    status: "completed",
-    closeLazyConnection: true,
-  });
-  process.exitCode = contractError.exitCode;
-});
+    if (error instanceof ContractError) {
+      // Contract helpers render once and throw. Audit the semantic outcome before
+      // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
+      if (!wasContractErrorAudited(error)) {
+        const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
+        await emitCliAuditEvent({
+          group,
+          name: operationParts.join("_") || "root",
+          tool: error.op.replace(/\s+/g, "_"),
+          outcome: contractFailureOutcome(error),
+          exitCode: error.exitCode,
+          errorCode: error.code,
+          status: "completed",
+          closeLazyConnection: true,
+        });
+      }
+      return terminateCliProcess(error.exitCode);
+    }
+    const contractError = unexpectedErrorToContractError("cli bootstrap");
+    renderContractError(contractError, process.argv.includes("--json"));
+    await emitCliAuditEvent({
+      group: "cli",
+      name: "bootstrap",
+      tool: "cli_bootstrap",
+      outcome: contractFailureOutcome(contractError),
+      exitCode: contractError.exitCode,
+      errorCode: contractError.code,
+      status: "completed",
+      closeLazyConnection: true,
+    });
+    return terminateCliProcess(contractError.exitCode);
+  })
+  .finally(() => flushProcessOutput());
 
 async function bootstrapCli(): Promise<void> {
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;
@@ -362,7 +372,7 @@ async function bootstrapCli(): Promise<void> {
     staticRootCommands: rootCommandNames(program),
   });
   if (handledByAppAlias) {
-    process.exit(process.exitCode ?? 0);
+    return terminateCliProcess(process.exitCode ?? 0);
   }
 
   await program.parseAsync();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,11 +50,6 @@ function isRootVersionRequest(args: string[]): boolean {
   return args.length === 1 && (args[0] === "--version" || args[0] === "-V");
 }
 
-if (isRootVersionRequest(process.argv.slice(2))) {
-  await writeProcessStdout(`${pkg.version}\n`);
-  await terminateCliProcess(0);
-}
-
 program
   .name("ravi")
   .description("Ravi Bot CLI - Claude-powered bot management")
@@ -321,7 +316,7 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-await bootstrapCli().catch(async (error: unknown) => {
+void bootstrapCli().catch(async (error: unknown) => {
   if (error instanceof CliTerminationRequest) {
     return terminateCliProcess(error.exitCode);
   }
@@ -359,6 +354,11 @@ await bootstrapCli().catch(async (error: unknown) => {
 });
 
 async function bootstrapCli(): Promise<void> {
+  if (isRootVersionRequest(process.argv.slice(2))) {
+    await writeProcessStdout(`${pkg.version}\n`);
+    return terminateCliProcess(0);
+  }
+
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;
 
   const handledByAppAlias = await maybeRunAppAliasRoute(process.argv.slice(2), {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,12 +36,7 @@ import { configureCliLogging } from "./logging.js";
 import { spawnDirectTui } from "./tui-launcher.js";
 import { maybeRunAppAliasRoute } from "../apps/router.js";
 import { buildRootOperationalHelp } from "../runtime/runtime-operational-context.js";
-import {
-  CliTerminationRequest,
-  flushProcessOutput,
-  terminateCliProcess,
-  writeProcessStdout,
-} from "./process-output.js";
+import { CliTerminationRequest, terminateCliProcess, writeProcessStdout } from "./process-output.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
@@ -326,44 +321,42 @@ program
 // migrated domain nodes, including unknown command suggestions.
 installRootUsageContract(program);
 
-await bootstrapCli()
-  .catch(async (error: unknown) => {
-    if (error instanceof CliTerminationRequest) {
-      return terminateCliProcess(error.exitCode);
+await bootstrapCli().catch(async (error: unknown) => {
+  if (error instanceof CliTerminationRequest) {
+    return terminateCliProcess(error.exitCode);
+  }
+  if (error instanceof ContractError) {
+    // Contract helpers render once and throw. Audit the semantic outcome before
+    // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
+    if (!wasContractErrorAudited(error)) {
+      const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
+      await emitCliAuditEvent({
+        group,
+        name: operationParts.join("_") || "root",
+        tool: error.op.replace(/\s+/g, "_"),
+        outcome: contractFailureOutcome(error),
+        exitCode: error.exitCode,
+        errorCode: error.code,
+        status: "completed",
+        closeLazyConnection: true,
+      });
     }
-    if (error instanceof ContractError) {
-      // Contract helpers render once and throw. Audit the semantic outcome before
-      // preserving the process taxonomy (1 failure · 2 usage · 3 blocked).
-      if (!wasContractErrorAudited(error)) {
-        const [group = "cli", ...operationParts] = error.op.trim().split(/\s+/);
-        await emitCliAuditEvent({
-          group,
-          name: operationParts.join("_") || "root",
-          tool: error.op.replace(/\s+/g, "_"),
-          outcome: contractFailureOutcome(error),
-          exitCode: error.exitCode,
-          errorCode: error.code,
-          status: "completed",
-          closeLazyConnection: true,
-        });
-      }
-      return terminateCliProcess(error.exitCode);
-    }
-    const contractError = unexpectedErrorToContractError("cli bootstrap");
-    renderContractError(contractError, process.argv.includes("--json"));
-    await emitCliAuditEvent({
-      group: "cli",
-      name: "bootstrap",
-      tool: "cli_bootstrap",
-      outcome: contractFailureOutcome(contractError),
-      exitCode: contractError.exitCode,
-      errorCode: contractError.code,
-      status: "completed",
-      closeLazyConnection: true,
-    });
-    return terminateCliProcess(contractError.exitCode);
-  })
-  .finally(() => flushProcessOutput());
+    return terminateCliProcess(error.exitCode);
+  }
+  const contractError = unexpectedErrorToContractError("cli bootstrap");
+  renderContractError(contractError, process.argv.includes("--json"));
+  await emitCliAuditEvent({
+    group: "cli",
+    name: "bootstrap",
+    tool: "cli_bootstrap",
+    outcome: contractFailureOutcome(contractError),
+    exitCode: contractError.exitCode,
+    errorCode: contractError.code,
+    status: "completed",
+    closeLazyConnection: true,
+  });
+  return terminateCliProcess(contractError.exitCode);
+});
 
 async function bootstrapCli(): Promise<void> {
   if (await maybeRunManagedRuntimeRebindFromEnv()) return;

--- a/src/cli/pagination.test.ts
+++ b/src/cli/pagination.test.ts
@@ -1,12 +1,41 @@
 import { describe, expect, it } from "bun:test";
+import { expectedErrorToContractError } from "./agent-contract.js";
+import { CliExpectedError } from "./expected-error.js";
 import { buildCliOffsetPagination, paginateCliItems, parseCliListLimit, parseCliListOffset } from "./pagination.js";
 
 describe("CLI pagination helpers", () => {
   it("parses standard list limit and offset options", () => {
     expect(parseCliListLimit(undefined)).toBe(50);
-    expect(parseCliListLimit("999", { maxLimit: 100 })).toBe(100);
+    expect(parseCliListLimit("100", { maxLimit: 100 })).toBe(100);
     expect(parseCliListOffset(undefined)).toBe(0);
     expect(parseCliListOffset("25")).toBe(25);
+  });
+
+  it("classifies invalid limit and offset values as public usage errors", () => {
+    const cases = [
+      () => parseCliListLimit("many"),
+      () => parseCliListLimit("0"),
+      () => parseCliListLimit("501"),
+      () => parseCliListOffset("-1"),
+      () => parseCliListOffset("1.5"),
+    ];
+
+    for (const attempt of cases) {
+      let failure: unknown;
+      try {
+        attempt();
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(CliExpectedError);
+      const contract = expectedErrorToContractError("agents list", failure);
+      expect(contract).toMatchObject({ code: "USAGE_ERROR", exitCode: 2 });
+      expect(contract?.envelope().error).toMatchObject({
+        code: "USAGE_ERROR",
+        retryable: false,
+      });
+      expect(contract?.envelope().error.message).not.toBe("Command could not be completed.");
+    }
   });
 
   it("paginates finite command lists", () => {

--- a/src/cli/pagination.ts
+++ b/src/cli/pagination.ts
@@ -1,4 +1,4 @@
-import { fail } from "./context.js";
+import { cliUsageError } from "./expected-error.js";
 import {
   buildCommand,
   buildOffsetPagination,
@@ -87,10 +87,22 @@ function parseBoundedIntegerOption(
   if (value === undefined || value === null || value === "") return options.defaultValue;
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
-    fail(`${label} must be an integer.`);
+    throw cliUsageError(`${label} must be an integer.`, {
+      suggestedAction: `Retry with an integer value for ${label}`,
+      details: { option: label, minimum: options.min, ...(options.max === undefined ? {} : { maximum: options.max }) },
+    });
   }
   if (parsed < options.min) {
-    fail(`${label} must be greater than or equal to ${options.min}.`);
+    throw cliUsageError(`${label} must be greater than or equal to ${options.min}.`, {
+      suggestedAction: `Retry with ${label} greater than or equal to ${options.min}`,
+      details: { option: label, minimum: options.min, ...(options.max === undefined ? {} : { maximum: options.max }) },
+    });
   }
-  return Math.min(options.max ?? parsed, parsed);
+  if (options.max !== undefined && parsed > options.max) {
+    throw cliUsageError(`${label} must be less than or equal to ${options.max}.`, {
+      suggestedAction: `Retry with ${label} less than or equal to ${options.max}`,
+      details: { option: label, minimum: options.min, maximum: options.max },
+    });
+  }
+  return parsed;
 }

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+setDefaultTimeout(90_000);
+
+const stateDir = mkdtempSync(join(tmpdir(), "ravi-cli-output-native-"));
+const packageVersion = (JSON.parse(readFileSync("package.json", "utf8")) as { version: string }).version;
+
+afterAll(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+interface CliProcessResult {
+  status: number | null;
+  stdout: Buffer;
+  stderr: Buffer;
+}
+
+function isolatedCliEnv(): NodeJS.ProcessEnv {
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("RAVI_")));
+  return {
+    ...env,
+    RAVI_STATE_DIR: stateDir,
+    RAVI_NO_AUDIT: "1",
+    RAVI_SUPPRESS_AUDIT_EVENTS: "1",
+  };
+}
+
+function runNativeCli(args: string[]): Promise<CliProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["src/cli/index.ts", ...args], {
+      cwd: process.cwd(),
+      env: isolatedCliEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("close", (status) => {
+      resolve({
+        status,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      });
+    });
+  });
+}
+
+describe("native CLI process output integrity", () => {
+  it("delivers a complete piped JSON document larger than 64 KiB", async () => {
+    const result = await runNativeCli(["tools", "list", "--json", "--limit", "500"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr.byteLength).toBe(0);
+    expect(result.stdout.byteLength).toBeGreaterThan(64 * 1024);
+
+    const payload = JSON.parse(result.stdout.toString("utf8")) as {
+      total: number;
+      items: unknown[];
+      tools: unknown[];
+    };
+    expect(payload.total).toBeGreaterThan(0);
+    expect(payload.items.length).toBeGreaterThan(0);
+    expect(payload.tools).toEqual(payload.items);
+  });
+
+  it("flushes failure output before preserving exit code 1", async () => {
+    const result = await runNativeCli(["audio", "blob", "__missing_output_integrity_probe__"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout.byteLength).toBe(0);
+    expect(result.stderr.toString("utf8")).toBe("Binary resource was not found.\n");
+  });
+
+  it("preserves the root version output and exit code 0", async () => {
+    const result = await runNativeCli(["--version"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).toBe(`${packageVersion}\n`);
+    expect(result.stderr.byteLength).toBe(0);
+  });
+});

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { waitUntilProcessOutputFlushed, type ProcessOutputStream } from "./process-output.js";
 
 setDefaultTimeout(90_000);
 
@@ -29,9 +30,9 @@ function isolatedCliEnv(): NodeJS.ProcessEnv {
   };
 }
 
-function runNativeCli(args: string[]): Promise<CliProcessResult> {
+function runNativeProcess(args: string[], timeoutMs: number): Promise<CliProcessResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["src/cli/index.ts", ...args], {
+    const child = spawn(process.execPath, args, {
       cwd: process.cwd(),
       env: isolatedCliEnv(),
       stdio: ["ignore", "pipe", "pipe"],
@@ -39,11 +40,32 @@ function runNativeCli(args: string[]): Promise<CliProcessResult> {
     });
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
+    let settled = false;
+    let timeoutError: Error | null = null;
+    const timeout = setTimeout(() => {
+      timeoutError = new Error(`Native process did not exit within ${timeoutMs}ms: ${args.join(" ")}`);
+      if (!child.kill()) {
+        settled = true;
+        reject(timeoutError);
+      }
+    }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.once("error", reject);
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
     child.once("close", (status) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (timeoutError) {
+        reject(timeoutError);
+        return;
+      }
       resolve({
         status,
         stdout: Buffer.concat(stdout),
@@ -53,7 +75,54 @@ function runNativeCli(args: string[]): Promise<CliProcessResult> {
   });
 }
 
+function runNativeCli(args: string[]): Promise<CliProcessResult> {
+  return runNativeProcess(["src/cli/index.ts", ...args], 30_000);
+}
+
 describe("native CLI process output integrity", () => {
+  it("bounds a permanently stuck output stream without busy-spinning", async () => {
+    const stuckStream: ProcessOutputStream = {
+      destroyed: false,
+      writableEnded: false,
+      writableLength: 1,
+      writableNeedDrain: true,
+      write: () => false,
+    };
+    const startedAt = performance.now();
+
+    await expect(waitUntilProcessOutputFlushed(stuckStream, 20)).rejects.toThrow(
+      "CLI output did not flush within 20ms.",
+    );
+
+    const elapsedMs = performance.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(15);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("kills and observes a child process that exceeds its native timeout", async () => {
+    const startedAt = performance.now();
+
+    await expect(runNativeProcess(["-e", "setInterval(() => {}, 1000)"], 100)).rejects.toThrow(
+      "Native process did not exit within 100ms",
+    );
+
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("preserves termination when a native process stream never reports progress", async () => {
+    const script = [
+      'Object.defineProperty(process.stdout, "writableLength", { get: () => 1 });',
+      'Object.defineProperty(process.stdout, "writableNeedDrain", { get: () => true });',
+      'const { terminateCliProcess } = await import("./src/cli/process-output.ts");',
+      "await terminateCliProcess(7, 20);",
+    ].join("\n");
+
+    const result = await runNativeProcess(["-e", script], 2_000);
+
+    expect(result.status).toBe(7);
+    expect(result.stderr.byteLength).toBe(0);
+  });
+
   it("delivers a complete piped JSON document larger than 64 KiB", async () => {
     const result = await runNativeCli(["tools", "list", "--json", "--limit", "500"]);
 

--- a/src/cli/process-output.native.test.ts
+++ b/src/cli/process-output.native.test.ts
@@ -42,26 +42,30 @@ function runNativeProcess(args: string[], timeoutMs: number): Promise<CliProcess
     const stderr: Buffer[] = [];
     let settled = false;
     let timeoutError: Error | null = null;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
     const timeout = setTimeout(() => {
       timeoutError = new Error(`Native process did not exit within ${timeoutMs}ms: ${args.join(" ")}`);
-      if (!child.kill()) {
-        settled = true;
-        reject(timeoutError);
-      }
+      child.kill();
+      forceKillTimeout = setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 250);
     }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
     child.once("error", (error) => {
       if (settled) return;
+      if (timeoutError && child.pid !== undefined) return;
       settled = true;
       clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       reject(error);
     });
     child.once("close", (status) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
       if (timeoutError) {
         reject(timeoutError);
         return;

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -22,6 +22,10 @@ export function requestCliTermination(code: CliExitCode): never {
   throw new CliTerminationRequest(code);
 }
 
+export function rethrowCliTermination(error: unknown): void {
+  if (error instanceof CliTerminationRequest) throw error;
+}
+
 export type ProcessOutputStream = Pick<
   NodeJS.WriteStream,
   "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -1,0 +1,70 @@
+type ProcessOutputChunk = string | Uint8Array;
+type CliExitCode = number | string;
+
+export class CliTerminationRequest extends Error {
+  readonly exitCode: CliExitCode;
+
+  constructor(exitCode: CliExitCode) {
+    super("CLI termination requested.");
+    this.name = "CliTerminationRequest";
+    this.exitCode = exitCode;
+  }
+}
+
+/**
+ * Synchronous adapters such as Commander exit hooks cannot await output. They
+ * throw this private control-flow signal so the top-level CLI boundary can
+ * flush output and terminate with the requested code.
+ */
+export function requestCliTermination(code: CliExitCode): never {
+  throw new CliTerminationRequest(code);
+}
+
+type ProcessOutputStream = Pick<
+  NodeJS.WriteStream,
+  "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"
+>;
+
+function nextEventLoopTurn(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function waitUntilFlushed(stream: ProcessOutputStream): Promise<void> {
+  while (stream.writableLength > 0 || stream.writableNeedDrain) {
+    if (stream.destroyed || stream.writableEnded) {
+      throw new Error("CLI output stream became unavailable before pending output completed.");
+    }
+    await nextEventLoopTurn();
+  }
+}
+
+async function writeAndWait(stream: ProcessOutputStream, chunk: ProcessOutputChunk): Promise<void> {
+  if (stream.destroyed || stream.writableEnded) {
+    throw new Error("CLI output stream is unavailable.");
+  }
+
+  stream.write(chunk);
+  await waitUntilFlushed(stream);
+}
+
+export function writeProcessStdout(chunk: ProcessOutputChunk): Promise<void> {
+  return writeAndWait(process.stdout, chunk);
+}
+
+export function writeProcessStderr(chunk: ProcessOutputChunk): Promise<void> {
+  return writeAndWait(process.stderr, chunk);
+}
+
+/**
+ * Wait until both process output buffers are empty. This keeps console output
+ * complete when stdout or stderr is connected to a pipe without relying on
+ * write callbacks, which Bun does not consistently invoke for process streams.
+ */
+export async function flushProcessOutput(): Promise<void> {
+  await Promise.all([waitUntilFlushed(process.stdout), waitUntilFlushed(process.stderr)]);
+}
+
+export async function terminateCliProcess(code: CliExitCode): Promise<never> {
+  await flushProcessOutput();
+  process.exit(code);
+}

--- a/src/cli/process-output.ts
+++ b/src/cli/process-output.ts
@@ -1,5 +1,7 @@
 type ProcessOutputChunk = string | Uint8Array;
 type CliExitCode = number | string;
+const DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS = 5_000;
+const OUTPUT_FLUSH_POLL_INTERVAL_MS = 4;
 
 export class CliTerminationRequest extends Error {
   readonly exitCode: CliExitCode;
@@ -20,21 +22,29 @@ export function requestCliTermination(code: CliExitCode): never {
   throw new CliTerminationRequest(code);
 }
 
-type ProcessOutputStream = Pick<
+export type ProcessOutputStream = Pick<
   NodeJS.WriteStream,
   "destroyed" | "writableEnded" | "writableLength" | "writableNeedDrain" | "write"
 >;
 
-function nextEventLoopTurn(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
+function waitForOutputProgress(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
-async function waitUntilFlushed(stream: ProcessOutputStream): Promise<void> {
+export async function waitUntilProcessOutputFlushed(
+  stream: ProcessOutputStream,
+  timeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS,
+): Promise<void> {
+  const startedAt = performance.now();
   while (stream.writableLength > 0 || stream.writableNeedDrain) {
     if (stream.destroyed || stream.writableEnded) {
       throw new Error("CLI output stream became unavailable before pending output completed.");
     }
-    await nextEventLoopTurn();
+    const remainingMs = timeoutMs - (performance.now() - startedAt);
+    if (remainingMs <= 0) {
+      throw new Error(`CLI output did not flush within ${timeoutMs}ms.`);
+    }
+    await waitForOutputProgress(Math.min(OUTPUT_FLUSH_POLL_INTERVAL_MS, remainingMs));
   }
 }
 
@@ -44,7 +54,7 @@ async function writeAndWait(stream: ProcessOutputStream, chunk: ProcessOutputChu
   }
 
   stream.write(chunk);
-  await waitUntilFlushed(stream);
+  await waitUntilProcessOutputFlushed(stream);
 }
 
 export function writeProcessStdout(chunk: ProcessOutputChunk): Promise<void> {
@@ -60,11 +70,20 @@ export function writeProcessStderr(chunk: ProcessOutputChunk): Promise<void> {
  * complete when stdout or stderr is connected to a pipe without relying on
  * write callbacks, which Bun does not consistently invoke for process streams.
  */
-export async function flushProcessOutput(): Promise<void> {
-  await Promise.all([waitUntilFlushed(process.stdout), waitUntilFlushed(process.stderr)]);
+export async function flushProcessOutput(timeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS): Promise<void> {
+  await Promise.all([
+    waitUntilProcessOutputFlushed(process.stdout, timeoutMs),
+    waitUntilProcessOutputFlushed(process.stderr, timeoutMs),
+  ]);
 }
 
-export async function terminateCliProcess(code: CliExitCode): Promise<never> {
-  await flushProcessOutput();
-  process.exit(code);
+export async function terminateCliProcess(
+  code: CliExitCode,
+  flushTimeoutMs = DEFAULT_OUTPUT_FLUSH_TIMEOUT_MS,
+): Promise<never> {
+  try {
+    await flushProcessOutput(flushTimeoutMs);
+  } finally {
+    process.exit(code);
+  }
 }

--- a/src/cli/registry-snapshot.ts
+++ b/src/cli/registry-snapshot.ts
@@ -22,7 +22,9 @@ import {
   getReturnsBinaryMetadata,
   getReturnsMetadata,
   getScopeMetadata,
+  resolveCommandSafetyMetadata,
   type CommandAccessOptions,
+  type CommandSafetyMetadata,
   type ScopeType,
 } from "./decorators.js";
 import { inferArgSchema, inferOptionSchema, type ParsedOptionFlags } from "./schema-inference.js";
@@ -117,6 +119,8 @@ export interface CommandRegistryEntry {
   skillGate?: SkillGateMetadata;
   /** Semantic operation contract used by the Permission Provider Runtime. */
   access?: CommandAccessOptions;
+  /** Stable operation/effect/risk/confirmation projection for agent consumers. */
+  safety: CommandSafetyMetadata;
 }
 
 export interface RegistrySnapshot {
@@ -199,6 +203,8 @@ export function buildRegistry(classes: CommandClass[]): RegistrySnapshot {
 
       const effectiveScope: ScopeType = scopeMap.get(cmdMeta.method) ?? groupMeta.scope ?? "admin";
       const fullName = `${groupMeta.name}.${cmdMeta.name}`;
+      const access = commandAccessMap.get(cmdMeta.method);
+      const safety = resolveCommandSafetyMetadata(access, fullName);
       const skillGate = resolveCommandSkillGate({
         groupPath: groupMeta.name,
         command: cmdMeta.name,
@@ -221,7 +227,8 @@ export function buildRegistry(classes: CommandClass[]): RegistrySnapshot {
         ...(binaryReturnsSet.has(cmdMeta.method) ? { binary: true } : {}),
         ...(cliOnlySet.has(cmdMeta.method) ? { cliOnly: true } : {}),
         ...(skillGate ? { skillGate } : {}),
-        ...(commandAccessMap.get(cmdMeta.method) ? { access: commandAccessMap.get(cmdMeta.method)! } : {}),
+        ...(access ? { access } : {}),
+        safety,
       };
 
       const existing = commandsByFullName.get(fullName);

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -34,6 +34,33 @@ class HiddenGroupCommands {
   debug() {}
 }
 
+@Group({
+  name: "helpful",
+  description: "Helpful commands",
+  scope: "open",
+  aliases: ["help-alias"],
+  showHelpOnBare: true,
+})
+class HelpfulListCommands {
+  @Command({ name: "list", description: "List helpful records" })
+  @CommandAccess({ kind: "read", resource: "helpful", action: "list", risk: "low", audit: "none" })
+  list() {}
+}
+
+@Group({ name: "helpful", description: "Helpful commands", scope: "open", showHelpOnBare: true })
+class HelpfulShowCommands {
+  @Command({ name: "show", description: "Show one helpful record" })
+  @CommandAccess({ kind: "read", resource: "helpful", action: "show", risk: "low", audit: "none" })
+  show() {}
+}
+
+@Group({ name: "shadow.item", description: "Nested help collision", scope: "open", showHelpOnBare: true })
+class ShadowHelpNestedCommands {
+  @Command({ name: "inspect", description: "Inspect nested item" })
+  @CommandAccess({ kind: "read", resource: "shadow.item", action: "inspect", risk: "low", audit: "none" })
+  inspect() {}
+}
+
 interface CapturedCall {
   id: string;
   json: boolean | undefined;
@@ -56,7 +83,7 @@ const semanticOnlyContext: ContextRecord = {
 @Group({ name: "shadow", description: "Direct command + nested group with --json", scope: "open" })
 class ShadowDirectCommands {
   @Command({ name: "item", description: "Show item directly" })
-  @CommandAccess({ kind: "read", resource: "shadow", action: "item", risk: "low", input: ["id"] })
+  @CommandAccess({ kind: "read", resource: "shadow", action: "item", risk: "low", input: ["id"], audit: "none" })
   item(@Arg("id") id: string, @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean) {
     capturedDirect.push({ id, json: asJson });
   }
@@ -65,7 +92,7 @@ class ShadowDirectCommands {
 @Group({ name: "shadow.item", description: "Nested item operations", scope: "open" })
 class ShadowNestedCommands {
   @Command({ name: "show", description: "Show nested item" })
-  @CommandAccess({ kind: "read", resource: "shadow.item", action: "show", risk: "low", input: ["id"] })
+  @CommandAccess({ kind: "read", resource: "shadow.item", action: "show", risk: "low", input: ["id"], audit: "none" })
   show(@Arg("id") id: string, @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean) {
     capturedNested.push({ id, json: asJson });
   }
@@ -302,6 +329,39 @@ describe("registerCommands", () => {
     registerCommands(program, [HiddenGroupCommands]);
 
     expect(program.commands.some((command) => command.name() === "internal")).toBe(false);
+  });
+
+  it("shows bare help once for a group assembled from multiple classes and through its alias", async () => {
+    for (const groupName of ["helpful", "help-alias"]) {
+      const output: string[] = [];
+      const program = new CommanderCommand();
+      program.exitOverride();
+      program.configureOutput({ writeOut: (value) => output.push(value), writeErr: (value) => output.push(value) });
+      registerCommands(program, [HelpfulListCommands, HelpfulShowCommands]);
+
+      await parseAsLocalOperator(program, ["node", "test", groupName]);
+
+      const rendered = output.join("");
+      expect(rendered).toContain("Usage: test helpful");
+      expect(rendered).toContain("list");
+      expect(rendered).toContain("show");
+    }
+  });
+
+  it("preserves a direct handler that shares a node with a showHelpOnBare nested group in either class order", async () => {
+    for (const classes of [
+      [ShadowDirectCommands, ShadowHelpNestedCommands],
+      [ShadowHelpNestedCommands, ShadowDirectCommands],
+    ]) {
+      capturedDirect.length = 0;
+      const program = new CommanderCommand();
+      program.exitOverride();
+      registerCommands(program, classes);
+
+      await parseAsLocalOperator(program, ["node", "test", "shadow", "item", "direct-id"]);
+
+      expect(capturedDirect).toEqual([{ id: "direct-id", json: undefined }]);
+    }
   });
 
   describe("dotted groups colliding with same-named direct command", () => {

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -41,6 +41,7 @@ import {
   type RemoteDispatchResult,
   type RemoteGatewayConfig,
 } from "./remote-gateway.js";
+import { terminateCliProcess, writeProcessStdout } from "./process-output.js";
 
 type CommandClass = new () => object;
 
@@ -230,7 +231,7 @@ function registerCommand(
     } catch (error) {
       if (!(error instanceof ContractError)) throw error;
       renderContractError(error, input.json === true);
-      process.exit(error.exitCode);
+      return terminateCliProcess(error.exitCode);
     }
 
     // The target gateway owns authorization for its context key. Performing a
@@ -293,7 +294,7 @@ function registerCommand(
           renderContractError(error, input.json === true);
           throw error;
         }
-        process.stdout.write(new Uint8Array(await returnValue.arrayBuffer()));
+        await writeProcessStdout(new Uint8Array(await returnValue.arrayBuffer()));
       }
     } catch (err) {
       const op = commandOperation(groupName, cmdMeta.name);
@@ -328,7 +329,7 @@ function registerCommand(
       closeLazyConnection: true,
     });
 
-    if (contractExitCode !== null) process.exit(contractExitCode);
+    if (contractExitCode !== null) return terminateCliProcess(contractExitCode);
   });
 }
 
@@ -383,7 +384,7 @@ async function dispatchRemoteCommand(input: DispatchRemoteCommandInput): Promise
       },
     );
     renderContractError(error, input.input.json === true);
-    process.exit(error.exitCode);
+    return terminateCliProcess(error.exitCode);
   }
 
   let result;
@@ -401,21 +402,21 @@ async function dispatchRemoteCommand(input: DispatchRemoteCommandInput): Promise
       suggestedAction: "Check gateway availability and retry",
     });
     renderContractError(error, input.input.json === true);
-    process.exit(error.exitCode);
+    return terminateCliProcess(error.exitCode);
   }
 
   const remoteError = remoteGatewayErrorToContractError(op, result);
   if (remoteError) {
     renderContractError(remoteError, input.input.json === true);
-    process.exit(remoteError.exitCode);
+    return terminateCliProcess(remoteError.exitCode);
   }
-  printRemoteResponse(result);
+  await printRemoteResponse(result);
   if (!result.ok) {
-    process.exit(remoteGatewayExitCode(result));
+    return terminateCliProcess(remoteGatewayExitCode(result));
   }
 }
 
-function printRemoteResponse(result: RemoteDispatchResult): void {
+async function printRemoteResponse(result: RemoteDispatchResult): Promise<void> {
   const output = remoteDispatchOutput(result);
-  if (output.value.length > 0) process.stdout.write(output.value);
+  if (output.value.length > 0) await writeProcessStdout(output.value);
 }

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -118,6 +118,9 @@ export function registerCommands(program: CommanderCommand, classes: CommandClas
     // Support nested groups via dot notation
     const segments = groupMeta.name.split(".");
     const group = resolveCommandPath(program, segments, groupMeta.description, groupMeta.aliases);
+    if (groupMeta.showHelpOnBare) {
+      group.action(() => group.outputHelp());
+    }
 
     const instance = new cls();
 

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -12,6 +12,7 @@ import {
   getArgsMetadata,
   getOptionsMetadata,
   getScopeMetadata,
+  shouldEmitCommandAudit,
   type CommandAccessOptions,
   type CommandMetadata,
   type ScopeType,
@@ -89,6 +90,7 @@ function resolveCommandPath(
  */
 export function registerCommands(program: CommanderCommand, classes: CommandClass[]): void {
   const seen = new Map<string, { cls: CommandClass; method: string }>();
+  const bareHelpGroups = new Map<string, CommanderCommand>();
   for (const cls of classes) {
     const groupMeta = getGroupMetadata(cls);
     if (!groupMeta) continue;
@@ -119,7 +121,7 @@ export function registerCommands(program: CommanderCommand, classes: CommandClas
     const segments = groupMeta.name.split(".");
     const group = resolveCommandPath(program, segments, groupMeta.description, groupMeta.aliases);
     if (groupMeta.showHelpOnBare) {
-      group.action(() => group.outputHelp());
+      bareHelpGroups.set(groupMeta.name, group);
     }
 
     const instance = new cls();
@@ -135,6 +137,12 @@ export function registerCommands(program: CommanderCommand, classes: CommandClas
       const effectiveScope: ScopeType = scopeMap.get(cmdMeta.method) ?? groupMeta.scope ?? "admin";
       registerCommand(group, instance, cmdMeta, toolGroupName, effectiveScope, commandAccessMap.get(cmdMeta.method));
     }
+  }
+
+  for (const [groupPath, group] of bareHelpGroups) {
+    // A dotted group can share its node with a direct parent command. Preserve
+    // that direct handler regardless of class registration order.
+    if (!seen.has(groupPath)) group.action(() => group.outputHelp());
   }
 }
 
@@ -251,6 +259,7 @@ function registerCommand(
       return;
     }
 
+    const auditEnabled = shouldEmitCommandAudit(access, toolName);
     const accessResult = enforceCliCommandAuthorization({
       group: groupName,
       command: cmdMeta.name,
@@ -266,19 +275,22 @@ function registerCommand(
         accessResult.errorMessage,
       );
       renderContractError(contractError, input.json === true);
-      await emitCliAuditEvent({
-        group: groupName,
-        name: cmdMeta.name,
-        tool: toolName,
-        input: auditInput,
-        outcome: "denied",
-        exitCode: 1,
-        errorCode: "PERMISSION_DENIED",
-        status: "completed",
-        closeLazyConnection: false,
-      });
-      const { flushAuditAndExit } = await import("../permissions/scope.js");
-      await flushAuditAndExit(1);
+      if (auditEnabled) {
+        await emitCliAuditEvent({
+          group: groupName,
+          name: cmdMeta.name,
+          tool: toolName,
+          input: auditInput,
+          outcome: "denied",
+          exitCode: 1,
+          errorCode: "PERMISSION_DENIED",
+          status: "completed",
+          closeLazyConnection: false,
+        });
+        const { flushAuditAndExit } = await import("../permissions/scope.js");
+        await flushAuditAndExit(1);
+      }
+      return terminateCliProcess(1);
     }
 
     // Execute and emit single event with input + output
@@ -319,18 +331,20 @@ function registerCommand(
       }
     }
 
-    await emitCliAuditEvent({
-      group: groupName,
-      name: cmdMeta.name,
-      tool: toolName,
-      input: auditInput,
-      outcome,
-      exitCode: contractExitCode ?? undefined,
-      errorCode: contractErrorCode,
-      status: "completed",
-      durationMs: Date.now() - startTime,
-      closeLazyConnection: true,
-    });
+    if (auditEnabled) {
+      await emitCliAuditEvent({
+        group: groupName,
+        name: cmdMeta.name,
+        tool: toolName,
+        input: auditInput,
+        outcome,
+        exitCode: contractExitCode ?? undefined,
+        errorCode: contractErrorCode,
+        status: "completed",
+        durationMs: Date.now() - startTime,
+        closeLazyConnection: true,
+      });
+    }
 
     if (contractExitCode !== null) return terminateCliProcess(contractExitCode);
   });

--- a/src/cli/tool-definitions.ts
+++ b/src/cli/tool-definitions.ts
@@ -3,6 +3,7 @@
  */
 
 import { extractTools, type ExportedTool } from "./tools-export.js";
+import type { CommandSafetyMetadata } from "./decorators.js";
 import { setCliToolsInitializer } from "./tool-registry.js";
 import { extractOptionName, isBooleanOption } from "./utils.js";
 
@@ -15,6 +16,11 @@ type CommandClass = new () => object;
 export interface SdkToolDefinition {
   name: string;
   description: string;
+  operationKind: CommandSafetyMetadata["operationKind"];
+  effectClass: CommandSafetyMetadata["effectClass"];
+  risk: CommandSafetyMetadata["risk"];
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyMetadata["classificationSource"];
   inputSchema: {
     type: "object";
     properties: Record<string, { type: string; description?: string }>;
@@ -97,9 +103,11 @@ export function getCliToolsByGroup(): Record<string, string[]> {
 export function createSdkTools(classes: CommandClass[], options: CreateSdkToolsOptions = {}): SdkToolDefinition[] {
   const { filter } = options;
 
-  // Use cache if using all classes, otherwise extract fresh
-  const allClasses = getAllCommandClasses();
-  let tools = classes === allClasses ? getCachedTools() : extractTools(classes);
+  // Do not initialize the complete command catalog merely to compare array
+  // identity. Focused callers and tests must remain proportional to the command
+  // classes they supplied. The cache is used only after getAllCommandClasses()
+  // has already established the canonical array.
+  let tools = _commandClasses !== null && classes === _commandClasses ? getCachedTools() : extractTools(classes);
 
   if (filter) {
     const regex = typeof filter === "string" ? new RegExp(filter) : filter;
@@ -147,6 +155,11 @@ function toSdkDefinition(tool: ExportedTool): SdkToolDefinition {
   return {
     name: tool.name,
     description: tool.description,
+    operationKind: tool.metadata.safety.operationKind,
+    effectClass: tool.metadata.safety.effectClass,
+    risk: tool.metadata.safety.risk,
+    requiresConfirmation: tool.metadata.safety.requiresConfirmation,
+    classificationSource: tool.metadata.safety.classificationSource,
     inputSchema: { type: "object", properties, required },
   };
 }

--- a/src/cli/tools-export.test.ts
+++ b/src/cli/tools-export.test.ts
@@ -1,11 +1,24 @@
 import "reflect-metadata";
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { AppsCommands } from "./commands/apps.js";
 import type { ContextRecord } from "../router/router-db.js";
 import { ContractError, contractDryRun, contractFail } from "./agent-contract.js";
 import { fail, runWithContext } from "./context.js";
 import { CliOnly, Command, CommandAccess, Group, Option, Returns } from "./decorators.js";
-import { extractTools } from "./tools-export.js";
+import { createSdkTools } from "./tool-definitions.js";
+import { extractTools, generateManifest, manifestToJSON } from "./tools-export.js";
+import { nats } from "../nats.js";
+
+const previousSuppressAuditEvents = process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+
+beforeAll(() => {
+  process.env.RAVI_SUPPRESS_AUDIT_EVENTS = "1";
+});
+
+afterAll(() => {
+  if (previousSuppressAuditEvents === undefined) delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+  else process.env.RAVI_SUPPRESS_AUDIT_EVENTS = previousSuppressAuditEvents;
+});
 
 @Group({ name: "negated", description: "Negated option fixture", scope: "open" })
 class NegatedToolCommands {
@@ -112,6 +125,28 @@ class CliOnlyToolCommands {
   }
 }
 
+let confirmedEffectCount = 0;
+
+@Group({ name: "effect-metadata", description: "Effect metadata fixture", scope: "open" })
+class EffectMetadataCommands {
+  @Command({ name: "apply", description: "Apply one externally visible effect" })
+  @CommandAccess({
+    kind: "mutate",
+    resource: "effect-metadata",
+    action: "apply",
+    risk: "high",
+    effectClass: "external",
+    requiresConfirmation: true,
+  })
+  apply(@Option({ flags: "--execute", description: "Apply the external effect" }) execute = false) {
+    if (!execute) {
+      contractDryRun("effect-metadata apply", { effect: "external" }, { asJson: true });
+    }
+    confirmedEffectCount += 1;
+    console.log(JSON.stringify({ applied: true }));
+  }
+}
+
 const mediaContext: ContextRecord = {
   contextId: "ctx_media_authorization_test",
   contextKey: "rctx_media_authorization_test",
@@ -150,6 +185,15 @@ const appsContext: ContextRecord = {
   createdAt: Date.now(),
 };
 
+const effectMetadataContext: ContextRecord = {
+  contextId: "ctx_effect_metadata_test",
+  contextKey: "rctx_effect_metadata_test",
+  kind: "test-runtime",
+  agentId: "effect-metadata-test",
+  capabilities: [{ permission: "mutate", objectType: "effect-metadata", objectId: "apply", source: "test" }],
+  createdAt: Date.now(),
+};
+
 describe("tools export negated options", () => {
   it("uses one semantic grant and the same no-prefixed logical contract as CLI and gateway calls", async () => {
     const tool = extractTools([NegatedToolCommands]).find((candidate) => candidate.name === "negated_run");
@@ -166,6 +210,74 @@ describe("tools export negated options", () => {
 describe("tools export surface", () => {
   it("never exports commands marked @CliOnly", () => {
     expect(extractTools([CliOnlyToolCommands]).map((tool) => tool.name)).toEqual(["terminal_status"]);
+  });
+
+  it("exports operation, effect, risk, and confirmation metadata to every agent manifest", () => {
+    const tool = extractTools([EffectMetadataCommands])[0];
+    expect(tool?.metadata.safety).toEqual({
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+    });
+
+    const expected = {
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+    };
+    expect(generateManifest([tool!])[0]).toMatchObject(expected);
+    expect(JSON.parse(manifestToJSON([tool!]))[0]).toMatchObject(expected);
+    expect(createSdkTools([EffectMetadataCommands])[0]).toMatchObject(expected);
+  });
+
+  it("does not contact the global audit transport for allowed or denied calls when suppressed", async () => {
+    const originalEmit = nats.emit;
+    let emits = 0;
+    nats.emit = async () => {
+      emits += 1;
+    };
+    try {
+      const tool = extractTools([NegatedToolCommands])[0];
+      await runWithContext({ agentId: context.agentId, context }, () => tool!.handler({}));
+
+      const deniedTool = extractTools([MediaAuthorizationCommands]).find(
+        (candidate) => candidate.name === "media_remove",
+      );
+      const denied = await runWithContext({ agentId: mediaContext.agentId, context: mediaContext }, () =>
+        deniedTool!.handler({}),
+      );
+      expect(denied).toMatchObject({ outcome: "denied", exitCode: 1 });
+      expect(emits).toBe(0);
+    } finally {
+      nats.emit = originalEmit;
+    }
+  });
+
+  it("blocks a declared confirmation path before its first effect", async () => {
+    confirmedEffectCount = 0;
+    const tool = extractTools([EffectMetadataCommands])[0];
+
+    const blocked = await runWithContext(
+      { agentId: effectMetadataContext.agentId, context: effectMetadataContext },
+      () => tool!.handler({}),
+    );
+    expect(blocked).toMatchObject({ isError: false, outcome: "blocked", exitCode: 3 });
+    expect(JSON.parse(blocked.content[0]?.text ?? "{}")).toMatchObject({
+      success: false,
+      error: { code: "WRITE_REQUIRES_EXECUTE", dryRun: true },
+    });
+    expect(confirmedEffectCount).toBe(0);
+
+    const applied = await runWithContext(
+      { agentId: effectMetadataContext.agentId, context: effectMetadataContext },
+      () => tool!.handler({ execute: true }),
+    );
+    expect(applied).toMatchObject({ isError: false, outcome: "succeeded" });
+    expect(confirmedEffectCount).toBe(1);
   });
 });
 

--- a/src/cli/tools-export.test.ts
+++ b/src/cli/tools-export.test.ts
@@ -29,6 +29,15 @@ class NegatedToolCommands {
   }
 }
 
+@Group({ name: "quiet", description: "Effect-free inspection fixture", scope: "open" })
+class QuietToolCommands {
+  @Command({ name: "inspect", description: "Inspect without contacting audit transport" })
+  @CommandAccess({ kind: "read", resource: "quiet", action: "inspect", risk: "low", audit: "none" })
+  inspect() {
+    console.log(JSON.stringify({ ok: true }));
+  }
+}
+
 const context: ContextRecord = {
   contextId: "ctx_negated_test",
   contextKey: "rctx_negated_test",
@@ -36,6 +45,22 @@ const context: ContextRecord = {
   agentId: "negated-test",
   capabilities: [{ permission: "read", objectType: "negated", objectId: "run", source: "test" }],
   createdAt: Date.now(),
+};
+
+const quietContext: ContextRecord = {
+  contextId: "ctx_quiet_test",
+  contextKey: "rctx_quiet_test",
+  kind: "test-runtime",
+  agentId: "quiet-test",
+  capabilities: [{ permission: "read", objectType: "quiet", objectId: "inspect", source: "test" }],
+  createdAt: Date.now(),
+};
+
+const quietDeniedContext: ContextRecord = {
+  ...quietContext,
+  contextId: "ctx_quiet_denied_test",
+  contextKey: "rctx_quiet_denied_test",
+  capabilities: [],
 };
 
 @Group({ name: "media", description: "Media authorization fixture", scope: "open" })
@@ -253,6 +278,33 @@ describe("tools export surface", () => {
       expect(denied).toMatchObject({ outcome: "denied", exitCode: 1 });
       expect(emits).toBe(0);
     } finally {
+      nats.emit = originalEmit;
+    }
+  });
+
+  it("does not contact the global audit transport for audit:none, without global suppression", async () => {
+    const originalEmit = nats.emit;
+    const suppressed = process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+    let emits = 0;
+    nats.emit = async () => {
+      emits += 1;
+    };
+    delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+    try {
+      const tool = extractTools([QuietToolCommands])[0];
+      const allowed = await runWithContext({ agentId: quietContext.agentId, context: quietContext }, () =>
+        tool!.handler({}),
+      );
+      const denied = await runWithContext({ agentId: quietDeniedContext.agentId, context: quietDeniedContext }, () =>
+        tool!.handler({}),
+      );
+
+      expect(allowed).toMatchObject({ isError: false, outcome: "succeeded" });
+      expect(denied).toMatchObject({ isError: true, outcome: "denied", exitCode: 1 });
+      expect(emits).toBe(0);
+    } finally {
+      if (suppressed === undefined) delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+      else process.env.RAVI_SUPPRESS_AUDIT_EVENTS = suppressed;
       nats.emit = originalEmit;
     }
   });

--- a/src/cli/tools-export.ts
+++ b/src/cli/tools-export.ts
@@ -11,6 +11,7 @@ import {
   getOptionsMetadata,
   getScopeMetadata,
   resolveCommandSafetyMetadata,
+  shouldEmitCommandAudit,
   type ArgMetadata,
   type CommandAccessOptions,
   type CommandSafetyMetadata,
@@ -237,6 +238,7 @@ function buildHandler(
     const agentId = ctx?.agentId;
     const startTime = Date.now();
     const auditInput = redactCommandAccessInput(access, toolArgs);
+    const auditEnabled = shouldEmitCommandAudit(access, toolName);
     const accessResult = enforceCliCommandAuthorization({
       group,
       command,
@@ -251,7 +253,7 @@ function buildHandler(
         accessResult.errorMessage,
       );
       const envelope = JSON.stringify(contractError.envelope());
-      if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+      if (auditEnabled && process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
         nats
           .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
             tool: toolName,
@@ -360,7 +362,7 @@ function buildHandler(
 
     const text = output.join("\n").trim() || "(no output)";
 
-    if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+    if (auditEnabled && process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
       nats
         .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
           tool: toolName,

--- a/src/cli/tools-export.ts
+++ b/src/cli/tools-export.ts
@@ -10,8 +10,10 @@ import {
   getArgsMetadata,
   getOptionsMetadata,
   getScopeMetadata,
+  resolveCommandSafetyMetadata,
   type ArgMetadata,
   type CommandAccessOptions,
+  type CommandSafetyMetadata,
   type OptionMetadata,
   type ScopeType,
 } from "./decorators.js";
@@ -52,6 +54,7 @@ export interface ExportedTool {
     scope?: ScopeType;
     skillGate?: SkillGateMetadata;
     access?: CommandAccessOptions;
+    safety: CommandSafetyMetadata;
   };
 }
 
@@ -68,6 +71,11 @@ export interface ToolResult {
 export interface ToolManifestEntry {
   name: string;
   description: string;
+  operationKind: CommandSafetyMetadata["operationKind"];
+  effectClass: CommandSafetyMetadata["effectClass"];
+  risk: CommandSafetyMetadata["risk"];
+  requiresConfirmation: boolean;
+  classificationSource: CommandSafetyMetadata["classificationSource"];
   parameters: Array<{
     name: string;
     type: string;
@@ -116,6 +124,7 @@ export function extractTools(classes: CommandClass[]): ExportedTool[] {
         method: cmdMeta.method,
       });
       const access = commandAccessMap.get(cmdMeta.method);
+      const safety = resolveCommandSafetyMetadata(access, `${groupMeta.name}.${cmdMeta.name}`);
 
       tools.push({
         name: `${normalizedGroup}_${cmdMeta.name}`,
@@ -140,6 +149,7 @@ export function extractTools(classes: CommandClass[]): ExportedTool[] {
           scope: effectiveScope,
           ...(skillGate ? { skillGate } : {}),
           ...(access ? { access } : {}),
+          safety,
         },
       });
     }
@@ -155,6 +165,11 @@ export function generateManifest(tools: ExportedTool[]): ToolManifestEntry[] {
   return tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
+    operationKind: tool.metadata.safety.operationKind,
+    effectClass: tool.metadata.safety.effectClass,
+    risk: tool.metadata.safety.risk,
+    requiresConfirmation: tool.metadata.safety.requiresConfirmation,
+    classificationSource: tool.metadata.safety.classificationSource,
     parameters: [
       ...tool.metadata.args.map((arg) => ({
         name: arg.name,
@@ -236,21 +251,23 @@ function buildHandler(
         accessResult.errorMessage,
       );
       const envelope = JSON.stringify(contractError.envelope());
-      nats
-        .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
-          tool: toolName,
-          input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
-          output: sanitizeCliAuditValue(accessResult.errorMessage, "output"),
-          isError: true,
-          outcome: "denied",
-          exitCode: 1,
-          errorCode: "PERMISSION_DENIED",
-          durationMs: Date.now() - startTime,
-          timestamp: new Date().toISOString(),
-          sessionKey,
-          agentId,
-        })
-        .catch(() => {});
+      if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+        nats
+          .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
+            tool: toolName,
+            input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
+            output: sanitizeCliAuditValue(accessResult.errorMessage, "output"),
+            isError: true,
+            outcome: "denied",
+            exitCode: 1,
+            errorCode: "PERMISSION_DENIED",
+            durationMs: Date.now() - startTime,
+            timestamp: new Date().toISOString(),
+            sessionKey,
+            agentId,
+          })
+          .catch(() => {});
+      }
       return {
         content: [{ type: "text", text: envelope }],
         isError: true,
@@ -343,23 +360,25 @@ function buildHandler(
 
     const text = output.join("\n").trim() || "(no output)";
 
-    nats
-      .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
-        tool: toolName,
-        input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
-        // Tool output may contain message bodies or provider payloads. Audit
-        // the semantic outcome, never the full returned content.
-        output: truncateForEvent(sanitizeCliAuditValue(text, "output")),
-        isError,
-        outcome,
-        ...(contractExitCode !== undefined ? { exitCode: contractExitCode } : {}),
-        ...(contractErrorCode !== undefined ? { errorCode: contractErrorCode } : {}),
-        durationMs: Date.now() - startTime,
-        timestamp: new Date().toISOString(),
-        sessionKey,
-        agentId,
-      })
-      .catch(() => {});
+    if (process.env.RAVI_SUPPRESS_AUDIT_EVENTS !== "1") {
+      nats
+        .emit(`ravi.${sessionKey}.cli.${group}.${command}`, {
+          tool: toolName,
+          input: truncateForEvent(sanitizeCliAuditValue(auditInput)),
+          // Tool output may contain message bodies or provider payloads. Audit
+          // the semantic outcome, never the full returned content.
+          output: truncateForEvent(sanitizeCliAuditValue(text, "output")),
+          isError,
+          outcome,
+          ...(contractExitCode !== undefined ? { exitCode: contractExitCode } : {}),
+          ...(contractErrorCode !== undefined ? { errorCode: contractErrorCode } : {}),
+          durationMs: Date.now() - startTime,
+          timestamp: new Date().toISOString(),
+          sessionKey,
+          agentId,
+        })
+        .catch(() => {});
+    }
 
     return {
       content: [{ type: "text", text }],

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -84,6 +84,12 @@ describe("Ravi Commands", () => {
       rawArguments: '123 "very high"',
       originalText: '#review 123 "very high"',
     });
+    const repeated = renderRaviCommand(command, {
+      id: "review",
+      token: "#review",
+      rawArguments: '123 "very high"',
+      originalText: '#review 123 "very high"',
+    });
 
     expect(rendered.prompt).toContain("Review 123 as very high.");
     expect(rendered.prompt).toContain('Raw=123 "very high"');
@@ -91,6 +97,7 @@ describe("Ravi Commands", () => {
     expect(rendered.prompt).toContain("shorthand=very high");
     expect(rendered.metadata.id).toBe("review");
     expect(rendered.metadata.renderedPromptSha256).toHaveLength(64);
+    expect(repeated).toEqual(rendered);
   });
 
   it("expands command prompts and leaves normal prompts unchanged", () => {

--- a/src/permissions/scope.ts
+++ b/src/permissions/scope.ts
@@ -13,6 +13,7 @@ import { closeNats } from "../nats.js";
 import type { ContextRecord, ContextSource } from "../router/router-db.js";
 import type { SessionEntry } from "../router/types.js";
 import type { ScopeType } from "../cli/decorators.js";
+import { terminateCliProcess } from "../cli/process-output.js";
 
 /**
  * Flush pending audit events and exit the process.
@@ -21,7 +22,7 @@ import type { ScopeType } from "../cli/decorators.js";
 export async function flushAuditAndExit(code: number): Promise<never> {
   await flushPermissionAuditEvents();
   await closeNats();
-  process.exit(code);
+  return terminateCliProcess(code);
 }
 
 interface ScopeDenialDiagnosis {

--- a/src/plugins/internal/ravi-system/skills/commands/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/commands/SKILL.md
@@ -37,6 +37,10 @@ Campos desconhecidos não são ignorados: o pedido inteiro falha com exit 2 e
 `acceptedFields`, inclusive se a lista estiver vazia. `--limit` aceita de 1 a
 500; `--offset` aceita zero ou mais; ambos exigem inteiros.
 
+A projecao JSON contem somente os campos pedidos e continua valida no contrato
+publicado depois de serializar. As quatro operacoes consultam o diretorio de
+agents sem inicializar ou alterar SQLite e nao publicam auditoria de transporte.
+
 Exemplos:
 
 ```bash

--- a/src/plugins/internal/ravi-system/skills/commands/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/commands/SKILL.md
@@ -16,26 +16,34 @@ Eles nao sao slash commands, nao sao shell commands e nao concedem permissao ext
 
 ## Contrato Do CLI
 
-Rode com `--json` sempre que for decidir programaticamente. Com `--json`, falha sai em envelope `{success:false, op, error:{code, message, retryable, suggestedAction, suggestions?|acceptedFlags?}}`.
+Rode com `--json` sempre que for decidir programaticamente. Com `--json`, falha sai em envelope `{success:false, op, error:{code, message, retryable, suggestedAction, suggestions?|acceptedFlags?|acceptedFields?}}`.
 
 Taxonomia de saída:
 
 - `0` sucesso.
 - `1` erro de execução (`COMMAND_NOT_FOUND`, `AGENT_NOT_FOUND`). O envelope traz `suggestions` com ids reais parecidos (commands do mesmo registry, agents do config local) — consulte antes de concluir "não existe".
-- `2` erro de uso (flag/argumento inválido).
+- `2` erro de uso (`INVALID_COMMAND_NAME` para nome vazio/inválido;
+  `USAGE_ERROR` para flag, paginação ou `--fields` inválido).
 - `3` freio de escrita — NÃO existe neste domínio.
 
 Sem freio (declarado): o domínio inteiro é read-only. `commands run` só RENDERIZA o prompt composto para preview — não publica em sessão, não executa runtime — então nada aqui exige `--execute`.
 
+`ravi commands` sem subcomando é descoberta: imprime o help do grupo e sai 0.
+
 Caso especial: `commands validate` mantém o exit 1 PRÉ-EXISTENTE quando há erros de validação nos arquivos — é veredito sobre os arquivos, não envelope de erro.
 
 Compact mode: `commands list` aceita `--fields a,b,c` (ex.: `--fields id,scope`).
+Campos desconhecidos não são ignorados: o pedido inteiro falha com exit 2 e
+`acceptedFields`, inclusive se a lista estiver vazia. `--limit` aceita de 1 a
+500; `--offset` aceita zero ou mais; ambos exigem inteiros.
 
 Exemplos:
 
 ```bash
 ravi commands show nope --json              # exit 1 + COMMAND_NOT_FOUND + suggestions
+ravi commands show "" --json                # exit 2 + INVALID_COMMAND_NAME
 ravi commands list --fields id,scope --json # itens compactos
+ravi commands list --fields id,nope --json  # exit 2 + acceptedFields
 ravi commands run restart --json -- "motivo" # renderiza; sem side effects
 ```
 

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -8961,8 +8961,9 @@ export interface ReadOnlyAgentDirectorySnapshot {
  * Read only the agent identity and cwd needed by discovery-only CLI domains.
  *
  * This deliberately bypasses getDb(): it must not create the state directory,
- * initialize schema, enable WAL, run migrations, or mutate an existing WAL/SHM
- * pair. Missing legacy tables are represented as an empty snapshot.
+ * initialize schema, enable WAL, run migrations, or mutate durable DB/WAL
+ * bytes. SQLite may update its ephemeral -shm coordination index while a WAL
+ * writer is active. Missing legacy tables are represented as an empty snapshot.
  */
 export function dbReadAgentDirectorySnapshot(): ReadOnlyAgentDirectorySnapshot {
   const dbPath = resolveDbPath();

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -8952,6 +8952,53 @@ export function dbListAgents(): AgentConfig[] {
   return rows.map(rowToAgent);
 }
 
+export interface ReadOnlyAgentDirectorySnapshot {
+  defaultAgent: string;
+  agents: Array<Pick<AgentConfig, "id" | "cwd">>;
+}
+
+/**
+ * Read only the agent identity and cwd needed by discovery-only CLI domains.
+ *
+ * This deliberately bypasses getDb(): it must not create the state directory,
+ * initialize schema, enable WAL, run migrations, or mutate an existing WAL/SHM
+ * pair. Missing legacy tables are represented as an empty snapshot.
+ */
+export function dbReadAgentDirectorySnapshot(): ReadOnlyAgentDirectorySnapshot {
+  const dbPath = resolveDbPath();
+  if (!existsSync(dbPath)) return { defaultAgent: "main", agents: [] };
+
+  const database = new Database(dbPath, { readonly: true, create: false });
+  try {
+    database.exec("PRAGMA busy_timeout = 1000");
+    const tables = new Set(
+      (
+        database
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('agents', 'settings')")
+          .all() as Array<{
+          name: string;
+        }>
+      ).map((row) => row.name),
+    );
+    const agents = tables.has("agents")
+      ? (database.prepare("SELECT id, cwd FROM agents ORDER BY id ASC").all() as Array<{
+          id: string;
+          cwd: string;
+        }>)
+      : [];
+    const defaultAgent = tables.has("settings")
+      ? ((
+          database.prepare("SELECT value FROM settings WHERE key = 'defaultAgent'").get() as
+            | { value: string }
+            | undefined
+        )?.value?.trim() ?? "main")
+      : "main";
+    return { defaultAgent: defaultAgent || "main", agents };
+  } finally {
+    database.close();
+  }
+}
+
 /**
  * Update an existing agent
  */

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import {
@@ -14,6 +16,7 @@ import {
   dbListChannels,
   dbListContexts,
   dbPruneContexts,
+  dbReadAgentDirectorySnapshot,
   dbUpdateAgent,
   dbUpdateChannel,
   dbUpsertChannel,
@@ -29,6 +32,17 @@ import { createRuntimeModelPreset } from "../runtime/model-preset-store.js";
 let stateDir: string | null = null;
 
 const DAY = 24 * 60 * 60 * 1000;
+
+function stateFilesDigest(directory: string): Array<{ name: string; sha256: string }> {
+  return readdirSync(directory)
+    .sort()
+    .map((name) => ({
+      name,
+      sha256: createHash("sha256")
+        .update(readFileSync(join(directory, name)))
+        .digest("hex"),
+    }));
+}
 
 function createContext(input: {
   id: string;
@@ -60,6 +74,26 @@ describe("router context queries", () => {
   afterEach(async () => {
     await cleanupIsolatedRaviState(stateDir);
     stateDir = null;
+  });
+
+  it("reads an empty agent directory without creating the missing database", () => {
+    const dbPath = join(stateDir!, "ravi.db");
+    expect(existsSync(dbPath)).toBe(false);
+
+    expect(dbReadAgentDirectorySnapshot()).toEqual({ defaultAgent: "main", agents: [] });
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it("reads the existing agent directory without changing any state file", () => {
+    dbCreateAgent({ id: "readonly-agent", cwd: "/tmp/ravi-readonly-agent" });
+    closeRouterDb();
+    const before = stateFilesDigest(stateDir!);
+
+    const snapshot = dbReadAgentDirectorySnapshot();
+
+    expect(snapshot.defaultAgent).toBe("main");
+    expect(snapshot.agents).toContainEqual({ id: "readonly-agent", cwd: "/tmp/ravi-readonly-agent" });
+    expect(stateFilesDigest(stateDir!)).toEqual(before);
   });
 
   it("lists contexts with SQL-backed filters and excludes inactive contexts by default", () => {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -263,6 +263,13 @@ describe("createCodexRuntimeProvider", () => {
       name: "tools_list",
       description: "List tools",
       inputSchema: { type: "object" },
+      safety: {
+        operationKind: "read" as const,
+        effectClass: "none" as const,
+        risk: "low" as const,
+        requiresConfirmation: false,
+        classificationSource: "declared" as const,
+      },
     };
 
     writeFileSync(

--- a/src/runtime/host-services.foundation.test.ts
+++ b/src/runtime/host-services.foundation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import type { SdkToolDefinition } from "../cli/tool-definitions.js";
+import { projectRuntimeDynamicToolSpec } from "./host-services.js";
+
+describe("runtime host agent-first tool catalog", () => {
+  it("preserves command safety metadata at the runtime boundary", () => {
+    const tool: SdkToolDefinition = {
+      name: "demo_apply",
+      description: "Apply a demo change",
+      operationKind: "mutate",
+      effectClass: "external",
+      risk: "high",
+      requiresConfirmation: true,
+      classificationSource: "declared",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    };
+
+    expect(projectRuntimeDynamicToolSpec(tool)).toEqual({
+      name: "demo_apply",
+      description: "Apply a demo change",
+      inputSchema: { type: "object", properties: {}, required: [] },
+      safety: {
+        operationKind: "mutate",
+        effectClass: "external",
+        risk: "high",
+        requiresConfirmation: true,
+        classificationSource: "declared",
+      },
+    });
+  });
+});

--- a/src/runtime/host-services.ts
+++ b/src/runtime/host-services.ts
@@ -1,5 +1,5 @@
 import { runWithContext } from "../cli/context.js";
-import { getAllCommandClasses, createSdkTools } from "../cli/tool-definitions.js";
+import { getAllCommandClasses, createSdkTools, type SdkToolDefinition } from "../cli/tool-definitions.js";
 import { extractTools, type ExportedTool, type ToolResult } from "../cli/tools-export.js";
 import { logger } from "../utils/logger.js";
 
@@ -89,13 +89,24 @@ function getRuntimeDynamicToolDefinitions(): ExportedTool[] {
 
 function getRuntimeDynamicToolSpecs(): RuntimeDynamicToolSpec[] {
   if (!cachedRuntimeDynamicToolSpecs) {
-    cachedRuntimeDynamicToolSpecs = createSdkTools(getAllCommandClasses()).map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-    }));
+    cachedRuntimeDynamicToolSpecs = createSdkTools(getAllCommandClasses()).map(projectRuntimeDynamicToolSpec);
   }
   return cachedRuntimeDynamicToolSpecs;
+}
+
+export function projectRuntimeDynamicToolSpec(tool: SdkToolDefinition): RuntimeDynamicToolSpec {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    safety: {
+      operationKind: tool.operationKind,
+      effectClass: tool.effectClass,
+      risk: tool.risk,
+      requiresConfirmation: tool.requiresConfirmation,
+      classificationSource: tool.classificationSource,
+    },
+  };
 }
 
 function getRuntimeDynamicToolSpecsForContext(context: ContextRecord): RuntimeDynamicToolSpec[] {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,5 +1,6 @@
 import type { RuntimeEffort } from "./effort.js";
 import type { RuntimeModelBrokerBinding, RuntimeModelBrokerCapabilities } from "./model-broker.js";
+import type { CommandSafetyMetadata } from "../cli/decorators.js";
 
 export type { RuntimeEffort } from "./effort.js";
 
@@ -177,6 +178,7 @@ export interface RuntimeDynamicToolSpec {
   name: string;
   description: string;
   inputSchema: unknown;
+  safety: CommandSafetyMetadata;
   deferLoading?: boolean;
 }
 

--- a/src/sdk/client-codegen/codegen.test.ts
+++ b/src/sdk/client-codegen/codegen.test.ts
@@ -219,7 +219,7 @@ describe("client-codegen :: compareSdkSource", () => {
     expect(result.equal).toBe(false);
   });
 
-  it("requires byte equality for client.ts / schemas.ts / types.ts", () => {
+  it("requires source equality for client.ts / schemas.ts / types.ts", () => {
     const a = emitWith({});
     expect(compareSdkSource("client.ts", a.client, a.client).equal).toBe(true);
     expect(compareSdkSource("schemas.ts", a.schemas, a.schemas).equal).toBe(true);
@@ -228,7 +228,7 @@ describe("client-codegen :: compareSdkSource", () => {
     const mutatedClient = `${a.client}// drift\n`;
     const clientResult = compareSdkSource("client.ts", mutatedClient, a.client);
     expect(clientResult.equal).toBe(false);
-    expect(clientResult.reason).toMatch(/byte mismatch/);
+    expect(clientResult.reason).toMatch(/source mismatch/);
     expect(clientResult.reason).not.toMatch(/GIT_SHA/);
 
     const mutatedSchemas = a.schemas.replace("export const", "export  const");
@@ -238,10 +238,32 @@ describe("client-codegen :: compareSdkSource", () => {
     expect(compareSdkSource("types.ts", mutatedTypes, a.types).equal).toBe(false);
   });
 
+  it("ignores checkout line-ending conversion without hiding source drift", () => {
+    const a = emitWith({});
+    const crlfClient = a.client.replace(/\n/g, "\r\n");
+    const crlfVersion = a.version.replace(/\n/g, "\r\n");
+
+    expect(compareSdkSource("client.ts", crlfClient, a.client).equal).toBe(true);
+    expect(compareSdkSource("version.ts", crlfVersion, a.version).equal).toBe(true);
+    expect(compareSdkSource("client.ts", `${crlfClient}// real drift\r\n`, a.client).equal).toBe(false);
+  });
+
   it("ignores GIT_SHA even when stored has the literal `unknown` placeholder", () => {
     const a = emitWith({ gitSha: "unknown" });
     const b = emitWith({ gitSha: "5e17fe5608f7" });
     expect(compareSdkSource("version.ts", a.version, b.version).equal).toBe(true);
+  });
+
+  it("rejects source appended to the GIT_SHA declaration line", () => {
+    const generated = emitWith({});
+    const storedWithAppendedSource = generated.version.replace(
+      /^(export const GIT_SHA = .*;)$/m,
+      "$1 void globalThis;",
+    );
+
+    const result = compareSdkSource("version.ts", storedWithAppendedSource, generated.version);
+    expect(result.equal).toBe(false);
+    expect(result.reason).toMatch(/source mismatch/);
   });
 });
 

--- a/src/sdk/client-codegen/codegen.test.ts
+++ b/src/sdk/client-codegen/codegen.test.ts
@@ -13,6 +13,7 @@ import "reflect-metadata";
 import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 import { Arg, Command, Group, Option, Returns } from "../../cli/decorators.js";
+import { commandsListReturnSchema } from "../../cli/commands/operational-return-schemas.js";
 import { buildRegistry } from "../../cli/registry-snapshot.js";
 import { compareSdkSource, computeRegistryHash, emitAll } from "./index.js";
 
@@ -67,6 +68,15 @@ class CrmCommands {
 class CrmAccountCommands {
   @Command({ name: "create", description: "Create account" })
   create(@Arg("name") _name: string) {
+    return {};
+  }
+}
+
+@Group({ name: "commands", description: "Ravi commands", scope: "open" })
+class CommandsContractCommands {
+  @Command({ name: "list", description: "List Ravi commands" })
+  @Returns(commandsListReturnSchema)
+  list() {
     return {};
   }
 }
@@ -144,6 +154,23 @@ describe("client-codegen :: emitAll", () => {
     expect(output.types).toContain("export type ArtifactsShowReturn = {");
     expect(output.types).toMatch(/id: string;/);
     expect(output.types).toMatch(/kind: string;/);
+  });
+
+  it("keeps commands projected rows non-empty and fully typed in generated TypeScript", () => {
+    const output = emitAll(buildRegistry([CommandsContractCommands]), { version: FIXED_VERSION });
+
+    expect(output.types).toContain("export type CommandsListReturn = {");
+    expect(output.types).toContain("arguments?: string[];");
+    expect(output.types).toContain("issues?: Array<{");
+    expect(output.types).not.toContain("RaviJSON");
+    expect(output.types).not.toContain("Record<string, unknown>");
+    expect(output.types).not.toContain("[k: string]: unknown");
+    expect(output.schemas).toContain('"title": "CommandsListItem"');
+    expect(
+      output.schemas.match(
+        /"required": \[\s+"(?:id|token|title|description|argumentHint|arguments|disabled|scope|path|relativePath|shadowedBy|shadows|issues)"\s+\]/g,
+      )?.length,
+    ).toBeGreaterThanOrEqual(13);
   });
 
   it("falls back to unknown for return when no @Returns", () => {

--- a/src/sdk/client-codegen/emit-files.ts
+++ b/src/sdk/client-codegen/emit-files.ts
@@ -381,8 +381,7 @@ export function emitVersion(input: EmitVersionInput): string {
  * the generated SDK surface is byte-stable. Mask the value before comparison
  * so drift detection reflects real registry/codegen changes.
  */
-const GIT_SHA_LINE_RE = /^export const GIT_SHA = .*$/m;
-const GIT_SHA_MASK = 'export const GIT_SHA = "<masked-for-drift-check>";';
+const GIT_SHA_VALUE_RE = /^(export const GIT_SHA = )"(?:\\.|[^"\\])*"([ \t]*;[ \t]*)$/m;
 
 export type GeneratedSdkFile = "client.ts" | "schemas.ts" | "types.ts" | "version.ts" | "streaming.generated.ts";
 
@@ -392,24 +391,32 @@ export interface SdkSourceComparison {
 }
 
 export function compareSdkSource(file: GeneratedSdkFile, stored: string, generated: string): SdkSourceComparison {
+  const canonicalStored = normalizeLineEndings(stored);
+  const canonicalGenerated = normalizeLineEndings(generated);
   if (file === "version.ts") {
-    const a = maskGitSha(stored);
-    const b = maskGitSha(generated);
+    const a = maskGitSha(canonicalStored);
+    const b = maskGitSha(canonicalGenerated);
     if (a === b) return { equal: true };
     return {
       equal: false,
-      reason: `byte mismatch ignoring GIT_SHA (stored=${stored.length}, live=${generated.length})`,
+      reason: `source mismatch ignoring GIT_SHA and line endings (stored=${stored.length}, live=${generated.length})`,
     };
   }
-  if (stored === generated) return { equal: true };
+  if (canonicalStored === canonicalGenerated) return { equal: true };
   return {
     equal: false,
-    reason: `byte mismatch (stored=${stored.length}, live=${generated.length})`,
+    reason: `source mismatch ignoring line endings (stored=${stored.length}, live=${generated.length})`,
   };
 }
 
+function normalizeLineEndings(source: string): string {
+  return source.replace(/\r\n/g, "\n");
+}
+
 function maskGitSha(source: string): string {
-  return source.replace(GIT_SHA_LINE_RE, GIT_SHA_MASK);
+  return source.replace(GIT_SHA_VALUE_RE, (_match, prefix: string, suffix: string) => {
+    return `${prefix}"<masked-for-drift-check>"${suffix}`;
+  });
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/sdk/client-codegen/json-schema-to-ts.ts
+++ b/src/sdk/client-codegen/json-schema-to-ts.ts
@@ -48,7 +48,13 @@ function render(schema: JsonSchema, indent: number): string {
     return uniqueUnion(branches);
   }
   if (Array.isArray((schema as { allOf?: unknown[] }).allOf)) {
-    const parts = (schema as { allOf: JsonSchema[] }).allOf.map((s) => render(s, indent));
+    const schemas = (schema as { allOf: JsonSchema[] }).allOf;
+    const hasClosedObject = schemas.some(
+      (part) =>
+        (part as { type?: unknown }).type === "object" &&
+        (part as { additionalProperties?: unknown }).additionalProperties === false,
+    );
+    const parts = schemas.map((part) => render(hasClosedObject ? withoutOpenObjectIndexes(part) : part, indent));
     if (parts.length === 0) return "unknown";
     if (parts.length === 1) return parts[0];
     return parts.map(parenthesize).join(" & ");
@@ -64,6 +70,31 @@ function render(schema: JsonSchema, indent: number): string {
   }
 
   return "unknown";
+}
+
+function withoutOpenObjectIndexes(schema: JsonSchema): JsonSchema {
+  const copy: JsonSchema = { ...schema };
+  if (
+    (copy as { type?: unknown }).type === "object" &&
+    isEmptySchema((copy as { additionalProperties?: unknown }).additionalProperties)
+  ) {
+    delete copy.additionalProperties;
+  }
+  for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
+    const branches = copy[keyword];
+    if (Array.isArray(branches)) {
+      copy[keyword] = branches.map((branch) =>
+        branch && typeof branch === "object" && !Array.isArray(branch)
+          ? withoutOpenObjectIndexes(branch as JsonSchema)
+          : branch,
+      );
+    }
+  }
+  return copy;
+}
+
+function isEmptySchema(value: unknown): boolean {
+  return value !== null && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
 }
 
 function renderTyped(schema: JsonSchema & { type: string }, indent: number): string {

--- a/src/sdk/client-codegen/return-schema-coverage.test.ts
+++ b/src/sdk/client-codegen/return-schema-coverage.test.ts
@@ -1,10 +1,15 @@
 import "reflect-metadata";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
 
 import { getRegistry } from "../../cli/registry-snapshot.js";
 import { UNTYPED_PUBLIC_RETURN_COMMANDS_BASELINE } from "./return-schema-baseline.js";
 import { WEAK_PUBLIC_RETURN_COMMANDS_BASELINE } from "./return-schema-quality-baseline.js";
 import { currentWeakPublicReturnCommands } from "./return-schema-quality.js";
+
+// A cold registry snapshot imports the complete CLI catalog. Five seconds is
+// below observed Windows startup time and made this deterministic coverage
+// assertion fail before it could compare the registry with its baseline.
+setDefaultTimeout(15_000);
 
 function currentUntypedPublicReturnCommands(): string[] {
   return getRegistry()

--- a/src/sdk/gateway/dispatcher.test.ts
+++ b/src/sdk/gateway/dispatcher.test.ts
@@ -20,6 +20,13 @@ const rejectedSensitiveInput = z.string().superRefine((value, ctx) => {
 
 @Group({ name: "demo", description: "Gateway demo commands", scope: "open" })
 class GatewayDemoCommands {
+  @Command({ name: "quiet", description: "Inspect without audit transport" })
+  @CommandAccess({ kind: "read", resource: "demo", action: "quiet", risk: "low", input: ["name"], audit: "none" })
+  @Returns(z.object({ name: z.string() }))
+  quiet(@Arg("name") name: string) {
+    return { name };
+  }
+
   @Command({ name: "negated", description: "Expose negated flag presence" })
   @CommandAccess({ kind: "read", resource: "demo", action: "negated", risk: "low", input: ["noCache"] })
   @Returns(z.object({ noCache: z.boolean() }))
@@ -119,7 +126,13 @@ class GatewayDemoCommands {
   @Returns(
     z
       .object({
-        items: z.array(z.object({ id: z.string(), label: z.string() }).strict()),
+        items: z.array(
+          z
+            .object({ id: z.string(), label: z.string() })
+            .partial()
+            .strict()
+            .refine((record) => Object.keys(record).length > 0),
+        ),
       })
       .strict(),
   )
@@ -566,7 +579,7 @@ describe("dispatch — validation", () => {
     });
   });
 
-  it("validates full projected rows while serializing only requested fields", async () => {
+  it("validates the honest projected row after serialization", async () => {
     const result = await dispatch(findCmd("demo.fields"), { fields: "id" }, {}, { contextRecord: demoContext });
 
     expect(result.response.status).toBe(200);
@@ -887,6 +900,31 @@ describe("dispatch — scope and superadmin gating", () => {
 });
 
 describe("dispatch — audit", () => {
+  it("skips the audit transport for audit:none on success, usage error, and denial", async () => {
+    const audits = captureAudits();
+    const success = await dispatch(
+      findCmd("demo.quiet"),
+      { name: "visible" },
+      {},
+      { contextRecord: demoContext, emitAudit: audits.emit },
+    );
+    const usage = await dispatch(findCmd("demo.quiet"), {}, {}, { emitAudit: audits.emit });
+    const denied = await dispatch(
+      findCmd("demo.quiet"),
+      { name: "blocked" },
+      {},
+      { contextRecord: gatewayContext([], "quiet-denied"), emitAudit: audits.emit },
+    );
+
+    expect(success.response.status).toBe(200);
+    expect(usage.response.status).toBe(400);
+    expect(denied.response.status).toBe(403);
+    expect(success.audit).toBeNull();
+    expect(usage.audit).toBeNull();
+    expect(denied.audit).toBeNull();
+    expect(audits.events).toEqual([]);
+  });
+
   it("emits exactly one audit per request, with tool=<group>_<command>", async () => {
     const audits = captureAudits();
     await dispatch(findCmd("demo.echo"), { name: "x" }, {}, { contextRecord: demoContext, emitAudit: audits.emit });

--- a/src/sdk/gateway/dispatcher.ts
+++ b/src/sdk/gateway/dispatcher.ts
@@ -38,6 +38,7 @@ import {
 } from "../../cli/agent-contract.js";
 import { isCloudAuthError } from "../../cloud-auth/errors.js";
 import { cloudErrorToContractError, commandOperation } from "../../cli/cloud-error-contract.js";
+import { shouldEmitCommandAudit } from "../../cli/decorators.js";
 import { contractErrorResponse, json, returnShapeError, type JsonIssue } from "./errors.js";
 
 export interface DispatchOptions {
@@ -48,6 +49,8 @@ export interface DispatchOptions {
   /** Resolved runtime context record for audit lineage and contextId fields. */
   contextRecord?: ContextRecord | null;
 }
+
+type DispatchAuditEmitter = DispatchOptions["emitAudit"] | false;
 
 export interface AuditEvent {
   group: string;
@@ -97,6 +100,7 @@ export async function dispatch(
   const group = cmd.groupSegments.join("_");
   const lineage = extractLineage(opts.contextRecord);
   const startedAt = Date.now();
+  const auditEmitter: DispatchAuditEmitter = shouldEmitCommandAudit(cmd.access, cmd.fullName) ? opts.emitAudit : false;
 
   if (cmd.scope === "superadmin" && !opts.allowSuperadmin) {
     const error = permissionDeniedToContractError(
@@ -105,18 +109,18 @@ export async function dispatch(
     );
     const response = contractErrorResponse(error, 403, "denied");
     const audit = buildAuditEvent(cmd, tool, {}, "denied", startedAt, lineage, 1, "PERMISSION_DENIED");
-    const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+    const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
     return { response, audit: auditEmitted ? audit : null };
   }
 
   const normalized = normalizeBody(cmd, body);
   if (!normalized.ok) {
-    return usageErrorResult(cmd, tool, group, normalized.issues, startedAt, lineage, opts.emitAudit);
+    return usageErrorResult(cmd, tool, group, normalized.issues, startedAt, lineage, auditEmitter);
   }
 
   const validation = validateAndPack(cmd, normalized.input);
   if (!validation.ok) {
-    return usageErrorResult(cmd, tool, group, validation.issues, startedAt, lineage, opts.emitAudit);
+    return usageErrorResult(cmd, tool, group, validation.issues, startedAt, lineage, auditEmitter);
   }
   const auditInput = redactCommandAccessInput(cmd.access, validation.inputForAudit);
 
@@ -135,7 +139,7 @@ export async function dispatch(
     const error = permissionDeniedToContractError(commandOperation(group, cmd.command), accessResult.errorMessage);
     const response = contractErrorResponse(error, 403, "denied");
     const audit = buildAuditEvent(cmd, tool, auditInput, "denied", startedAt, lineage, 1, "PERMISSION_DENIED");
-    const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+    const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
     return { response, audit: auditEmitted ? audit : null };
   }
 
@@ -198,7 +202,7 @@ export async function dispatch(
       response = contractErrorResponse(unexpectedError, 500);
     }
     const audit = buildAuditEvent(cmd, tool, auditInput, outcome, startedAt, lineage, auditExitCode, auditErrorCode);
-    const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+    const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
     return { response, audit: auditEmitted ? audit : null };
   }
 
@@ -212,7 +216,7 @@ export async function dispatch(
         },
       ]);
       const audit = buildAuditEvent(cmd, tool, auditInput, "failed", startedAt, lineage, 1, "RETURN_SHAPE_ERROR");
-      const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+      const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
       return { response, audit: auditEmitted ? audit : null };
     }
     if (!returnValue.ok) {
@@ -230,11 +234,11 @@ export async function dispatch(
         error.exitCode,
         error.code,
       );
-      const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+      const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
       return { response, audit: auditEmitted ? audit : null };
     }
     const audit = buildAuditEvent(cmd, tool, auditInput, "succeeded", startedAt, lineage);
-    const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+    const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
     return { response: returnValue, audit: auditEmitted ? audit : null };
   }
 
@@ -245,14 +249,14 @@ export async function dispatch(
     if (returnIssues) {
       response = returnShapeError(commandOperation(group, cmd.command), returnIssues);
       const audit = buildAuditEvent(cmd, tool, auditInput, "failed", startedAt, lineage, 1, "RETURN_SHAPE_ERROR");
-      const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+      const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
       return { response, audit: auditEmitted ? audit : null };
     }
   }
 
   response = json(200, responseValue);
   const audit = buildAuditEvent(cmd, tool, auditInput, "succeeded", startedAt, lineage);
-  const auditEmitted = await emitDispatchAudit(audit, opts.emitAudit);
+  const auditEmitted = await emitDispatchAudit(audit, auditEmitter);
   return { response, audit: auditEmitted ? audit : null };
 }
 
@@ -312,7 +316,7 @@ async function usageErrorResult(
   issues: JsonIssue[],
   startedAt: number,
   lineage: AuditLineage,
-  emitAudit: DispatchOptions["emitAudit"],
+  emitAudit: DispatchAuditEmitter,
 ): Promise<DispatchResult> {
   const op = commandOperation(group, cmd.command);
   const error = new ContractError(op, "USAGE_ERROR", `Invalid input for ${op}.`, CONTRACT_EXIT_USAGE, {
@@ -491,7 +495,8 @@ function asToolContext(scope: ScopeContext, record: ContextRecord | null): ToolC
   return ctx;
 }
 
-async function emitDispatchAudit(event: AuditEvent, override: DispatchOptions["emitAudit"]): Promise<boolean> {
+async function emitDispatchAudit(event: AuditEvent, override: DispatchAuditEmitter): Promise<boolean> {
+  if (override === false) return false;
   if (override) {
     await override(event);
     return true;

--- a/src/sdk/openapi/emit.test.ts
+++ b/src/sdk/openapi/emit.test.ts
@@ -252,13 +252,13 @@ describe("openapi emit (live registry)", () => {
     const nonCliOnlyCommands = reg.commands.filter((cmd) => !cmd.cliOnly).length;
     expect(Object.keys(spec.paths).length).toBe(nonCliOnlyCommands);
     expect(spec.openapi).toBe("3.1.0");
-  });
+  }, 30_000);
 
   it("every operation has a unique operationId on the live registry", () => {
     const spec = emit(getRegistry());
     const ids = Object.values(spec.paths).map((p) => p.post.operationId);
     expect(new Set(ids).size).toBe(ids.length);
-  });
+  }, 30_000);
 });
 
 describe("sortKeysDeep", () => {

--- a/src/sdk/openapi/emit.test.ts
+++ b/src/sdk/openapi/emit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 
 import { Arg, Command, Group, Option, Returns, Scope } from "../../cli/decorators.js";
+import { commandsListReturnSchema } from "../../cli/commands/operational-return-schemas.js";
 import { buildRegistry, getRegistry } from "../../cli/registry-snapshot.js";
 import { emit, emitJson, commandPath } from "./emit.js";
 import { sortKeysDeep, stableStringify } from "./stable-stringify.js";
@@ -44,6 +45,15 @@ class NestedDemo {
   ) {
     void id;
     void rest;
+  }
+}
+
+@Group({ name: "commands", description: "Ravi commands", scope: "open" })
+class CommandsContractCommands {
+  @Command({ name: "list", description: "List Ravi commands" })
+  @Returns(commandsListReturnSchema)
+  list() {
+    return {};
   }
 }
 
@@ -116,6 +126,24 @@ describe("openapi emit", () => {
     const props = schema.properties as Record<string, unknown>;
     expect(props.ok).toBeDefined();
     expect(props.message).toBeDefined();
+  });
+
+  it("publishes commands projection as a typed non-empty union in OpenAPI", () => {
+    const spec = emit(buildRegistry([CommandsContractCommands]));
+    const response = spec.paths["/api/v1/commands/list"]!.post.responses["200"]!.content!["application/json"]
+      .schema as Record<string, unknown>;
+    const properties = response.properties as Record<string, Record<string, unknown>>;
+    const itemSchema = properties.items.items as { allOf: Array<Record<string, unknown>>; title: string };
+    const subset = itemSchema.allOf.find((part) => Array.isArray(part.anyOf)) as {
+      anyOf: Array<Record<string, unknown>>;
+    };
+
+    expect(response.additionalProperties).toBe(false);
+    expect(itemSchema.title).toBe("CommandsListItem");
+    expect(subset.anyOf).toHaveLength(13);
+    expect(subset.anyOf.every((branch) => (branch.required as string[]).length === 1)).toBe(true);
+    const shape = itemSchema.allOf.find((part) => part.additionalProperties === false) as Record<string, unknown>;
+    expect(Object.keys(shape.properties as Record<string, unknown>)).toHaveLength(13);
   });
 
   it("falls back to additionalProperties: true response when no @Returns", () => {

--- a/src/sdk/swift-codegen/codegen.test.ts
+++ b/src/sdk/swift-codegen/codegen.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 import { Arg, Command, Group, Option, Returns } from "../../cli/decorators.js";
+import { commandsListReturnSchema } from "../../cli/commands/operational-return-schemas.js";
 import { buildRegistry } from "../../cli/registry-snapshot.js";
 import { compareSwiftSdkSource, computeRegistryHash, emitAllSwift } from "./index.js";
 import { jsonSchemaToSwift } from "./json-schema-to-swift.js";
@@ -100,6 +101,15 @@ class CollisionCommands {
   }
 }
 
+@Group({ name: "commands", description: "Ravi commands", scope: "open" })
+class CommandsContractCommands {
+  @Command({ name: "list", description: "List Ravi commands" })
+  @Returns(commandsListReturnSchema)
+  list() {
+    return {};
+  }
+}
+
 const FIXED_VERSION = {
   sdkVersion: "9.9.9",
   registryHash: "sha256:fixed",
@@ -164,6 +174,19 @@ describe("swift-codegen :: emitAllSwift", () => {
     expect(output.types).toContain("public typealias ContextCredentialsListReturn = RaviJSON");
     expect(output.types).toContain("public typealias ArtifactsBlobReturn = RaviBinaryResponse");
     expect(output.client).toContain("return try await transport.callBinary");
+  });
+
+  it("emits typed commands projection models without RaviJSON", () => {
+    const output = emitAllSwift(buildRegistry([CommandsContractCommands]), { version: FIXED_VERSION });
+
+    expect(output.types).toContain("public struct CommandsListItem: Codable, Sendable");
+    expect(output.types).toContain("public var arguments: [String]?");
+    expect(output.types).toContain("public var issues: [CommandsListIssue]?");
+    expect(output.types).toContain("CommandsListItem requires at least one field.");
+    expect(output.types).toContain("CommandsListItem contains an unknown field.");
+    expect(output.types).toContain("public var items: [CommandsListItem]");
+    expect(output.types).toContain("public var agent: CommandsListAgent");
+    expect(output.types).not.toContain("RaviJSON");
   });
 
   it("emits Swift return structs for top-level object schemas", () => {

--- a/src/sdk/swift-codegen/emit-files.ts
+++ b/src/sdk/swift-codegen/emit-files.ts
@@ -18,6 +18,7 @@ import {
   propertyName,
   returnSchemaName,
   returnTypeName,
+  swiftTypeName,
   uniquePropertyNames,
 } from "./naming.js";
 import { jsonSchemaToSwift, type JsonSchema } from "./json-schema-to-swift.js";
@@ -67,6 +68,15 @@ export function emitAllSwift(registry: RegistrySnapshot, options: EmitSwiftOptio
 
 export function emitSwiftTypes(commands: CommandRegistryEntry[]): string {
   const lines: string[] = [HEADER, "", "import Foundation", ""];
+  const namedReturnSchemas = collectNamedReturnSchemas(commands);
+  if (namedReturnSchemas.size > 0) {
+    lines.push(renderGeneratedCodingKey(), "");
+    for (const [title, schema] of [...namedReturnSchemas.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      lines.push(renderNamedReturnStruct(swiftTypeName(title), schema), "");
+    }
+  }
   for (const cmd of commands) {
     const optionsDecl = renderOptionsStruct(cmd);
     if (optionsDecl) {
@@ -75,6 +85,176 @@ export function emitSwiftTypes(commands: CommandRegistryEntry[]): string {
     lines.push(renderReturnDeclaration(cmd), "");
   }
   return ensureTrailingNewline(lines.join("\n"));
+}
+
+function collectNamedReturnSchemas(commands: CommandRegistryEntry[]): Map<string, JsonSchema> {
+  const schemas = new Map<string, JsonSchema>();
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      if (Array.isArray(value)) value.forEach(visit);
+      return;
+    }
+    const schema = value as JsonSchema;
+    const title = (schema as { title?: unknown }).title;
+    if (typeof title === "string" && title.trim() && isNamedObjectSchema(schema) && !schemas.has(title)) {
+      schemas.set(title, schema);
+    }
+    for (const nested of Object.values(schema)) visit(nested);
+  };
+
+  for (const command of commands) visit(buildReturnSchema(command));
+  return schemas;
+}
+
+function isNamedObjectSchema(schema: JsonSchema): boolean {
+  if (findNamedObjectShape(schema)) return true;
+  const alternatives = (schema as { anyOf?: JsonSchema[] }).anyOf;
+  return Array.isArray(alternatives) && alternatives.length > 0 && alternatives.every(isObjectWithProperties);
+}
+
+function findNamedObjectShape(schema: JsonSchema): JsonSchema | null {
+  if (isObjectWithProperties(schema)) return schema;
+  const intersections = (schema as { allOf?: JsonSchema[] }).allOf;
+  if (!Array.isArray(intersections)) return null;
+  return intersections.find(isObjectWithProperties) ?? null;
+}
+
+function renderGeneratedCodingKey(): string {
+  return [
+    "private struct RaviGeneratedCodingKey: CodingKey {",
+    "  let stringValue: String",
+    "  let intValue: Int?",
+    "",
+    "  init?(stringValue: String) {",
+    "    self.stringValue = stringValue",
+    "    self.intValue = nil",
+    "  }",
+    "",
+    "  init?(intValue: Int) {",
+    "    self.stringValue = String(intValue)",
+    "    self.intValue = intValue",
+    "  }",
+    "}",
+  ].join("\n");
+}
+
+function renderNamedReturnStruct(name: string, schema: JsonSchema): string {
+  const normalized = normalizeNamedObjectSchema(schema);
+  const props = normalized.properties;
+  const required = normalized.required;
+  const rawNames = Object.keys(props).sort();
+  const swiftNames = uniquePropertyNames(rawNames);
+  const fields = rawNames.map((rawName) => {
+    const swiftName = swiftNames.get(rawName)!;
+    const { schema: valueSchema, nullable } = unwrapNullableSchema(props[rawName]);
+    const isRequired = required.has(rawName);
+    const isOptional = nullable || !isRequired;
+    return {
+      rawName,
+      swiftName,
+      swiftType: jsonSchemaToSwift(valueSchema),
+      isRequired,
+      isOptional,
+    };
+  });
+  const lines = [
+    `public struct ${name}: Codable, Sendable {`,
+    ...fields.map((field) => `  public var ${field.swiftName}: ${field.swiftType}${field.isOptional ? "?" : ""}`),
+    "",
+    "  enum CodingKeys: String, CodingKey, CaseIterable {",
+    ...fields.map((field) => `    case ${field.swiftName} = ${JSON.stringify(field.rawName)}`),
+    "  }",
+    "",
+    "  public init(from decoder: Decoder) throws {",
+    "    let rawContainer = try decoder.container(keyedBy: RaviGeneratedCodingKey.self)",
+    "    let allowedKeys = Set(CodingKeys.allCases.map(\\.rawValue))",
+    "    guard rawContainer.allKeys.allSatisfy({ allowedKeys.contains($0.stringValue) }) else {",
+    `      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "${name} contains an unknown field."))`,
+    "    }",
+  ];
+  if (normalized.requiresAtLeastOne) {
+    lines.push(
+      "    guard !rawContainer.allKeys.isEmpty else {",
+      `      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "${name} requires at least one field."))`,
+      "    }",
+    );
+  }
+  lines.push("    let container = try decoder.container(keyedBy: CodingKeys.self)");
+  for (const field of fields) {
+    if (field.isRequired && field.isOptional) {
+      lines.push(
+        `    guard container.contains(.${field.swiftName}) else {`,
+        `      throw DecodingError.keyNotFound(CodingKeys.${field.swiftName}, .init(codingPath: decoder.codingPath, debugDescription: "Missing required field ${field.rawName}."))`,
+        "    }",
+      );
+    }
+    const decodeMethod = field.isOptional ? "decodeIfPresent" : "decode";
+    lines.push(
+      `    self.${field.swiftName} = try container.${decodeMethod}(${field.swiftType}.self, forKey: .${field.swiftName})`,
+    );
+  }
+  lines.push(
+    "  }",
+    "",
+    "  public func encode(to encoder: Encoder) throws {",
+    "    var container = encoder.container(keyedBy: CodingKeys.self)",
+  );
+  for (const field of fields) {
+    const encodeMethod = field.isRequired ? "encode" : "encodeIfPresent";
+    lines.push(`    try container.${encodeMethod}(self.${field.swiftName}, forKey: .${field.swiftName})`);
+  }
+  lines.push("  }", "}");
+  return lines.join("\n");
+}
+
+function normalizeNamedObjectSchema(schema: JsonSchema): {
+  properties: Record<string, JsonSchema>;
+  required: Set<string>;
+  requiresAtLeastOne: boolean;
+} {
+  if (isObjectWithProperties(schema)) {
+    return {
+      properties: (schema as { properties: Record<string, JsonSchema> }).properties,
+      required: new Set((schema as { required?: string[] }).required ?? []),
+      requiresAtLeastOne: false,
+    };
+  }
+
+  const objectShape = findNamedObjectShape(schema);
+  if (objectShape) {
+    const intersections = (schema as { allOf?: JsonSchema[] }).allOf ?? [];
+    return {
+      properties: (objectShape as { properties: Record<string, JsonSchema> }).properties,
+      required: new Set((objectShape as { required?: string[] }).required ?? []),
+      requiresAtLeastOne: intersections.some((part) => Array.isArray((part as { anyOf?: unknown[] }).anyOf)),
+    };
+  }
+
+  const alternatives = (schema as { anyOf: JsonSchema[] }).anyOf;
+  const properties = (alternatives[0] as { properties: Record<string, JsonSchema> }).properties;
+  const requiredSets = alternatives.map(
+    (alternative) => new Set((alternative as { required?: string[] }).required ?? []),
+  );
+  const required = new Set(
+    Object.keys(properties).filter((key) => requiredSets.every((requiredSet) => requiredSet.has(key))),
+  );
+  return { properties, required, requiresAtLeastOne: true };
+}
+
+function unwrapNullableSchema(schema: JsonSchema): { schema: JsonSchema; nullable: boolean } {
+  const alternatives = (schema as { anyOf?: JsonSchema[] }).anyOf;
+  if (Array.isArray(alternatives)) {
+    const nonNull = alternatives.filter((alternative) => (alternative as { type?: unknown }).type !== "null");
+    if (nonNull.length === 1 && nonNull.length !== alternatives.length) {
+      return { schema: nonNull[0], nullable: true };
+    }
+  }
+  const type = (schema as { type?: unknown }).type;
+  if (Array.isArray(type) && type.includes("null")) {
+    const nonNull = type.filter((value) => value !== "null");
+    if (nonNull.length === 1) return { schema: { ...schema, type: nonNull[0] }, nullable: true };
+  }
+  return { schema, nullable: false };
 }
 
 function renderOptionsStruct(cmd: CommandRegistryEntry): string | null {

--- a/src/sdk/swift-codegen/json-schema-to-swift.ts
+++ b/src/sdk/swift-codegen/json-schema-to-swift.ts
@@ -5,10 +5,15 @@
  * shapes when safe; fall back to RaviJSON for complex unions.
  */
 
+import { swiftTypeName } from "./naming.js";
+
 export type JsonSchema = Record<string, unknown>;
 
 export function jsonSchemaToSwift(schema: JsonSchema | undefined | null): string {
   if (!schema || typeof schema !== "object") return "RaviJSON";
+
+  const title = (schema as { title?: unknown }).title;
+  if (typeof title === "string" && title.trim()) return swiftTypeName(title);
 
   const constValue = (schema as { const?: unknown }).const;
   if (constValue !== undefined) return literalType(constValue);


### PR DESCRIPTION
# Commands: agent-first discovery contract

## Objective

Make `ravi commands` a deterministic, typed and effect-free facade for command
discovery, validation and prompt preview, suitable for direct agent use.

## Problem

The previous surface had several gaps that could mislead an agent:

- compact projections were not represented honestly across runtime, SDK,
  OpenAPI and Swift;
- command discovery resolved agents through database paths that could
  initialize or migrate state;
- nominally read-only calls could attempt audit transport;
- input errors, pagination and missing resources were not uniformly typed;
- the generated Swift surface lowered important projected rows to untyped
  `RaviJSON`;
- the zero-effect proof did not cover an active SQLite WAL writer.

## Solution

- keep the existing `list`, `show`, `validate` and `run` operations behind one
  explicit read-only contract;
- publish stable typed failures, pagination and non-empty `--fields`
  projections;
- isolate serialized-only projection behavior to COMMANDS while preserving
  legacy pre-serialization consumers such as AGENTS;
- resolve the agent directory through an existing-database, read-only SQLite
  snapshot with no initialization or migration;
- declare `audit:none` only for low-risk reads whose resolved effect is `none`,
  enforced consistently by CLI, exported tools and gateway;
- preserve command files, every logical row and all durable runtime files,
  including `ravi.db` and its WAL, while allowing SQLite's ephemeral `-shm`
  coordination index to operate safely with an active writer;
- generate typed TypeScript, JSON Schema, OpenAPI and Swift contracts for every
  non-empty subset of the 13 supported list fields;
- document the contract and recovery boundary through the Ravi Spec quartet,
  migration ledger and revision-preserving postmortem.

## Practical impact

Agents can discover commands, inspect one definition, validate all command
sources and render a prompt preview without changing command files, database
rows or durable runtime state. Machine consumers receive stable exit codes,
structured errors, deterministic pagination and typed generated clients.

## What does not change

- Existing command names and positional syntax remain available.
- `commands run` remains a prompt preview; it does not publish a session.
- No command file, database schema or persistent row is migrated by this PR.
- Shared compact projection remains legacy-compatible unless a domain opts in.
- Package version is intentionally unchanged.
- Merge and VPS deployment are not authorized by this PR.

## Ravi Spec

The normative contract and evidence live in:

- `.ravi/specs/cli/commands/SPEC.md`
- `.ravi/specs/cli/commands/WHY.md`
- `.ravi/specs/cli/commands/CHECKS.md`
- `.ravi/specs/cli/commands/RUNBOOK.md`
- `.ravi/specs/commands/` for the underlying command-file behavior

## Validation

- independent review: GO on exact commit
  `e91cfec9c85c84f4051910996e26634ad64459eb`, with no high or medium finding;
- typecheck and full build: passed;
- focused COMMANDS, AGENTS, renderer and foundation checks: 93 tests, 303
  assertions;
- real installed-process contract, including active WAL writer: 11 tests, 57
  assertions;
- router: 12 tests, 60 assertions;
- gateway: 41 tests, 171 assertions;
- native process-output integrity: six tests, 19 assertions;
- ordinary OpenAPI emitter command: 22 tests, 61 assertions;
- SDK: 76 tests, 305 assertions, followed by a current SDK check;
- both OpenAPI snapshots and deterministic Swift artifacts: current;
- quality runner: passed for the exact 43 changed paths, with 274 specs
  indexed; its own suite passed 40 tests and 90 assertions;
- Biome on 23 TypeScript files, Markdown lint on 11 documents and
  `git diff --check`: passed;
- clean archive installation: eight installed-bundle checks passed for version,
  help, list projection, show, validate, run preview and exit-1/exit-2 errors;
- the installed fixture hash remained unchanged and no runtime state was
  created.

The full `test:agent-contract` chain passed every preceding file and then
reproduced two known Windows-only failures in `src/artifacts/store.test.ts`:
one blob expectation and one symlink creation denied with `EPERM`. Running that
file on the exact foundation commit reproduced the same two failures. This
suite is therefore not claimed as green, and the comparison is retained as
pre-existing evidence.

The repository pre-push suite was also stopped by one Windows path-separator
expectation in `src/channels/slack/socket-mode.test.ts`: the test expected
`/attachments/`, while the valid Windows result contained `\\attachments\\`.
The exact isolated test failed identically on this candidate and on foundation
commit `560517a4`; it is recorded as pre-existing and is not claimed green.

Swift compilation was not available on this Windows host. Linux CI remains the
authority for that compiler check.

## Release evidence

- candidate commit: `e91cfec9c85c84f4051910996e26634ad64459eb`;
- package: `ravi.bot-3.260817.2.tgz`;
- package size: 4,950,791 bytes;
- package SHA-256:
  `AF1408565B5D079988C42CB7804BBEA07C17F20EA6EC03C6BCDADCF27D91BE32`;
- package contents: eight expected files;
- package receipt: local coordinator evidence outside the repository.

## Dependency and promotion state

This branch is based on foundation PR #426. Until #426 merges, GitHub may show
its commits in this PR's diff; after that merge, the PR contracts to the
COMMANDS domain delta. This PR must remain draft until Linux CI passes on the
exact candidate and the dependency is reconciled.

## Risks

- SQLite may update its `-shm` coordination index during a safe concurrent
  read; DB, WAL, logical rows and all other durable state remain protected.
- The typed non-empty projection union increases generated contract size.
- Audit opt-out depends on the shared policy continuing to reject mutations,
  medium-risk reads and any effect class other than `none`.
- Windows cannot locally compile Swift and has pre-existing symlink-related
  artifact-store and path-separator test failures; Linux CI must remain
  mandatory.

## Rollback

Revert the COMMANDS commits and reinstall the previously approved package. No
database or command-file rollback is required because this domain performs no
persistent mutation.

## Follow-ups

- merge and reconcile foundation PR #426 through the normal human process;
- use this corrected generator and audit boundary when rebasing `self` and
  `routes`;
- add an explicit returned-value freshness probe for a future COMMANDS field if
  the surface begins exposing a WAL-backed setting;
- keep VPS rollout serial and separately authorized after merge.
