### PR TITLE
feat(runtime): live provider/model defaults; env is fallback only

### DIFF
--- a/.ravi/specs/agents/SPEC.md
+++ b/.ravi/specs/agents/SPEC.md
@@ -96,7 +96,9 @@ of a direct `model`. The two are mutually exclusive on every create/update/set
 path: assigning `modelPreset` clears the direct `model`, and writing a direct
 `model` clears `modelPresetId`, both in one transaction. Provider writes fail
 with an actionable error when incompatible with a referenced preset. Agent JSON
-(`agents list/show`) exposes `effectiveProvider`, `effectiveModel`,
-`modelSource` (`agent_preset` | `agent_default` | `global_default`),
-`modelPresetId`, and `modelPresetVersion`, resolved through the canonical
-`resolveEffectiveAgentModel`. See `runtime/model-presets`.
+(`agents list/show`) exposes `effectiveProvider`, `providerSource`,
+`effectiveModel`, `modelSource` (`agent_preset` | `agent_default` |
+`global_default` | `env_fallback` | `runtime_default`), `modelPresetId`,
+`modelPresetVersion`, and `modelError`, resolved through the canonical
+`resolveEffectiveAgentModel` / `resolveRequestedRuntimeProvider`. See
+`runtime/model-presets` and `runtime/defaults`.

--- a/.ravi/specs/runtime/defaults/CHECKS.md
+++ b/.ravi/specs/runtime/defaults/CHECKS.md
@@ -23,10 +23,12 @@ bun test src/cli/commands/settings.test.ts src/cli/commands/sessions.test.ts
 
 ## Resolution Checks
 
-- Stored `runtime.defaultModel` wins over `RAVI_MODEL`.
-- `RAVI_MODEL` is used only when no stored/session/agent/preset model exists.
-- Stored `runtime.defaultProvider` wins over the hardcoded default.
-- Session/agent/preset values win over stored globals and env.
-- A missing or disabled preset does not swallow into env.
-- `sessions info` reports the same provider/model/effort and sources as launch
-  and does not invent a model from a provider-only override.
+- Stored `runtime.defaultModel` MUST win over `RAVI_MODEL`.
+- Resolution MUST use `RAVI_MODEL` only when no stored/session/agent/preset
+  model exists.
+- Stored `runtime.defaultProvider` MUST win over the hardcoded default.
+- Session/agent/preset values MUST win over stored globals and env.
+- A missing or disabled preset MUST reject launch and MUST NOT swallow into
+  env.
+- `sessions info` MUST report the same provider/model/effort and sources as
+  launch and MUST NOT invent a model from a provider-only override.

--- a/.ravi/specs/runtime/defaults/CHECKS.md
+++ b/.ravi/specs/runtime/defaults/CHECKS.md
@@ -1,0 +1,32 @@
+# Runtime Defaults Checks
+
+## Commands
+
+```bash
+ravi settings set runtime.defaultProvider claude
+ravi settings set runtime.defaultModel opus
+ravi settings set runtime.defaultEffort high
+ravi settings get runtime.defaultModel --json
+ravi settings delete runtime.defaultModel --execute
+ravi sessions info <session> --json
+ravi agents show <id> --json
+```
+
+## Focused Tests
+
+```bash
+bun test src/runtime/runtime-defaults.test.ts src/runtime/runtime-selection.test.ts
+bun test src/runtime/task-runtime-context.test.ts src/runtime/session-resolver.test.ts
+bun test src/tasks/runtime-options.test.ts
+bun test src/cli/commands/settings.test.ts src/cli/commands/sessions.test.ts
+```
+
+## Resolution Checks
+
+- Stored `runtime.defaultModel` wins over `RAVI_MODEL`.
+- `RAVI_MODEL` is used only when no stored/session/agent/preset model exists.
+- Stored `runtime.defaultProvider` wins over the hardcoded default.
+- Session/agent/preset values win over stored globals and env.
+- A missing or disabled preset does not swallow into env.
+- `sessions info` reports the same provider/model/effort and sources as launch
+  and does not invent a model from a provider-only override.

--- a/.ravi/specs/runtime/defaults/RUNBOOK.md
+++ b/.ravi/specs/runtime/defaults/RUNBOOK.md
@@ -1,0 +1,48 @@
+# Runtime Defaults Runbook
+
+## Change The Next-Turn Defaults
+
+```bash
+ravi settings set runtime.defaultProvider claude
+ravi settings set runtime.defaultModel opus
+ravi settings set runtime.defaultEffort high
+```
+
+These writes are immediate (no `--execute`). The next unshadowed turn uses the
+new values. No daemon restart is required.
+
+## Inspect What The Next Turn Will Use
+
+```bash
+ravi sessions info <session> --json
+ravi agents show <id> --json
+ravi settings get runtime.defaultModel
+```
+
+Read `effectiveProvider` / `providerSource`, `effectiveModel` / `modelSource`,
+and `runtimeOptions.effort`. Sources are `session_override`, `agent_preset`,
+`agent_default`, `global_default`, `env_fallback`, or `runtime_default`.
+
+## Clear A Stored Default
+
+```bash
+ravi settings delete runtime.defaultModel          # dry-run, exit 3
+ravi settings delete runtime.defaultModel --execute
+```
+
+After delete, resolution falls back to `RAVI_MODEL` if set, otherwise the
+hardcoded last resort (`sonnet` / `codex` / `xhigh`).
+
+## Session And Agent Overrides
+
+```bash
+ravi sessions set-provider <session> claude
+ravi sessions set-model <session> opus
+ravi sessions set-effort <session> high
+ravi agents set <id> provider claude
+ravi agents set <id> model opus
+ravi agents set <id> effort high
+```
+
+These remain the per-session and per-agent knobs. They win over the stored
+globals. Use `clear` on the session commands to remove only the override.

--- a/.ravi/specs/runtime/defaults/SPEC.md
+++ b/.ravi/specs/runtime/defaults/SPEC.md
@@ -1,0 +1,92 @@
+---
+id: runtime/defaults
+title: "Runtime Defaults"
+kind: capability
+domain: runtime
+capabilities:
+  - runtime-defaults
+tags:
+  - runtime
+  - model
+  - provider
+  - settings
+applies_to:
+  - src/runtime/runtime-defaults.ts
+  - src/runtime/runtime-selection.ts
+  - src/runtime/task-runtime-context.ts
+  - src/runtime/session-resolver.ts
+  - src/cli/commands/settings.ts
+  - src/cli/commands/sessions.ts
+  - src/cli/commands/agents.ts
+owners:
+  - ravi-dev
+status: active
+normative: true
+---
+
+# Runtime Defaults
+
+## Intent
+
+Operators need one stored, live-readable way to set the provider, model, and
+effort that the next unshadowed turn actually uses. Environment variables are
+last-resort fallbacks, never the live source of truth.
+
+## Operator Method
+
+Set or clear the stored global defaults through the existing settings surface:
+
+```bash
+ravi settings set runtime.defaultProvider claude
+ravi settings set runtime.defaultModel opus
+ravi settings set runtime.defaultEffort high
+ravi settings delete runtime.defaultModel --execute
+ravi sessions info <session> --json
+ravi agents show <id> --json
+```
+
+Session (`ravi sessions set-model` / `set-provider` / `set-effort`), agent
+(`ravi agents set`), preset, and task/profile overrides remain the higher
+precedence knobs. This capability does not add a fifth override namespace.
+
+`settings set` stays unbraked. `settings delete` remains dry-run unless
+`--execute`.
+
+## Precedence
+
+Provider, model, and effort are independent axes. Highest first:
+
+1. launch / observation / prompt / dispatch / task / profile override
+2. session override
+3. agent preset or direct agent value
+4. stored global setting (`runtime.defaultProvider`, `runtime.defaultModel`,
+   `runtime.defaultEffort`) — source `global_default`
+5. env fallback (`RAVI_MODEL` only; no provider/effort env sibling) — source
+   `env_fallback`
+6. hardcoded last resort — source `runtime_default`
+
+A stored setting MUST win over env. Env MUST NOT win over a stored
+agent/session/settings/preset value.
+
+## Display Matches Launch
+
+`resolveRequestedRuntimeProvider` and `resolveEffectiveSessionRuntime` are the
+canonical next-turn resolvers. `sessions info` / `sessions list` and
+`agents show` / `agents list` MUST reuse them. Display MUST NOT invent a model
+when only a provider override is set.
+
+Each axis MUST report its source. Session JSON exposes `providerSource`,
+`modelSource`, `runtimeOptions`, and `modelError` when a referenced preset is
+unusable.
+
+## Unusable Presets
+
+A missing, disabled, or provider-incompatible agent preset MUST NOT fall
+through to env or the hardcoded model. Launch MUST reject the turn unless a
+higher-priority model already won. See `runtime/model-presets`.
+
+## Live Application
+
+Stored settings are read from SQLite on each resolve. The next turn uses the
+new values without a daemon restart. `settings set` / `delete --execute` still
+emit `ravi.config.changed`.

--- a/.ravi/specs/runtime/defaults/WHY.md
+++ b/.ravi/specs/runtime/defaults/WHY.md
@@ -1,0 +1,14 @@
+# Runtime Defaults Rationale
+
+`RAVI_MODEL` (and similar env) used to behave like the live default. That made
+it impossible to change the next-turn engine from SQLite without a restart, and
+it let env silently win over a stored agent, session, preset, or setting.
+
+Settings already own global daemon configuration and already emit
+`ravi.config.changed`. Reusing `runtime.defaultProvider`,
+`runtime.defaultModel`, and `runtime.defaultEffort` avoids a fifth override
+namespace while giving operators one obvious runtime method.
+
+Provider and model stay independent: selecting a provider does not invent a
+catalog model, and selecting a model does not imply a provider. Display and
+launch share one resolver so `sessions info` cannot lie about the next turn.

--- a/.ravi/specs/runtime/model-presets/CHECKS.md
+++ b/.ravi/specs/runtime/model-presets/CHECKS.md
@@ -40,7 +40,8 @@ bun test src/tasks/runtime-options.test.ts
 - Direct `model` and `modelPresetId` are mutually exclusive in one transaction;
   clearing both falls through to the global default.
 - Missing/disabled/provider-incompatible preset references fail before commit
-  without silent global fallback.
+  without silent global or env fallback. A stale unusable reference MUST also
+  fail the next unshadowed launch instead of swallowing into `RAVI_MODEL`.
 - Legacy agents without a preset preserve current behavior exactly.
 - Session, prompt/dispatch, task, and profile overrides win over the preset and
   are reported as shadowing.

--- a/.ravi/specs/runtime/model-presets/RUNBOOK.md
+++ b/.ravi/specs/runtime/model-presets/RUNBOOK.md
@@ -84,7 +84,9 @@ ravi sessions info <session> --json
 - `modelSource=agent_preset` → the effective model came from the assigned preset.
 - `modelSource=agent_default` → the agent uses a direct model.
 - `modelSource=session_override` → a session model override shadows the agent.
-- `modelSource=global_default` → no agent-level or session model is set.
+- `modelSource=global_default` → stored `runtime.defaultModel` is in effect.
+- `modelSource=env_fallback` → `RAVI_MODEL` is in effect because nothing stored won.
+- `modelSource=runtime_default` → hardcoded last resort (`sonnet`).
 
 If an agent shows both a direct model and a preset (legacy drift), the direct
 model is preferred and a warning is traced.

--- a/.ravi/specs/runtime/model-presets/SPEC.md
+++ b/.ravi/specs/runtime/model-presets/SPEC.md
@@ -56,13 +56,16 @@ model without rewriting agent, session, task, dispatch, or profile state.
   3. profile runtime default
   4. session override
   5. agent preset or direct agent model
-  6. global default
+  6. stored global runtime default (`runtime.defaultModel`)
+  7. env fallback (`RAVI_MODEL`)
+  8. hardcoded last resort
 - MUST NOT mutate session, task, dispatch, or profile state to apply a preset.
 - MUST keep direct `model` and `modelPresetId` mutually exclusive on every
   supported create/update/set path. Legacy drift (both fields set) MUST prefer
   the direct `model` and emit an observable warning/trace.
 - MUST reject missing, disabled, or provider-incompatible preset references
-  without silent global fallback.
+  without silent global or env fallback. Launch MUST fail the turn when the
+  unusable preset would have been the selected model. See `runtime/defaults`.
 - MUST block disable/delete for referenced presets and return paginated
   dependencies plus an actionable correction command.
 - MUST keep the preset provider immutable in this first version.

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -143,8 +143,11 @@ Agents MUST consult `ravi sessions actions --json` before using a conversational
 ## Effective Model And Presets
 
 Session JSON (`sessions list/info`) exposes the resolved `effectiveProvider`,
-`effectiveModel`, `modelSource` (`session_override` | `agent_preset` |
-`agent_default` | `global_default`), `modelPresetId`, and `modelPresetVersion`.
-A session `modelOverride` continues to win over the agent-level selection and is
-reported as `session_override`, shadowing any agent preset. Applying a preset
-MUST NOT mutate session state. See `runtime/model-presets`.
+`providerSource`, `effectiveModel`, `modelSource` (`session_override` |
+`agent_preset` | `agent_default` | `global_default` | `env_fallback` |
+`runtime_default`), `modelPresetId`, `modelPresetVersion`, and `modelError`.
+Display MUST match launch and MUST NOT invent a model when only a provider
+override is set. A session `modelOverride` continues to win over the
+agent-level selection and is reported as `session_override`, shadowing any
+agent preset. Applying a preset MUST NOT mutate session state. See
+`runtime/model-presets` and `runtime/defaults`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "035eb8a0686f51ec"
+    "version": "b9151d6e7c765be5"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -1298,6 +1298,16 @@
                           "model": {
                             "type": "string"
                           },
+                          "modelError": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "modelPresetId": {
                             "anyOf": [
                               {
@@ -1324,7 +1334,9 @@
                                 "enum": [
                                   "agent_preset",
                                   "agent_default",
-                                  "global_default"
+                                  "global_default",
+                                  "env_fallback",
+                                  "runtime_default"
                                 ],
                                 "type": "string"
                               },
@@ -1337,6 +1349,9 @@
                             "type": "string"
                           },
                           "provider": {
+                            "type": "string"
+                          },
+                          "providerSource": {
                             "type": "string"
                           },
                           "remote": {
@@ -1463,9 +1478,11 @@
                           "modelPresetId",
                           "isDefault",
                           "effectiveProvider",
+                          "providerSource",
                           "effectiveModel",
                           "modelSource",
                           "modelPresetVersion",
+                          "modelError",
                           "tags"
                         ],
                         "type": "object"
@@ -1620,6 +1637,16 @@
                           "model": {
                             "type": "string"
                           },
+                          "modelError": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "modelPresetId": {
                             "anyOf": [
                               {
@@ -1646,7 +1673,9 @@
                                 "enum": [
                                   "agent_preset",
                                   "agent_default",
-                                  "global_default"
+                                  "global_default",
+                                  "env_fallback",
+                                  "runtime_default"
                                 ],
                                 "type": "string"
                               },
@@ -1659,6 +1688,9 @@
                             "type": "string"
                           },
                           "provider": {
+                            "type": "string"
+                          },
+                          "providerSource": {
                             "type": "string"
                           },
                           "remote": {
@@ -1785,9 +1817,11 @@
                           "modelPresetId",
                           "isDefault",
                           "effectiveProvider",
+                          "providerSource",
                           "effectiveModel",
                           "modelSource",
                           "modelPresetVersion",
+                          "modelError",
                           "tags"
                         ],
                         "type": "object"
@@ -2099,6 +2133,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -2125,7 +2169,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -2138,6 +2184,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -2264,9 +2313,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -2616,6 +2667,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -2642,7 +2703,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -2655,6 +2718,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -2781,9 +2847,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -3472,6 +3540,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -3498,7 +3576,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -3511,6 +3591,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -3637,9 +3720,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -73404,7 +73489,14 @@
                               "type": "string"
                             },
                             "effectiveModel": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "effectiveProvider": {
                               "type": "string"
@@ -73438,6 +73530,16 @@
                             "label": {
                               "type": "string"
                             },
+                            "modelError": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
                             "modelOverride": {
                               "type": "string"
                             },
@@ -73462,9 +73564,19 @@
                               ]
                             },
                             "modelSource": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "name": {
+                              "type": "string"
+                            },
+                            "providerSource": {
                               "type": "string"
                             },
                             "runtimeOptions": {
@@ -73477,6 +73589,7 @@
                                       "enum": [
                                         "session_override",
                                         "agent_default",
+                                        "global_default",
                                         "runtime_default"
                                       ],
                                       "type": "string"
@@ -73502,6 +73615,36 @@
                                   "type": "object"
                                 },
                                 "model": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "provider": {
                                   "additionalProperties": false,
                                   "properties": {
                                     "source": {
@@ -73549,6 +73692,7 @@
                                 }
                               },
                               "required": [
+                                "provider",
                                 "model",
                                 "effort",
                                 "thinking"
@@ -73564,10 +73708,12 @@
                             "label",
                             "agentId",
                             "effectiveProvider",
+                            "providerSource",
                             "effectiveModel",
                             "modelSource",
                             "modelPresetId",
                             "modelPresetVersion",
+                            "modelError",
                             "ephemeral",
                             "expiresAt",
                             "runtimeOptions"
@@ -73590,7 +73736,14 @@
                           "type": "string"
                         },
                         "effectiveModel": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "effectiveProvider": {
                           "type": "string"
@@ -73624,6 +73777,16 @@
                         "label": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelOverride": {
                           "type": "string"
                         },
@@ -73648,9 +73811,19 @@
                           ]
                         },
                         "modelSource": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "name": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "runtimeOptions": {
@@ -73663,6 +73836,7 @@
                                   "enum": [
                                     "session_override",
                                     "agent_default",
+                                    "global_default",
                                     "runtime_default"
                                   ],
                                   "type": "string"
@@ -73688,6 +73862,36 @@
                               "type": "object"
                             },
                             "model": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "provider": {
                               "additionalProperties": false,
                               "properties": {
                                 "source": {
@@ -73735,6 +73939,7 @@
                             }
                           },
                           "required": [
+                            "provider",
                             "model",
                             "effort",
                             "thinking"
@@ -73750,10 +73955,12 @@
                         "label",
                         "agentId",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetId",
                         "modelPresetVersion",
+                        "modelError",
                         "ephemeral",
                         "expiresAt",
                         "runtimeOptions"
@@ -73780,6 +73987,7 @@
                       "enum": [
                         "session_override",
                         "agent_default",
+                        "global_default",
                         "runtime_default"
                       ],
                       "type": "string"
@@ -73953,7 +74161,14 @@
                               "type": "string"
                             },
                             "effectiveModel": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "effectiveProvider": {
                               "type": "string"
@@ -73987,6 +74202,16 @@
                             "label": {
                               "type": "string"
                             },
+                            "modelError": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
                             "modelOverride": {
                               "type": "string"
                             },
@@ -74011,9 +74236,19 @@
                               ]
                             },
                             "modelSource": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "name": {
+                              "type": "string"
+                            },
+                            "providerSource": {
                               "type": "string"
                             },
                             "runtimeOptions": {
@@ -74026,6 +74261,7 @@
                                       "enum": [
                                         "session_override",
                                         "agent_default",
+                                        "global_default",
                                         "runtime_default"
                                       ],
                                       "type": "string"
@@ -74051,6 +74287,36 @@
                                   "type": "object"
                                 },
                                 "model": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "provider": {
                                   "additionalProperties": false,
                                   "properties": {
                                     "source": {
@@ -74098,6 +74364,7 @@
                                 }
                               },
                               "required": [
+                                "provider",
                                 "model",
                                 "effort",
                                 "thinking"
@@ -74113,10 +74380,12 @@
                             "label",
                             "agentId",
                             "effectiveProvider",
+                            "providerSource",
                             "effectiveModel",
                             "modelSource",
                             "modelPresetId",
                             "modelPresetVersion",
+                            "modelError",
                             "ephemeral",
                             "expiresAt",
                             "runtimeOptions"
@@ -74139,7 +74408,14 @@
                           "type": "string"
                         },
                         "effectiveModel": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "effectiveProvider": {
                           "type": "string"
@@ -74173,6 +74449,16 @@
                         "label": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelOverride": {
                           "type": "string"
                         },
@@ -74197,9 +74483,19 @@
                           ]
                         },
                         "modelSource": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "name": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "runtimeOptions": {
@@ -74212,6 +74508,7 @@
                                   "enum": [
                                     "session_override",
                                     "agent_default",
+                                    "global_default",
                                     "runtime_default"
                                   ],
                                   "type": "string"
@@ -74237,6 +74534,36 @@
                               "type": "object"
                             },
                             "model": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "provider": {
                               "additionalProperties": false,
                               "properties": {
                                 "source": {
@@ -74284,6 +74611,7 @@
                             }
                           },
                           "required": [
+                            "provider",
                             "model",
                             "effort",
                             "thinking"
@@ -74299,10 +74627,12 @@
                         "label",
                         "agentId",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetId",
                         "modelPresetVersion",
+                        "modelError",
                         "ephemeral",
                         "expiresAt",
                         "runtimeOptions"
@@ -74313,6 +74643,9 @@
                       "type": "boolean"
                     },
                     "effectiveProvider": {
+                      "type": "string"
+                    },
+                    "providerSource": {
                       "type": "string"
                     },
                     "runtimeProviderOverride": {
@@ -74348,6 +74681,7 @@
                     "after",
                     "runtimeProviderOverride",
                     "effectiveProvider",
+                    "providerSource",
                     "appliesOn"
                   ],
                   "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "035eb8a0686f51ec"
+    "version": "b9151d6e7c765be5"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -1298,6 +1298,16 @@
                           "model": {
                             "type": "string"
                           },
+                          "modelError": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "modelPresetId": {
                             "anyOf": [
                               {
@@ -1324,7 +1334,9 @@
                                 "enum": [
                                   "agent_preset",
                                   "agent_default",
-                                  "global_default"
+                                  "global_default",
+                                  "env_fallback",
+                                  "runtime_default"
                                 ],
                                 "type": "string"
                               },
@@ -1337,6 +1349,9 @@
                             "type": "string"
                           },
                           "provider": {
+                            "type": "string"
+                          },
+                          "providerSource": {
                             "type": "string"
                           },
                           "remote": {
@@ -1463,9 +1478,11 @@
                           "modelPresetId",
                           "isDefault",
                           "effectiveProvider",
+                          "providerSource",
                           "effectiveModel",
                           "modelSource",
                           "modelPresetVersion",
+                          "modelError",
                           "tags"
                         ],
                         "type": "object"
@@ -1620,6 +1637,16 @@
                           "model": {
                             "type": "string"
                           },
+                          "modelError": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "modelPresetId": {
                             "anyOf": [
                               {
@@ -1646,7 +1673,9 @@
                                 "enum": [
                                   "agent_preset",
                                   "agent_default",
-                                  "global_default"
+                                  "global_default",
+                                  "env_fallback",
+                                  "runtime_default"
                                 ],
                                 "type": "string"
                               },
@@ -1659,6 +1688,9 @@
                             "type": "string"
                           },
                           "provider": {
+                            "type": "string"
+                          },
+                          "providerSource": {
                             "type": "string"
                           },
                           "remote": {
@@ -1785,9 +1817,11 @@
                           "modelPresetId",
                           "isDefault",
                           "effectiveProvider",
+                          "providerSource",
                           "effectiveModel",
                           "modelSource",
                           "modelPresetVersion",
+                          "modelError",
                           "tags"
                         ],
                         "type": "object"
@@ -2099,6 +2133,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -2125,7 +2169,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -2138,6 +2184,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -2264,9 +2313,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -2616,6 +2667,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -2642,7 +2703,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -2655,6 +2718,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -2781,9 +2847,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -3472,6 +3540,16 @@
                         "model": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelPresetId": {
                           "anyOf": [
                             {
@@ -3498,7 +3576,9 @@
                               "enum": [
                                 "agent_preset",
                                 "agent_default",
-                                "global_default"
+                                "global_default",
+                                "env_fallback",
+                                "runtime_default"
                               ],
                               "type": "string"
                             },
@@ -3511,6 +3591,9 @@
                           "type": "string"
                         },
                         "provider": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "remote": {
@@ -3637,9 +3720,11 @@
                         "modelPresetId",
                         "isDefault",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetVersion",
+                        "modelError",
                         "tags"
                       ],
                       "type": "object"
@@ -73404,7 +73489,14 @@
                               "type": "string"
                             },
                             "effectiveModel": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "effectiveProvider": {
                               "type": "string"
@@ -73438,6 +73530,16 @@
                             "label": {
                               "type": "string"
                             },
+                            "modelError": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
                             "modelOverride": {
                               "type": "string"
                             },
@@ -73462,9 +73564,19 @@
                               ]
                             },
                             "modelSource": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "name": {
+                              "type": "string"
+                            },
+                            "providerSource": {
                               "type": "string"
                             },
                             "runtimeOptions": {
@@ -73477,6 +73589,7 @@
                                       "enum": [
                                         "session_override",
                                         "agent_default",
+                                        "global_default",
                                         "runtime_default"
                                       ],
                                       "type": "string"
@@ -73502,6 +73615,36 @@
                                   "type": "object"
                                 },
                                 "model": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "provider": {
                                   "additionalProperties": false,
                                   "properties": {
                                     "source": {
@@ -73549,6 +73692,7 @@
                                 }
                               },
                               "required": [
+                                "provider",
                                 "model",
                                 "effort",
                                 "thinking"
@@ -73564,10 +73708,12 @@
                             "label",
                             "agentId",
                             "effectiveProvider",
+                            "providerSource",
                             "effectiveModel",
                             "modelSource",
                             "modelPresetId",
                             "modelPresetVersion",
+                            "modelError",
                             "ephemeral",
                             "expiresAt",
                             "runtimeOptions"
@@ -73590,7 +73736,14 @@
                           "type": "string"
                         },
                         "effectiveModel": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "effectiveProvider": {
                           "type": "string"
@@ -73624,6 +73777,16 @@
                         "label": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelOverride": {
                           "type": "string"
                         },
@@ -73648,9 +73811,19 @@
                           ]
                         },
                         "modelSource": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "name": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "runtimeOptions": {
@@ -73663,6 +73836,7 @@
                                   "enum": [
                                     "session_override",
                                     "agent_default",
+                                    "global_default",
                                     "runtime_default"
                                   ],
                                   "type": "string"
@@ -73688,6 +73862,36 @@
                               "type": "object"
                             },
                             "model": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "provider": {
                               "additionalProperties": false,
                               "properties": {
                                 "source": {
@@ -73735,6 +73939,7 @@
                             }
                           },
                           "required": [
+                            "provider",
                             "model",
                             "effort",
                             "thinking"
@@ -73750,10 +73955,12 @@
                         "label",
                         "agentId",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetId",
                         "modelPresetVersion",
+                        "modelError",
                         "ephemeral",
                         "expiresAt",
                         "runtimeOptions"
@@ -73780,6 +73987,7 @@
                       "enum": [
                         "session_override",
                         "agent_default",
+                        "global_default",
                         "runtime_default"
                       ],
                       "type": "string"
@@ -73953,7 +74161,14 @@
                               "type": "string"
                             },
                             "effectiveModel": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "effectiveProvider": {
                               "type": "string"
@@ -73987,6 +74202,16 @@
                             "label": {
                               "type": "string"
                             },
+                            "modelError": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
                             "modelOverride": {
                               "type": "string"
                             },
@@ -74011,9 +74236,19 @@
                               ]
                             },
                             "modelSource": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             },
                             "name": {
+                              "type": "string"
+                            },
+                            "providerSource": {
                               "type": "string"
                             },
                             "runtimeOptions": {
@@ -74026,6 +74261,7 @@
                                       "enum": [
                                         "session_override",
                                         "agent_default",
+                                        "global_default",
                                         "runtime_default"
                                       ],
                                       "type": "string"
@@ -74051,6 +74287,36 @@
                                   "type": "object"
                                 },
                                 "model": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "source": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "value",
+                                    "source"
+                                  ],
+                                  "type": "object"
+                                },
+                                "provider": {
                                   "additionalProperties": false,
                                   "properties": {
                                     "source": {
@@ -74098,6 +74364,7 @@
                                 }
                               },
                               "required": [
+                                "provider",
                                 "model",
                                 "effort",
                                 "thinking"
@@ -74113,10 +74380,12 @@
                             "label",
                             "agentId",
                             "effectiveProvider",
+                            "providerSource",
                             "effectiveModel",
                             "modelSource",
                             "modelPresetId",
                             "modelPresetVersion",
+                            "modelError",
                             "ephemeral",
                             "expiresAt",
                             "runtimeOptions"
@@ -74139,7 +74408,14 @@
                           "type": "string"
                         },
                         "effectiveModel": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "effectiveProvider": {
                           "type": "string"
@@ -74173,6 +74449,16 @@
                         "label": {
                           "type": "string"
                         },
+                        "modelError": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "modelOverride": {
                           "type": "string"
                         },
@@ -74197,9 +74483,19 @@
                           ]
                         },
                         "modelSource": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "name": {
+                          "type": "string"
+                        },
+                        "providerSource": {
                           "type": "string"
                         },
                         "runtimeOptions": {
@@ -74212,6 +74508,7 @@
                                   "enum": [
                                     "session_override",
                                     "agent_default",
+                                    "global_default",
                                     "runtime_default"
                                   ],
                                   "type": "string"
@@ -74237,6 +74534,36 @@
                               "type": "object"
                             },
                             "model": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "source": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "source"
+                              ],
+                              "type": "object"
+                            },
+                            "provider": {
                               "additionalProperties": false,
                               "properties": {
                                 "source": {
@@ -74284,6 +74611,7 @@
                             }
                           },
                           "required": [
+                            "provider",
                             "model",
                             "effort",
                             "thinking"
@@ -74299,10 +74627,12 @@
                         "label",
                         "agentId",
                         "effectiveProvider",
+                        "providerSource",
                         "effectiveModel",
                         "modelSource",
                         "modelPresetId",
                         "modelPresetVersion",
+                        "modelError",
                         "ephemeral",
                         "expiresAt",
                         "runtimeOptions"
@@ -74313,6 +74643,9 @@
                       "type": "boolean"
                     },
                     "effectiveProvider": {
+                      "type": "string"
+                    },
+                    "providerSource": {
                       "type": "string"
                     },
                     "runtimeProviderOverride": {
@@ -74348,6 +74681,7 @@
                     "after",
                     "runtimeProviderOverride",
                     "effectiveProvider",
+                    "providerSource",
                     "appliesOn"
                   ],
                   "type": "object"

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -1053,6 +1053,16 @@ export const AgentsListReturnSchema = {
           "model": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelPresetId": {
             "anyOf": [
               {
@@ -1079,7 +1089,9 @@ export const AgentsListReturnSchema = {
                 "enum": [
                   "agent_preset",
                   "agent_default",
-                  "global_default"
+                  "global_default",
+                  "env_fallback",
+                  "runtime_default"
                 ],
                 "type": "string"
               },
@@ -1092,6 +1104,9 @@ export const AgentsListReturnSchema = {
             "type": "string"
           },
           "provider": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "remote": {
@@ -1218,9 +1233,11 @@ export const AgentsListReturnSchema = {
           "modelPresetId",
           "isDefault",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetVersion",
+          "modelError",
           "tags"
         ],
         "type": "object"
@@ -1375,6 +1392,16 @@ export const AgentsListReturnSchema = {
           "model": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelPresetId": {
             "anyOf": [
               {
@@ -1401,7 +1428,9 @@ export const AgentsListReturnSchema = {
                 "enum": [
                   "agent_preset",
                   "agent_default",
-                  "global_default"
+                  "global_default",
+                  "env_fallback",
+                  "runtime_default"
                 ],
                 "type": "string"
               },
@@ -1414,6 +1443,9 @@ export const AgentsListReturnSchema = {
             "type": "string"
           },
           "provider": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "remote": {
@@ -1540,9 +1572,11 @@ export const AgentsListReturnSchema = {
           "modelPresetId",
           "isDefault",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetVersion",
+          "modelError",
           "tags"
         ],
         "type": "object"
@@ -1816,6 +1850,16 @@ export const AgentsModelBrokerReturnSchema = {
         "model": {
           "type": "string"
         },
+        "modelError": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "modelPresetId": {
           "anyOf": [
             {
@@ -1842,7 +1886,9 @@ export const AgentsModelBrokerReturnSchema = {
               "enum": [
                 "agent_preset",
                 "agent_default",
-                "global_default"
+                "global_default",
+                "env_fallback",
+                "runtime_default"
               ],
               "type": "string"
             },
@@ -1855,6 +1901,9 @@ export const AgentsModelBrokerReturnSchema = {
           "type": "string"
         },
         "provider": {
+          "type": "string"
+        },
+        "providerSource": {
           "type": "string"
         },
         "remote": {
@@ -1981,9 +2030,11 @@ export const AgentsModelBrokerReturnSchema = {
         "modelPresetId",
         "isDefault",
         "effectiveProvider",
+        "providerSource",
         "effectiveModel",
         "modelSource",
         "modelPresetVersion",
+        "modelError",
         "tags"
       ],
       "type": "object"
@@ -2295,6 +2346,16 @@ export const AgentsPermissionsReturnSchema = {
         "model": {
           "type": "string"
         },
+        "modelError": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "modelPresetId": {
           "anyOf": [
             {
@@ -2321,7 +2382,9 @@ export const AgentsPermissionsReturnSchema = {
               "enum": [
                 "agent_preset",
                 "agent_default",
-                "global_default"
+                "global_default",
+                "env_fallback",
+                "runtime_default"
               ],
               "type": "string"
             },
@@ -2334,6 +2397,9 @@ export const AgentsPermissionsReturnSchema = {
           "type": "string"
         },
         "provider": {
+          "type": "string"
+        },
+        "providerSource": {
           "type": "string"
         },
         "remote": {
@@ -2460,9 +2526,11 @@ export const AgentsPermissionsReturnSchema = {
         "modelPresetId",
         "isDefault",
         "effectiveProvider",
+        "providerSource",
         "effectiveModel",
         "modelSource",
         "modelPresetVersion",
+        "modelError",
         "tags"
       ],
       "type": "object"
@@ -2999,6 +3067,16 @@ export const AgentsShowReturnSchema = {
         "model": {
           "type": "string"
         },
+        "modelError": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "modelPresetId": {
           "anyOf": [
             {
@@ -3025,7 +3103,9 @@ export const AgentsShowReturnSchema = {
               "enum": [
                 "agent_preset",
                 "agent_default",
-                "global_default"
+                "global_default",
+                "env_fallback",
+                "runtime_default"
               ],
               "type": "string"
             },
@@ -3038,6 +3118,9 @@ export const AgentsShowReturnSchema = {
           "type": "string"
         },
         "provider": {
+          "type": "string"
+        },
+        "providerSource": {
           "type": "string"
         },
         "remote": {
@@ -3164,9 +3247,11 @@ export const AgentsShowReturnSchema = {
         "modelPresetId",
         "isDefault",
         "effectiveProvider",
+        "providerSource",
         "effectiveModel",
         "modelSource",
         "modelPresetVersion",
+        "modelError",
         "tags"
       ],
       "type": "object"
@@ -58531,7 +58616,14 @@ export const SessionsSetEffortReturnSchema = {
               "type": "string"
             },
             "effectiveModel": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "effectiveProvider": {
               "type": "string"
@@ -58565,6 +58657,16 @@ export const SessionsSetEffortReturnSchema = {
             "label": {
               "type": "string"
             },
+            "modelError": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "modelOverride": {
               "type": "string"
             },
@@ -58589,9 +58691,19 @@ export const SessionsSetEffortReturnSchema = {
               ]
             },
             "modelSource": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "name": {
+              "type": "string"
+            },
+            "providerSource": {
               "type": "string"
             },
             "runtimeOptions": {
@@ -58604,6 +58716,7 @@ export const SessionsSetEffortReturnSchema = {
                       "enum": [
                         "session_override",
                         "agent_default",
+                        "global_default",
                         "runtime_default"
                       ],
                       "type": "string"
@@ -58629,6 +58742,36 @@ export const SessionsSetEffortReturnSchema = {
                   "type": "object"
                 },
                 "model": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "source"
+                  ],
+                  "type": "object"
+                },
+                "provider": {
                   "additionalProperties": false,
                   "properties": {
                     "source": {
@@ -58676,6 +58819,7 @@ export const SessionsSetEffortReturnSchema = {
                 }
               },
               "required": [
+                "provider",
                 "model",
                 "effort",
                 "thinking"
@@ -58691,10 +58835,12 @@ export const SessionsSetEffortReturnSchema = {
             "label",
             "agentId",
             "effectiveProvider",
+            "providerSource",
             "effectiveModel",
             "modelSource",
             "modelPresetId",
             "modelPresetVersion",
+            "modelError",
             "ephemeral",
             "expiresAt",
             "runtimeOptions"
@@ -58717,7 +58863,14 @@ export const SessionsSetEffortReturnSchema = {
           "type": "string"
         },
         "effectiveModel": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "effectiveProvider": {
           "type": "string"
@@ -58751,6 +58904,16 @@ export const SessionsSetEffortReturnSchema = {
         "label": {
           "type": "string"
         },
+        "modelError": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "modelOverride": {
           "type": "string"
         },
@@ -58775,9 +58938,19 @@ export const SessionsSetEffortReturnSchema = {
           ]
         },
         "modelSource": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "name": {
+          "type": "string"
+        },
+        "providerSource": {
           "type": "string"
         },
         "runtimeOptions": {
@@ -58790,6 +58963,7 @@ export const SessionsSetEffortReturnSchema = {
                   "enum": [
                     "session_override",
                     "agent_default",
+                    "global_default",
                     "runtime_default"
                   ],
                   "type": "string"
@@ -58815,6 +58989,36 @@ export const SessionsSetEffortReturnSchema = {
               "type": "object"
             },
             "model": {
+              "additionalProperties": false,
+              "properties": {
+                "source": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "value",
+                "source"
+              ],
+              "type": "object"
+            },
+            "provider": {
               "additionalProperties": false,
               "properties": {
                 "source": {
@@ -58862,6 +59066,7 @@ export const SessionsSetEffortReturnSchema = {
             }
           },
           "required": [
+            "provider",
             "model",
             "effort",
             "thinking"
@@ -58877,10 +59082,12 @@ export const SessionsSetEffortReturnSchema = {
         "label",
         "agentId",
         "effectiveProvider",
+        "providerSource",
         "effectiveModel",
         "modelSource",
         "modelPresetId",
         "modelPresetVersion",
+        "modelError",
         "ephemeral",
         "expiresAt",
         "runtimeOptions"
@@ -58907,6 +59114,7 @@ export const SessionsSetEffortReturnSchema = {
       "enum": [
         "session_override",
         "agent_default",
+        "global_default",
         "runtime_default"
       ],
       "type": "string"
@@ -59024,7 +59232,14 @@ export const SessionsSetProviderReturnSchema = {
               "type": "string"
             },
             "effectiveModel": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "effectiveProvider": {
               "type": "string"
@@ -59058,6 +59273,16 @@ export const SessionsSetProviderReturnSchema = {
             "label": {
               "type": "string"
             },
+            "modelError": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "modelOverride": {
               "type": "string"
             },
@@ -59082,9 +59307,19 @@ export const SessionsSetProviderReturnSchema = {
               ]
             },
             "modelSource": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "name": {
+              "type": "string"
+            },
+            "providerSource": {
               "type": "string"
             },
             "runtimeOptions": {
@@ -59097,6 +59332,7 @@ export const SessionsSetProviderReturnSchema = {
                       "enum": [
                         "session_override",
                         "agent_default",
+                        "global_default",
                         "runtime_default"
                       ],
                       "type": "string"
@@ -59122,6 +59358,36 @@ export const SessionsSetProviderReturnSchema = {
                   "type": "object"
                 },
                 "model": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "source"
+                  ],
+                  "type": "object"
+                },
+                "provider": {
                   "additionalProperties": false,
                   "properties": {
                     "source": {
@@ -59169,6 +59435,7 @@ export const SessionsSetProviderReturnSchema = {
                 }
               },
               "required": [
+                "provider",
                 "model",
                 "effort",
                 "thinking"
@@ -59184,10 +59451,12 @@ export const SessionsSetProviderReturnSchema = {
             "label",
             "agentId",
             "effectiveProvider",
+            "providerSource",
             "effectiveModel",
             "modelSource",
             "modelPresetId",
             "modelPresetVersion",
+            "modelError",
             "ephemeral",
             "expiresAt",
             "runtimeOptions"
@@ -59210,7 +59479,14 @@ export const SessionsSetProviderReturnSchema = {
           "type": "string"
         },
         "effectiveModel": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "effectiveProvider": {
           "type": "string"
@@ -59244,6 +59520,16 @@ export const SessionsSetProviderReturnSchema = {
         "label": {
           "type": "string"
         },
+        "modelError": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "modelOverride": {
           "type": "string"
         },
@@ -59268,9 +59554,19 @@ export const SessionsSetProviderReturnSchema = {
           ]
         },
         "modelSource": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "name": {
+          "type": "string"
+        },
+        "providerSource": {
           "type": "string"
         },
         "runtimeOptions": {
@@ -59283,6 +59579,7 @@ export const SessionsSetProviderReturnSchema = {
                   "enum": [
                     "session_override",
                     "agent_default",
+                    "global_default",
                     "runtime_default"
                   ],
                   "type": "string"
@@ -59308,6 +59605,36 @@ export const SessionsSetProviderReturnSchema = {
               "type": "object"
             },
             "model": {
+              "additionalProperties": false,
+              "properties": {
+                "source": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "value",
+                "source"
+              ],
+              "type": "object"
+            },
+            "provider": {
               "additionalProperties": false,
               "properties": {
                 "source": {
@@ -59355,6 +59682,7 @@ export const SessionsSetProviderReturnSchema = {
             }
           },
           "required": [
+            "provider",
             "model",
             "effort",
             "thinking"
@@ -59370,10 +59698,12 @@ export const SessionsSetProviderReturnSchema = {
         "label",
         "agentId",
         "effectiveProvider",
+        "providerSource",
         "effectiveModel",
         "modelSource",
         "modelPresetId",
         "modelPresetVersion",
+        "modelError",
         "ephemeral",
         "expiresAt",
         "runtimeOptions"
@@ -59384,6 +59714,9 @@ export const SessionsSetProviderReturnSchema = {
       "type": "boolean"
     },
     "effectiveProvider": {
+      "type": "string"
+    },
+    "providerSource": {
       "type": "string"
     },
     "runtimeProviderOverride": {
@@ -59419,6 +59752,7 @@ export const SessionsSetProviderReturnSchema = {
     "after",
     "runtimeProviderOverride",
     "effectiveProvider",
+    "providerSource",
     "appliesOn"
   ],
   "type": "object"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -215,11 +215,13 @@ export type AgentsListReturn = {
     memoryModel?: string;
     mode?: "active" | "sentinel";
     model?: string;
+    modelError: string | null;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default") | null;
     name?: string;
     provider?: string;
+    providerSource: string;
     remote?: string;
     remoteUser?: string;
     settingSources?: Array<"user" | "project">;
@@ -269,11 +271,13 @@ export type AgentsListReturn = {
     memoryModel?: string;
     mode?: "active" | "sentinel";
     model?: string;
+    modelError: string | null;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default") | null;
     name?: string;
     provider?: string;
+    providerSource: string;
     remote?: string;
     remoteUser?: string;
     settingSources?: Array<"user" | "project">;
@@ -344,11 +348,13 @@ export type AgentsModelBrokerReturn = {
     memoryModel?: string;
     mode?: "active" | "sentinel";
     model?: string;
+    modelError: string | null;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default") | null;
     name?: string;
     provider?: string;
+    providerSource: string;
     remote?: string;
     remoteUser?: string;
     settingSources?: Array<"user" | "project">;
@@ -425,11 +431,13 @@ export type AgentsPermissionsReturn = {
     memoryModel?: string;
     mode?: "active" | "sentinel";
     model?: string;
+    modelError: string | null;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default") | null;
     name?: string;
     provider?: string;
+    providerSource: string;
     remote?: string;
     remoteUser?: string;
     settingSources?: Array<"user" | "project">;
@@ -565,11 +573,13 @@ export type AgentsShowReturn = {
     memoryModel?: string;
     mode?: "active" | "sentinel";
     model?: string;
+    modelError: string | null;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: ("agent_preset" | "agent_default" | "global_default") | null;
+    modelSource: ("agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default") | null;
     name?: string;
     provider?: string;
+    providerSource: string;
     remote?: string;
     remoteUser?: string;
     settingSources?: Array<"user" | "project">;
@@ -12075,23 +12085,29 @@ export type SessionsSetEffortReturn = {
   action: "set-effort";
   after: ({
     agentId: string;
-    effectiveModel: string;
+    effectiveModel: string | null;
     effectiveProvider: string;
     effortOverride?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
     ephemeral: boolean;
     expiresAt: number | null;
     label: string;
+    modelError: string | null;
     modelOverride?: string;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: string;
+    modelSource: string | null;
     name?: string;
+    providerSource: string;
     runtimeOptions: {
       effort: {
-        source: "session_override" | "agent_default" | "runtime_default";
+        source: "session_override" | "agent_default" | "global_default" | "runtime_default";
         value: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
       };
       model: {
+        source: string | null;
+        value: string | null;
+      };
+      provider: {
         source: string;
         value: string;
       };
@@ -12105,23 +12121,29 @@ export type SessionsSetEffortReturn = {
   appliesOn: "next-turn-runtime-restart";
   before: {
     agentId: string;
-    effectiveModel: string;
+    effectiveModel: string | null;
     effectiveProvider: string;
     effortOverride?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
     ephemeral: boolean;
     expiresAt: number | null;
     label: string;
+    modelError: string | null;
     modelOverride?: string;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: string;
+    modelSource: string | null;
     name?: string;
+    providerSource: string;
     runtimeOptions: {
       effort: {
-        source: "session_override" | "agent_default" | "runtime_default";
+        source: "session_override" | "agent_default" | "global_default" | "runtime_default";
         value: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
       };
       model: {
+        source: string | null;
+        value: string | null;
+      };
+      provider: {
         source: string;
         value: string;
       };
@@ -12134,7 +12156,7 @@ export type SessionsSetEffortReturn = {
   };
   changed: boolean;
   effectiveEffort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
-  effectiveEffortSource: "session_override" | "agent_default" | "runtime_default";
+  effectiveEffortSource: "session_override" | "agent_default" | "global_default" | "runtime_default";
   effortOverride: ("none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra") | null;
   sessionKey: string;
   sessionName: string | null;
@@ -12160,23 +12182,29 @@ export type SessionsSetProviderReturn = {
   action: "set-provider";
   after: ({
     agentId: string;
-    effectiveModel: string;
+    effectiveModel: string | null;
     effectiveProvider: string;
     effortOverride?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
     ephemeral: boolean;
     expiresAt: number | null;
     label: string;
+    modelError: string | null;
     modelOverride?: string;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: string;
+    modelSource: string | null;
     name?: string;
+    providerSource: string;
     runtimeOptions: {
       effort: {
-        source: "session_override" | "agent_default" | "runtime_default";
+        source: "session_override" | "agent_default" | "global_default" | "runtime_default";
         value: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
       };
       model: {
+        source: string | null;
+        value: string | null;
+      };
+      provider: {
         source: string;
         value: string;
       };
@@ -12190,23 +12218,29 @@ export type SessionsSetProviderReturn = {
   appliesOn: "next-turn-runtime-restart";
   before: {
     agentId: string;
-    effectiveModel: string;
+    effectiveModel: string | null;
     effectiveProvider: string;
     effortOverride?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
     ephemeral: boolean;
     expiresAt: number | null;
     label: string;
+    modelError: string | null;
     modelOverride?: string;
     modelPresetId: string | null;
     modelPresetVersion: number | null;
-    modelSource: string;
+    modelSource: string | null;
     name?: string;
+    providerSource: string;
     runtimeOptions: {
       effort: {
-        source: "session_override" | "agent_default" | "runtime_default";
+        source: "session_override" | "agent_default" | "global_default" | "runtime_default";
         value: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
       };
       model: {
+        source: string | null;
+        value: string | null;
+      };
+      provider: {
         source: string;
         value: string;
       };
@@ -12219,6 +12253,7 @@ export type SessionsSetProviderReturn = {
   };
   changed: boolean;
   effectiveProvider: string;
+  providerSource: string;
   runtimeProviderOverride: string | null;
   sessionKey: string;
   sessionName: string | null;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:e34286d91e1da6bb4fd22f541e888ec37567b3efed4fa0fbb38d2ce76470340d";
+export const REGISTRY_HASH = "sha256:ed28232a9c795f729bd93141d26aeb189a46153dc951fdab1a6d9e2249767a49";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "571b155daf90";
+export const GIT_SHA = "b6046936fce0";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -1061,6 +1061,16 @@ public enum RaviSchemas {
             "model": {
               "type": "string"
             },
+            "modelError": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "modelPresetId": {
               "anyOf": [
                 {
@@ -1087,7 +1097,9 @@ public enum RaviSchemas {
                   "enum": [
                     "agent_preset",
                     "agent_default",
-                    "global_default"
+                    "global_default",
+                    "env_fallback",
+                    "runtime_default"
                   ],
                   "type": "string"
                 },
@@ -1100,6 +1112,9 @@ public enum RaviSchemas {
               "type": "string"
             },
             "provider": {
+              "type": "string"
+            },
+            "providerSource": {
               "type": "string"
             },
             "remote": {
@@ -1226,9 +1241,11 @@ public enum RaviSchemas {
             "modelPresetId",
             "isDefault",
             "effectiveProvider",
+            "providerSource",
             "effectiveModel",
             "modelSource",
             "modelPresetVersion",
+            "modelError",
             "tags"
           ],
           "type": "object"
@@ -1383,6 +1400,16 @@ public enum RaviSchemas {
             "model": {
               "type": "string"
             },
+            "modelError": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "modelPresetId": {
               "anyOf": [
                 {
@@ -1409,7 +1436,9 @@ public enum RaviSchemas {
                   "enum": [
                     "agent_preset",
                     "agent_default",
-                    "global_default"
+                    "global_default",
+                    "env_fallback",
+                    "runtime_default"
                   ],
                   "type": "string"
                 },
@@ -1422,6 +1451,9 @@ public enum RaviSchemas {
               "type": "string"
             },
             "provider": {
+              "type": "string"
+            },
+            "providerSource": {
               "type": "string"
             },
             "remote": {
@@ -1548,9 +1580,11 @@ public enum RaviSchemas {
             "modelPresetId",
             "isDefault",
             "effectiveProvider",
+            "providerSource",
             "effectiveModel",
             "modelSource",
             "modelPresetVersion",
+            "modelError",
             "tags"
           ],
           "type": "object"
@@ -1826,6 +1860,16 @@ public enum RaviSchemas {
           "model": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelPresetId": {
             "anyOf": [
               {
@@ -1852,7 +1896,9 @@ public enum RaviSchemas {
                 "enum": [
                   "agent_preset",
                   "agent_default",
-                  "global_default"
+                  "global_default",
+                  "env_fallback",
+                  "runtime_default"
                 ],
                 "type": "string"
               },
@@ -1865,6 +1911,9 @@ public enum RaviSchemas {
             "type": "string"
           },
           "provider": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "remote": {
@@ -1991,9 +2040,11 @@ public enum RaviSchemas {
           "modelPresetId",
           "isDefault",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetVersion",
+          "modelError",
           "tags"
         ],
         "type": "object"
@@ -2307,6 +2358,16 @@ public enum RaviSchemas {
           "model": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelPresetId": {
             "anyOf": [
               {
@@ -2333,7 +2394,9 @@ public enum RaviSchemas {
                 "enum": [
                   "agent_preset",
                   "agent_default",
-                  "global_default"
+                  "global_default",
+                  "env_fallback",
+                  "runtime_default"
                 ],
                 "type": "string"
               },
@@ -2346,6 +2409,9 @@ public enum RaviSchemas {
             "type": "string"
           },
           "provider": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "remote": {
@@ -2472,9 +2538,11 @@ public enum RaviSchemas {
           "modelPresetId",
           "isDefault",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetVersion",
+          "modelError",
           "tags"
         ],
         "type": "object"
@@ -3019,6 +3087,16 @@ public enum RaviSchemas {
           "model": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelPresetId": {
             "anyOf": [
               {
@@ -3045,7 +3123,9 @@ public enum RaviSchemas {
                 "enum": [
                   "agent_preset",
                   "agent_default",
-                  "global_default"
+                  "global_default",
+                  "env_fallback",
+                  "runtime_default"
                 ],
                 "type": "string"
               },
@@ -3058,6 +3138,9 @@ public enum RaviSchemas {
             "type": "string"
           },
           "provider": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "remote": {
@@ -3184,9 +3267,11 @@ public enum RaviSchemas {
           "modelPresetId",
           "isDefault",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetVersion",
+          "modelError",
           "tags"
         ],
         "type": "object"
@@ -59471,7 +59556,14 @@ public enum RaviSchemas {
                 "type": "string"
               },
               "effectiveModel": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "effectiveProvider": {
                 "type": "string"
@@ -59505,6 +59597,16 @@ public enum RaviSchemas {
               "label": {
                 "type": "string"
               },
+              "modelError": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "modelOverride": {
                 "type": "string"
               },
@@ -59529,9 +59631,19 @@ public enum RaviSchemas {
                 ]
               },
               "modelSource": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "name": {
+                "type": "string"
+              },
+              "providerSource": {
                 "type": "string"
               },
               "runtimeOptions": {
@@ -59544,6 +59656,7 @@ public enum RaviSchemas {
                         "enum": [
                           "session_override",
                           "agent_default",
+                          "global_default",
                           "runtime_default"
                         ],
                         "type": "string"
@@ -59569,6 +59682,36 @@ public enum RaviSchemas {
                     "type": "object"
                   },
                   "model": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "provider": {
                     "additionalProperties": false,
                     "properties": {
                       "source": {
@@ -59616,6 +59759,7 @@ public enum RaviSchemas {
                   }
                 },
                 "required": [
+                  "provider",
                   "model",
                   "effort",
                   "thinking"
@@ -59631,10 +59775,12 @@ public enum RaviSchemas {
               "label",
               "agentId",
               "effectiveProvider",
+              "providerSource",
               "effectiveModel",
               "modelSource",
               "modelPresetId",
               "modelPresetVersion",
+              "modelError",
               "ephemeral",
               "expiresAt",
               "runtimeOptions"
@@ -59657,7 +59803,14 @@ public enum RaviSchemas {
             "type": "string"
           },
           "effectiveModel": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "effectiveProvider": {
             "type": "string"
@@ -59691,6 +59844,16 @@ public enum RaviSchemas {
           "label": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelOverride": {
             "type": "string"
           },
@@ -59715,9 +59878,19 @@ public enum RaviSchemas {
             ]
           },
           "modelSource": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "name": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "runtimeOptions": {
@@ -59730,6 +59903,7 @@ public enum RaviSchemas {
                     "enum": [
                       "session_override",
                       "agent_default",
+                      "global_default",
                       "runtime_default"
                     ],
                     "type": "string"
@@ -59755,6 +59929,36 @@ public enum RaviSchemas {
                 "type": "object"
               },
               "model": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "provider": {
                 "additionalProperties": false,
                 "properties": {
                   "source": {
@@ -59802,6 +60006,7 @@ public enum RaviSchemas {
               }
             },
             "required": [
+              "provider",
               "model",
               "effort",
               "thinking"
@@ -59817,10 +60022,12 @@ public enum RaviSchemas {
           "label",
           "agentId",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetId",
           "modelPresetVersion",
+          "modelError",
           "ephemeral",
           "expiresAt",
           "runtimeOptions"
@@ -59847,6 +60054,7 @@ public enum RaviSchemas {
         "enum": [
           "session_override",
           "agent_default",
+          "global_default",
           "runtime_default"
         ],
         "type": "string"
@@ -59968,7 +60176,14 @@ public enum RaviSchemas {
                 "type": "string"
               },
               "effectiveModel": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "effectiveProvider": {
                 "type": "string"
@@ -60002,6 +60217,16 @@ public enum RaviSchemas {
               "label": {
                 "type": "string"
               },
+              "modelError": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "modelOverride": {
                 "type": "string"
               },
@@ -60026,9 +60251,19 @@ public enum RaviSchemas {
                 ]
               },
               "modelSource": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "name": {
+                "type": "string"
+              },
+              "providerSource": {
                 "type": "string"
               },
               "runtimeOptions": {
@@ -60041,6 +60276,7 @@ public enum RaviSchemas {
                         "enum": [
                           "session_override",
                           "agent_default",
+                          "global_default",
                           "runtime_default"
                         ],
                         "type": "string"
@@ -60066,6 +60302,36 @@ public enum RaviSchemas {
                     "type": "object"
                   },
                   "model": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "source": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "source"
+                    ],
+                    "type": "object"
+                  },
+                  "provider": {
                     "additionalProperties": false,
                     "properties": {
                       "source": {
@@ -60113,6 +60379,7 @@ public enum RaviSchemas {
                   }
                 },
                 "required": [
+                  "provider",
                   "model",
                   "effort",
                   "thinking"
@@ -60128,10 +60395,12 @@ public enum RaviSchemas {
               "label",
               "agentId",
               "effectiveProvider",
+              "providerSource",
               "effectiveModel",
               "modelSource",
               "modelPresetId",
               "modelPresetVersion",
+              "modelError",
               "ephemeral",
               "expiresAt",
               "runtimeOptions"
@@ -60154,7 +60423,14 @@ public enum RaviSchemas {
             "type": "string"
           },
           "effectiveModel": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "effectiveProvider": {
             "type": "string"
@@ -60188,6 +60464,16 @@ public enum RaviSchemas {
           "label": {
             "type": "string"
           },
+          "modelError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "modelOverride": {
             "type": "string"
           },
@@ -60212,9 +60498,19 @@ public enum RaviSchemas {
             ]
           },
           "modelSource": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "name": {
+            "type": "string"
+          },
+          "providerSource": {
             "type": "string"
           },
           "runtimeOptions": {
@@ -60227,6 +60523,7 @@ public enum RaviSchemas {
                     "enum": [
                       "session_override",
                       "agent_default",
+                      "global_default",
                       "runtime_default"
                     ],
                     "type": "string"
@@ -60252,6 +60549,36 @@ public enum RaviSchemas {
                 "type": "object"
               },
               "model": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "value",
+                  "source"
+                ],
+                "type": "object"
+              },
+              "provider": {
                 "additionalProperties": false,
                 "properties": {
                   "source": {
@@ -60299,6 +60626,7 @@ public enum RaviSchemas {
               }
             },
             "required": [
+              "provider",
               "model",
               "effort",
               "thinking"
@@ -60314,10 +60642,12 @@ public enum RaviSchemas {
           "label",
           "agentId",
           "effectiveProvider",
+          "providerSource",
           "effectiveModel",
           "modelSource",
           "modelPresetId",
           "modelPresetVersion",
+          "modelError",
           "ephemeral",
           "expiresAt",
           "runtimeOptions"
@@ -60328,6 +60658,9 @@ public enum RaviSchemas {
         "type": "boolean"
       },
       "effectiveProvider": {
+        "type": "string"
+      },
+      "providerSource": {
         "type": "string"
       },
       "runtimeProviderOverride": {
@@ -60363,6 +60696,7 @@ public enum RaviSchemas {
       "after",
       "runtimeProviderOverride",
       "effectiveProvider",
+      "providerSource",
       "appliesOn"
     ],
     "type": "object"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -19943,17 +19943,19 @@ public struct SessionsSetProviderReturn: Codable, Sendable {
   public var before: RaviJSON
   public var changed: Bool
   public var effectiveProvider: String
+  public var providerSource: String
   public var runtimeProviderOverride: RaviJSON
   public var sessionKey: String
   public var sessionName: RaviJSON
 
-  public init(action: String, after: RaviJSON, appliesOn: String, before: RaviJSON, changed: Bool, effectiveProvider: String, runtimeProviderOverride: RaviJSON, sessionKey: String, sessionName: RaviJSON) {
+  public init(action: String, after: RaviJSON, appliesOn: String, before: RaviJSON, changed: Bool, effectiveProvider: String, providerSource: String, runtimeProviderOverride: RaviJSON, sessionKey: String, sessionName: RaviJSON) {
     self.action = action
     self.after = after
     self.appliesOn = appliesOn
     self.before = before
     self.changed = changed
     self.effectiveProvider = effectiveProvider
+    self.providerSource = providerSource
     self.runtimeProviderOverride = runtimeProviderOverride
     self.sessionKey = sessionKey
     self.sessionName = sessionName
@@ -19966,6 +19968,7 @@ public struct SessionsSetProviderReturn: Codable, Sendable {
     case before = "before"
     case changed = "changed"
     case effectiveProvider = "effectiveProvider"
+    case providerSource = "providerSource"
     case runtimeProviderOverride = "runtimeProviderOverride"
     case sessionKey = "sessionKey"
     case sessionName = "sessionName"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:e34286d91e1da6bb4fd22f541e888ec37567b3efed4fa0fbb38d2ce76470340d"
-public let RAVI_GIT_SHA = "571b155daf90"
+public let RAVI_REGISTRY_HASH = "sha256:ed28232a9c795f729bd93141d26aeb189a46153dc951fdab1a6d9e2249767a49"
+public let RAVI_GIT_SHA = "b6046936fce0"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -16,6 +16,7 @@ import { notifyRuntimeRecoveryExhausted } from "./runtime/runtime-recovery-alert
 import { safeEmit } from "./runtime/safe-emit.js";
 import { RuntimeSessionDispatcher, type RuntimeAbortProvenance } from "./runtime/session-dispatcher.js";
 import { resolveRuntimeInteractiveReservedSlots, resolveRuntimeSessionPoolMax } from "./runtime/session-pool.js";
+import { resolveGlobalRuntimeModel } from "./runtime/runtime-defaults.js";
 
 export type {
   ChannelContext,
@@ -76,7 +77,7 @@ export class RaviBot {
       notifyRuntimeRecoveryExhausted: async (input) => {
         await notifyRuntimeRecoveryExhausted(input);
       },
-      getConfigModel: () => this.config.model,
+      getConfigModel: () => resolveGlobalRuntimeModel(),
       crashRecovery: this.crashRecovery,
     });
     this.hostSubscriptions = new RuntimeHostSubscriptions({

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -57,7 +57,8 @@ import {
 import { validateRuntimeModelSelector } from "../../runtime/model-validation.js";
 import { getRuntimeModelPreset } from "../../runtime/model-preset-store.js";
 import { resolveEffectiveAgentModel } from "../../runtime/model-preset-resolver.js";
-import { loadConfig } from "../../utils/config.js";
+import { resolveRuntimeDefaults } from "../../runtime/runtime-defaults.js";
+import { resolveRequestedRuntimeProvider } from "../../runtime/runtime-selection.js";
 import { formatRuntimeEffortLevels, parseRuntimeEffort } from "../../runtime/effort.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
 import {
@@ -165,10 +166,12 @@ interface AgentSetMutationPayload {
 type AgentJsonSummary = Omit<AgentConfig, "modelPresetId"> & {
   isDefault: boolean;
   effectiveProvider: string;
+  providerSource: string;
   effectiveModel: string | null;
-  modelSource: "agent_preset" | "agent_default" | "global_default" | null;
+  modelSource: "agent_preset" | "agent_default" | "global_default" | "env_fallback" | "runtime_default" | null;
   modelPresetId: string | null;
   modelPresetVersion: number | null;
+  modelError: string | null;
   tags: TagBinding[];
 };
 
@@ -283,15 +286,21 @@ function listSessionTagsForSummary(session: { sessionKey: string; name?: string 
 }
 
 function buildAgentJson(agent: AgentConfig, defaultAgent: string): AgentJsonSummary {
-  const effective = resolveEffectiveAgentModel(agent, loadConfig().model);
+  const defaults = resolveRuntimeDefaults();
+  const effective = resolveEffectiveAgentModel(agent, defaults.model.value, {
+    globalDefaultSource: defaults.model.source,
+  });
+  const provider = resolveRequestedRuntimeProvider({ agent, defaults });
   return {
     ...agent,
     isDefault: agent.id === defaultAgent,
-    effectiveProvider: effective.effectiveProvider,
+    effectiveProvider: provider.value,
+    providerSource: provider.source,
     effectiveModel: effective.effectiveModel,
     modelSource: effective.modelSource,
     modelPresetId: effective.modelPresetId,
     modelPresetVersion: effective.modelPresetVersion,
+    modelError: effective.error,
     tags: listAgentTags(agent.id),
   };
 }
@@ -638,9 +647,14 @@ export class AgentsCommands {
       console.log(`\nAgent: ${agent.id}${isDefault ? " (default)" : ""}`);
       console.log(`  Name:          ${agent.name || "-"}`);
       console.log(`  CWD:           ${agent.cwd}`);
-      console.log(`  Model:         ${agent.model || "-"}`);
+      console.log(
+        `  Model:         ${payload.agent.effectiveModel ?? "-"} (${payload.agent.modelSource ?? "unresolved"})`,
+      );
       console.log(`  Effort:        ${agent.effort || "-"}`);
-      console.log(`  Provider:      ${agent.provider || DEFAULT_RUNTIME_PROVIDER_ID}`);
+      console.log(`  Provider:      ${payload.agent.effectiveProvider} (${payload.agent.providerSource})`);
+      if (payload.agent.modelError) {
+        console.log(`  Model error:   ${payload.agent.modelError}`);
+      }
       console.log(`  DM Scope:      ${agent.dmScope || "-"}`);
       console.log(`  Mode:          ${agent.mode ?? "active"}`);
       console.log(`  Permissions:   ${describeRuntimePermissionConfig(runtimePermissions)}`);

--- a/src/cli/commands/operational-return-schemas.ts
+++ b/src/cli/commands/operational-return-schemas.ts
@@ -1901,9 +1901,13 @@ export const agentJsonSummaryReturnSchema = z
     defaults: jsonObjectSchema.nullable().optional(),
     isDefault: z.boolean(),
     effectiveProvider: z.string(),
+    providerSource: z.string(),
     effectiveModel: z.string().nullable(),
-    modelSource: z.enum(["agent_preset", "agent_default", "global_default"]).nullable(),
+    modelSource: z
+      .enum(["agent_preset", "agent_default", "global_default", "env_fallback", "runtime_default"])
+      .nullable(),
     modelPresetVersion: z.number().nullable(),
+    modelError: z.string().nullable(),
     tags: z.array(agentTagBindingReturnSchema),
   })
   .strict();

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -1891,8 +1891,8 @@ describe("SessionCommands info", () => {
     expect(output).toContain(
       "Key:          agent:main:whatsapp:main:group:123456  [source=session-db freshness=persisted]",
     );
-    expect(output).toContain("Configured:   codex  [source=config-db freshness=persisted via=router-config]");
-    expect(output).toContain("Model:        gpt-5  [source=config-db freshness=persisted via=router-config]");
+    expect(output).toContain("Provider:     codex (agent_default)  [source=session-db freshness=persisted]");
+    expect(output).toContain("Model:        gpt-5.4-mini (session_override)  [source=session-db freshness=persisted]");
     expect(output).toContain("Override:     gpt-5.4-mini  [source=session-db freshness=persisted]");
     expect(output).toContain("Runtime:      codex  [source=runtime-snapshot freshness=persisted]");
     expect(output).toContain("Lifetime toks:");

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -57,14 +57,8 @@ import {
 } from "../../router/sessions.js";
 import { deriveSourceFromSessionKey } from "../../router/session-key.js";
 import { loadRouterConfig, expandHome } from "../../router/index.js";
-import { loadConfig } from "../../utils/config.js";
-import { resolveEffectiveAgentModel } from "../../runtime/model-preset-resolver.js";
-import {
-  createRuntimeProvider,
-  DEFAULT_RUNTIME_PROVIDER_ID,
-  listRegisteredRuntimeProviderIds,
-} from "../../runtime/provider-registry.js";
-import { getDefaultModelForProvider } from "../../runtime/model-catalog.js";
+import { createRuntimeProvider, listRegisteredRuntimeProviderIds } from "../../runtime/provider-registry.js";
+import { resolveEffectiveSessionRuntime } from "../../runtime/runtime-selection.js";
 import type { ChannelContext, ResponseMessage, SessionRelayAction } from "../../runtime/message-types.js";
 import { buildSessionRelayTurnOrigin } from "../../runtime/turn-origin.js";
 import { toPersistedChannelContext } from "../../channels/context.js";
@@ -107,12 +101,7 @@ import {
   type ContextRecord,
 } from "../../router/router-db.js";
 import type { SessionEntry } from "../../router/types.js";
-import {
-  DEFAULT_RUNTIME_EFFORT,
-  RUNTIME_EFFORT_LEVELS,
-  formatRuntimeEffortLevels,
-  parseRuntimeEffort,
-} from "../../runtime/effort.js";
+import { RUNTIME_EFFORT_LEVELS, formatRuntimeEffortLevels, parseRuntimeEffort } from "../../runtime/effort.js";
 import type { RuntimeProviderId } from "../../runtime/types.js";
 import { publicRuntimeFailureDetail } from "../../runtime/public-failure.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
@@ -180,11 +169,6 @@ const MESSAGE_DELETE_TOPIC = "ravi.outbound.message.delete";
 const MESSAGE_DELETE_TIMEOUT_MS = 15000;
 const MESSAGE_EDIT_TOPIC = "ravi.outbound.message.edit";
 const MESSAGE_EDIT_TIMEOUT_MS = 15000;
-const CONFIG_DB_META = {
-  source: "config-db",
-  freshness: "persisted",
-  via: "router-config",
-} as const;
 const SESSION_DB_META = {
   source: "session-db",
   freshness: "persisted",
@@ -212,11 +196,20 @@ const NEXT_COMMANDS_META = {
   via: "session-inspect",
 } as const;
 const runtimeEffortReturnSchema = z.enum(RUNTIME_EFFORT_LEVELS);
-const sessionEffortSourceReturnSchema = z.enum(["session_override", "agent_default", "runtime_default"]);
+const sessionEffortSourceReturnSchema = z.enum([
+  "session_override",
+  "agent_default",
+  "global_default",
+  "runtime_default",
+]);
 const sessionRuntimeOptionsReturnSchema = z.object({
-  model: z.object({
+  provider: z.object({
     value: z.string(),
     source: z.string(),
+  }),
+  model: z.object({
+    value: z.string().nullable(),
+    source: z.string().nullable(),
   }),
   effort: z.object({
     value: runtimeEffortReturnSchema,
@@ -233,10 +226,12 @@ const sessionMutationSnapshotReturnSchema = z.object({
   label: z.string(),
   agentId: z.string(),
   effectiveProvider: z.string(),
-  effectiveModel: z.string(),
-  modelSource: z.string(),
+  providerSource: z.string(),
+  effectiveModel: z.string().nullable(),
+  modelSource: z.string().nullable(),
   modelPresetId: z.string().nullable(),
   modelPresetVersion: z.number().nullable(),
+  modelError: z.string().nullable(),
   modelOverride: z.string().optional(),
   effortOverride: runtimeEffortReturnSchema.optional(),
   ephemeral: z.boolean(),
@@ -264,6 +259,7 @@ const sessionSetProviderReturnSchema = z.object({
   after: sessionMutationSnapshotReturnSchema.nullable(),
   runtimeProviderOverride: z.string().nullable(),
   effectiveProvider: z.string(),
+  providerSource: z.string(),
   appliesOn: z.literal("next-turn-runtime-restart"),
 });
 const sessionCommandTargetReturnSchema = z
@@ -1111,10 +1107,12 @@ function buildSessionJson(session: SessionEntry, options: { live?: boolean } = {
     label: session.name ?? session.sessionKey,
     runtimeId,
     effectiveProvider: effective.effectiveProvider,
+    providerSource: effective.providerSource,
     effectiveModel: effective.effectiveModel,
     modelSource: effective.modelSource,
     modelPresetId: effective.modelPresetId,
     modelPresetVersion: effective.modelPresetVersion,
+    modelError: effective.modelError,
     // Legacy alias. This is a lifetime accumulator, not the live context size.
     tokenTotal: lifetimeTotal,
     lifetimeTokens: {
@@ -1344,91 +1342,49 @@ function buildRelatedContextJson(context: ContextRecord): Record<string, unknown
 
 interface EffectiveSessionModel {
   effectiveProvider: string;
-  effectiveModel: string;
-  modelSource: "session_override" | "agent_preset" | "agent_default" | "global_default";
+  providerSource: string;
+  effectiveModel: string | null;
+  modelSource: string | null;
   modelPresetId: string | null;
   modelPresetVersion: number | null;
+  modelError: string | null;
 }
 
 function resolveEffectiveSessionSelection(session: SessionEntry, modelOverride: string | null): EffectiveSessionModel {
   const routerConfig = loadRouterConfig();
-  const runtimeConfig = loadConfig();
   const agent = routerConfig.agents[session.agentId] ?? routerConfig.agents[routerConfig.defaultAgent];
-  const agentEffective = agent
-    ? resolveEffectiveAgentModel(agent, runtimeConfig.model)
-    : {
-        effectiveProvider: DEFAULT_RUNTIME_PROVIDER_ID,
-        effectiveModel: runtimeConfig.model,
-        modelSource: "global_default" as const,
-        modelPresetId: null,
-        modelPresetVersion: null,
-      };
-
-  const providerOverride = session.runtimeProviderOverride?.trim() || undefined;
-  const effectiveProvider = providerOverride ?? agentEffective.effectiveProvider;
-
-  // Session model override wins over the agent-level selection.
-  if (modelOverride) {
-    return {
-      effectiveProvider,
-      effectiveModel: modelOverride,
-      modelSource: "session_override",
-      modelPresetId: agentEffective.modelPresetId,
-      modelPresetVersion: agentEffective.modelPresetVersion,
-    };
-  }
-
-  if (providerOverride && providerOverride !== agentEffective.effectiveProvider) {
-    return {
-      effectiveProvider: providerOverride,
-      effectiveModel: getDefaultModelForProvider(providerOverride),
-      modelSource: "session_override",
-      modelPresetId: agentEffective.modelPresetId,
-      modelPresetVersion: agentEffective.modelPresetVersion,
-    };
-  }
-
+  const candidate = modelOverride === null ? { ...session, modelOverride: undefined } : { ...session, modelOverride };
+  const resolved = resolveEffectiveSessionRuntime({ session: candidate, agent });
   return {
-    effectiveProvider,
-    effectiveModel: agentEffective.effectiveModel ?? runtimeConfig.model,
-    modelSource: agentEffective.modelSource ?? "global_default",
-    modelPresetId: agentEffective.modelPresetId,
-    modelPresetVersion: agentEffective.modelPresetVersion,
+    effectiveProvider: resolved.provider.value,
+    providerSource: resolved.provider.source,
+    effectiveModel: resolved.model.value,
+    modelSource: resolved.model.source,
+    modelPresetId: resolved.model.presetId,
+    modelPresetVersion: resolved.model.presetVersion,
+    modelError: resolved.model.error,
   };
 }
 
 function resolveEffectiveSessionModel(session: SessionEntry, modelOverride: string | null): string {
-  const candidate = modelOverride === null ? { ...session, modelOverride: undefined } : { ...session, modelOverride };
-  return resolveSessionRuntimeOptions(candidate).model.value;
+  return resolveEffectiveSessionSelection(session, modelOverride).effectiveModel ?? "";
 }
 
-type SessionRuntimeOptionSource =
-  | "session_override"
-  | "agent_preset"
-  | "agent_default"
-  | "global_default"
-  | "runtime_default"
-  | null;
-
 function resolveSessionRuntimeOptions(session: SessionEntry): {
-  model: { value: string; source: SessionRuntimeOptionSource };
-  effort: { value: NonNullable<SessionEntry["effortOverride"]>; source: SessionRuntimeOptionSource };
-  thinking: { value: SessionEntry["thinkingLevel"] | null; source: SessionRuntimeOptionSource };
+  provider: { value: string; source: string };
+  model: { value: string | null; source: string | null };
+  effort: { value: NonNullable<SessionEntry["effortOverride"]>; source: string };
+  thinking: { value: SessionEntry["thinkingLevel"] | null; source: string | null };
 } {
   const routerConfig = loadRouterConfig();
   const agent = routerConfig.agents[session.agentId] ?? routerConfig.agents[routerConfig.defaultAgent];
-  const modelSelection = resolveEffectiveSessionSelection(session, session.modelOverride ?? null);
-  const model = { value: modelSelection.effectiveModel, source: modelSelection.modelSource };
-  const effort =
-    session.effortOverride !== undefined
-      ? { value: session.effortOverride, source: "session_override" as const }
-      : agent?.effort
-        ? { value: agent.effort, source: "agent_default" as const }
-        : { value: DEFAULT_RUNTIME_EFFORT, source: "runtime_default" as const };
-  const thinking = session.thinkingLevel
-    ? { value: session.thinkingLevel, source: "session_override" as const }
-    : { value: null, source: null };
-  return { model, effort, thinking };
+  const resolved = resolveEffectiveSessionRuntime({ session, agent });
+  return {
+    provider: resolved.provider,
+    model: { value: resolved.model.value, source: resolved.model.source },
+    effort: resolved.effort,
+    thinking: resolved.thinking,
+  };
 }
 
 function resolveEffectiveSessionEffort(
@@ -1436,14 +1392,14 @@ function resolveEffectiveSessionEffort(
   effortOverride: SessionEntry["effortOverride"] | null,
 ): {
   effort: NonNullable<SessionEntry["effortOverride"]>;
-  source: "session_override" | "agent_default" | "runtime_default";
+  source: "session_override" | "agent_default" | "global_default" | "runtime_default";
 } {
   const candidate =
     effortOverride === null ? { ...session, effortOverride: undefined } : { ...session, effortOverride };
   const resolved = resolveSessionRuntimeOptions(candidate).effort;
   return {
     effort: resolved.value,
-    source: resolved.source as "session_override" | "agent_default" | "runtime_default",
+    source: resolved.source as "session_override" | "agent_default" | "global_default" | "runtime_default",
   };
 }
 
@@ -2667,6 +2623,7 @@ export class SessionCommands {
     const suggestedCommands = buildSuggestedDebugCommands(s, relatedContexts, relatedAdapters);
     const turnUsage = getSessionTurnUsageSummary(s.sessionKey);
     const runtimeOptions = resolveSessionRuntimeOptions(s);
+    const effective = resolveEffectiveSessionSelection(s, s.modelOverride ?? null);
 
     if (asJson) {
       const adapters = relatedAdapters.map((adapter) => {
@@ -2701,9 +2658,21 @@ export class SessionCommands {
     printInspectionField("Agent CWD", s.agentCwd, SESSION_DB_META, {
       labelWidth: 14,
     });
-    printInspectionField("Configured", agentConfig?.provider ?? "claude", CONFIG_DB_META, { labelWidth: 14 });
-    printInspectionField("Model", agentConfig?.model ?? "(default)", CONFIG_DB_META, { labelWidth: 14 });
-    printInspectionField("Override", s.modelOverride ?? "(agent default)", SESSION_DB_META, { labelWidth: 14 });
+    printInspectionField(
+      "Provider",
+      `${runtimeOptions.provider.value} (${runtimeOptions.provider.source})`,
+      SESSION_DB_META,
+      { labelWidth: 14 },
+    );
+    printInspectionField(
+      "Model",
+      runtimeOptions.model.value
+        ? `${runtimeOptions.model.value} (${runtimeOptions.model.source})`
+        : `(unresolved${effective.modelError ? `: ${effective.modelError}` : ""})`,
+      SESSION_DB_META,
+      { labelWidth: 14 },
+    );
+    printInspectionField("Override", s.modelOverride ?? "(none)", SESSION_DB_META, { labelWidth: 14 });
     printInspectionField(
       "Effort",
       `${runtimeOptions.effort.value} (${runtimeOptions.effort.source})`,
@@ -3250,6 +3219,7 @@ export class SessionCommands {
       const payload = buildSessionMutationJson("set-provider", s, after, beforeProviderOverride !== providerOverride, {
         runtimeProviderOverride: providerOverride,
         effectiveProvider: resolveEffectiveSessionSelection(after, after.modelOverride ?? null).effectiveProvider,
+        providerSource: resolveEffectiveSessionSelection(after, after.modelOverride ?? null).providerSource,
         appliesOn: "next-turn-runtime-restart",
       });
       printJson(payload);

--- a/src/cli/commands/settings.test.ts
+++ b/src/cli/commands/settings.test.ts
@@ -108,7 +108,7 @@ describe("SettingsCommands", () => {
       new SettingsCommands().list(true);
     });
 
-    expect(output).toContain("Settings (14 returned of 14, limit 50, offset 0):");
+    expect(output).toContain("Settings (17 returned of 17, limit 50, offset 0):");
     expect(output).toContain("account.main.dmPolicy: pairing");
     expect(output).toContain("section: legacy");
   });
@@ -124,6 +124,25 @@ describe("SettingsCommands", () => {
 
     expect(output).toContain("Legacy setting shadowed by instances: account.main.dmPolicy: pairing");
     expect(output).toContain("Use `ravi instances set main dmPolicy <value>` instead.");
+  });
+
+  it("registers stored runtime defaults and keeps env as fallback only", () => {
+    const commands = new SettingsCommands();
+    expect(() => commands.set("runtime.defaultProvider", "not-a-provider")).toThrow(/Invalid provider/);
+    expect(() => commands.set("runtime.defaultProvider", "claude", true)).not.toThrow();
+    expect(settingsStore["runtime.defaultProvider"]).toBe("claude");
+
+    expect(() => commands.set("runtime.defaultEffort", "ludicrous")).toThrow(/Invalid runtime effort/);
+    expect(() => commands.set("runtime.defaultEffort", "high", true)).not.toThrow();
+    expect(settingsStore["runtime.defaultEffort"]).toBe("high");
+
+    expect(() => commands.set("runtime.defaultModel", "opus", true)).not.toThrow();
+    expect(settingsStore["runtime.defaultModel"]).toBe("opus");
+
+    const output = captureLogs(() => {
+      commands.get("runtime.defaultModel");
+    });
+    expect(output).toContain("runtime.defaultModel: opus");
   });
 
   it("registers a strict global model-broker-required switch", () => {

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -11,6 +11,16 @@ import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
 import { cliOffsetPaginationSchema, commandTargetSchema } from "../return-schemas.js";
 import { nats } from "../../nats.js";
 import { parseDurationMs } from "../../cron/schedule.js";
+import { DEFAULT_RUNTIME_EFFORT, formatRuntimeEffortLevels, parseRuntimeEffort } from "../../runtime/effort.js";
+import {
+  HARDCODED_RUNTIME_MODEL,
+  RUNTIME_DEFAULT_EFFORT_SETTING,
+  RUNTIME_DEFAULT_MODEL_ENV,
+  RUNTIME_DEFAULT_MODEL_SETTING,
+  RUNTIME_DEFAULT_PROVIDER_SETTING,
+} from "../../runtime/runtime-defaults.js";
+import { DEFAULT_RUNTIME_PROVIDER_ID, listRegisteredRuntimeProviderIds } from "../../runtime/provider-registry.js";
+import { validateRuntimeModelSelector } from "../../runtime/model-validation.js";
 
 /** Notify gateway that config changed */
 function emitConfigChanged() {
@@ -77,6 +87,31 @@ function isValidTimezone(tz: string): boolean {
 }
 
 const KNOWN_SETTINGS: Record<string, { description: string; validate?: (value: string) => void }> = {
+  [RUNTIME_DEFAULT_PROVIDER_SETTING]: {
+    description: "Stored global runtime provider default for the next unshadowed turn",
+    validate: (value: string) => {
+      const normalized = value.trim();
+      if (!listRegisteredRuntimeProviderIds().includes(normalized)) {
+        throw new Error(`Invalid provider. Must be one of: ${listRegisteredRuntimeProviderIds().join(", ")}`);
+      }
+    },
+  },
+  [RUNTIME_DEFAULT_MODEL_SETTING]: {
+    description: "Stored global runtime model default. Env RAVI_MODEL is fallback only when this is unset",
+    validate: (value: string) => {
+      const provider = dbGetSetting(RUNTIME_DEFAULT_PROVIDER_SETTING) ?? DEFAULT_RUNTIME_PROVIDER_ID;
+      const result = validateRuntimeModelSelector(provider, value);
+      if (!result.ok) {
+        throw new Error(result.error ?? `Invalid model: ${value}`);
+      }
+    },
+  },
+  [RUNTIME_DEFAULT_EFFORT_SETTING]: {
+    description: "Stored global runtime effort default for the next unshadowed turn",
+    validate: (value: string) => {
+      parseRuntimeEffort(value);
+    },
+  },
   "runtime.model_broker.required": {
     description: "Require every active agent to resolve inference through its selected model broker",
     validate: (value: string) => {
@@ -208,6 +243,10 @@ function knownSettingDefault(key: string): string | null {
   if (key === "image.mode") return "fast";
   if (key === "tasks.sessionTtl") return "1d";
   if (key === "tasks.sessionTtl.knowledgeEngineer") return "5m";
+  if (key === RUNTIME_DEFAULT_PROVIDER_SETTING) return DEFAULT_RUNTIME_PROVIDER_ID;
+  if (key === RUNTIME_DEFAULT_MODEL_SETTING)
+    return process.env[RUNTIME_DEFAULT_MODEL_ENV]?.trim() || HARDCODED_RUNTIME_MODEL;
+  if (key === RUNTIME_DEFAULT_EFFORT_SETTING) return DEFAULT_RUNTIME_EFFORT;
   return null;
 }
 
@@ -358,6 +397,17 @@ export class SettingsCommands {
           console.log("  Default: main");
         } else if (key === "defaultDmScope") {
           console.log("  Default: per-peer");
+        } else if (key === RUNTIME_DEFAULT_PROVIDER_SETTING) {
+          console.log(`  Fallback: ${DEFAULT_RUNTIME_PROVIDER_ID} (hardcoded)`);
+        } else if (key === RUNTIME_DEFAULT_MODEL_SETTING) {
+          const envModel = process.env[RUNTIME_DEFAULT_MODEL_ENV]?.trim();
+          console.log(
+            envModel
+              ? `  Fallback: ${envModel} (env ${RUNTIME_DEFAULT_MODEL_ENV})`
+              : `  Fallback: ${HARDCODED_RUNTIME_MODEL} (hardcoded; env ${RUNTIME_DEFAULT_MODEL_ENV} unset)`,
+          );
+        } else if (key === RUNTIME_DEFAULT_EFFORT_SETTING) {
+          console.log(`  Fallback: ${DEFAULT_RUNTIME_EFFORT} (hardcoded; ${formatRuntimeEffortLevels()})`);
         }
       }
     } else if (legacy) {

--- a/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/sessions/SKILL.md
@@ -79,8 +79,15 @@ ravi sessions rename <name> <novo-nome-canonico>
 # Definir label humano/display-only
 ravi sessions set-display <name> "Novo Nome Humano"
 
-# Definir modelo override
+# Definir modelo override (vence agent/global/env no próximo turno)
 ravi sessions set-model <name> <model>
+
+# Definir provider override (eixo independente do model)
+ravi sessions set-provider <name> <provider|clear>
+
+# Defaults globais do próximo turno (sem restart; env fica só fallback)
+# ravi settings set runtime.defaultProvider claude
+# ravi settings set runtime.defaultModel opus
 
 # Definir thinking level
 ravi sessions set-thinking <name> <level>

--- a/src/plugins/internal/ravi-system/skills/settings/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/settings/SKILL.md
@@ -64,6 +64,9 @@ ravi settings delete <key> --execute  # apaga de verdade
 | `defaultAgent` | Agent padrão quando nenhuma rota casa | ID do agent |
 | `defaultDmScope` | Escopo padrão de DMs | main, per-peer, per-channel-peer, per-account-channel-peer |
 | `defaultTimezone` | Fuso horário padrão | America/Sao_Paulo, etc |
+| `runtime.defaultProvider` | Provider runtime global (próximo turno sem override) | `codex`, `claude`, `pi` |
+| `runtime.defaultModel` | Model runtime global. `RAVI_MODEL` só é fallback se esta key estiver unset | seletor de model |
+| `runtime.defaultEffort` | Effort runtime global | `none\|minimal\|low\|medium\|high\|xhigh\|max\|ultra` |
 | `tasks.sessionTtl` | TTL padrão para sessões de trabalho de tasks | duração como 1d, 12h, ou off |
 | `tasks.sessionTtl.knowledgeEngineer` | TTL para sessões de task de `knowledge-engineer-*` | duração como 5m, 1h, ou off |
 
@@ -82,6 +85,17 @@ A migração acontece automaticamente na primeira inicialização do daemon.
 Por default, `ravi settings list` esconde essas keys; use `--legacy` só para inspecionar ou limpar restos antigos.
 
 ## Exemplos
+
+Definir defaults runtime (provider/model/effort do próximo turno sem override):
+```bash
+ravi settings set runtime.defaultProvider claude
+ravi settings set runtime.defaultModel opus
+ravi settings set runtime.defaultEffort high
+ravi settings get runtime.defaultModel
+ravi sessions info <session> --json   # source de cada eixo
+```
+
+`RAVI_MODEL` no `~/.ravi/.env` é só fallback quando `runtime.defaultModel` não está setada.
 
 Definir agent default:
 ```bash

--- a/src/runtime/model-catalog.test.ts
+++ b/src/runtime/model-catalog.test.ts
@@ -151,4 +151,14 @@ describe("agent model preset resolution", () => {
     expect(direct.modelSource).toBe("agent_default");
     expect(direct.effectiveModel).toBe("opus");
   });
+
+  test("does not swallow an unusable preset into the global or env default", () => {
+    const effective = resolveEffectiveAgentModel({ modelPresetId: "fast-sonnet" }, "haiku", {
+      lookupPreset: lookupPreset(fakePreset({ enabled: false })),
+      globalDefaultSource: "env_fallback",
+    });
+    expect(effective.effectiveModel).toBeNull();
+    expect(effective.modelSource).toBeNull();
+    expect(effective.error).toContain("disabled");
+  });
 });

--- a/src/runtime/model-preset-resolver.ts
+++ b/src/runtime/model-preset-resolver.ts
@@ -148,22 +148,37 @@ export function resolveAgentModelSelection(
  * Convenience view for observability surfaces: resolves the agent selection and
  * folds in the global default so callers can report the true effective model.
  */
+export type EffectiveAgentModelSource =
+  | "agent_preset"
+  | "agent_default"
+  | "global_default"
+  | "env_fallback"
+  | "runtime_default";
+
 export interface EffectiveAgentModel {
   effectiveProvider: string;
   effectiveModel: string | null;
-  modelSource: "agent_preset" | "agent_default" | "global_default" | null;
+  modelSource: EffectiveAgentModelSource | null;
   modelPresetId: string | null;
   modelPresetVersion: number | null;
   warning: string | null;
   error: string | null;
 }
 
+export interface ResolveEffectiveAgentModelOptions extends ResolveAgentModelSelectionOptions {
+  /** Source of `globalDefaultModel` when it is applied. Defaults to `global_default`. */
+  globalDefaultSource?: Exclude<EffectiveAgentModelSource, "agent_preset" | "agent_default">;
+}
+
 export function resolveEffectiveAgentModel(
   agent: Pick<AgentConfig, "model" | "modelPresetId" | "provider">,
   globalDefaultModel?: string | null,
-  options: ResolveAgentModelSelectionOptions = {},
+  options: ResolveEffectiveAgentModelOptions = {},
 ): EffectiveAgentModel {
   const selection = resolveAgentModelSelection(agent, options);
+  if (selection.error) {
+    return { ...selection, effectiveModel: null, modelSource: null };
+  }
   if (selection.effectiveModel !== null) {
     return { ...selection, modelSource: selection.modelSource };
   }
@@ -171,6 +186,6 @@ export function resolveEffectiveAgentModel(
   return {
     ...selection,
     effectiveModel: globalModel,
-    modelSource: globalModel ? "global_default" : null,
+    modelSource: globalModel ? (options.globalDefaultSource ?? "global_default") : null,
   };
 }

--- a/src/runtime/runtime-defaults.test.ts
+++ b/src/runtime/runtime-defaults.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_RUNTIME_EFFORT } from "./effort.js";
+import { DEFAULT_RUNTIME_PROVIDER_ID } from "./provider-registry.js";
+import {
+  HARDCODED_RUNTIME_MODEL,
+  RUNTIME_DEFAULT_EFFORT_SETTING,
+  RUNTIME_DEFAULT_MODEL_ENV,
+  RUNTIME_DEFAULT_MODEL_SETTING,
+  RUNTIME_DEFAULT_PROVIDER_SETTING,
+  resolveRuntimeDefaults,
+} from "./runtime-defaults.js";
+
+describe("resolveRuntimeDefaults", () => {
+  it("uses stored settings ahead of env and hardcoded fallbacks", () => {
+    const resolved = resolveRuntimeDefaults({
+      getSetting: (key) => {
+        if (key === RUNTIME_DEFAULT_PROVIDER_SETTING) return "claude";
+        if (key === RUNTIME_DEFAULT_MODEL_SETTING) return "opus";
+        if (key === RUNTIME_DEFAULT_EFFORT_SETTING) return "high";
+        return null;
+      },
+      env: { [RUNTIME_DEFAULT_MODEL_ENV]: "sonnet-from-env" },
+    });
+
+    expect(resolved.provider).toEqual({ value: "claude", source: "global_default" });
+    expect(resolved.model).toEqual({ value: "opus", source: "global_default" });
+    expect(resolved.effort).toEqual({ value: "high", source: "global_default" });
+  });
+
+  it("uses RAVI_MODEL only when no stored model exists", () => {
+    const resolved = resolveRuntimeDefaults({
+      getSetting: () => null,
+      env: { [RUNTIME_DEFAULT_MODEL_ENV]: "haiku-from-env" },
+    });
+
+    expect(resolved.model).toEqual({ value: "haiku-from-env", source: "env_fallback" });
+    expect(resolved.provider).toEqual({ value: DEFAULT_RUNTIME_PROVIDER_ID, source: "runtime_default" });
+    expect(resolved.effort).toEqual({ value: DEFAULT_RUNTIME_EFFORT, source: "runtime_default" });
+  });
+
+  it("uses hardcoded defaults when neither setting nor env is present", () => {
+    const resolved = resolveRuntimeDefaults({
+      getSetting: () => null,
+      env: {},
+    });
+
+    expect(resolved.provider).toEqual({ value: DEFAULT_RUNTIME_PROVIDER_ID, source: "runtime_default" });
+    expect(resolved.model).toEqual({ value: HARDCODED_RUNTIME_MODEL, source: "runtime_default" });
+    expect(resolved.effort).toEqual({ value: DEFAULT_RUNTIME_EFFORT, source: "runtime_default" });
+  });
+
+  it("ignores an unknown stored provider instead of inventing a live engine", () => {
+    const resolved = resolveRuntimeDefaults({
+      getSetting: (key) => (key === RUNTIME_DEFAULT_PROVIDER_SETTING ? "not-a-provider" : null),
+      env: {},
+    });
+
+    expect(resolved.provider).toEqual({ value: DEFAULT_RUNTIME_PROVIDER_ID, source: "runtime_default" });
+  });
+});

--- a/src/runtime/runtime-defaults.ts
+++ b/src/runtime/runtime-defaults.ts
@@ -1,0 +1,99 @@
+/**
+ * Live global runtime defaults.
+ *
+ * Stored settings are the operator-configured source of truth. Environment
+ * variables (`RAVI_MODEL` and any sibling) are last-resort fallbacks used only
+ * when no stored value exists. Hardcoded constants are the final last resort
+ * when neither a setting nor an env value is present.
+ *
+ * Callers MUST go through this module (or `runtime-selection.ts`) instead of
+ * treating `loadConfig().model` as the live default.
+ */
+
+import { dbGetSetting } from "../router/router-db.js";
+import { DEFAULT_RUNTIME_EFFORT, parseRuntimeEffort, type RuntimeEffort } from "./effort.js";
+import { DEFAULT_RUNTIME_PROVIDER_ID, listRegisteredRuntimeProviderIds } from "./provider-registry.js";
+import type { RuntimeProviderId } from "./types.js";
+
+export const RUNTIME_DEFAULT_PROVIDER_SETTING = "runtime.defaultProvider";
+export const RUNTIME_DEFAULT_MODEL_SETTING = "runtime.defaultModel";
+export const RUNTIME_DEFAULT_EFFORT_SETTING = "runtime.defaultEffort";
+export const RUNTIME_DEFAULT_MODEL_ENV = "RAVI_MODEL";
+export const HARDCODED_RUNTIME_MODEL = "sonnet";
+
+export type RuntimeDefaultSource = "global_default" | "env_fallback" | "runtime_default";
+
+export interface RuntimeDefaultValue<T> {
+  value: T;
+  source: RuntimeDefaultSource;
+}
+
+export interface ResolvedRuntimeDefaults {
+  provider: RuntimeDefaultValue<RuntimeProviderId>;
+  model: RuntimeDefaultValue<string>;
+  effort: RuntimeDefaultValue<RuntimeEffort>;
+}
+
+export interface RuntimeDefaultsDeps {
+  getSetting?: (key: string) => string | null;
+  env?: NodeJS.ProcessEnv;
+}
+
+function readStoredSetting(key: string, deps?: RuntimeDefaultsDeps): string | null {
+  try {
+    const raw = (deps?.getSetting ?? dbGetSetting)(key);
+    const normalized = raw?.trim();
+    return normalized ? normalized : null;
+  } catch {
+    return null;
+  }
+}
+
+function readEnv(name: string, deps?: RuntimeDefaultsDeps): string | null {
+  const raw = (deps?.env ?? process.env)[name]?.trim();
+  return raw ? raw : null;
+}
+
+function isRegisteredProvider(value: string): value is RuntimeProviderId {
+  return listRegisteredRuntimeProviderIds().includes(value);
+}
+
+export function resolveRuntimeDefaults(deps?: RuntimeDefaultsDeps): ResolvedRuntimeDefaults {
+  const storedProvider = readStoredSetting(RUNTIME_DEFAULT_PROVIDER_SETTING, deps);
+  const storedModel = readStoredSetting(RUNTIME_DEFAULT_MODEL_SETTING, deps);
+  const storedEffort = readStoredSetting(RUNTIME_DEFAULT_EFFORT_SETTING, deps);
+  const envModel = readEnv(RUNTIME_DEFAULT_MODEL_ENV, deps);
+
+  const provider: RuntimeDefaultValue<RuntimeProviderId> =
+    storedProvider && isRegisteredProvider(storedProvider)
+      ? { value: storedProvider, source: "global_default" }
+      : { value: DEFAULT_RUNTIME_PROVIDER_ID, source: "runtime_default" };
+
+  const model: RuntimeDefaultValue<string> = storedModel
+    ? { value: storedModel, source: "global_default" }
+    : envModel
+      ? { value: envModel, source: "env_fallback" }
+      : { value: HARDCODED_RUNTIME_MODEL, source: "runtime_default" };
+
+  let effort: RuntimeDefaultValue<RuntimeEffort> = {
+    value: DEFAULT_RUNTIME_EFFORT,
+    source: "runtime_default",
+  };
+  if (storedEffort) {
+    try {
+      const parsed = parseRuntimeEffort(storedEffort);
+      if (parsed) {
+        effort = { value: parsed, source: "global_default" };
+      }
+    } catch {
+      // Invalid stored effort is ignored; hardcoded default remains last resort.
+    }
+  }
+
+  return { provider, model, effort };
+}
+
+/** Live model used when no session/agent/preset/task value exists. */
+export function resolveGlobalRuntimeModel(deps?: RuntimeDefaultsDeps): string {
+  return resolveRuntimeDefaults(deps).model.value;
+}

--- a/src/runtime/runtime-selection.test.ts
+++ b/src/runtime/runtime-selection.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+import type { RuntimeModelPreset } from "./model-preset-store.js";
+import {
+  HARDCODED_RUNTIME_MODEL,
+  RUNTIME_DEFAULT_MODEL_ENV,
+  RUNTIME_DEFAULT_MODEL_SETTING,
+  RUNTIME_DEFAULT_PROVIDER_SETTING,
+  resolveRuntimeDefaults,
+} from "./runtime-defaults.js";
+import {
+  UnusableAgentModelPresetError,
+  assertUsableAgentModelPreset,
+  resolveEffectiveSessionRuntime,
+  resolveRequestedRuntimeProvider,
+} from "./runtime-selection.js";
+
+function fakePreset(overrides: Partial<RuntimeModelPreset> = {}): RuntimeModelPreset {
+  return {
+    id: "fast-sonnet",
+    provider: "claude",
+    model: "sonnet",
+    description: null,
+    enabled: true,
+    version: 2,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("resolveRequestedRuntimeProvider", () => {
+  it("follows session override, then agent, then stored default, then hardcoded", () => {
+    const defaults = resolveRuntimeDefaults({
+      getSetting: (key) => (key === RUNTIME_DEFAULT_PROVIDER_SETTING ? "pi" : null),
+      env: {},
+    });
+
+    expect(
+      resolveRequestedRuntimeProvider({
+        sessionProviderOverride: "claude",
+        agent: { provider: "codex" },
+        defaults,
+      }),
+    ).toMatchObject({ value: "claude", source: "session_override" });
+
+    expect(
+      resolveRequestedRuntimeProvider({
+        agent: { provider: "codex" },
+        defaults,
+      }),
+    ).toMatchObject({ value: "codex", source: "agent_default" });
+
+    expect(
+      resolveRequestedRuntimeProvider({
+        agent: {},
+        defaults,
+      }),
+    ).toMatchObject({ value: "pi", source: "global_default" });
+
+    expect(
+      resolveRequestedRuntimeProvider({
+        agent: {},
+        defaults: resolveRuntimeDefaults({ getSetting: () => null, env: {} }),
+      }),
+    ).toMatchObject({ value: "codex", source: "runtime_default" });
+  });
+
+  it("uses a usable agent preset provider before stored/env defaults", () => {
+    const defaults = resolveRuntimeDefaults({
+      getSetting: (key) => (key === RUNTIME_DEFAULT_PROVIDER_SETTING ? "pi" : null),
+      env: {},
+    });
+
+    expect(
+      resolveRequestedRuntimeProvider({
+        agent: { modelPresetId: "fast-sonnet" },
+        defaults,
+        lookupPreset: () => fakePreset(),
+      }),
+    ).toMatchObject({ value: "claude", source: "agent_preset" });
+  });
+});
+
+describe("resolveEffectiveSessionRuntime", () => {
+  it("keeps provider and model independent and does not invent a model", () => {
+    const defaults = resolveRuntimeDefaults({
+      getSetting: (key) => (key === RUNTIME_DEFAULT_MODEL_SETTING ? "stored-opus" : null),
+      env: { [RUNTIME_DEFAULT_MODEL_ENV]: "env-sonnet" },
+    });
+
+    const resolved = resolveEffectiveSessionRuntime({
+      session: { agentId: "main", runtimeProviderOverride: "claude" },
+      agent: { model: "agent-gpt" },
+      defaults,
+    });
+
+    expect(resolved.provider).toEqual({ value: "claude", source: "session_override" });
+    expect(resolved.model.value).toBe("agent-gpt");
+    expect(resolved.model.source).toBe("agent_default");
+  });
+
+  it("lets stored runtime config beat env, and env beat the hardcoded model", () => {
+    const stored = resolveEffectiveSessionRuntime({
+      session: { agentId: "main" },
+      agent: {},
+      defaults: resolveRuntimeDefaults({
+        getSetting: (key) => (key === RUNTIME_DEFAULT_MODEL_SETTING ? "stored-opus" : null),
+        env: { [RUNTIME_DEFAULT_MODEL_ENV]: "env-sonnet" },
+      }),
+    });
+    expect(stored.model).toMatchObject({ value: "stored-opus", source: "global_default" });
+
+    const env = resolveEffectiveSessionRuntime({
+      session: { agentId: "main" },
+      agent: {},
+      defaults: resolveRuntimeDefaults({
+        getSetting: () => null,
+        env: { [RUNTIME_DEFAULT_MODEL_ENV]: "env-sonnet" },
+      }),
+    });
+    expect(env.model).toMatchObject({ value: "env-sonnet", source: "env_fallback" });
+
+    const hardcoded = resolveEffectiveSessionRuntime({
+      session: { agentId: "main" },
+      agent: {},
+      defaults: resolveRuntimeDefaults({ getSetting: () => null, env: {} }),
+    });
+    expect(hardcoded.model).toMatchObject({ value: HARDCODED_RUNTIME_MODEL, source: "runtime_default" });
+  });
+
+  it("does not apply env when an agent preset is missing or disabled", () => {
+    const defaults = resolveRuntimeDefaults({
+      getSetting: () => null,
+      env: { [RUNTIME_DEFAULT_MODEL_ENV]: "env-sonnet" },
+    });
+
+    const missing = resolveEffectiveSessionRuntime({
+      session: { agentId: "main" },
+      agent: { modelPresetId: "missing-preset" },
+      defaults,
+      lookupPreset: () => null,
+    });
+    expect(missing.model.value).toBeNull();
+    expect(missing.model.source).toBeNull();
+    expect(missing.model.error).toContain("not found");
+
+    const disabled = resolveEffectiveSessionRuntime({
+      session: { agentId: "main" },
+      agent: { modelPresetId: "fast-sonnet" },
+      defaults,
+      lookupPreset: () => fakePreset({ enabled: false }),
+    });
+    expect(disabled.model.value).toBeNull();
+    expect(disabled.model.error).toContain("disabled");
+  });
+
+  it("still applies a session model override when the agent preset is unusable", () => {
+    const resolved = resolveEffectiveSessionRuntime({
+      session: { agentId: "main", modelOverride: "session-opus" },
+      agent: { modelPresetId: "fast-sonnet" },
+      defaults: resolveRuntimeDefaults({
+        getSetting: () => null,
+        env: { [RUNTIME_DEFAULT_MODEL_ENV]: "env-sonnet" },
+      }),
+      lookupPreset: () => null,
+    });
+
+    expect(resolved.model).toMatchObject({ value: "session-opus", source: "session_override" });
+    expect(resolved.model.error).toContain("not found");
+  });
+});
+
+describe("assertUsableAgentModelPreset", () => {
+  it("rejects an unusable preset unless a higher model already won", () => {
+    expect(() =>
+      assertUsableAgentModelPreset({
+        error: "Model preset not found: missing.",
+        modelPresetId: "missing",
+        shadowedByHigherModel: false,
+      }),
+    ).toThrow(UnusableAgentModelPresetError);
+
+    expect(() =>
+      assertUsableAgentModelPreset({
+        error: "Model preset not found: missing.",
+        modelPresetId: "missing",
+        shadowedByHigherModel: true,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/runtime/runtime-selection.ts
+++ b/src/runtime/runtime-selection.ts
@@ -1,0 +1,215 @@
+/**
+ * Canonical next-turn runtime selection.
+ *
+ * Provider, model, and effort are independent axes. Display and launch MUST
+ * share this module so `sessions info` cannot invent a model or disagree with
+ * the start path. A missing/invalid agent preset never swallows into env.
+ */
+
+import type { AgentConfig, SessionEntry } from "../router/types.js";
+import { DEFAULT_RUNTIME_EFFORT, type RuntimeEffort } from "./effort.js";
+import { resolveAgentModelSelection, type ResolveAgentModelSelectionOptions } from "./model-preset-resolver.js";
+import { resolveRuntimeDefaults, type ResolvedRuntimeDefaults, type RuntimeDefaultsDeps } from "./runtime-defaults.js";
+import type { RuntimeProviderId } from "./types.js";
+
+export type RuntimeProviderSource =
+  | "launch_override"
+  | "observation_override"
+  | "session_override"
+  | "agent_preset"
+  | "agent_default"
+  | "global_default"
+  | "runtime_default";
+
+export type RuntimeModelSource =
+  | "session_override"
+  | "agent_preset"
+  | "agent_default"
+  | "global_default"
+  | "env_fallback"
+  | "runtime_default";
+
+export type RuntimeEffortSource = "session_override" | "agent_default" | "global_default" | "runtime_default";
+
+export type RuntimeThinkingSource = "session_override" | null;
+
+export interface RequestedRuntimeProviderResolution {
+  value: RuntimeProviderId;
+  source: RuntimeProviderSource;
+  warning: string | null;
+  error: string | null;
+}
+
+export interface EffectiveSessionRuntimeSelection {
+  provider: { value: RuntimeProviderId; source: RuntimeProviderSource };
+  model: {
+    value: string | null;
+    source: RuntimeModelSource | null;
+    presetId: string | null;
+    presetVersion: number | null;
+    warning: string | null;
+    error: string | null;
+  };
+  effort: { value: RuntimeEffort; source: RuntimeEffortSource };
+  thinking: { value: SessionEntry["thinkingLevel"] | null; source: RuntimeThinkingSource };
+}
+
+export class UnusableAgentModelPresetError extends Error {
+  readonly modelPresetId: string | null;
+
+  constructor(message: string, modelPresetId: string | null = null) {
+    super(message);
+    this.name = "UnusableAgentModelPresetError";
+    this.modelPresetId = modelPresetId;
+  }
+}
+
+export function resolveRequestedRuntimeProvider(input: {
+  runtimeProviderIdOverride?: RuntimeProviderId;
+  observationProviderId?: RuntimeProviderId;
+  sessionProviderOverride?: RuntimeProviderId | null;
+  agent: Pick<AgentConfig, "model" | "modelPresetId" | "provider">;
+  defaults?: ResolvedRuntimeDefaults;
+  defaultsDeps?: RuntimeDefaultsDeps;
+  lookupPreset?: ResolveAgentModelSelectionOptions["lookupPreset"];
+}): RequestedRuntimeProviderResolution {
+  const defaults = input.defaults ?? resolveRuntimeDefaults(input.defaultsDeps);
+  const agentSelection = resolveAgentModelSelection(input.agent, {
+    ...(input.lookupPreset ? { lookupPreset: input.lookupPreset } : {}),
+  });
+
+  if (input.runtimeProviderIdOverride) {
+    return {
+      value: input.runtimeProviderIdOverride,
+      source: "launch_override",
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    };
+  }
+
+  if (input.observationProviderId) {
+    return {
+      value: input.observationProviderId,
+      source: "observation_override",
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    };
+  }
+
+  const sessionOverride = input.sessionProviderOverride?.trim() || undefined;
+  if (sessionOverride) {
+    return {
+      value: sessionOverride as RuntimeProviderId,
+      source: "session_override",
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    };
+  }
+
+  if (agentSelection.modelSource === "agent_preset") {
+    return {
+      value: agentSelection.effectiveProvider as RuntimeProviderId,
+      source: "agent_preset",
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    };
+  }
+
+  const agentProvider = input.agent.provider?.trim();
+  if (agentProvider) {
+    return {
+      value: agentProvider as RuntimeProviderId,
+      source: "agent_default",
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    };
+  }
+
+  return {
+    value: defaults.provider.value,
+    source: defaults.provider.source === "global_default" ? "global_default" : "runtime_default",
+    warning: agentSelection.warning,
+    error: agentSelection.error,
+  };
+}
+
+export function resolveEffectiveSessionRuntime(input: {
+  session: Pick<
+    SessionEntry,
+    "agentId" | "runtimeProviderOverride" | "modelOverride" | "effortOverride" | "thinkingLevel"
+  >;
+  agent?: Pick<AgentConfig, "model" | "modelPresetId" | "provider" | "effort"> | null;
+  defaults?: ResolvedRuntimeDefaults;
+  defaultsDeps?: RuntimeDefaultsDeps;
+  lookupPreset?: ResolveAgentModelSelectionOptions["lookupPreset"];
+}): EffectiveSessionRuntimeSelection {
+  const defaults = input.defaults ?? resolveRuntimeDefaults(input.defaultsDeps);
+  const agent = input.agent ?? {};
+  const provider = resolveRequestedRuntimeProvider({
+    sessionProviderOverride: input.session.runtimeProviderOverride,
+    agent,
+    defaults,
+    lookupPreset: input.lookupPreset,
+  });
+  const agentSelection = resolveAgentModelSelection(agent, {
+    ...(input.lookupPreset ? { lookupPreset: input.lookupPreset } : {}),
+  });
+
+  const sessionModel = input.session.modelOverride?.trim() || undefined;
+  let modelValue: string | null = null;
+  let modelSource: RuntimeModelSource | null = null;
+
+  if (sessionModel) {
+    modelValue = sessionModel;
+    modelSource = "session_override";
+  } else if (agentSelection.error) {
+    modelValue = null;
+    modelSource = null;
+  } else if (agentSelection.modelSource === "agent_preset" && agentSelection.effectiveModel) {
+    modelValue = agentSelection.effectiveModel;
+    modelSource = "agent_preset";
+  } else if (agentSelection.modelSource === "agent_default" && agentSelection.effectiveModel) {
+    modelValue = agentSelection.effectiveModel;
+    modelSource = "agent_default";
+  } else {
+    modelValue = defaults.model.value;
+    modelSource = defaults.model.source;
+  }
+
+  const effort = input.session.effortOverride
+    ? { value: input.session.effortOverride, source: "session_override" as const }
+    : agent.effort
+      ? { value: agent.effort, source: "agent_default" as const }
+      : defaults.effort.source === "global_default"
+        ? { value: defaults.effort.value, source: "global_default" as const }
+        : { value: DEFAULT_RUNTIME_EFFORT, source: "runtime_default" as const };
+
+  const thinking = input.session.thinkingLevel
+    ? { value: input.session.thinkingLevel, source: "session_override" as const }
+    : { value: null, source: null };
+
+  return {
+    provider: { value: provider.value, source: provider.source },
+    model: {
+      value: modelValue,
+      source: modelSource,
+      presetId: agentSelection.modelPresetId,
+      presetVersion: agentSelection.modelPresetVersion,
+      warning: agentSelection.warning,
+      error: agentSelection.error,
+    },
+    effort,
+    thinking,
+  };
+}
+
+export function assertUsableAgentModelPreset(input: {
+  error: string | null;
+  modelPresetId: string | null;
+  shadowedByHigherModel: boolean;
+}): void {
+  if (!input.error || input.shadowedByHigherModel) {
+    return;
+  }
+  throw new UnusableAgentModelPresetError(input.error, input.modelPresetId);
+}

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -52,8 +52,7 @@ import {
   type RuntimeUserMessage,
 } from "./host-session.js";
 import { applyDirectRuntimeModelSwitch, resolveRuntimeModelSwitchStrategy } from "./model-switch.js";
-import { resolveAgentModelSelection } from "./model-preset-resolver.js";
-import { DEFAULT_RUNTIME_PROVIDER_ID } from "./provider-registry.js";
+import { resolveRequestedRuntimeProvider } from "./runtime-selection.js";
 import {
   MODEL_BROKER_REQUIRED_SETTING,
   buildRuntimeModelBrokerPhysicalFingerprint,
@@ -803,18 +802,16 @@ export class RuntimeSessionDispatcher {
     if (modelBrokerPlan && prompt._modelBrokerTurnId !== modelBrokerTurnId) {
       prompt = { ...prompt, _modelBrokerTurnId: modelBrokerTurnId };
     }
-    const agentSelection = resolveAgentModelSelection(agent);
     const sessionRuntimeProviderOverride =
       prompt._observation && prompt._runtimeProviderId ? undefined : sessionEntry?.runtimeProviderOverride;
     const requestedProvider: RuntimeProviderId = modelBrokerPlan
       ? modelBrokerPlan.lease.runtimeProvider
-      : prompt._observation && prompt._runtimeProviderId
-        ? prompt._runtimeProviderId
-        : sessionRuntimeProviderOverride
-          ? sessionRuntimeProviderOverride
-          : agentSelection.modelSource === "agent_preset"
-            ? agentSelection.effectiveProvider
-            : (agent.provider ?? DEFAULT_RUNTIME_PROVIDER_ID);
+      : resolveRequestedRuntimeProvider({
+          observationProviderId:
+            prompt._observation && prompt._runtimeProviderId ? prompt._runtimeProviderId : undefined,
+          sessionProviderOverride: sessionRuntimeProviderOverride,
+          agent,
+        }).value;
     let retainReleasedSlot = false;
 
     if (existing && !existing.done) {

--- a/src/runtime/session-resolver.test.ts
+++ b/src/runtime/session-resolver.test.ts
@@ -7,6 +7,8 @@ import {
   updateProviderSession,
   updateSessionRuntimeProviderOverride,
 } from "../router/sessions.js";
+import { dbSetSetting } from "../router/router-db.js";
+import { RUNTIME_DEFAULT_PROVIDER_SETTING } from "./runtime-defaults.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import { configStore } from "../config-store.js";
 import { resolveRuntimeSession } from "./session-resolver.js";
@@ -118,6 +120,20 @@ describe("runtime session resolver", () => {
       staleCleared: true,
     });
     expect(getSession(SESSION_KEY)?.providerSessionId).toBeUndefined();
+  });
+
+  it("uses a stored runtime.defaultProvider before the hardcoded default", () => {
+    getOrCreateSession(SESSION_KEY, "main", stateDir ?? "/tmp", { name: SESSION_NAME });
+    dbSetSetting(RUNTIME_DEFAULT_PROVIDER_SETTING, "claude");
+    configStore.refresh();
+
+    const resolved = resolveRuntimeSession({
+      sessionName: SESSION_NAME,
+      prompt: { prompt: "use stored provider default" },
+      defaultRuntimeProviderId: "codex",
+    });
+
+    expect(resolved?.runtimeProviderId).toBe("claude");
   });
 
   it("uses session runtime provider override before agent/default provider", () => {

--- a/src/runtime/session-resolver.ts
+++ b/src/runtime/session-resolver.ts
@@ -9,8 +9,9 @@ import {
 } from "../router/index.js";
 import { logger } from "../utils/logger.js";
 import { createRuntimeProvider } from "./provider-registry.js";
-import { resolveAgentModelSelection } from "./model-preset-resolver.js";
 import type { RuntimeProviderId } from "./types.js";
+import { resolveRuntimeDefaults } from "./runtime-defaults.js";
+import { resolveRequestedRuntimeProvider } from "./runtime-selection.js";
 import { resolveStoredRuntimeProvider } from "./host-session.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import type { RuntimeCapabilities, SessionRuntimeProvider } from "./types.js";
@@ -76,20 +77,25 @@ export function resolveRuntimeSession(options: {
   const identity = options.identity ?? resolveRuntimeSessionIdentity(options);
   if (!identity) return null;
   const { sessionEntry, agent, session, sessionCwd, dbSessionKey } = identity;
-  const agentSelection = resolveAgentModelSelection(agent);
   const sessionRuntimeProviderOverride =
     options.prompt._observation && options.prompt._runtimeProviderId
       ? undefined
       : sessionEntry?.runtimeProviderOverride;
-  const runtimeProviderId: RuntimeProviderId = options.runtimeProviderIdOverride
-    ? options.runtimeProviderIdOverride
-    : options.prompt._observation && options.prompt._runtimeProviderId
-      ? options.prompt._runtimeProviderId
-      : sessionRuntimeProviderOverride
-        ? sessionRuntimeProviderOverride
-        : agentSelection.modelSource === "agent_preset"
-          ? agentSelection.effectiveProvider
-          : (agent.provider ?? options.defaultRuntimeProviderId);
+  const defaults = resolveRuntimeDefaults();
+  const runtimeProviderId = resolveRequestedRuntimeProvider({
+    runtimeProviderIdOverride: options.runtimeProviderIdOverride,
+    observationProviderId:
+      options.prompt._observation && options.prompt._runtimeProviderId ? options.prompt._runtimeProviderId : undefined,
+    sessionProviderOverride: sessionRuntimeProviderOverride,
+    agent,
+    defaults: {
+      ...defaults,
+      provider:
+        defaults.provider.source === "global_default"
+          ? defaults.provider
+          : { value: options.defaultRuntimeProviderId, source: "runtime_default" },
+    },
+  }).value;
   const runtimeProvider = createRuntimeProvider(runtimeProviderId);
   const runtimeCapabilities = runtimeProvider.getCapabilities();
 

--- a/src/runtime/task-runtime-context.test.ts
+++ b/src/runtime/task-runtime-context.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createAgent } from "../router/config.js";
+import { dbSetSetting } from "../router/router-db.js";
+import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
+import { configStore } from "../config-store.js";
+import {
+  HARDCODED_RUNTIME_MODEL,
+  RUNTIME_DEFAULT_MODEL_ENV,
+  RUNTIME_DEFAULT_MODEL_SETTING,
+} from "./runtime-defaults.js";
+import { UnusableAgentModelPresetError } from "./runtime-selection.js";
+import { resolveRuntimeForPrompt } from "./task-runtime-context.js";
+
+let stateDir: string | null = null;
+let previousRaviModel: string | undefined;
+
+describe("resolveRuntimeForPrompt", () => {
+  beforeEach(async () => {
+    previousRaviModel = process.env[RUNTIME_DEFAULT_MODEL_ENV];
+    process.env[RUNTIME_DEFAULT_MODEL_ENV] = "env-sonnet";
+    stateDir = await createIsolatedRaviState("ravi-task-runtime-context-");
+    configStore.refresh();
+  });
+
+  afterEach(async () => {
+    if (previousRaviModel === undefined) {
+      delete process.env[RUNTIME_DEFAULT_MODEL_ENV];
+    } else {
+      process.env[RUNTIME_DEFAULT_MODEL_ENV] = previousRaviModel;
+    }
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  it("rejects a missing agent preset instead of swallowing into env", () => {
+    expect(() =>
+      resolveRuntimeForPrompt({
+        sessionName: "preset-session",
+        prompt: { prompt: "hello" },
+        session: null,
+        agent: {
+          id: "preset-agent",
+          cwd: stateDir ?? "/tmp",
+          modelPresetId: "does-not-exist",
+        },
+      }),
+    ).toThrow(UnusableAgentModelPresetError);
+  });
+
+  it("keeps a stored agent model ahead of RAVI_MODEL", () => {
+    const agent = createAgent({
+      id: "direct-agent",
+      cwd: stateDir ?? "/tmp",
+      model: "agent-opus",
+    });
+
+    const resolved = resolveRuntimeForPrompt({
+      sessionName: "direct-session",
+      prompt: { prompt: "hello" },
+      session: null,
+      agent,
+    });
+
+    expect(resolved.options.model).toBe("agent-opus");
+    expect(resolved.sources.model).toBe("agent_default");
+  });
+
+  it("uses a stored runtime.defaultModel ahead of RAVI_MODEL", () => {
+    dbSetSetting(RUNTIME_DEFAULT_MODEL_SETTING, "stored-opus");
+    const agent = createAgent({
+      id: "plain-agent",
+      cwd: stateDir ?? "/tmp",
+    });
+
+    const resolved = resolveRuntimeForPrompt({
+      sessionName: "plain-session",
+      prompt: { prompt: "hello" },
+      session: null,
+      agent,
+    });
+
+    expect(resolved.options.model).toBe("stored-opus");
+    expect(resolved.sources.model).toBe("global_default");
+    expect(resolved.options.model).not.toBe("env-sonnet");
+    expect(resolved.options.model).not.toBe(HARDCODED_RUNTIME_MODEL);
+  });
+});

--- a/src/runtime/task-runtime-context.ts
+++ b/src/runtime/task-runtime-context.ts
@@ -3,12 +3,14 @@ import { resolveTaskProfileForTask } from "../tasks/profiles.js";
 import { resolveTaskRuntimeOptions } from "../tasks/runtime-options.js";
 import { emitTaskEvent } from "../tasks/service.js";
 import { dbMarkTaskAcceptedForSession, dbResolveActiveTaskBindingForSession } from "../tasks/task-db.js";
-import type { TaskRuntimeResolution } from "../tasks/types.js";
+import type { TaskRuntimeOptionsSource, TaskRuntimeResolution } from "../tasks/types.js";
 import { logger } from "../utils/logger.js";
 import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
 import type { RuntimeHostStreamingSession } from "./host-session.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { resolveAgentModelSelection } from "./model-preset-resolver.js";
+import { resolveRuntimeDefaults } from "./runtime-defaults.js";
+import { assertUsableAgentModelPreset } from "./runtime-selection.js";
 
 const log = logger.child("runtime:task-context");
 
@@ -17,7 +19,8 @@ export function resolveRuntimeForPrompt(options: {
   prompt: RuntimeLaunchPrompt;
   session: SessionEntry | null | undefined;
   agent: AgentConfig;
-  configModel: string;
+  configModel?: string;
+  configModelSource?: Extract<TaskRuntimeOptionsSource, "global_default" | "env_fallback" | "runtime_default">;
 }): TaskRuntimeResolution {
   const binding = options.prompt.taskBarrierTaskId
     ? dbResolveActiveTaskBindingForSession(options.sessionName, options.prompt.taskBarrierTaskId)
@@ -59,6 +62,19 @@ export function resolveRuntimeForPrompt(options: {
     });
   }
 
+  const hasHigherPriorityModel = Boolean(
+    promptOverride?.model ||
+      binding?.assignment?.runtimeOverride?.model ||
+      binding?.task?.runtimeOverride?.model ||
+      profile?.runtimeDefaults?.model ||
+      options.session?.modelOverride,
+  );
+  assertUsableAgentModelPreset({
+    error: agentSelection.error,
+    modelPresetId: agentSelection.modelPresetId,
+    shadowedByHigherModel: hasHigherPriorityModel,
+  });
+
   const agentModelPreset =
     agentSelection.modelSource === "agent_preset" &&
     agentSelection.effectiveModel &&
@@ -71,6 +87,11 @@ export function resolveRuntimeForPrompt(options: {
         }
       : null;
   const agentModel = agentSelection.modelSource === "agent_default" ? agentSelection.effectiveModel : undefined;
+  const defaults = resolveRuntimeDefaults();
+  const configModel = options.configModel ?? defaults.model.value;
+  const configModelSource =
+    options.configModelSource ??
+    (options.configModel && options.configModel !== defaults.model.value ? "global_default" : defaults.model.source);
 
   return resolveTaskRuntimeOptions({
     promptOverride,
@@ -83,7 +104,9 @@ export function resolveRuntimeForPrompt(options: {
     agentModel,
     agentModelPreset,
     agentEffort: options.agent.effort,
-    configModel: options.configModel,
+    configModel,
+    configModelSource,
+    configEffort: defaults.effort.source === "global_default" ? defaults.effort.value : undefined,
   });
 }
 

--- a/src/tasks/runtime-options.test.ts
+++ b/src/tasks/runtime-options.test.ts
@@ -102,4 +102,33 @@ describe("task runtime options", () => {
       }),
     ).toThrow(/Invalid runtime effort/);
   });
+
+  it("labels env fallback separately from stored global defaults", () => {
+    const env = resolveTaskRuntimeOptions({
+      configModel: "env-sonnet",
+      configModelSource: "env_fallback",
+    });
+    expect(env.options.model).toBe("env-sonnet");
+    expect(env.sources.model).toBe("env_fallback");
+
+    const stored = resolveTaskRuntimeOptions({
+      configModel: "stored-opus",
+      configModelSource: "global_default",
+      configEffort: "high",
+    });
+    expect(stored.options.model).toBe("stored-opus");
+    expect(stored.sources.model).toBe("global_default");
+    expect(stored.options.effort).toBe("high");
+    expect(stored.sources.effort).toBe("global_default");
+  });
+
+  it("keeps a stored agent model ahead of env fallback", () => {
+    const resolved = resolveTaskRuntimeOptions({
+      agentModel: "agent-opus",
+      configModel: "env-sonnet",
+      configModelSource: "env_fallback",
+    });
+    expect(resolved.options.model).toBe("agent-opus");
+    expect(resolved.sources.model).toBe("agent_default");
+  });
 });

--- a/src/tasks/runtime-options.ts
+++ b/src/tasks/runtime-options.ts
@@ -106,6 +106,12 @@ export function resolveTaskRuntimeOptions(input: {
   agentModelPreset?: { model: string; presetId: string; version: number } | null;
   agentEffort?: TaskRuntimeEffort | string | null;
   configModel?: string | null;
+  /**
+   * Source of `configModel` when it is applied. Defaults to `global_default`
+   * for callers that still pass a pre-resolved string.
+   */
+  configModelSource?: Extract<TaskRuntimeOptionsSource, "global_default" | "env_fallback" | "runtime_default">;
+  configEffort?: TaskRuntimeEffort | string | null;
 }): TaskRuntimeResolution {
   const promptOverride = normalizeTaskRuntimeOptions(input.promptOverride);
   const dispatchOverride = normalizeTaskRuntimeOptions(
@@ -124,7 +130,9 @@ export function resolveTaskRuntimeOptions(input: {
     model: input.agentModel ?? undefined,
     effort: input.agentEffort ?? undefined,
   });
-  const configOptions = normalizeTaskRuntimeOptions({ model: input.configModel ?? undefined });
+  const configModelSource = input.configModelSource ?? "global_default";
+  const configModelOptions = normalizeTaskRuntimeOptions({ model: input.configModel ?? undefined });
+  const configEffortOptions = normalizeTaskRuntimeOptions({ effort: input.configEffort ?? undefined });
 
   const sources: Array<[TaskRuntimeOptionsSource, TaskRuntimeOptions | undefined]> = [
     ["prompt_override", promptOverride],
@@ -134,7 +142,8 @@ export function resolveTaskRuntimeOptions(input: {
     ["session_override", sessionOptions],
     ["agent_preset", agentPresetOptions],
     ["agent_default", agentOptions],
-    ["global_default", configOptions],
+    [configModelSource, configModelOptions],
+    ["global_default", configEffortOptions],
   ];
 
   const pick = (key: keyof TaskRuntimeOptions): { value?: string; source: TaskRuntimeOptionsSource | null } => {

--- a/src/tasks/service.ts
+++ b/src/tasks/service.ts
@@ -5,7 +5,7 @@ import { expandHome } from "../router/resolver.js";
 import { findSessionByChatId, getOrCreateSession, getSessionByName, resolveSession } from "../router/sessions.js";
 import { getProjectSurfaceByWorkflowRunId, type ProjectTaskSurface } from "../projects/index.js";
 import { logger } from "../utils/logger.js";
-import { loadConfig } from "../utils/config.js";
+import { resolveRuntimeDefaults } from "../runtime/runtime-defaults.js";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { isAbsolute, relative as relativePath, resolve as resolvePath } from "node:path";
 import { z } from "zod";
@@ -1656,6 +1656,7 @@ export function resolveTaskRuntimeForRead(
     options.sessionEffortOverride !== undefined ? options.sessionEffortOverride : runtimeSession?.effortOverride;
   const sessionThinkingLevel =
     options.sessionThinkingLevel !== undefined ? options.sessionThinkingLevel : runtimeSession?.thinkingLevel;
+  const defaults = resolveRuntimeDefaults();
   return resolveTaskRuntimeOptions({
     task,
     profile,
@@ -1666,7 +1667,8 @@ export function resolveTaskRuntimeForRead(
     sessionThinkingLevel,
     agentModel,
     agentEffort,
-    configModel: loadConfig().model,
+    configModel: defaults.model.value,
+    configModelSource: defaults.model.source,
   });
 }
 

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -37,6 +37,7 @@ export type TaskRuntimeOptionsSource =
   | "agent_preset"
   | "agent_default"
   | "global_default"
+  | "env_fallback"
   | "runtime_default";
 
 export interface TaskRuntimeOptions {

--- a/src/tui/hooks/useSessionMetadata.ts
+++ b/src/tui/hooks/useSessionMetadata.ts
@@ -3,7 +3,7 @@ import { subscribe } from "../../nats.js";
 import { dbGetAgent } from "../../router/router-db.js";
 import { resolveSession } from "../../router/sessions.js";
 import type { AgentConfig, SessionEntry } from "../../router/index.js";
-import { loadConfig } from "../../utils/config.js";
+import { resolveGlobalRuntimeModel } from "../../runtime/runtime-defaults.js";
 
 export interface SessionMetadata {
   session: SessionEntry | null;
@@ -15,7 +15,7 @@ function snapshot(sessionName: string): SessionMetadata {
   const session = resolveSession(sessionName);
   const agentId = session?.agentId;
   const agent = agentId ? dbGetAgent(agentId) : null;
-  return { session, agent, defaultModel: loadConfig().model };
+  return { session, agent, defaultModel: resolveGlobalRuntimeModel() };
 }
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,11 @@
 export interface Config {
   /** ANTHROPIC_API_KEY for Claude API access */
   apiKey: string;
-  /** Model to use (default: claude-sonnet-4-20250514) */
+  /**
+   * Env-only model fallback (`RAVI_MODEL` or hardcoded `sonnet`).
+   * Not the live runtime default — use `resolveRuntimeDefaults()` for the
+   * next-turn selection. Stored settings win over this value.
+   */
   model: string;
   /** Log level */
   logLevel: "debug" | "info" | "warn" | "error";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Give operators one stored, live-readable way to set the provider, model, and effort the next turn actually uses. Session/agent/preset knobs stay higher. `RAVI_MODEL` becomes last-resort fallback, never the live source of truth. Display (`sessions info`, `agents show`) now reports the same selection and source as launch.

## Problem

- Operators could not reliably change what engine/model a session or agent would use on the next turn without a daemon restart or hoping env won.
- `RAVI_MODEL` (and `loadConfig().model`) acted like the real default. A stored agent/session/preset value could lose to env, or a missing/invalid preset could warn and swallow into env.
- Provider and model are independent stacks. `sessions info` invented a model when only a provider override was set, so display could lie about the next turn.
- Several CLIs looked like they set the same thing (`agents set`, `sessions set-model`/`set-provider`, presets, `~/.ravi/.env`).

## Solution

Reuse the existing settings surface. No fifth knob.

```bash
ravi settings set runtime.defaultProvider claude
ravi settings set runtime.defaultModel opus
ravi settings set runtime.defaultEffort high
ravi settings delete runtime.defaultModel --execute
ravi sessions info <session> --json
ravi agents show <id> --json
```

Precedence (independent axes, highest first):

1. launch / observation / prompt / dispatch / task / profile
2. session override
3. agent preset or direct agent value
4. stored setting → source `global_default`
5. `RAVI_MODEL` only → source `env_fallback`
6. hardcoded last resort (`codex` / `sonnet` / default effort) → source `runtime_default`

Launch and display share `resolveRequestedRuntimeProvider` / `resolveEffectiveSessionRuntime`. Settings are read from SQLite on each resolve, so the next turn picks up the new values without a daemon restart. An unusable agent preset now rejects the turn instead of falling through to env.

## Practical impact

- Operators set/clear global next-turn defaults with `ravi settings set|delete runtime.default*`.
- `sessions info` / `agents show` show effective provider/model/effort plus source (`session_override`, `agent`, `preset`, `global_default`, `env_fallback`, `runtime_default`).
- `RAVI_MODEL` in `~/.ravi/.env` still works when no stored default exists; it no longer wins over stored config.
- Session, agent, and preset overrides keep working as the higher knobs.

## What does NOT change

- No new `RAVI_RUNTIME_OVERRIDE_*` env or `ravi runtime defaults` command.
- No Grok / xAI / Cloud Agents provider. Independent of open PR #422.
- `settings set` stays unbraked; `settings delete` stays dry-run unless `--execute`.
- `loadConfig().model` itself is still `RAVI_MODEL || "sonnet"` (env-only snapshot). Live callers go through the resolver.
- Session `set-model` / `set-provider` / `set-effort` and `agents set` / presets remain the higher-precedence surfaces.

## Validation

- `bun test` on `runtime-defaults`, `runtime-selection`, `task-runtime-context`, `session-resolver`, `model-catalog`, `runtime-options`, `session-dispatcher`, `bot.runtime-guards`, `runtime/index`
- Isolated CLI: `settings.test.ts`, `sessions.test.ts`, `agents.test.ts`
- `bunx tsc --noEmit`
- `sdk client generate` / `sdk client check` / `sdk openapi check` / `sdk swift generate` / `sdk swift check`
- Pre-push hook on this branch passed (SDK + OpenAPI snapshots current)
- No live model calls

## Risks

- A previously working-but-wrong launch that used a broken preset and fell through to `RAVI_MODEL` will now fail closed. That is the spec.
- Unknown stored `runtime.defaultProvider` is ignored (falls to hardcoded `codex`), same as an unset setting.
- Combining some CLI test files in one bun process can still hit pre-existing mock pollution; isolated runs pass.

## Rollback

Revert this PR. Existing session/agent/preset overrides keep working. Env-only installs behave as before (`RAVI_MODEL` or `sonnet`).

## Follow-ups

- Consider a sibling `RAVI_PROVIDER` env only if operators still need an env fallback for provider. This PR deliberately has none; provider env was never a live sibling.
- TUI could surface source labels the same way `sessions info` now does.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bcdf1f4-f63e-491c-9fb4-2451f4da02f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bcdf1f4-f63e-491c-9fb4-2451f4da02f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

