### PR TITLE
fix(cli): always include user_code in Cloud login authorize URL

### DIFF
--- a/.ravi/specs/cli/cloud-auth/CHECKS.md
+++ b/.ravi/specs/cli/cloud-auth/CHECKS.md
@@ -24,6 +24,9 @@ ravi whoami --json
 Expected:
 
 - auth completes through browser/device flow;
+- the printed Verification URL and JSON `auth.authorizationUrl` /
+  `auth.verificationUriComplete` include `?user_code=<issued-code>`;
+- the bare `/cli/authorize` URL is never presented as the link to open;
 - `whoami` returns user, organization, installation, scopes, and expiry;
 - no raw token appears in stdout/stderr.
 

--- a/.ravi/specs/cli/cloud-auth/RUNBOOK.md
+++ b/.ravi/specs/cli/cloud-auth/RUNBOOK.md
@@ -9,7 +9,12 @@ ravi login --console https://console.ravi.bot --json
 Check:
 
 - Console auth config endpoint is reachable.
-- Browser/device verification URL is shown.
+- Browser/device verification URL is shown and already includes
+  `?user_code=<issued-code>` (example shape:
+  `https://console.ravi.bot/cli/authorize?user_code=<CODE>`).
+- JSON `auth.authorizationUrl` / `auth.verificationUriComplete` match that
+  complete URL. Do not open the bare `/cli/authorize` page; it does not bind
+  the pending device grant.
 - CLI does not require a client secret.
 - Exchange endpoint returns Ravi CLI credentials.
 - Credentials are stored outside stdout.

--- a/.ravi/specs/cli/cloud-auth/SPEC.md
+++ b/.ravi/specs/cli/cloud-auth/SPEC.md
@@ -74,13 +74,28 @@ Commands consumed by agents MUST support `--json`.
 `ravi login` SHOULD open a browser when possible and MUST also print a fallback
 verification URL/code for headless or remote environments.
 
+When Console issues a device `user_code`, the URL that humans and agents open
+MUST already include it as the `user_code` query parameter:
+
+`https://<console>/cli/authorize?user_code=<CODE>`
+
+The CLI MUST NOT present the bare `/cli/authorize` page as the link to open.
+That page does not bind the pending device grant. If Console omits
+`verification_uri_complete`, the CLI MUST construct it from `verification_uri`
+plus the issued `user_code` (URL-encoded). The printed code MAY still be shown
+as a fallback, but the URL itself MUST already contain it.
+
+`--json` MUST expose the same complete URL on `auth.authorizationUrl` and any
+other URL field agents copy (`verificationUriComplete`, `verificationUri`).
+
 ## Auth Flow
 
 The CLI SHOULD implement a browser/device OAuth flow:
 
 1. Fetch public auth config from Console.
 2. Start provider login using public client metadata.
-3. Display verification URL and user code when provided.
+3. Display the complete verification URL (with `user_code`) and the user code
+   when provided.
 4. Poll or receive completion according to the provider flow.
 5. Send the provider access token to the Console exchange endpoint.
 6. Store only Ravi-owned CLI credentials returned by Console.
@@ -170,6 +185,10 @@ safe error code.
 ## Acceptance Criteria
 
 - `ravi login` can link a local CLI without storing provider or browser secrets.
+- `ravi login` human output and `--json` expose
+  `https://<console>/cli/authorize?user_code=<CODE>` as the URL to open whenever
+  a device `user_code` exists. The bare `/cli/authorize` URL is never the link
+  to follow.
 - `ravi login --help` identifies the Console contract and default, does not
   expose `--endpoint`, and the root command does not expose a product-linking
   command.

--- a/.ravi/specs/cli/cloud-auth/WHY.md
+++ b/.ravi/specs/cli/cloud-auth/WHY.md
@@ -19,6 +19,13 @@ semantics.
 The CLI should prove the human through the browser, then operate with CLI
 credentials issued for that local installation.
 
+The complete authorize URL must carry `user_code`. Console's bare
+`/cli/authorize` page does not attach the pending device grant, so a human or
+agent who opens that page can approve a session the CLI will never receive.
+Printing the code on a separate line is not enough: operators and agents copy
+the first URL they see. If Console omits `verification_uri_complete`, the CLI
+must add `user_code` itself rather than falling back to the bare URI.
+
 ## Why Keep Local Artifacts Offline-Capable
 
 Artifacts are a Ravi primitive. Cloud publishing is an extension of that

--- a/src/cli/commands/cloud-auth.test.ts
+++ b/src/cli/commands/cloud-auth.test.ts
@@ -114,9 +114,103 @@ describe("cloud auth root command handlers", () => {
     });
     expect(payload.session.accessTokenExpiresAt).toBe("2026-05-10T00:00:00.000Z");
     expect(payload.auth.authorizationUrl).toBe("https://console.example/device?user_code=ABC");
+    expect(payload.auth.verificationUriComplete).toBe("https://console.example/device?user_code=ABC");
+    expect(payload.auth.verificationUri).toBe("https://console.example/device?user_code=ABC");
+    expect(new URL(payload.auth.authorizationUrl).searchParams.get("user_code")).toBe("ABC");
     expect(encoded).not.toContain("login-access-secret");
     expect(encoded).not.toContain("login-refresh-secret");
     expect(encoded).not.toContain("provider-secret");
+  });
+
+  it("prints and opens the authorize URL with user_code even when Console omits the complete URI", async () => {
+    const opened: string[] = [];
+    const client = {
+      getAuthConfig: mock(async () => ({
+        configured: true,
+        clientId: "ravi-cli",
+        mode: "console_device",
+        endpoints: {
+          deviceAuthorization: "https://console.example/api/cli/auth/device",
+          token: null,
+        },
+      })),
+      startDeviceAuthorization: mock(async () => ({
+        verificationUri: "https://console.example/cli/authorize",
+        userCode: "ABCD-EFGH",
+        deviceCode: "device-secret",
+        interval: 1,
+      })),
+      exchange: mock(async (input: CredentialExchangeInput) => ({
+        ...makeCredentials(),
+        installationId: input.installationId,
+      })),
+    } as unknown as ConsoleApiClient;
+
+    const { output } = await captureConsole(() =>
+      runLogin(
+        { console: "https://console.example", open: true, poll: false },
+        {
+          client,
+          readCredentials: () => null,
+          writeCredentials: () => {},
+          openExternal: (url) => {
+            opened.push(url);
+          },
+        },
+      ),
+    );
+
+    const completeUrl = "https://console.example/cli/authorize?user_code=ABCD-EFGH";
+    expect(opened).toEqual([completeUrl]);
+    expect(output).toContain(`Verification URL: ${completeUrl}`);
+    expect(output).toContain("Code: ABCD-EFGH");
+    expect(output).not.toMatch(/Verification URL: https:\/\/console\.example\/cli\/authorize$/m);
+  });
+
+  it("returns the complete authorize URL from JSON login when only the bare verification URI is present", async () => {
+    const client = {
+      getAuthConfig: mock(async () => ({
+        configured: true,
+        clientId: "ravi-cli",
+        mode: "console_device",
+        endpoints: {
+          deviceAuthorization: "https://console.example/api/cli/auth/device",
+          token: null,
+        },
+      })),
+      startDeviceAuthorization: mock(async () => ({
+        verificationUriComplete: "https://console.example/cli/authorize",
+        verificationUri: "https://console.example/cli/authorize",
+        userCode: "ABCD-EFGH",
+        deviceCode: "device-secret",
+        interval: 1,
+      })),
+      exchange: mock(async (input: CredentialExchangeInput) => ({
+        ...makeCredentials(),
+        installationId: input.installationId,
+      })),
+    } as unknown as ConsoleApiClient;
+
+    const { output } = await captureConsole(() =>
+      runLogin(
+        { console: "https://console.example", json: true, open: false, poll: false },
+        {
+          client,
+          readCredentials: () => null,
+          writeCredentials: () => {},
+        },
+      ),
+    );
+    const payload = JSON.parse(output);
+    const completeUrl = "https://console.example/cli/authorize?user_code=ABCD-EFGH";
+
+    expect(payload.auth.authorizationUrl).toBe(completeUrl);
+    expect(payload.auth.verificationUriComplete).toBe(completeUrl);
+    expect(payload.auth.verificationUri).toBe(completeUrl);
+    expect(payload.auth.userCode).toBe("ABCD-EFGH");
+    expect(new URL(payload.auth.authorizationUrl).searchParams.get("user_code")).toBe("ABCD-EFGH");
+    expect(payload.auth.authorizationUrl).not.toBe("https://console.example/cli/authorize");
+    expect(payload.auth.verificationUri).not.toBe("https://console.example/cli/authorize");
   });
 
   it("revokes on logout, deletes local credentials, and redacts JSON output", async () => {

--- a/src/cli/commands/cloud-auth.ts
+++ b/src/cli/commands/cloud-auth.ts
@@ -17,6 +17,7 @@ import {
 } from "../../cloud-auth/storage.js";
 import type { CloudCredentials, ConsoleAuthConfig, ConsoleMeResponse } from "../../cloud-auth/types.js";
 import { DEFAULT_CONSOLE_URL } from "../../cloud-auth/types.js";
+import { completeVerificationUri } from "../../cloud-auth/verification-uri.js";
 
 export interface CloudLoginOptions {
   console?: string;
@@ -58,9 +59,8 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
   const installationId = existing?.consoleUrl === consoleUrl ? existing.installationId : crypto.randomUUID();
   const config = await client.getAuthConfig();
   const deviceAuth = await client.startDeviceAuthorization(config);
-  const authUrl = deviceAuth.verificationUriComplete;
-  const verificationUrl = deviceAuth.verificationUri;
   const userCode = deviceAuth.userCode;
+  const authUrl = resolveAuthorizeUrl(deviceAuth, config);
   const openBrowser = options.open !== false;
 
   if (authUrl && openBrowser) {
@@ -72,7 +72,7 @@ export async function runLogin(options: CloudLoginOptions = {}, deps: CloudAuthC
   }
 
   if (!options.json) {
-    printLoginStart({ consoleUrl, authUrl, verificationUrl, userCode, openBrowser });
+    printLoginStart({ consoleUrl, authUrl, userCode, openBrowser });
   }
 
   const credentials = await exchangeUntilComplete({
@@ -312,32 +312,52 @@ function safeAuthConfig(
     interval?: number | null;
   },
 ): Record<string, unknown> {
+  const authorizationUrl = resolveAuthorizeUrl(deviceAuth, config);
   return redactCloudAuthPayload({
     provider: config.provider ?? null,
-    authorizationUrl: firstString(
-      deviceAuth?.verificationUriComplete,
-      config.verificationUriComplete,
-      config.authorizationUrl,
-      config.authUrl,
-      config.loginUrl,
-    ),
-    verificationUri: firstString(deviceAuth?.verificationUri, config.verificationUri, config.verificationUrl),
+    authorizationUrl,
+    verificationUriComplete: authorizationUrl,
+    verificationUri: authorizationUrl,
     userCode: firstString(deviceAuth?.userCode, config.userCode),
     expiresIn: deviceAuth?.expiresIn ?? config.expiresIn ?? null,
     interval: deviceAuth?.interval ?? config.interval ?? null,
   });
 }
 
+function resolveAuthorizeUrl(
+  deviceAuth:
+    | {
+        verificationUriComplete?: string;
+        verificationUri?: string;
+        userCode?: string;
+      }
+    | undefined,
+  config: ConsoleAuthConfig,
+): string | undefined {
+  const userCode = firstString(deviceAuth?.userCode, config.userCode);
+  const candidate = firstString(
+    deviceAuth?.verificationUriComplete,
+    config.verificationUriComplete,
+    config.authorizationUrl,
+    config.authUrl,
+    config.loginUrl,
+    deviceAuth?.verificationUri,
+    config.verificationUri,
+    config.verificationUrl,
+  );
+  if (!candidate) return undefined;
+  return userCode ? completeVerificationUri(candidate, userCode) : candidate;
+}
+
 function printLoginStart(input: {
   consoleUrl: string;
   authUrl?: string;
-  verificationUrl?: string;
   userCode?: string;
   openBrowser: boolean;
 }): void {
   console.log(`Ravi Cloud login: ${input.consoleUrl}`);
   if (input.openBrowser && input.authUrl) console.log("Opening browser for authentication...");
-  if (input.verificationUrl) console.log(`Verification URL: ${input.verificationUrl}`);
+  if (input.authUrl) console.log(`Verification URL: ${input.authUrl}`);
   if (input.userCode) console.log(`Code: ${input.userCode}`);
 }
 

--- a/src/cloud-auth/client.test.ts
+++ b/src/cloud-auth/client.test.ts
@@ -92,6 +92,8 @@ describe("ConsoleApiClient", () => {
 
     expect(config.clientId).toBe("ravi-cli");
     expect(device.userCode).toBe("ABC");
+    expect(device.verificationUri).toBe("https://console.example/cli/authorize");
+    expect(device.verificationUriComplete).toBe("https://console.example/cli/authorize?user_code=ABC");
     expect(credentials).toMatchObject({
       consoleUrl: "https://console.example",
       installationId: "ins_123",
@@ -132,6 +134,71 @@ describe("ConsoleApiClient", () => {
         body: null,
       },
     ]);
+  });
+
+  it("constructs verification_uri_complete from verification_uri and user_code when omitted", async () => {
+    const fetchImpl = mock(async (url: string) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/cli/auth/config") {
+        return jsonResponse({
+          configured: true,
+          clientId: "ravi-cli",
+          mode: "console_device",
+          endpoints: {
+            deviceAuthorization: "https://console.example/api/cli/auth/device",
+            token: null,
+          },
+        });
+      }
+      if (path === "/api/cli/auth/device") {
+        return jsonResponse({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://console.example/cli/authorize",
+          expires_in: 600,
+          interval: 1,
+        });
+      }
+      return jsonResponse({ error: { code: "SERVER_UNAVAILABLE" } }, 500);
+    });
+    const client = new ConsoleApiClient({ consoleUrl: "https://console.example/", fetch: fetchImpl });
+    const device = await client.startDeviceAuthorization(await client.getAuthConfig());
+
+    expect(device.verificationUri).toBe("https://console.example/cli/authorize");
+    expect(device.verificationUriComplete).toBe("https://console.example/cli/authorize?user_code=ABCD-EFGH");
+    expect(new URL(device.verificationUriComplete).searchParams.get("user_code")).toBe("ABCD-EFGH");
+  });
+
+  it("does not treat a bare verification_uri_complete as the URL to open", async () => {
+    const fetchImpl = mock(async (url: string) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/cli/auth/config") {
+        return jsonResponse({
+          configured: true,
+          clientId: "ravi-cli",
+          mode: "console_device",
+          endpoints: {
+            deviceAuthorization: "https://console.example/api/cli/auth/device",
+            token: null,
+          },
+        });
+      }
+      if (path === "/api/cli/auth/device") {
+        return jsonResponse({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://console.example/cli/authorize",
+          verification_uri_complete: "https://console.example/cli/authorize",
+          expires_in: 600,
+          interval: 1,
+        });
+      }
+      return jsonResponse({ error: { code: "SERVER_UNAVAILABLE" } }, 500);
+    });
+    const client = new ConsoleApiClient({ consoleUrl: "https://console.example/", fetch: fetchImpl });
+    const device = await client.startDeviceAuthorization(await client.getAuthConfig());
+
+    expect(device.verificationUriComplete).toBe("https://console.example/cli/authorize?user_code=ABCD-EFGH");
   });
 
   it("creates artifact upload sessions through the CLI bearer endpoint", async () => {

--- a/src/cloud-auth/client.ts
+++ b/src/cloud-auth/client.ts
@@ -13,6 +13,7 @@ import type {
   LogoutInput,
 } from "./types.js";
 import { DEFAULT_CONSOLE_URL } from "./types.js";
+import { completeVerificationUri } from "./verification-uri.js";
 
 type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
@@ -535,10 +536,9 @@ function deviceAuthorizationFromResponse(response: unknown): DeviceAuthorization
   const deviceCode = stringValue(data?.deviceCode) ?? stringValue(data?.device_code);
   const userCode = stringValue(data?.userCode) ?? stringValue(data?.user_code);
   const verificationUri = stringValue(data?.verificationUri) ?? stringValue(data?.verification_uri);
-  const verificationUriComplete =
-    stringValue(data?.verificationUriComplete) ?? stringValue(data?.verification_uri_complete) ?? verificationUri;
+  const providedComplete = stringValue(data?.verificationUriComplete) ?? stringValue(data?.verification_uri_complete);
 
-  if (!deviceCode || !userCode || !verificationUri || !verificationUriComplete) {
+  if (!deviceCode || !userCode || !verificationUri) {
     throw new CloudAuthError("PAYLOAD_INVALID", "Provider did not return device authorization metadata.");
   }
 
@@ -546,7 +546,7 @@ function deviceAuthorizationFromResponse(response: unknown): DeviceAuthorization
     deviceCode,
     userCode,
     verificationUri,
-    verificationUriComplete,
+    verificationUriComplete: completeVerificationUri(providedComplete ?? verificationUri, userCode),
     expiresIn: numberValue(data?.expiresIn) ?? numberValue(data?.expires_in),
     interval: numberValue(data?.interval),
   };

--- a/src/cloud-auth/verification-uri.test.ts
+++ b/src/cloud-auth/verification-uri.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { completeVerificationUri } from "./verification-uri.js";
+
+describe("completeVerificationUri", () => {
+  it("appends user_code to a bare authorize URL", () => {
+    expect(completeVerificationUri("https://console.example/cli/authorize", "ABCD-EFGH")).toBe(
+      "https://console.example/cli/authorize?user_code=ABCD-EFGH",
+    );
+  });
+
+  it("preserves an already-complete URL with the same user_code", () => {
+    const complete = "https://console.example/cli/authorize?user_code=ABCD-EFGH";
+    expect(completeVerificationUri(complete, "ABCD-EFGH")).toBe(complete);
+  });
+
+  it("replaces a mismatched user_code with the issued code", () => {
+    expect(completeVerificationUri("https://console.example/cli/authorize?user_code=STALE-CODE", "ABCD-EFGH")).toBe(
+      "https://console.example/cli/authorize?user_code=ABCD-EFGH",
+    );
+  });
+
+  it("keeps existing query params and URL-encodes the user_code", () => {
+    expect(completeVerificationUri("https://console.example/cli/authorize?source=cli", "AB CD/EF")).toBe(
+      "https://console.example/cli/authorize?source=cli&user_code=AB+CD%2FEF",
+    );
+  });
+
+  it("appends user_code to relative authorize paths", () => {
+    expect(completeVerificationUri("/cli/authorize", "ABCD-EFGH")).toBe("/cli/authorize?user_code=ABCD-EFGH");
+  });
+
+  it("returns the original URI when the user code is empty", () => {
+    expect(completeVerificationUri("https://console.example/cli/authorize", "   ")).toBe(
+      "https://console.example/cli/authorize",
+    );
+  });
+});

--- a/src/cloud-auth/verification-uri.ts
+++ b/src/cloud-auth/verification-uri.ts
@@ -1,0 +1,34 @@
+const USER_CODE_PARAM = "user_code";
+
+/**
+ * Build the device-authorization URL that binds a pending grant.
+ * Console's `/cli/authorize` page only attaches the device code when
+ * `user_code` is present on the query string.
+ */
+export function completeVerificationUri(verificationUri: string, userCode: string): string {
+  const uri = verificationUri.trim();
+  const code = userCode.trim();
+  if (!uri || !code) return uri;
+
+  try {
+    const url = new URL(uri);
+    if (url.searchParams.get(USER_CODE_PARAM) === code) return uri;
+    url.searchParams.set(USER_CODE_PARAM, code);
+    return url.toString();
+  } catch {
+    return appendUserCodeToOpaqueUri(uri, code);
+  }
+}
+
+function appendUserCodeToOpaqueUri(uri: string, code: string): string {
+  const hashIndex = uri.indexOf("#");
+  const beforeHash = hashIndex >= 0 ? uri.slice(0, hashIndex) : uri;
+  const hash = hashIndex >= 0 ? uri.slice(hashIndex) : "";
+  const queryIndex = beforeHash.indexOf("?");
+  const path = queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash;
+  const query = queryIndex >= 0 ? beforeHash.slice(queryIndex + 1) : "";
+  const params = new URLSearchParams(query);
+  if (params.get(USER_CODE_PARAM) === code) return uri;
+  params.set(USER_CODE_PARAM, code);
+  return `${path}?${params.toString()}${hash}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

`ravi login` now always presents the device-authorization URL with `?user_code=<CODE>`, so humans and agents open the page that actually binds the pending Console grant.

## Problem

During `ravi login`, Console already issues a device code (example shape: `ABCD-EFGH`). The page that binds that grant is:

`https://console.ravi.bot/cli/authorize?user_code=<CODE>`

What operators and agents were shown or followed was the bare URL:

`https://console.ravi.bot/cli/authorize`

That page does not attach the pending device grant. People authorize in the browser, the CLI never receives the token (or hits rate limit / a stale code), and they have to start over.

The CLI already preferred `verificationUriComplete` when opening a browser, but:

- human output printed `verificationUri` (the bare authorize page) as `Verification URL:`
- `verificationUriComplete` could fall back to that same bare URI
- JSON still exposed the bare `verificationUri`, which agents copied

## Solution

- Add `completeVerificationUri()` that appends the issued `user_code` query param (URL-encoded) when it is missing.
- Console device responses now always resolve `verificationUriComplete` from `verification_uri` + `user_code` when the complete URI is omitted or is itself the bare authorize page.
- `ravi login` human output, browser open, and JSON (`authorizationUrl`, `verificationUriComplete`, `verificationUri`) all use that complete URL. The code is still printed as a fallback.
- Specs, runbook, checks, and WHY for `cli/cloud-auth` now require the complete URL and explicitly tell agents not to open bare `/cli/authorize`.

## Practical impact

- Operators running `ravi login` get a clickable URL that already includes the device code.
- Agents consuming `--json` copy `auth.authorizationUrl` / `auth.verificationUri` and still land on the bound grant page.
- A missing or stale `verification_uri_complete` from Console no longer silently degrades to the unbound page.

## What does NOT change

- Console (`filipexyz/ravi-console`) is unchanged. It already returns `verification_uri_complete` with `user_code`.
- Token storage, polling, exchange, and logout are unchanged.
- No secrets are committed. Test fixtures use `ABCD-EFGH`, not a live device code.

## Validation

- `bun test src/cloud-auth/verification-uri.test.ts src/cloud-auth/client.test.ts src/cli/commands/cloud-auth.test.ts src/cloud-auth/redaction.test.ts` — 24 pass
- `bunx biome check` on the changed TypeScript files
- Pre-push hook (build + quality + targeted tests) passed on push

## Risks

- JSON `auth.verificationUri` is now the complete URL (with `user_code`) instead of the RFC bare `verification_uri`. Agents that previously copied this field now get the correct link. Any consumer that assumed the field was query-free will see `?user_code=`.
- If a future Console complete URL uses a different query name, the CLI still forces `user_code`.

## Rollback

Revert this commit. Login output returns to printing the bare `/cli/authorize` URL.

## Follow-ups

- None in this repo. A Console-side change is not required unless a future authorize page stops reading `user_code`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c9faf9c-f7b0-462f-a49e-c8ac4ace0e3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c9faf9c-f7b0-462f-a49e-c8ac4ace0e3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

