### PR TITLE
fix(slack): open agent factory modal immediately

### DIFF
--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { EventEmitter } from "node:events";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { configStore } from "../../config-store.js";
 import {
   createContact,
@@ -59,6 +61,7 @@ import {
   getSlackThreadLifecycle,
   markSlackThreadRootDelivered,
 } from "./thread-lifecycle-store.js";
+import { dbCreateTrigger } from "../../triggers/triggers-db.js";
 import type { SlackRoutingPolicy, SlackSocketEnvelope } from "./types.js";
 
 class FakeSlackWebSocket extends EventEmitter {
@@ -1182,6 +1185,275 @@ describe("Slack Socket Mode routing", () => {
       },
     ]);
     expect(JSON.stringify(interactions[0]?.payload)).not.toContain("hooks.slack.com");
+  });
+
+  it("opens the agent factory modal in Socket Mode instead of publishing the shell trigger event", async () => {
+    const workflowRoot = join(stateDir!, "workflow-root");
+    const workflowDir = join(workflowRoot, ".ravi", "workflows", "agent-factory");
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(
+      join(workflowDir, "modal-view.json"),
+      JSON.stringify({
+        type: "modal",
+        callback_id: "agent_factory_create_modal",
+        title: { type: "plain_text", text: "Novo agent" },
+        submit: { type: "plain_text", text: "Criar" },
+        blocks: [],
+      }),
+      "utf8",
+    );
+
+    dbCreateTrigger({
+      name: "agent factory open modal",
+      topic: "ravi.inbound.interaction",
+      message: "",
+      executionType: "shell",
+      shellCommand: `cd ${workflowRoot} && RAVI_SLACK_CONNECTION=hana-slack bun .ravi/workflows/agent-factory/handler.ts`,
+      filter:
+        'data.provider == "slack" && data.interactionType == "block_actions" && data.channelId == "CFACTORY" && data.blockId == "agent_factory_actions" && data.actionId == "agent_factory_open_modal"',
+      session: "isolated",
+      cooldownMs: 1000,
+    });
+
+    const order: string[] = [];
+    const interactions: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+    const viewsOpen = mock(async (_input: { triggerId: string; view: Record<string, unknown> }) => {
+      order.push("views.open");
+      return { ok: true, view: { id: "VFACTORY", hash: "h1" } };
+    });
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "hana-slack",
+      routeAccountId: "hana-slack",
+      instanceId: "hana-slack",
+      getRouterConfig: () => ({
+        agents: {},
+        routes: [],
+        defaultAgent: "ravi-workflows",
+        defaultDmScope: "per-peer",
+        accountAgents: {},
+        instanceToAccount: {},
+        instances: {},
+      }),
+      publishInteraction: async (topic, payload) => {
+        order.push("publish");
+        interactions.push({ topic, payload });
+      },
+      webClient: { viewsOpen } as never,
+    });
+
+    const result = await service.handleEnvelope(
+      {
+        envelope_id: "env-agent-factory-open-1",
+        payload: {
+          type: "block_actions",
+          team: { id: "T1" },
+          user: { id: "U123" },
+          channel: { id: "CFACTORY" },
+          trigger_id: "trigger-agent-factory-1",
+          container: {
+            type: "message",
+            channel_id: "CFACTORY",
+            message_ts: "1713000000.000100",
+          },
+          message: {
+            ts: "1713000000.000100",
+          },
+          actions: [
+            {
+              type: "button",
+              block_id: "agent_factory_actions",
+              action_id: "agent_factory_open_modal",
+              action_ts: "1713000001.000200",
+            },
+          ],
+        },
+      },
+      async () => {
+        order.push("ack");
+      },
+    );
+
+    expect(result).toBe("processed");
+    expect(order).toEqual(["ack", "views.open"]);
+    expect(interactions).toHaveLength(0);
+    expect(viewsOpen).toHaveBeenCalledTimes(1);
+
+    const opened = viewsOpen.mock.calls[0]?.[0];
+    const privateMetadata = opened?.view.private_metadata;
+    expect(opened?.triggerId).toBe("trigger-agent-factory-1");
+    expect(opened?.view).toMatchObject({
+      type: "modal",
+      callback_id: "agent_factory_create_modal",
+    });
+    expect(privateMetadata).toEqual(expect.any(String));
+    expect(JSON.parse(privateMetadata as string)).toMatchObject({
+      source: "slack.socket_mode.native_agent_factory",
+      accountId: "hana-slack",
+      instanceId: "hana-slack",
+      envelopeId: "env-agent-factory-open-1",
+      userId: "U123",
+      sourceChannelId: "CFACTORY",
+      sourceMessageTs: "1713000000.000100",
+    });
+  });
+
+  it("keeps agent factory modal open failures out of the delayed shell trigger path", async () => {
+    const workflowRoot = join(stateDir!, "workflow-root-failed-modal");
+    const workflowDir = join(workflowRoot, ".ravi", "workflows", "agent-factory");
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(
+      join(workflowDir, "modal-view.json"),
+      JSON.stringify({
+        type: "modal",
+        callback_id: "agent_factory_create_modal",
+        title: { type: "plain_text", text: "Novo agent" },
+        submit: { type: "plain_text", text: "Criar" },
+        blocks: [],
+      }),
+      "utf8",
+    );
+
+    dbCreateTrigger({
+      name: "agent factory open modal failure",
+      topic: "ravi.inbound.interaction",
+      message: "",
+      executionType: "shell",
+      shellCommand: `cd ${workflowRoot} && RAVI_SLACK_CONNECTION=hana-slack bun .ravi/workflows/agent-factory/handler.ts`,
+      filter:
+        'data.provider == "slack" && data.interactionType == "block_actions" && data.channelId == "CFAIL" && data.blockId == "agent_factory_actions" && data.actionId == "agent_factory_open_modal"',
+      session: "isolated",
+      cooldownMs: 1000,
+    });
+
+    const order: string[] = [];
+    const interactions: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+    const viewsOpen = mock(async () => {
+      order.push("views.open");
+      throw new Error("expired_trigger_id");
+    });
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "hana-slack",
+      routeAccountId: "hana-slack",
+      instanceId: "hana-slack",
+      getRouterConfig: () => ({
+        agents: {},
+        routes: [],
+        defaultAgent: "ravi-workflows",
+        defaultDmScope: "per-peer",
+        accountAgents: {},
+        instanceToAccount: {},
+        instances: {},
+      }),
+      publishInteraction: async (topic, payload) => {
+        order.push("publish");
+        interactions.push({ topic, payload });
+      },
+      webClient: { viewsOpen } as never,
+    });
+
+    const result = await service.handleEnvelope(
+      {
+        envelope_id: "env-agent-factory-open-failed-1",
+        payload: {
+          type: "block_actions",
+          team: { id: "T1" },
+          user: { id: "U123" },
+          channel: { id: "CFAIL" },
+          trigger_id: "trigger-agent-factory-expired-1",
+          container: {
+            type: "message",
+            channel_id: "CFAIL",
+            message_ts: "1713000000.000100",
+          },
+          message: {
+            ts: "1713000000.000100",
+          },
+          actions: [
+            {
+              type: "button",
+              block_id: "agent_factory_actions",
+              action_id: "agent_factory_open_modal",
+              action_ts: "1713000001.000200",
+            },
+          ],
+        },
+      },
+      async () => {
+        order.push("ack");
+      },
+    );
+
+    expect(result).toBe("processed");
+    expect(order).toEqual(["ack", "views.open"]);
+    expect(interactions).toHaveLength(0);
+  });
+
+  it("projects Slack modal private_metadata onto view submission interaction events", async () => {
+    const interactions: Array<{ topic: string; payload: Record<string, unknown> }> = [];
+    const service = new SlackSocketModeService({
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      accountId: "hana-slack",
+      routeAccountId: "hana-slack",
+      instanceId: "slack-instance-1",
+      getRouterConfig: () => ({
+        agents: {},
+        routes: [],
+        defaultAgent: "ravi-hil",
+        defaultDmScope: "per-peer",
+        accountAgents: {},
+        instanceToAccount: {},
+        instances: {},
+      }),
+      publishInteraction: async (topic, payload) => {
+        interactions.push({ topic, payload });
+      },
+      webClient: {} as never,
+    });
+
+    await expect(
+      service.handleEnvelope({
+        envelope_id: "env-view-submit-1",
+        payload: {
+          type: "view_submission",
+          team: { id: "T1" },
+          user: { id: "U123" },
+          view: {
+            id: "V123",
+            callback_id: "agent_factory_create_modal",
+            private_metadata: JSON.stringify({
+              sourceChannelId: "CFACTORY",
+              sourceMessageTs: "1713000000.000100",
+            }),
+            state: { values: {} },
+          },
+        },
+      }),
+    ).resolves.toBe("processed");
+
+    expect(interactions).toEqual([
+      {
+        topic: "ravi.inbound.interaction",
+        payload: expect.objectContaining({
+          provider: "slack",
+          source: "slack.socket_mode",
+          accountId: "hana-slack",
+          instanceId: "slack-instance-1",
+          envelopeId: "env-view-submit-1",
+          interactionType: "view_submission",
+          teamId: "T1",
+          userId: "U123",
+          viewId: "V123",
+          viewCallbackId: "agent_factory_create_modal",
+          viewPrivateMetadata: expect.any(String),
+          stateValues: {},
+        }),
+      },
+    ]);
   });
 
   it("publishes Slack Work Object link and detail events as inbound interactions", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve as resolvePathname } from "node:path";
 import { WebSocket as NodeWebSocket } from "ws";
 import { configStore } from "../../config-store.js";
 import {
@@ -9,6 +11,8 @@ import {
 } from "../../contacts.js";
 import { publish } from "../../nats.js";
 import { publishSessionPrompt } from "../../omni/session-stream.js";
+import { evaluateFilter } from "../../triggers/filter.js";
+import { dbListTriggers } from "../../triggers/triggers-db.js";
 import {
   attachChatToSession,
   commitMatchedRoute,
@@ -727,6 +731,7 @@ export class SlackSocketModeService {
 
     const interaction = this.normalizeInteractionEnvelope(envelope);
     if (interaction) {
+      if (await this.handleNativeImmediateInteraction(interaction)) return "processed";
       await this.publishInteraction("ravi.inbound.interaction", interaction);
       return "processed";
     }
@@ -1269,6 +1274,7 @@ export class SlackSocketModeService {
       containerType: stringField(container, "type"),
       viewId: stringField(view, "id"),
       viewCallbackId: stringField(view, "callback_id"),
+      viewPrivateMetadata: stringField(view, "private_metadata"),
       actionId: stringField(firstAction, "action_id"),
       blockId: stringField(firstAction, "block_id"),
       actionType: stringField(firstAction, "type"),
@@ -1282,6 +1288,50 @@ export class SlackSocketModeService {
         (Array.isArray(record.response_urls) && record.response_urls.length > 0),
       receivedAt: Date.now(),
     });
+  }
+
+  private async handleNativeImmediateInteraction(interaction: Record<string, unknown>): Promise<boolean> {
+    if (stringField(interaction, "interactionType") !== "block_actions") return false;
+    if (stringField(interaction, "actionId") !== "agent_factory_open_modal") return false;
+    if (stringField(interaction, "blockId") !== "agent_factory_actions") return false;
+
+    const triggerId = stringField(interaction, "triggerId");
+    if (!triggerId) {
+      log.warn("Slack agent factory modal action did not include a trigger_id", {
+        accountId: this.options.accountId,
+        channelId: stringField(interaction, "channelId"),
+      });
+      return true;
+    }
+
+    const modalViewFile = resolveAgentFactoryModalViewFile(interaction);
+    if (!modalViewFile) {
+      log.warn("Slack agent factory modal view file was not resolved", {
+        accountId: this.options.accountId,
+        channelId: stringField(interaction, "channelId"),
+      });
+      return false;
+    }
+
+    try {
+      const view = JSON.parse(readFileSync(modalViewFile, "utf8")) as Record<string, unknown>;
+      view.private_metadata = agentFactoryModalPrivateMetadata(interaction);
+      await this.webClient.viewsOpen({ triggerId, view });
+      log.info("Opened Slack agent factory modal through native immediate handler", {
+        accountId: this.options.accountId,
+        channelId: stringField(interaction, "channelId"),
+        modalViewFile,
+      });
+      return true;
+    } catch (error) {
+      log.warn("Slack native immediate modal handler failed; shell fallback skipped", {
+        accountId: this.options.accountId,
+        channelId: stringField(interaction, "channelId"),
+        modalViewFile,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return true;
+    }
   }
 
   private normalizeWorkObjectEventEnvelope(envelope: SlackSocketEnvelope): Record<string, unknown> | null {
@@ -2306,6 +2356,66 @@ function compactInteractionPayload(input: Record<string, unknown>): Record<strin
     if (value !== undefined && value !== null && value !== "") output[key] = value;
   }
   return output;
+}
+
+function resolveAgentFactoryModalViewFile(interaction: Record<string, unknown>): string | undefined {
+  const triggers = dbListTriggers({ enabledOnly: true });
+  for (const trigger of triggers) {
+    if (trigger.topic !== "ravi.inbound.interaction") continue;
+    if (trigger.executionType !== "shell") continue;
+    if (!trigger.shellCommand?.includes("agent-factory/handler.ts")) continue;
+    if (!evaluateFilter(trigger.filter, interaction)) continue;
+
+    const modalViewFile = modalViewFileFromAgentFactoryShellCommand(trigger.shellCommand);
+    if (modalViewFile && existsSync(modalViewFile)) return modalViewFile;
+  }
+  return undefined;
+}
+
+function modalViewFileFromAgentFactoryShellCommand(command: string): string | undefined {
+  const handlerToken = matchShellToken(command, /agent-factory\/handler\.ts$/);
+  if (!handlerToken) return undefined;
+
+  const cwd = parseShellCd(command) ?? process.cwd();
+  const handlerPath = isAbsolute(handlerToken) ? handlerToken : resolvePathname(cwd, handlerToken);
+  return join(dirname(handlerPath), "modal-view.json");
+}
+
+function parseShellCd(command: string): string | undefined {
+  const match = command.match(/(?:^|\s|&&|\|\|)cd\s+("[^"]+"|'[^']+'|[^\s;&|]+)/);
+  return match?.[1] ? unquoteShellToken(match[1]) : undefined;
+}
+
+function matchShellToken(command: string, predicate: RegExp): string | undefined {
+  for (const match of command.matchAll(/"[^"]+"|'[^']+'|[^\s;&|]+/g)) {
+    const token = unquoteShellToken(match[0] ?? "");
+    if (predicate.test(token)) return token;
+  }
+  return undefined;
+}
+
+function unquoteShellToken(token: string): string {
+  const trimmed = token.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function agentFactoryModalPrivateMetadata(interaction: Record<string, unknown>): string {
+  return JSON.stringify(
+    compactInteractionPayload({
+      source: "slack.socket_mode.native_agent_factory",
+      accountId: stringField(interaction, "accountId"),
+      instanceId: stringField(interaction, "instanceId"),
+      envelopeId: stringField(interaction, "envelopeId"),
+      userId: stringField(interaction, "userId"),
+      sourceChannelId: stringField(interaction, "channelId"),
+      sourceMessageTs: stringField(interaction, "messageTs"),
+      targetMessageId: stringField(interaction, "targetMessageId"),
+      createdAt: new Date().toISOString(),
+    }),
+  );
 }
 
 function syncSlackSessionSubscription(


### PR DESCRIPTION
## Summary
- open the Agent Factory modal directly inside Slack Socket Mode before publishing delayed interaction triggers
- resolve the workflow modal view from the matching enabled trigger command and preserve shell fallback when the workflow cannot be resolved
- project modal `private_metadata` onto normalized Slack interaction events for `view_submission`

## Why
Slack `trigger_id` expires quickly, so opening the modal from the existing shell trigger path can arrive too late and fail with `expired_trigger_id`.

## Validation
- `bun test src/channels/slack/socket-mode.test.ts`
- `bun tsc --noEmit`
- `bun run build:cli`
- `bunx biome check src/channels/slack/socket-mode.ts src/channels/slack/socket-mode.test.ts`
- pre-push checks passed

## Operational notes
- live `ravi-channels` was rebuilt and restarted from the updated bundle
- agent factory modal payload validated with `ravi slack blocks-validate --target view --channel hana-slack`
