### PR TITLE
fix(runtime): ack prompts only after dispatch

### DIFF
--- a/src/runtime/prompt-subscription.test.ts
+++ b/src/runtime/prompt-subscription.test.ts
@@ -94,11 +94,15 @@ describe("RuntimePromptSubscription", () => {
     });
   });
 
-  it("ACKs and dispatches a prompt only after the intake fence accepts it", async () => {
+  it("ACKs a prompt only after the intake fence and dispatch both accept it", async () => {
     const message = makePromptMessage("ravi.session.dev.prompt", { prompt: "continue" });
     consumedMessages = [message];
     const canAcceptPrompt = mock(() => true);
-    const handlePrompt = mock(async () => {});
+    const callOrder: string[] = [];
+    message.ack = mock(() => callOrder.push("ack"));
+    const handlePrompt = mock(async () => {
+      callOrder.push("dispatch");
+    });
     const subscription = new RuntimePromptSubscription({
       isRunning: () => running,
       canAcceptPrompt,
@@ -115,7 +119,32 @@ describe("RuntimePromptSubscription", () => {
     expect(message.ack).toHaveBeenCalledTimes(1);
     expect(message.nak).not.toHaveBeenCalled();
     expect(handlePrompt).toHaveBeenCalledWith("dev", { prompt: "continue" });
+    expect(callOrder).toEqual(["dispatch", "ack"]);
     expect(subscription.promptsReceived).toBe(1);
+  });
+
+  it("delays redelivery without ACKing or counting a prompt when dispatch fails", async () => {
+    const message = makePromptMessage("ravi.session.dev.prompt", { prompt: "retry me" });
+    consumedMessages = [message];
+    const handlePrompt = mock(async () => {
+      throw new Error("dispatch failed");
+    });
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => true,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt,
+    });
+
+    subscription.subscribe();
+    await waitUntil(() => !subscription.active);
+
+    expect(handlePrompt).toHaveBeenCalledTimes(1);
+    expect(message.nak).toHaveBeenCalledWith(5_000);
+    expect(message.ack).not.toHaveBeenCalled();
+    expect(subscription.promptsReceived).toBe(0);
   });
 
   it("NAKs and stops the pull before ACK or dispatch when intake is fenced", async () => {

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -12,6 +12,7 @@ import { classifyTurnProvenance } from "./turn-provenance.js";
 import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
 
 const log = logger.child("runtime:prompt-subscription");
+const PROMPT_DISPATCH_RETRY_DELAY_MS = 5_000;
 
 export interface RuntimePromptSubscriptionOptions {
   isRunning(): boolean;
@@ -143,6 +144,23 @@ export class RuntimePromptSubscription {
               break;
             }
 
+            try {
+              // Keep the JetStream work item durable until the dispatcher has
+              // accepted the prompt. Provider/bootstrap failures can happen
+              // before a turn exists, so acknowledging earlier loses the only
+              // retryable copy.
+              await this.options.handlePrompt(sessionName, prompt);
+            } catch (error) {
+              log.error("Failed to handle prompt before acknowledgement", {
+                sessionName,
+                subject: msg.subject,
+                retryDelayMs: PROMPT_DISPATCH_RETRY_DELAY_MS,
+                error,
+              });
+              msg.nak(PROMPT_DISPATCH_RETRY_DELAY_MS);
+              continue;
+            }
+
             msg.ack();
             this.promptsReceived++;
 
@@ -169,9 +187,6 @@ export class RuntimePromptSubscription {
                   error,
                 });
               });
-            this.options.handlePrompt(sessionName, prompt).catch((err) => {
-              log.error("Failed to handle prompt", err);
-            });
           }
 
           if (!this.options.isRunning() || intakeFenced) {


### PR DESCRIPTION
## Objective

Prevent a transient provider-runtime dispatch failure from permanently losing a JetStream prompt.

## Problem

The prompt consumer acknowledged each message before awaiting `handlePrompt`. If identityd or the model broker rejected the dispatch, the message had already been removed from the stream and the user saw presence without ever receiving an answer.

## Solution

- Await prompt dispatch before acknowledging the JetStream message.
- Negatively acknowledge failed dispatches with a bounded five-second delay so JetStream can redeliver them.
- Keep failed attempts out of the handled counter.
- Add ordering and failure-path regression coverage.

## Practical impact

Transient identityd or broker failures now retry the same prompt instead of silently losing it. Successful prompts preserve the existing acknowledgement behavior.

## What does NOT change

- Prompt payloads, subjects, routing, or consumer identity.
- The model broker lease protocol.
- Successful dispatch behavior outside acknowledgement timing.

## Validation

- `bun test src/runtime/prompt-subscription.test.ts`: 4 passed
- `bun run typecheck`
- `bun run lint`
- Architecture contract suite: 23 passed
- `bun run build`
- Two unrelated five-second task-suite timeout flakes during the pre-push aggregate both passed immediately when rerun in isolation.

## Risks

A persistently failing dispatch is redelivered every five seconds. This is intentional at-least-once delivery and is bounded by the existing JetStream consumer policy.

## Rollback

Revert this PR to restore acknowledgement-before-dispatch behavior.