### PR TITLE
fix(runtime): self-heal message delivery and Codex transport failures

### DIFF
--- a/src/channels/outbound-consumer.test.ts
+++ b/src/channels/outbound-consumer.test.ts
@@ -176,6 +176,38 @@ describe("channel outbound consumer", () => {
     );
   });
 
+  it("acknowledges permanent Slack text authentication failures instead of redelivering forever", async () => {
+    const emitEvent = mock(async () => {});
+    const delivery: NativeTextDelivery = {
+      channelId: "slack",
+      supports: () => true,
+      deliverText: mock(async () => {
+        throw new Error("Slack chat.postMessage failed: account_inactive");
+      }),
+    };
+
+    const result = await processChannelOutboundJob(makeJob(), {
+      deliveries: [delivery],
+      emitEvent,
+      persistDelivery: false,
+    });
+
+    expect(result).toMatchObject({
+      disposition: "ack",
+      status: "failed",
+      retryable: false,
+      phase: "send",
+    });
+    expect(emitEvent).toHaveBeenCalledWith(
+      "ravi.session.ravi-channels.delivery",
+      expect.objectContaining({
+        status: "failed",
+        retryable: false,
+        unavailableReasonCode: "missing_connection",
+      }),
+    );
+  });
+
   it("dispatches chat actions only through a matching native action adapter", async () => {
     const emitEvent = mock(async () => {});
     const actionDelivery = makeActionDelivery();

--- a/src/channels/outbound-consumer.ts
+++ b/src/channels/outbound-consumer.ts
@@ -579,7 +579,7 @@ function classifyNativeOutboundFailure(
   retryable: boolean;
   reasonCode?: "missing_connection" | "missing_scope" | "permission_denied" | "invalid_target";
 } {
-  if (job.request.content.type !== "chat_action" || job.request.channelId.toLowerCase() !== "slack") {
+  if (job.request.channelId.toLowerCase() !== "slack") {
     return { retryable: true };
   }
   const normalized = message.toLowerCase();

--- a/src/ci/quality-gate.test.ts
+++ b/src/ci/quality-gate.test.ts
@@ -327,6 +327,13 @@ describe("runCoverageGate", () => {
     expect(result.triggeredPrefixes).toEqual(["src/runtime/"]);
   });
 
+  it("accepts the focused outbound consumer regression for channel delivery changes", () => {
+    const result = runCoverageGate(["src/channels/outbound-consumer.ts", "src/channels/outbound-consumer.test.ts"]);
+
+    expect(result.ok).toBe(true);
+    expect(result.triggeredPrefixes).toEqual(["src/channels/"]);
+  });
+
   it("requires a focused native channel test in the diff", () => {
     const missing = runCoverageGate(["src/channels/slack/socket-mode.ts"]);
     const covered = runCoverageGate(["src/channels/slack/socket-mode.ts", "src/channels/slack/socket-mode.test.ts"]);

--- a/src/ci/quality-gate.ts
+++ b/src/ci/quality-gate.ts
@@ -25,6 +25,7 @@ export const RUNTIME_PATH_MAP: Record<string, string[]> = {
   "src/channels/": [
     "src/channels/backend.test.ts",
     "src/channels/health.test.ts",
+    "src/channels/outbound-consumer.test.ts",
     "src/channels/runtime-events.test.ts",
     "src/channels/runner.test.ts",
     "src/channels/session-prompt.test.ts",

--- a/src/omni/session-stream.test.ts
+++ b/src/omni/session-stream.test.ts
@@ -73,7 +73,7 @@ describe("session prompt JetStream infrastructure", () => {
     await ensureSessionPromptInfrastructure(currentJsm as never);
     await ensureSessionPromptInfrastructure(currentJsm as never);
 
-    expect(streamInfo).toHaveBeenCalledTimes(1);
+    expect(streamInfo).toHaveBeenCalledTimes(2);
     expect(consumerInfo).toHaveBeenCalledTimes(1);
   });
 
@@ -95,7 +95,7 @@ describe("session prompt JetStream infrastructure", () => {
     await ensureSessionPromptInfrastructure(currentJsm as never);
     await ensureSessionPromptInfrastructure(currentJsm as never, { force: true });
 
-    expect(streamInfo).toHaveBeenCalledTimes(2);
+    expect(streamInfo).toHaveBeenCalledTimes(4);
     expect(consumerInfo).toHaveBeenCalledTimes(2);
   });
 
@@ -143,6 +143,26 @@ describe("session prompt JetStream infrastructure", () => {
 
     expect(consumerAdd).toHaveBeenCalledTimes(1);
     expect(consumerInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("recreates a stale consumer when its sequence is ahead of the stream", async () => {
+    const consumerDelete = mock(async () => true);
+    const consumerAdd = mock(async () => ({}));
+    currentJsm = makePromptJsm({
+      streams: {
+        info: mock(async () => ({ state: { last_seq: 16 } })),
+      },
+      consumers: {
+        info: mock(async () => ({ ack_floor: { stream_seq: 3_276 }, delivered: { stream_seq: 3_276 } })),
+        delete: consumerDelete,
+        add: consumerAdd,
+      },
+    });
+
+    await ensureSessionConsumer(currentJsm as never);
+
+    expect(consumerDelete).toHaveBeenCalledWith("SESSION_PROMPTS", "ravi-prompts");
+    expect(consumerAdd).toHaveBeenCalledTimes(1);
   });
 
   it("announces a sourced prompt to the runtime after its durable publish", async () => {

--- a/src/omni/session-stream.ts
+++ b/src/omni/session-stream.ts
@@ -147,11 +147,22 @@ export async function ensureSessionConsumer(jsm: JetStreamManager): Promise<void
   await ensureLegacyConsumersCleaned(jsm);
 
   try {
-    await jsm.consumers.info(SESSION_STREAM, CONSUMER_NAME);
-    log.debug("Session consumer already exists", { consumerName: CONSUMER_NAME });
-    return;
-  } catch {
-    // Consumer doesn't exist — create it
+    const consumerInfo = await jsm.consumers.info(SESSION_STREAM, CONSUMER_NAME);
+    const streamInfo = await jsm.streams.info(SESSION_STREAM);
+    if (isStaleSessionConsumer(consumerInfo, streamInfo)) {
+      log.warn("Deleting stale session prompt consumer", {
+        consumerName: CONSUMER_NAME,
+        consumerStreamSeq: maxConsumerStreamSeq(consumerInfo),
+        streamLastSeq: streamLastSeq(streamInfo),
+      });
+      await jsm.consumers.delete(SESSION_STREAM, CONSUMER_NAME);
+    } else {
+      log.debug("Session consumer already exists", { consumerName: CONSUMER_NAME });
+      return;
+    }
+  } catch (err) {
+    if (!isNotFoundError(err)) throw err;
+    // Consumer doesn't exist — create it.
   }
 
   try {
@@ -308,6 +319,34 @@ async function ensureConsumerExistsAfterRace(jsm: JetStreamManager, originalErro
 function isNotFoundError(err: unknown): boolean {
   const message = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
   return message.includes("not found") || message.includes("deleted");
+}
+
+function isStaleSessionConsumer(consumerInfo: unknown, streamInfo: unknown): boolean {
+  const consumerSeq = maxConsumerStreamSeq(consumerInfo);
+  const lastSeq = streamLastSeq(streamInfo);
+  return consumerSeq > 0 && lastSeq >= 0 && consumerSeq > lastSeq;
+}
+
+function maxConsumerStreamSeq(info: unknown): number {
+  const record = info as {
+    ack_floor?: { stream_seq?: unknown };
+    delivered?: { stream_seq?: unknown };
+  };
+  return Math.max(toNumber(record.ack_floor?.stream_seq), toNumber(record.delivered?.stream_seq));
+}
+
+function streamLastSeq(info: unknown): number {
+  const record = info as { state?: { last_seq?: unknown } };
+  return toNumber(record.state?.last_seq, -1);
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
 }
 
 function isPromptPublishInfrastructureError(err: unknown): boolean {

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -1242,6 +1242,27 @@ process.on("SIGTERM", () => {
     ).toEqual(["rctx_first", "rctx_second"]);
   });
 
+  it("classifies a clean exit without a terminal event as a recoverable transport failure", async () => {
+    const { transport } = createMockTransport([
+      () => ({
+        events: (async function* () {})(),
+        result: Promise.resolve({ exitCode: 0, signal: null, stderr: "" }),
+      }),
+    ]);
+    const provider = createCodexRuntimeProvider({ transport: transport as any, defaultModel: "gpt-5" });
+    const session = provider.startSession(makeStartRequest(["retry me"]));
+
+    const events = await collectEvents(session.events);
+
+    expect(findEventsByType(events, "turn.failed")).toEqual([
+      expect.objectContaining({
+        error: "Codex CLI exited without a terminal event (code 0)",
+        recoverable: true,
+        failureKind: "transport",
+      }),
+    ]);
+  });
+
   it("maps CLI completion events and composes prompts with system instructions", async () => {
     const { calls, transport } = createMockTransport([
       () => ({

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -865,6 +865,7 @@ async function* normalizeCodexEvents(
         }
 
         const stderrMessage = result.stderr.trim();
+        const missingTerminalEvent = !lastErrorMessage && !stderrMessage;
         const metadata = buildCodexEventMetadata(
           { type: "turn.failed", thread_id: turnSessionId, turn_id: activeTurnId },
           { threadId: turnSessionId, turnId: activeTurnId },
@@ -874,6 +875,7 @@ async function* normalizeCodexEvents(
             lastErrorMessage ??
             (stderrMessage || `Codex CLI exited without a terminal event (code ${result.exitCode ?? "unknown"})`),
           recoverable: true,
+          failureKind: missingTerminalEvent ? "transport" : undefined,
           metadata,
         });
         if (terminal) {
@@ -1020,7 +1022,18 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     pendingRequests.clear();
   };
 
-  const handleChildTermination = (exitCode: number | null, signal: NodeJS.Signals | null, error?: Error) => {
+  const handleChildTermination = (
+    expectedTransport: CodexTransport,
+    exitCode: number | null,
+    signal: NodeJS.Signals | null,
+    error?: Error,
+  ) => {
+    // A planned env refresh replaces the process and transport. Late close or
+    // websocket callbacks from the retired generation must not tear down or
+    // fail the turn already owned by its replacement.
+    if (transport !== expectedTransport) {
+      return;
+    }
     if (closed && child === null && transport === null) {
       // Already cleaned up — guard against duplicate close/error events from
       // both the child process and the websocket layer.
@@ -1073,6 +1086,9 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
       cwd: input.cwd,
       env: spawnEnv,
       onMessage: (line: string) => {
+        if (transport !== newTransport || intentionalChildRestart) {
+          return;
+        }
         try {
           const parsed = JSON.parse(line) as CodexJsonRpcMessage;
           routeAppServerMessage(parsed);
@@ -1084,6 +1100,9 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
         }
       },
       onTransportError: (error) => {
+        if (transport !== newTransport || intentionalChildRestart) {
+          return;
+        }
         if (activeTurn) {
           settleTurn(activeTurn, { exitCode: 1, stderr: getStderr() }, { failQueue: error });
         }
@@ -1103,11 +1122,11 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     log.info("codex spawn", { pid: newTransport.child.pid, transport: newTransport.kind });
 
     newTransport.child.on("error", (error) => {
-      handleChildTermination(1, null, error);
+      handleChildTermination(newTransport, 1, null, error);
     });
 
     newTransport.child.on("close", (exitCode, signal) => {
-      handleChildTermination(exitCode, signal);
+      handleChildTermination(newTransport, exitCode, signal);
     });
 
     // For WebSocket transport, we must wait for the listener to be ready
@@ -1115,7 +1134,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     try {
       await newTransport.ready;
     } catch (error) {
-      handleChildTermination(1, null, error instanceof Error ? error : new Error(String(error)));
+      handleChildTermination(newTransport, 1, null, error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
   };

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -98,6 +98,7 @@ const MAX_OUTPUT_LENGTH = 1000;
 const MAX_TURN_FAILURE_LOG_DETAIL = 1800;
 const PROVIDER_INACTIVE_AFTER_TOOL_REASON = "provider_inactive";
 const PROVIDER_TURN_INACTIVITY_REASON = "provider_turn_inactive";
+const PROVIDER_TRANSPORT_FAILURE_REASON = "provider_transport_failure";
 const TOOL_INACTIVITY_REASON = "tool_inactive";
 const IDLE_SESSION_TTL_REASON = "idle_session_ttl";
 const RUNTIME_SESSION_CLOSE_TIMEOUT_MS = 5_000;
@@ -2032,9 +2033,16 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
               const interruptedRecoverable = streaming.interrupted && isRecoverableInterruptionFailure(event);
               const internalAbortReason = streaming.internalAbortReason;
               const internalRecoverable = Boolean(internalAbortReason) && isRecoverableInterruptionFailure(event);
+              const transportRecoverable =
+                event.recoverable !== false &&
+                event.failureKind === "transport" &&
+                getRuntimeTurnReplaySafety(streaming, crashRecovery).replayable;
               return {
                 internalAbortReason,
-                suppressedRecoverable: interruptedRecoverable || internalRecoverable,
+                suppressedRecoverable: interruptedRecoverable || internalRecoverable || transportRecoverable,
+                recoveryReason: transportRecoverable
+                  ? PROVIDER_TRANSPORT_FAILURE_REASON
+                  : (internalAbortReason ?? "recoverable_interrupt_failure"),
               };
             })()
           : undefined;
@@ -2887,6 +2895,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
 
       if (event.type === "turn.failed") {
         const internalAbortReason = receivedFailureClassification?.internalAbortReason;
+        const recoveryReason = receivedFailureClassification?.recoveryReason;
         const suppressedRecoverable = receivedFailureClassification?.suppressedRecoverable ?? false;
         const rawEventSummary = summarizeRuntimeFailureRawEvent(event.rawEvent);
         const currentTurnReplaySafety = getRuntimeTurnReplaySafety(streaming, crashRecovery);
@@ -2925,7 +2934,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           await emitRuntimeEvent({
             type: "turn.interrupted",
             provider: runtimeSession.provider,
-            reason: internalAbortReason ?? "recoverable_interrupt_failure",
+            reason: recoveryReason,
             metadata: event.metadata,
           });
           await releasePendingProviderRawEvent(correlatedProviderRawEvent);
@@ -2933,7 +2942,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           recordTerminalTraceOnce({
             status: "interrupted",
             eventType: "turn.interrupted",
-            abortReason: internalAbortReason ?? "recoverable_interrupt_failure",
+            abortReason: recoveryReason,
             error: null,
             payloadJson: {
               recoverable: event.recoverable ?? true,
@@ -2948,7 +2957,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
             recoverable: event.recoverable ?? true,
             suppressedRecoverable,
             error: null,
-            abortReason: internalAbortReason ?? "recoverable_interrupt_failure",
+            abortReason: recoveryReason,
           });
         }
 
@@ -2963,7 +2972,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         streaming.internalAbortReason = undefined;
 
         if (suppressedRecoverable) {
-          const restartReason = internalAbortReason ?? "recoverable_interrupt_failure";
+          const restartReason = recoveryReason ?? "recoverable_interrupt_failure";
           markRuntimeLiveIdle(sessionName, "turn interrupted");
           log.info("Suppressing recoverable interrupted turn failure", {
             runId,

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -606,6 +606,59 @@ describe("RuntimeSessionDispatcher runtime recovery", () => {
       }),
     ]);
   });
+
+  it("bounds recoverable provider transport restarts", async () => {
+    const emitted: Array<{ topic: string; data: Record<string, unknown> }> = [];
+    const alerts: RuntimeRecoveryExhaustedAlertInput[] = [];
+    const dispatcher = new RuntimeSessionDispatcher({
+      instanceId: "test",
+      maxConcurrentSessions: 10,
+      interactiveReservedSessions: 0,
+      safeEmit: async (topic, data) => {
+        emitted.push({ topic, data });
+      },
+      notifyRuntimeRecoveryExhausted: async (input) => {
+        alerts.push(input);
+      },
+      getConfigModel: () => "test-model",
+      crashRecovery: crashRecoveryStub,
+    });
+    dispatcher.stashedMessages.set("transport-failure", [
+      createQueuedRuntimeUserMessage({ prompt: "retry transport", _agentId: "main" }),
+    ]);
+
+    let starts = 0;
+    dispatcher.startStreamingSession = mock(async () => {
+      starts++;
+    });
+    const recovery = dispatcher as unknown as {
+      restartStashedSession(sessionName: string, reason: string): Promise<void>;
+    };
+
+    await recovery.restartStashedSession("transport-failure", "provider_transport_failure");
+    await recovery.restartStashedSession("transport-failure", "provider_transport_failure");
+    await recovery.restartStashedSession("transport-failure", "provider_transport_failure");
+
+    expect(starts).toBe(2);
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        sessionName: "transport-failure",
+        reason: "provider_transport_failure",
+        restartAttempts: 2,
+      }),
+    ]);
+    expect(emitted).toEqual([
+      expect.objectContaining({
+        topic: "ravi.session.transport-failure.runtime",
+        data: expect.objectContaining({
+          type: "dispatch.restart_suppressed",
+          reason: "provider_transport_failure",
+          restartAttempts: 2,
+          userResponseSuppressed: true,
+        }),
+      }),
+    ]);
+  });
 });
 
 describe("RuntimeSessionDispatcher native runtime steer", () => {

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -84,11 +84,14 @@ import {
 const log = logger.child("runtime:session-dispatcher");
 const RUNTIME_EVENT_LOOP_CLOSED_REASON = "runtime_event_loop_closed";
 const PROVIDER_TURN_INACTIVE_REASON = "provider_turn_inactive";
+const PROVIDER_TRANSPORT_FAILURE_REASON = "provider_transport_failure";
 const MAX_RUNTIME_EVENT_LOOP_RESTARTS = 2;
 const MAX_PROVIDER_TURN_INACTIVE_RESTARTS = 1;
+const MAX_PROVIDER_TRANSPORT_FAILURE_RESTARTS = 2;
 const RUNTIME_RECOVERY_RESTART_LIMITS: Readonly<Partial<Record<string, number>>> = {
   [RUNTIME_EVENT_LOOP_CLOSED_REASON]: MAX_RUNTIME_EVENT_LOOP_RESTARTS,
   [PROVIDER_TURN_INACTIVE_REASON]: MAX_PROVIDER_TURN_INACTIVE_RESTARTS,
+  [PROVIDER_TRANSPORT_FAILURE_REASON]: MAX_PROVIDER_TRANSPORT_FAILURE_RESTARTS,
 };
 const RUNTIME_RESTART_EXHAUSTED_ERROR =
   "Runtime provider stream closed repeatedly. Automatic recovery was stopped; send a new message to retry.";

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1148,9 +1148,10 @@ describe("runtime session trace instrumentation", () => {
       materializedOutput: false,
     });
     expect(getRuntimeLiveStateForSession(makeSession())?.loadedSkills).toEqual(["trace-skill"]);
-    expect(
-      (getSession(SESSION_KEY)?.runtimeSessionParams?.skillVisibility as RuntimeSkillVisibilitySnapshot).loadedSkills,
-    ).toEqual(["trace-skill"]);
+    const persistedSkillVisibility = getSession(SESSION_KEY)?.runtimeSessionParams?.skillVisibility as
+      | RuntimeSkillVisibilitySnapshot
+      | undefined;
+    expect(persistedSkillVisibility?.loadedSkills).toEqual(["trace-skill"]);
     expect(events[1]).toMatchObject({
       eventType: "tool.start",
       canonicalChatId: "chat_1",
@@ -3428,6 +3429,86 @@ describe("runtime session trace instrumentation", () => {
       },
     ]);
     expect(streaming.done).toBe(true);
+  });
+
+  it("replays a recoverable provider transport failure before any effect instead of exposing INTERNAL", async () => {
+    const queued = createQueuedRuntimeUserMessage({
+      prompt: "survive a transient websocket close",
+      deliveryBarrier: "after_tool",
+      source,
+      _agentId: AGENT_ID,
+    });
+    const streaming = makeStreamingSession({
+      pendingMessages: [queued],
+      currentTurnPendingIds: queued.pendingId ? [queued.pendingId] : [],
+    });
+    seedAdapterTrace(streaming, "turn-transport-failure-before-effect");
+    const stashedMessages = new Map<string, RuntimeUserMessage[]>();
+    const restartRequests: Array<{ sessionName: string; reason: string }> = [];
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        {
+          type: "turn.failed",
+          error: "Codex CLI exited without a terminal event (code 0)",
+          recoverable: true,
+          failureKind: "transport",
+        },
+      ]),
+      {
+        stashedMessages,
+        restartStashedSession: async (input) => {
+          restartRequests.push(input);
+        },
+      },
+    );
+
+    expect(stashedMessages.get(SESSION_NAME)?.map((message) => message.message.content)).toEqual([
+      "survive a transient websocket close",
+    ]);
+    expect(restartRequests).toEqual([{ sessionName: SESSION_NAME, reason: "provider_transport_failure" }]);
+    expect(streaming.done).toBe(true);
+  });
+
+  it("does not replay a provider transport failure after a tool effect", async () => {
+    const queued = createQueuedRuntimeUserMessage({
+      prompt: "do not duplicate this effect",
+      deliveryBarrier: "after_tool",
+      source,
+      _agentId: AGENT_ID,
+    });
+    const streaming = makeStreamingSession({
+      pendingMessages: [queued],
+      currentTurnPendingIds: queued.pendingId ? [queued.pendingId] : [],
+    });
+    seedAdapterTrace(streaming, "turn-transport-failure-after-effect");
+    const attemptId = streaming.currentCrashRecoveryAttemptId!;
+    crashRecovery.markTurnAttemptSafety({ attemptId, startedTool: true });
+    const stashedMessages = new Map<string, RuntimeUserMessage[]>();
+    const restartRequests: Array<{ sessionName: string; reason: string }> = [];
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        {
+          type: "turn.failed",
+          error: "Codex CLI exited without a terminal event (code 0)",
+          recoverable: true,
+          failureKind: "transport",
+        },
+      ]),
+      {
+        stashedMessages,
+        restartStashedSession: async (input) => {
+          restartRequests.push(input);
+        },
+      },
+    );
+
+    expect(stashedMessages.get(SESSION_NAME)).toBeUndefined();
+    expect(restartRequests).toEqual([]);
+    expect(getRuntimeTurnAttempt(attemptId)).toMatchObject({ status: "failed", startedTool: true });
   });
 
   it("does not remove a replacement runtime when the previous event loop exits", async () => {

--- a/src/runtime/terminality.ts
+++ b/src/runtime/terminality.ts
@@ -12,6 +12,7 @@ export function isRuntimeTerminalEvent(event: RuntimeEvent): event is RuntimeTer
 export interface RuntimeFailedTerminalInput {
   error: string;
   recoverable?: boolean;
+  failureKind?: "transport";
   rawEvent?: Record<string, unknown>;
   metadata?: RuntimeEventMetadata;
 }
@@ -54,6 +55,7 @@ export function createRuntimeTerminalEventTracker(): RuntimeTerminalEventTracker
         type: "turn.failed",
         error: input.error,
         recoverable: input.recoverable,
+        ...(input.failureKind ? { failureKind: input.failureKind } : {}),
         ...(input.rawEvent ? { rawEvent: input.rawEvent } : {}),
         ...(input.metadata ? { metadata: input.metadata } : {}),
       };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -527,6 +527,8 @@ export type RuntimeEvent =
       type: "turn.failed";
       error: string;
       recoverable?: boolean;
+      /** Canonical failure class used by the host to apply bounded, replay-safe recovery. */
+      failureKind?: "transport";
       rawEvent?: Record<string, unknown>;
     } & RuntimeEventBase)
   | ({


### PR DESCRIPTION
## Objective

Prevent the production no-response and INTERNAL failure chain across prompt intake, outbound delivery, and Codex transport recovery.

## Problem

- SESSION_PROMPTS could restore ravi-prompts with an ACK floor ahead of the stream, leaving accepted Slack messages permanently unconsumed.
- Permanent Slack authentication failures such as account_inactive were retried forever for text messages, accumulating poison outbound jobs.
- During a planned Codex app-server respawn, late callbacks from the retired transport could affect the replacement turn.
- A clean Codex exit without a terminal event was marked recoverable by the provider but still surfaced as Unable to complete the request (INTERNAL) instead of replaying safe input.

## Solution

- Detect impossible SESSION_PROMPTS consumer sequence state and recreate only the stale durable consumer.
- Apply permanent Slack error classification to every Slack content type, including text.
- Fence Codex transport callbacks by transport generation and ignore callbacks during intentional process replacement.
- Add a canonical transport failure kind to provider terminal events.
- Replay transport failures only when the durable turn safety ledger proves no tool or output effect occurred.
- Bound transport recovery to two restarts and suppress technical channel errors when recovery is exhausted.
- Teach the quality gate to recognize the focused outbound consumer regression.

## Practical impact

- Prompt intake self-heals after the JetStream metadata mismatch seen in production.
- Inactive Slack accounts no longer create endlessly redelivered text jobs.
- Transient Codex websocket or missing-terminal failures no longer become user-facing INTERNAL errors before effects; the exact queued request is retried on a fresh runtime.
- Turns that may already have produced effects remain fail-closed and are never blindly replayed.

## What does NOT change

- Healthy JetStream consumers are not recreated.
- Retryable Slack failures still redeliver.
- Provider failures with concrete stderr or provider error content are not mislabeled as transport failures.
- Unsafe turns after tools or durable output are not replayed.

## Validation

- Added the production stale-sequence regression with consumer sequence 3276 and stream sequence 16.
- Added permanent Slack text authentication failure coverage.
- Added Codex missing-terminal classification, replay-before-effect, no-replay-after-effect, bounded-restart, and environment respawn coverage.
- Focused runtime suites: 169 passed, 0 failed.
- Channel runtime projection retry: 16 passed, 0 failed.
- Typecheck passed.
- Local quality gate passed.
- Full pre-push suite is executed before the branch update.

## Risks

- Safe transport replay can repeat provider computation, but only while the durable safety ledger proves no tool or materialized output crossed the effect fence.
- Recovery is capped at two restarts; exhaustion remains operator-visible while the user-facing technical error stays suppressed.

## Rollback

- Revert commits 3f53bec5, c83bc78a, 823a16cf, and f6e796ef independently for prompt recovery, Slack classification, transport recovery, and CI coverage mapping.

## Follow-ups

- Monitor provider_transport_failure restart and exhaustion events after deployment to tune the bounded retry count if production evidence warrants it.