### PR TITLE
fix(runtime): unblock stale Codex PreToolUse hook sessions

### DIFF
--- a/.ravi/specs/runtime/providers/codex/CHECKS.md
+++ b/.ravi/specs/runtime/providers/codex/CHECKS.md
@@ -20,6 +20,10 @@
 
 ## Regression Cases
 
+- Generated `hooks.json` command contains `codex-bash-hook` and does not contain `codex-tool-hook`.
+- `ravi context codex-tool-hook` is a registered alias of `codex-bash-hook`.
+- Doctor fails on a stale `codex-tool-hook` command and on a matcher other than `^(Bash|shell)$`.
+- Rematerialize replaces a legacy wide-matcher `codex-tool-hook` group instead of leaving it in place.
 - Dynamic tool handler throws.
 - Dynamic tool handler returns no content.
 - Dynamic tool handler returns image content.

--- a/.ravi/specs/runtime/providers/codex/RUNBOOK.md
+++ b/.ravi/specs/runtime/providers/codex/RUNBOOK.md
@@ -29,7 +29,8 @@ ravi sessions runtime fork <session> --json
 - Confirm the Codex app-server process receives `RAVI_CONTEXT_KEY`.
 - If the session reuses an existing app-server process, confirm the provider respawned it when the `RAVI_*` env signature changed.
 - Confirm the Codex app-server was launched with `shell_environment_policy.inherit=all`, `shell_environment_policy.ignore_default_excludes=true`, and an `include_only` glob allowlist containing `RAVI_*`.
-- Confirm `~/.codex/hooks.json` points the `^(Bash|shell)$` hook at `ravi context codex-bash-hook` or repo `bin/ravi context codex-bash-hook`, not a test file.
+- Confirm `~/.codex/hooks.json` points the `^(Bash|shell)$` hook at `ravi context codex-bash-hook` or repo `bin/ravi context codex-bash-hook`, not a test file and not `codex-tool-hook`.
+- If doctor reports a stale `codex-tool-hook` command or an invalid matcher, it rewrites the Ravi group. The live Codex app-server still has to respawn to reload the file. `ravi context codex-tool-hook` remains a deprecated alias so a stale worker does not hard-block Bash, including Pages `list` / `published` / `publish`.
 - Confirm the Bash hook returns `{}` for allowed Bash calls. It is a permission/skill-gate hook, not an env injector.
 - Confirm the shell command env contains `RAVI_CONTEXT_KEY`; if it does not, debug `shell_environment_policy`, not the hook output.
 - Confirm model-initiated Ravi actions use shell commands, for example `ravi tasks list`, not native Codex dynamic tools.

--- a/.ravi/specs/runtime/providers/codex/SPEC.md
+++ b/.ravi/specs/runtime/providers/codex/SPEC.md
@@ -15,8 +15,10 @@ tags:
   - app-server
 applies_to:
   - src/runtime/codex-provider.ts
+  - src/runtime/codex-hooks.ts
   - src/plugins/codex-skills.ts
   - src/runtime/codex-provider.test.ts
+  - src/runtime/codex-hooks.test.ts
 owners:
   - ravi-dev
 status: active
@@ -85,7 +87,11 @@ The Codex provider adapts the Codex app-server transport into Ravi's canonical r
 - A reused Codex app-server process MUST be respawned before the next turn when its Ravi env signature differs from the current runtime env.
 - The provider MUST launch the Codex app-server with `shell_environment_policy.inherit=all`, `shell_environment_policy.ignore_default_excludes=true`, and an `include_only` glob allowlist that includes `RAVI_*` plus minimal core shell variables. This is required because Codex default shell env exclusions can strip env names containing `KEY`.
 - The global Codex Bash hook command MUST resolve to a stable Ravi CLI entrypoint such as `bin/ravi` or the bundled CLI, never to a test file or transient runner script.
-- The global Codex Bash hook matcher MUST cover both Codex tool names currently observed for shell execution: `Bash` and `shell`.
+- Generated hooks MUST emit `ravi context codex-bash-hook` as the preferred command. They MUST NOT emit `codex-tool-hook` as the preferred command.
+- The CLI MUST accept `ravi context codex-tool-hook` as a deprecated alias of `codex-bash-hook` with the same access and payload so stale `~/.codex/hooks.json` files and in-memory Codex workers cannot hard-block Bash, including `ravi pages list|published|publish`.
+- The global Codex Bash hook matcher MUST be exactly `^(Bash|shell)$`. It MUST cover both Codex tool names currently observed for shell execution: `Bash` and `shell`.
+- Rematerializing hooks MUST replace legacy Ravi groups (old status `ravi codex native tool permission gate`, old command `codex-tool-hook`, or a non-canonical matcher) instead of appending a second group beside them.
+- A reused Codex app-server process MUST be respawned before the next turn when `hooks.json` changes. Thread/resume MUST keep session history.
 - The global Codex Bash hook MUST enforce Ravi shell permissions and runtime skill gates only. It MUST NOT rely on `PreToolUse.updatedInput` to inject env because current Codex rejects unsupported updated input for this hook.
 - Ravi provider-owned grants such as `full-access` authorize Ravi's permission layer only. They MUST NOT be documented as a bypass for provider-native hooks, global Codex hooks, or external PreToolUse transforms that may still deny a shell command after Ravi allows it.
 - The shell env bridge MUST NOT print or embed `RAVI_CONTEXT_KEY` directly in user-visible command text or traces.
@@ -103,6 +109,7 @@ The Codex provider adapts the Codex app-server transport into Ravi's canonical r
 ## Validation
 
 - `bun test src/runtime/codex-provider.test.ts`
+- `bun test src/runtime/codex-hooks.test.ts`
 - `bun test src/runtime/provider-contract.test.ts`
 - `bun test src/runtime/model-catalog.test.ts`
 - `bun test src/plugins/codex-skills.test.ts`

--- a/src/cli/commands/context-hook-alias.test.ts
+++ b/src/cli/commands/context-hook-alias.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { getRegistry } from "../registry-snapshot.js";
+
+describe("context Codex hook alias", () => {
+  it("registers codex-tool-hook as a deprecated alias of codex-bash-hook", () => {
+    const command = getRegistry().commands.find((entry) => entry.fullName === "context.codex-bash-hook");
+    expect(command?.aliases).toEqual(["codex-tool-hook"]);
+    expect(command?.access).toMatchObject({
+      kind: "read",
+      resource: "context",
+      action: "codex-bash-hook",
+    });
+    expect(getRegistry().commands.some((entry) => entry.fullName === "context.codex-tool-hook")).toBe(false);
+  });
+});

--- a/src/cli/commands/context.test.ts
+++ b/src/cli/commands/context.test.ts
@@ -1039,8 +1039,6 @@ describe("ContextCommands", () => {
 
     it("registers codex-tool-hook as a deprecated alias of codex-bash-hook", async () => {
       const { getRegistry } = await import("../registry-snapshot.js");
-      const { Command } = await import("commander");
-      const { registerCommands } = await import("../registry.js");
       const command = getRegistry().commands.find((entry) => entry.fullName === "context.codex-bash-hook");
       expect(command?.aliases).toEqual(["codex-tool-hook"]);
       expect(command?.access).toMatchObject({
@@ -1049,13 +1047,6 @@ describe("ContextCommands", () => {
         action: "codex-bash-hook",
       });
       expect(getRegistry().commands.some((entry) => entry.fullName === "context.codex-tool-hook")).toBe(false);
-
-      const program = new Command();
-      program.exitOverride();
-      registerCommands(program, [ContextCommands]);
-      const context = program.commands.find((entry) => entry.name() === "context");
-      const hook = context?.commands.find((entry) => entry.name() === "codex-bash-hook");
-      expect(hook?.aliases()).toContain("codex-tool-hook");
     });
   });
 

--- a/src/cli/commands/context.test.ts
+++ b/src/cli/commands/context.test.ts
@@ -1036,18 +1036,6 @@ describe("ContextCommands", () => {
       ]);
       expect(JSON.stringify(publishedAuditEvents[0].data)).not.toContain("'hello'");
     });
-
-    it("registers codex-tool-hook as a deprecated alias of codex-bash-hook", async () => {
-      const { getRegistry } = await import("../registry-snapshot.js");
-      const command = getRegistry().commands.find((entry) => entry.fullName === "context.codex-bash-hook");
-      expect(command?.aliases).toEqual(["codex-tool-hook"]);
-      expect(command?.access).toMatchObject({
-        kind: "read",
-        resource: "context",
-        action: "codex-bash-hook",
-      });
-      expect(getRegistry().commands.some((entry) => entry.fullName === "context.codex-tool-hook")).toBe(false);
-    });
   });
 
   describe("return schema conformance", () => {

--- a/src/cli/commands/context.test.ts
+++ b/src/cli/commands/context.test.ts
@@ -1036,6 +1036,27 @@ describe("ContextCommands", () => {
       ]);
       expect(JSON.stringify(publishedAuditEvents[0].data)).not.toContain("'hello'");
     });
+
+    it("registers codex-tool-hook as a deprecated alias of codex-bash-hook", async () => {
+      const { getRegistry } = await import("../registry-snapshot.js");
+      const { Command } = await import("commander");
+      const { registerCommands } = await import("../registry.js");
+      const command = getRegistry().commands.find((entry) => entry.fullName === "context.codex-bash-hook");
+      expect(command?.aliases).toEqual(["codex-tool-hook"]);
+      expect(command?.access).toMatchObject({
+        kind: "read",
+        resource: "context",
+        action: "codex-bash-hook",
+      });
+      expect(getRegistry().commands.some((entry) => entry.fullName === "context.codex-tool-hook")).toBe(false);
+
+      const program = new Command();
+      program.exitOverride();
+      registerCommands(program, [ContextCommands]);
+      const context = program.commands.find((entry) => entry.name() === "context");
+      const hook = context?.commands.find((entry) => entry.name() === "codex-bash-hook");
+      expect(hook?.aliases()).toContain("codex-tool-hook");
+    });
   });
 
   describe("return schema conformance", () => {

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -590,6 +590,9 @@ export class ContextCommands {
   @Command({
     name: "codex-bash-hook",
     description: "Evaluate a Codex PreToolUse Bash hook payload from stdin using the current Ravi context",
+    aliases: ["codex-tool-hook"],
+    helpAfter:
+      "codex-tool-hook is a deprecated compatibility alias for stale Codex sessions and hooks.json files. It uses the same access and payload as codex-bash-hook. Generated hooks must keep emitting codex-bash-hook.",
   })
   @CommandAccess({ kind: "read", resource: "context", action: "codex-bash-hook", risk: "low" })
   codexBashHook(@Option({ flags: "--json", description: "Print raw JSON result" }) _asJson = false) {

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -209,6 +209,86 @@ describe("inspectDoctor", () => {
     expect(report.findings.every((finding) => finding.severity !== "error")).toBe(true);
   });
 
+  it("fails and rewrites a stale codex-tool-hook command", () => {
+    const deps = makeHealthyDeps();
+    const hooksPath = join(deps.homeDir(), ".codex", "hooks.json");
+    writeFileSync(
+      hooksPath,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "^(Bash|shell)$",
+                hooks: [
+                  {
+                    type: "command",
+                    command: "ravi context codex-tool-hook",
+                    statusMessage: "ravi codex native tool permission gate",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const report = inspectDoctor(deps);
+    const check = report.checks.find((item) => item.id === "codex.bash-hook");
+    const finding = report.findings.find((item) => item.id === "codex.bash-hook");
+    expect(check?.status).toBe("fail");
+    expect(check?.data?.staleCommand).toBe(true);
+    expect(finding?.summary).toContain("codex-tool-hook");
+    expect(finding?.summary).toContain("codex-bash-hook");
+
+    const rewritten = JSON.parse(readFileSync(hooksPath, "utf8"));
+    expect(rewritten.hooks.PreToolUse).toHaveLength(1);
+    expect(rewritten.hooks.PreToolUse[0]?.matcher).toBe("^(Bash|shell)$");
+    expect(rewritten.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("codex-bash-hook");
+    expect(rewritten.hooks.PreToolUse[0]?.hooks[0]?.command).not.toContain("codex-tool-hook");
+  });
+
+  it("fails and repairs an invalid PreToolUse matcher", () => {
+    const deps = makeHealthyDeps();
+    const hooksPath = join(deps.homeDir(), ".codex", "hooks.json");
+    writeFileSync(
+      hooksPath,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "^(Bash|shell|exec_command|view_image)$",
+                hooks: [
+                  {
+                    type: "command",
+                    command: "ravi context codex-bash-hook",
+                    statusMessage: "ravi codex bash permission gate",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const report = inspectDoctor(deps);
+    const check = report.checks.find((item) => item.id === "codex.bash-hook");
+    const finding = report.findings.find((item) => item.id === "codex.bash-hook");
+    expect(check?.status).toBe("fail");
+    expect(check?.data?.matcherOk).toBe(false);
+    expect(finding?.summary).toContain("^(Bash|shell)$");
+
+    const rewritten = JSON.parse(readFileSync(hooksPath, "utf8"));
+    expect(rewritten.hooks.PreToolUse[0]?.matcher).toBe("^(Bash|shell)$");
+  });
+
   it("passes the disk/temp pressure check when free space is healthy", () => {
     const deps = makeHealthyDeps();
     const report = inspectDoctor(deps);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -25,6 +25,13 @@ import {
   materializeSubjectCapabilities,
 } from "../../permissions/provider-runtime.js";
 import { inspectAgentInstructionFiles, type AgentInstructionState } from "../../runtime/agent-instructions.js";
+import {
+  ensureCodexBashHookConfig,
+  inspectCodexHookConfig,
+  RAVI_CODEX_BASH_HOOK_COMMAND,
+  RAVI_CODEX_BASH_HOOK_MATCHER,
+  RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND,
+} from "../../runtime/codex-hooks.js";
 import { getRuntimeCompatibilityIssues, listRegisteredRuntimeProviderIds } from "../../runtime/provider-registry.js";
 import type { RuntimeCompatibilityIssue, RuntimeProviderId } from "../../runtime/types.js";
 import {
@@ -2579,44 +2586,86 @@ function buildCronTargetsCheck(deps: DoctorDeps): LegacyDoctorCheck {
 }
 
 function buildCodexHookCheck(hooksPath: string, deps: DoctorDeps): LegacyDoctorCheck {
-  if (!deps.exists(hooksPath)) {
+  const raw = deps.exists(hooksPath) ? safeReadDoctorFile(hooksPath, deps) : null;
+  const before = inspectCodexHookConfig(raw, hooksPath);
+  let repaired = false;
+  let after = before;
+
+  if (!before.ok) {
+    try {
+      const result = ensureCodexBashHookConfig(dirname(hooksPath));
+      repaired = result.changed;
+      after = inspectCodexHookConfig(deps.exists(hooksPath) ? safeReadDoctorFile(hooksPath, deps) : null, hooksPath);
+    } catch (error) {
+      return {
+        id: "codex.bash-hook",
+        title: "Global Codex bash hook",
+        status: "fail",
+        summary: before.reasons[0] ?? "failed to inspect or rewrite ~/.codex/hooks.json",
+        details: [hooksPath, ...before.reasons, error instanceof Error ? error.message : String(error)],
+        fixHint: buildCodexHookFixHint(before),
+        data: {
+          path: hooksPath,
+          exists: before.exists,
+          valid: false,
+          matcherOk: before.matcherOk,
+          staleCommand: before.staleCommand,
+          preferredCommand: before.preferredCommand,
+          repaired: false,
+          reasons: before.reasons,
+        },
+      };
+    }
+  }
+
+  if (!after.ok) {
     return {
       id: "codex.bash-hook",
       title: "Global Codex bash hook",
       status: "fail",
-      summary: "global Codex hooks file is missing",
-      details: [hooksPath],
-      fixHint: "materialize ~/.codex/hooks.json through the Codex provider or restart the daemon",
-      data: { path: hooksPath, exists: false, valid: false },
+      summary: after.reasons[0] ?? "global Codex hooks file exists but Ravi bash governance is missing",
+      details: [hooksPath, ...after.reasons],
+      fixHint: buildCodexHookFixHint(after),
+      data: {
+        path: hooksPath,
+        exists: after.exists,
+        valid: false,
+        matcherOk: after.matcherOk,
+        staleCommand: after.staleCommand,
+        preferredCommand: after.preferredCommand,
+        repaired,
+        reasons: after.reasons,
+      },
     };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(deps.readFile(hooksPath));
-  } catch (error) {
+  if (before.staleCommand || !before.matcherOk || before.staleStatus) {
     return {
       id: "codex.bash-hook",
       title: "Global Codex bash hook",
       status: "fail",
-      summary: "global Codex hooks file is not valid JSON",
-      details: [hooksPath, error instanceof Error ? error.message : String(error)],
-      fixHint: "rewrite ~/.codex/hooks.json with the Ravi bash hook group",
-      data: { path: hooksPath, exists: true, valid: false },
-    };
-  }
-
-  const valid = hasRaviCodexBashHook(parsed);
-  if (!valid) {
-    return {
-      id: "codex.bash-hook",
-      title: "Global Codex bash hook",
-      status: "fail",
-      summary: "global Codex hooks file exists but Ravi bash governance is missing",
-      details: [hooksPath],
+      summary: before.staleCommand
+        ? `stale PreToolUse command \`${RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND}\` was rewritten to \`${RAVI_CODEX_BASH_HOOK_COMMAND}\``
+        : !before.matcherOk
+          ? `invalid PreToolUse matcher was rewritten to \`${RAVI_CODEX_BASH_HOOK_MATCHER}\``
+          : "legacy Ravi Codex hook group was rewritten to the bash-only matcher",
+      details: [
+        hooksPath,
+        ...before.reasons,
+        repaired ? "rewrote ~/.codex/hooks.json" : "hooks file already matched after reread",
+      ],
       fixHint:
-        "rewrite ~/.codex/hooks.json so `PreToolUse` for `^(Bash|shell)$` points at `ravi context codex-bash-hook`",
-      data: { path: hooksPath, exists: true, valid: false },
+        "respawn the live Codex app-server without wiping session history so it reloads hooks.json; stale `codex-tool-hook` invocations are now accepted as an alias",
+      data: {
+        path: hooksPath,
+        exists: true,
+        valid: true,
+        matcherOk: before.matcherOk,
+        staleCommand: before.staleCommand,
+        preferredCommand: before.preferredCommand,
+        repaired,
+        reasons: before.reasons,
+      },
     };
   }
 
@@ -2626,47 +2675,34 @@ function buildCodexHookCheck(hooksPath: string, deps: DoctorDeps): LegacyDoctorC
     status: "ok",
     summary: "Ravi Codex bash governance is present in ~/.codex/hooks.json",
     details: [hooksPath],
-    data: { path: hooksPath, exists: true, valid: true },
+    data: {
+      path: hooksPath,
+      exists: true,
+      valid: true,
+      matcherOk: true,
+      staleCommand: false,
+      preferredCommand: true,
+      repaired: false,
+    },
   };
 }
 
-function hasRaviCodexBashHook(value: unknown): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
+function safeReadDoctorFile(path: string, deps: DoctorDeps): string | null {
+  try {
+    return deps.readFile(path);
+  } catch {
+    return null;
   }
+}
 
-  const hooks = (value as Record<string, unknown>).hooks;
-  if (!hooks || typeof hooks !== "object" || Array.isArray(hooks)) {
-    return false;
+function buildCodexHookFixHint(inspection: { staleCommand: boolean; matcherOk: boolean }): string {
+  if (inspection.staleCommand) {
+    return `rewrite ~/.codex/hooks.json so PreToolUse uses \`ravi context ${RAVI_CODEX_BASH_HOOK_COMMAND}\` instead of \`${RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND}\``;
   }
-
-  const preToolUse = (hooks as Record<string, unknown>).PreToolUse;
-  if (!Array.isArray(preToolUse)) {
-    return false;
+  if (!inspection.matcherOk) {
+    return `rewrite ~/.codex/hooks.json so PreToolUse matcher is exactly \`${RAVI_CODEX_BASH_HOOK_MATCHER}\``;
   }
-
-  return preToolUse.some((group) => {
-    if (!group || typeof group !== "object" || Array.isArray(group)) {
-      return false;
-    }
-    const matcher = (group as Record<string, unknown>).matcher;
-    const handlers = (group as Record<string, unknown>).hooks;
-    if (matcher !== "^(Bash|shell)$" || !Array.isArray(handlers)) {
-      return false;
-    }
-    return handlers.some((handler) => {
-      if (!handler || typeof handler !== "object" || Array.isArray(handler)) {
-        return false;
-      }
-      const record = handler as Record<string, unknown>;
-      return (
-        record.type === "command" &&
-        record.statusMessage === "ravi codex bash permission gate" &&
-        typeof record.command === "string" &&
-        record.command.includes("codex-bash-hook")
-      );
-    });
-  });
+  return `rewrite ~/.codex/hooks.json so \`PreToolUse\` for \`${RAVI_CODEX_BASH_HOOK_MATCHER}\` points at \`ravi context ${RAVI_CODEX_BASH_HOOK_COMMAND}\``;
 }
 
 function printDoctorReport(report: DoctorReport, options: { full?: boolean } = {}): void {

--- a/src/cli/skill-gates.ts
+++ b/src/cli/skill-gates.ts
@@ -83,6 +83,7 @@ const RAVI_GATE_EXEMPT_COMMANDS = new Set([
   "tools.manifest",
   "tools.schema",
   "context.codex-bash-hook",
+  "context.codex-tool-hook",
   "context.visibility",
   "sessions.visibility",
 ]);

--- a/src/plugins/internal/ravi-dev/skills/context-cli/SKILL.md
+++ b/src/plugins/internal/ravi-dev/skills/context-cli/SKILL.md
@@ -36,6 +36,7 @@ Ensine o agent a:
 - checar capacidade com `ravi context check`
 - pedir approval com `ravi context authorize`
 - auditar/inspecionar com `ravi context list/info/revoke`
+- tratar `ravi context codex-tool-hook` como alias depreciado de `ravi context codex-bash-hook` (mesmo acesso e payload). Hooks gerados devem continuar emitindo `codex-bash-hook`.
 
 ## Fluxo Canonico
 

--- a/src/plugins/internal/ravi-system/skills/artifacts/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/artifacts/SKILL.md
@@ -183,6 +183,11 @@ ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --visibilit
 
 O upload de conteúdo do Pages é `ravi pages publish`.
 
+Em sessões Codex, `ravi pages list|published|publish` passam por Bash/shell e pelo
+PreToolUse `ravi context codex-bash-hook`. O nome legado `codex-tool-hook` é só
+alias; se o hook falhar com `unknown command`, leitura e publish de Pages
+ficam bloqueados junto com qualquer outra ferramenta local.
+
 Para proteger uma rota já publicada sem reenviar o conteúdo (`set`/`remove` são freados; o `set` sem `--execute` nem pede a senha):
 
 ```bash

--- a/src/runtime/codex-hooks.test.ts
+++ b/src/runtime/codex-hooks.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRaviCodexHookCommand,
+  ensureCodexBashHookConfig,
+  inspectCodexHookConfig,
+  inspectParsedCodexHookConfig,
+  isRaviCodexHookGroup,
+  RAVI_CODEX_BASH_HOOK_COMMAND,
+  RAVI_CODEX_BASH_HOOK_MATCHER,
+  RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND,
+  upsertRaviCodexBashHook,
+} from "./codex-hooks.js";
+
+function staleToolHookConfig() {
+  return {
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "^(Read|Bash|shell|exec_command|view_image)$",
+          hooks: [
+            {
+              type: "command",
+              command: "ravi context codex-tool-hook",
+              statusMessage: "ravi codex native tool permission gate",
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("codex hook materialization", () => {
+  it("emits codex-bash-hook as the preferred command and never the legacy name", () => {
+    const command = buildRaviCodexHookCommand();
+    expect(command).toContain(RAVI_CODEX_BASH_HOOK_COMMAND);
+    expect(command).not.toContain(RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND);
+  });
+
+  it("recognizes legacy tool-hook groups so rematerialize can replace them", () => {
+    expect(isRaviCodexHookGroup(staleToolHookConfig().hooks.PreToolUse[0])).toBe(true);
+  });
+
+  it("replaces a stale wide-matcher tool-hook group with the bash-only preferred hook", () => {
+    const next = upsertRaviCodexBashHook(staleToolHookConfig());
+    const groups = (next.hooks as { PreToolUse: unknown[] }).PreToolUse;
+    expect(groups).toHaveLength(1);
+    const group = groups[0] as {
+      matcher: string;
+      hooks: Array<{ type: string; command: string; statusMessage: string }>;
+    };
+    expect(group.matcher).toBe(RAVI_CODEX_BASH_HOOK_MATCHER);
+    expect(group.hooks[0]?.type).toBe("command");
+    expect(group.hooks[0]?.statusMessage).toBe("ravi codex bash permission gate");
+    const command = group.hooks[0]?.command;
+    expect(command).toContain(RAVI_CODEX_BASH_HOOK_COMMAND);
+    expect(command).not.toContain(RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND);
+  });
+
+  it("inspects stale command and invalid matcher separately", () => {
+    const stale = inspectParsedCodexHookConfig(staleToolHookConfig(), "/tmp/hooks.json");
+    expect(stale.ok).toBe(false);
+    expect(stale.staleCommand).toBe(true);
+    expect(stale.matcherOk).toBe(false);
+    expect(stale.reasons.join(" ")).toContain("codex-tool-hook");
+    expect(stale.reasons.join(" ")).toContain(RAVI_CODEX_BASH_HOOK_MATCHER);
+
+    const missing = inspectCodexHookConfig(null, "/tmp/hooks.json");
+    expect(missing.exists).toBe(false);
+    expect(missing.ok).toBe(false);
+  });
+
+  it("rewrites a stale hooks.json in place", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-codex-hooks-"));
+    const hooksPath = join(dir, "hooks.json");
+    writeFileSync(hooksPath, `${JSON.stringify(staleToolHookConfig(), null, 2)}\n`);
+
+    const result = ensureCodexBashHookConfig(dir);
+    expect(result.changed).toBe(true);
+    expect(result.path).toBe(hooksPath);
+
+    const rewritten = JSON.parse(readFileSync(hooksPath, "utf8"));
+    const inspection = inspectParsedCodexHookConfig(rewritten, hooksPath);
+    expect(inspection.ok).toBe(true);
+    expect(inspection.staleCommand).toBe(false);
+    expect(inspection.matcherOk).toBe(true);
+    expect(inspection.preferredCommand).toBe(true);
+  });
+});

--- a/src/runtime/codex-hooks.ts
+++ b/src/runtime/codex-hooks.ts
@@ -1,0 +1,312 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const RAVI_CODEX_BASH_HOOK_STATUS = "ravi codex bash permission gate";
+export const RAVI_CODEX_LEGACY_TOOL_HOOK_STATUS = "ravi codex native tool permission gate";
+export const RAVI_CODEX_BASH_HOOK_MATCHER = "^(Bash|shell)$";
+export const RAVI_CODEX_BASH_HOOK_COMMAND = "codex-bash-hook";
+export const RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND = "codex-tool-hook";
+
+export interface CodexHookEnsureResult {
+  path: string;
+  changed: boolean;
+  signature: string;
+}
+
+export interface CodexHookInspection {
+  path: string;
+  exists: boolean;
+  validJson: boolean;
+  parseError?: string;
+  ok: boolean;
+  matcherOk: boolean;
+  preferredCommand: boolean;
+  staleCommand: boolean;
+  staleStatus: boolean;
+  reasons: string[];
+}
+
+export function getGlobalCodexConfigDir(): string {
+  return join(process.env.HOME ?? homedir(), ".codex");
+}
+
+export function getCodexHooksPath(configDir = getGlobalCodexConfigDir()): string {
+  return join(configDir, "hooks.json");
+}
+
+export function ensureCodexBashHookConfig(configDir = getGlobalCodexConfigDir()): CodexHookEnsureResult {
+  const hooksPath = getCodexHooksPath(configDir);
+  mkdirSync(configDir, { recursive: true });
+
+  const nextConfig = upsertRaviCodexBashHook(readCodexHooksConfig(hooksPath));
+  const nextJson = JSON.stringify(nextConfig, null, 2) + "\n";
+  const currentJson = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : null;
+  const changed = currentJson !== nextJson;
+  if (changed) {
+    writeFileSync(hooksPath, nextJson, "utf8");
+  }
+
+  return { path: hooksPath, changed, signature: nextJson };
+}
+
+export function inspectCodexHookConfig(raw: string | null, hooksPath: string): CodexHookInspection {
+  if (raw === null) {
+    return {
+      path: hooksPath,
+      exists: false,
+      validJson: false,
+      ok: false,
+      matcherOk: false,
+      preferredCommand: false,
+      staleCommand: false,
+      staleStatus: false,
+      reasons: ["global Codex hooks file is missing"],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      path: hooksPath,
+      exists: true,
+      validJson: false,
+      parseError: error instanceof Error ? error.message : String(error),
+      ok: false,
+      matcherOk: false,
+      preferredCommand: false,
+      staleCommand: false,
+      staleStatus: false,
+      reasons: ["global Codex hooks file is not valid JSON"],
+    };
+  }
+
+  return inspectParsedCodexHookConfig(parsed, hooksPath);
+}
+
+export function inspectParsedCodexHookConfig(value: unknown, hooksPath: string): CodexHookInspection {
+  const groups = listPreToolUseGroups(value);
+  if (!groups) {
+    return {
+      path: hooksPath,
+      exists: true,
+      validJson: true,
+      ok: false,
+      matcherOk: false,
+      preferredCommand: false,
+      staleCommand: false,
+      staleStatus: false,
+      reasons: ["Ravi Codex bash governance is missing from PreToolUse"],
+    };
+  }
+
+  const raviGroups = groups.filter(isRaviCodexHookGroup);
+  if (raviGroups.length === 0) {
+    return {
+      path: hooksPath,
+      exists: true,
+      validJson: true,
+      ok: false,
+      matcherOk: false,
+      preferredCommand: false,
+      staleCommand: false,
+      staleStatus: false,
+      reasons: ["Ravi Codex bash governance is missing from PreToolUse"],
+    };
+  }
+
+  const matcherOk = raviGroups.some((group) => group.matcher === RAVI_CODEX_BASH_HOOK_MATCHER);
+  const preferredCommand = raviGroups.some((group) =>
+    listHookCommands(group).some(
+      (command) =>
+        commandIncludesHookName(command, RAVI_CODEX_BASH_HOOK_COMMAND) &&
+        !commandIncludesHookName(command, RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND),
+    ),
+  );
+  const staleCommand = raviGroups.some((group) =>
+    listHookCommands(group).some((command) => commandIncludesHookName(command, RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND)),
+  );
+  const staleStatus = raviGroups.some((group) =>
+    listHookStatusMessages(group).includes(RAVI_CODEX_LEGACY_TOOL_HOOK_STATUS),
+  );
+
+  const reasons: string[] = [];
+  if (!matcherOk) {
+    reasons.push(`PreToolUse matcher must be exactly \`${RAVI_CODEX_BASH_HOOK_MATCHER}\``);
+  }
+  if (staleCommand) {
+    reasons.push(
+      `stale PreToolUse command \`codex-tool-hook\` must be rewritten to \`${RAVI_CODEX_BASH_HOOK_COMMAND}\``,
+    );
+  }
+  if (!preferredCommand && !staleCommand) {
+    reasons.push(`PreToolUse command must invoke \`ravi context ${RAVI_CODEX_BASH_HOOK_COMMAND}\``);
+  }
+  if (staleStatus && reasons.length === 0) {
+    reasons.push("legacy Ravi Codex tool-hook status is still present");
+  }
+
+  return {
+    path: hooksPath,
+    exists: true,
+    validJson: true,
+    ok: reasons.length === 0 && raviGroups.length === 1 && matcherOk && preferredCommand,
+    matcherOk,
+    preferredCommand,
+    staleCommand,
+    staleStatus,
+    reasons,
+  };
+}
+
+export function upsertRaviCodexBashHook(config: Record<string, unknown>): Record<string, unknown> {
+  const hooks = asRecord(config.hooks) ?? {};
+  const preToolUse = Array.isArray(hooks.PreToolUse) ? [...hooks.PreToolUse] : [];
+  const raviGroup = {
+    matcher: RAVI_CODEX_BASH_HOOK_MATCHER,
+    hooks: [
+      {
+        type: "command",
+        command: buildRaviCodexHookCommand(),
+        statusMessage: RAVI_CODEX_BASH_HOOK_STATUS,
+      },
+    ],
+  };
+
+  const nextPreToolUse = preToolUse.filter((group) => !isRaviCodexHookGroup(group));
+  nextPreToolUse.push(raviGroup);
+
+  return {
+    ...config,
+    hooks: {
+      ...hooks,
+      PreToolUse: nextPreToolUse,
+    },
+  };
+}
+
+export function isRaviCodexHookGroup(value: unknown): boolean {
+  const group = asRecord(value);
+  if (!group) {
+    return false;
+  }
+
+  const handlers = Array.isArray(group.hooks) ? group.hooks : [];
+  return handlers.some((handler) => {
+    const entry = asRecord(handler);
+    if (!entry) {
+      return false;
+    }
+    if (
+      entry.statusMessage === RAVI_CODEX_BASH_HOOK_STATUS ||
+      entry.statusMessage === RAVI_CODEX_LEGACY_TOOL_HOOK_STATUS
+    ) {
+      return true;
+    }
+    return (
+      typeof entry.command === "string" &&
+      (commandIncludesHookName(entry.command, RAVI_CODEX_BASH_HOOK_COMMAND) ||
+        commandIncludesHookName(entry.command, RAVI_CODEX_LEGACY_TOOL_HOOK_COMMAND))
+    );
+  });
+}
+
+export function buildRaviCodexHookCommand(): string {
+  const configuredRaviBin = process.env.RAVI_BIN?.trim();
+  if (configuredRaviBin) {
+    return [configuredRaviBin, "context", RAVI_CODEX_BASH_HOOK_COMMAND].map(shellEscape).join(" ");
+  }
+
+  const bundlePath = process.argv[1];
+  if (isRunnableRaviCliEntrypoint(bundlePath)) {
+    return [process.execPath, bundlePath, "context", RAVI_CODEX_BASH_HOOK_COMMAND].map(shellEscape).join(" ");
+  }
+
+  const sourceRaviBin = resolveSourceRaviBinPath();
+  if (sourceRaviBin) {
+    return [sourceRaviBin, "context", RAVI_CODEX_BASH_HOOK_COMMAND].map(shellEscape).join(" ");
+  }
+
+  return ["ravi", "context", RAVI_CODEX_BASH_HOOK_COMMAND].map(shellEscape).join(" ");
+}
+
+function readCodexHooksConfig(path: string): Record<string, unknown> {
+  if (!existsSync(path)) {
+    return { hooks: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return asRecord(parsed) ?? { hooks: {} };
+  } catch {
+    return { hooks: {} };
+  }
+}
+
+function listPreToolUseGroups(value: unknown): unknown[] | null {
+  const root = asRecord(value);
+  const hooks = asRecord(root?.hooks);
+  if (!hooks || !Array.isArray(hooks.PreToolUse)) {
+    return null;
+  }
+  return hooks.PreToolUse;
+}
+
+function listHookCommands(group: unknown): string[] {
+  const record = asRecord(group);
+  const handlers = Array.isArray(record?.hooks) ? record.hooks : [];
+  return handlers.flatMap((handler) => {
+    const entry = asRecord(handler);
+    return typeof entry?.command === "string" ? [entry.command] : [];
+  });
+}
+
+function listHookStatusMessages(group: unknown): string[] {
+  const record = asRecord(group);
+  const handlers = Array.isArray(record?.hooks) ? record.hooks : [];
+  return handlers.flatMap((handler) => {
+    const entry = asRecord(handler);
+    return typeof entry?.statusMessage === "string" ? [entry.statusMessage] : [];
+  });
+}
+
+function commandIncludesHookName(command: string, hookName: string): boolean {
+  return command.split(/\s+/).some((token) => token.replace(/^['"]|['"]$/g, "") === hookName);
+}
+
+function isRunnableRaviCliEntrypoint(entrypoint?: string): entrypoint is string {
+  if (!entrypoint || !existsSync(entrypoint)) {
+    return false;
+  }
+  if (/\.test\.[cm]?[jt]sx?$/.test(entrypoint)) {
+    return false;
+  }
+  return entrypoint.endsWith("/dist/bundle/index.js") || entrypoint.endsWith("/src/cli/index.ts");
+}
+
+function resolveSourceRaviBinPath(): string | null {
+  try {
+    const modulePath = fileURLToPath(import.meta.url);
+    const candidate = join(dirname(dirname(dirname(modulePath))), "bin", "ravi");
+    return existsSync(candidate) ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+function shellEscape(value: string): string {
+  if (value.length === 0) {
+    return "''";
+  }
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/runtime/codex-hooks.ts
+++ b/src/runtime/codex-hooks.ts
@@ -118,7 +118,7 @@ export function inspectParsedCodexHookConfig(value: unknown, hooksPath: string):
     };
   }
 
-  const matcherOk = raviGroups.some((group) => group.matcher === RAVI_CODEX_BASH_HOOK_MATCHER);
+  const matcherOk = raviGroups.some((group) => asRecord(group)?.matcher === RAVI_CODEX_BASH_HOOK_MATCHER);
   const preferredCommand = raviGroups.some((group) =>
     listHookCommands(group).some(
       (command) =>

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -158,7 +158,7 @@ describe("createCodexRuntimeProvider", () => {
     expect(synced).toEqual([{ type: "local", path: "/tmp/ravi/plugins/ravi-system" }]);
   });
 
-  it("materializes the global Codex native tool hook in ~/.codex/hooks.json", () => {
+  it("materializes the global Codex bash hook in ~/.codex/hooks.json", () => {
     const home = mkdtempSync(join(tmpdir(), "ravi-codex-home-"));
     const originalHome = process.env.HOME;
     process.env.HOME = home;
@@ -188,6 +188,61 @@ describe("createCodexRuntimeProvider", () => {
       expect(raviHookGroup.hooks[0]?.command).toContain("codex-bash-hook");
       expect(raviHookGroup.hooks[0]?.command).not.toContain("codex-tool-hook");
       expect(raviHookGroup.hooks[0]?.command).not.toContain(".test.");
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it("replaces a stale codex-tool-hook group instead of leaving it beside the bash hook", () => {
+    const home = mkdtempSync(join(tmpdir(), "ravi-codex-home-"));
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const hooksPath = join(home, ".codex", "hooks.json");
+      mkdirSync(join(home, ".codex"), { recursive: true });
+      writeFileSync(
+        hooksPath,
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: "^(Read|Bash|shell|exec_command|view_image)$",
+                  hooks: [
+                    {
+                      type: "command",
+                      command: "ravi context codex-tool-hook",
+                      statusMessage: "ravi codex native tool permission gate",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const provider = createCodexRuntimeProvider();
+      provider.prepareSession?.({
+        agentId: "main",
+        cwd: "/tmp/ravi-codex",
+        plugins: [],
+      });
+
+      const payload = JSON.parse(readFileSync(hooksPath, "utf8"));
+      const preToolUse = Array.isArray(payload?.hooks?.PreToolUse) ? payload.hooks.PreToolUse : [];
+      expect(preToolUse).toHaveLength(1);
+      expect(preToolUse[0]?.matcher).toBe("^(Bash|shell)$");
+      expect(preToolUse[0]?.hooks[0]?.command).toContain("codex-bash-hook");
+      expect(preToolUse[0]?.hooks[0]?.command).not.toContain("codex-tool-hook");
+      expect(preToolUse[0]?.hooks[0]?.statusMessage).toBe("ravi codex bash permission gate");
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -1,11 +1,9 @@
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
 import { createInterface } from "node:readline";
-import { fileURLToPath } from "node:url";
 import { syncCodexSkills } from "../plugins/codex-skills.js";
 import { logger } from "../utils/logger.js";
+import { ensureCodexBashHookConfig } from "./codex-hooks.js";
 import {
   createCodexTransport,
   resolveCodexTransportKind,
@@ -63,8 +61,6 @@ const DEFAULT_CODEX_MODEL = "gpt-5";
 const INTERRUPT_GRACE_MS = 1_500;
 const CODEX_APP_SERVER_SANDBOX = "danger-full-access";
 const CODEX_SUB_AGENT_DIRECT_INPUT_ERROR = "direct app-server input is not allowed for multi-agent v2 sub-agents";
-const RAVI_CODEX_BASH_HOOK_STATUS = "ravi codex bash permission gate";
-const RAVI_CODEX_BASH_HOOK_MATCHER = "^(Bash|shell)$";
 const CODEX_APP_SERVER_ENV_KEY_PREFIXES = ["RAVI_"];
 const CODEX_APP_SERVER_ENV_KEYS = new Set(["CODEX_HOME", "PATH"]);
 const CODEX_SHELL_ENV_INCLUDE_ONLY = [
@@ -946,6 +942,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
   let bootstrapPromise: Promise<void> | null = null;
   let activeTurn: AppServerTurnState | null = null;
   let activeSpawnEnvSignature: string | null = null;
+  let activeHookConfigSignature: string | null = null;
   let intentionalChildRestart = false;
   let closePromise: Promise<void> | null = null;
   let resumedThreadResponse: Record<string, unknown> | null = null;
@@ -1065,12 +1062,13 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     }
     child = null;
     activeSpawnEnvSignature = null;
+    activeHookConfigSignature = null;
   };
 
   const spawnChild = async (input: CodexCliTurnRequest): Promise<void> => {
-    if (shouldMaterializeCodexHookForCommand(command)) {
-      ensureCodexBashHookConfig(input.env?.CODEX_HOME);
-    }
+    const hookResult = shouldMaterializeCodexHookForCommand(command)
+      ? ensureCodexBashHookConfig(input.env?.CODEX_HOME)
+      : null;
     // RUST_LOG defaults to `warn` so only warnings/errors from codex reach our stderr forwarder.
     // Override via `RAVI_CODEX_RUST_LOG` (e.g. "codex_app_server=debug,codex=info,warn") when
     // diagnosing silent hangs in the JSON-RPC layer.
@@ -1113,6 +1111,7 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
     transport = newTransport;
     child = newTransport.child;
     activeSpawnEnvSignature = buildCodexAppServerEnvSignature(input.env);
+    activeHookConfigSignature = hookResult?.signature ?? null;
     closed = false;
     nextRequestId = 1;
     pendingRequests = new Map();
@@ -1834,12 +1833,21 @@ function createCodexAppServerTransport(options: { command?: string } = {}): Code
   }
 
   async function ensureClient(input: CodexCliTurnRequest): Promise<void> {
+    const hookResult = shouldMaterializeCodexHookForCommand(command)
+      ? ensureCodexBashHookConfig(input.env?.CODEX_HOME)
+      : null;
     const nextEnvSignature = buildCodexAppServerEnvSignature(input.env);
-    if (!closed && child && !bootstrapPromise && activeSpawnEnvSignature !== nextEnvSignature) {
-      log.info("codex env changed; respawning app-server", {
-        pid: child.pid,
-        envKeys: listCodexAppServerEnvSignatureKeys(input.env),
-      });
+    const hookChanged =
+      hookResult !== null && activeHookConfigSignature !== null && hookResult.signature !== activeHookConfigSignature;
+    if (!closed && child && !bootstrapPromise && (activeSpawnEnvSignature !== nextEnvSignature || hookChanged)) {
+      log.info(
+        hookChanged ? "codex hooks changed; respawning app-server" : "codex env changed; respawning app-server",
+        {
+          pid: child.pid,
+          envKeys: listCodexAppServerEnvSignatureKeys(input.env),
+          hookChanged,
+        },
+      );
       intentionalChildRestart = true;
       try {
         await close();
@@ -3455,116 +3463,9 @@ function extractAppServerErrorMessage(params: Record<string, unknown>): string |
   return extractJsonRpcError(params.error);
 }
 
-function ensureCodexBashHookConfig(configDir = getGlobalCodexConfigDir()): void {
-  const hooksPath = join(configDir, "hooks.json");
-  mkdirSync(configDir, { recursive: true });
-
-  const nextConfig = upsertRaviCodexBashHook(readCodexHooksConfig(hooksPath));
-  const nextJson = JSON.stringify(nextConfig, null, 2) + "\n";
-  const currentJson = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : null;
-  if (currentJson !== nextJson) {
-    writeFileSync(hooksPath, nextJson, "utf8");
-  }
-}
-
-function getGlobalCodexConfigDir(): string {
-  return join(process.env.HOME ?? homedir(), ".codex");
-}
-
-function readCodexHooksConfig(path: string): Record<string, unknown> {
-  if (!existsSync(path)) {
-    return { hooks: {} };
-  }
-
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf8"));
-    return asRecord(parsed) ?? { hooks: {} };
-  } catch {
-    return { hooks: {} };
-  }
-}
-
-function upsertRaviCodexBashHook(config: Record<string, unknown>): Record<string, unknown> {
-  const hooks = asRecord(config.hooks) ?? {};
-  const preToolUse = Array.isArray(hooks.PreToolUse) ? [...hooks.PreToolUse] : [];
-  const raviGroup = {
-    matcher: RAVI_CODEX_BASH_HOOK_MATCHER,
-    hooks: [
-      {
-        type: "command",
-        command: buildRaviCodexHookCommand(),
-        statusMessage: RAVI_CODEX_BASH_HOOK_STATUS,
-      },
-    ],
-  };
-
-  const nextPreToolUse = preToolUse.filter((group) => !isRaviCodexHookGroup(group));
-  nextPreToolUse.push(raviGroup);
-
-  return {
-    ...config,
-    hooks: {
-      ...hooks,
-      PreToolUse: nextPreToolUse,
-    },
-  };
-}
-
-function isRaviCodexHookGroup(value: unknown): boolean {
-  const group = asRecord(value);
-  if (!group) {
-    return false;
-  }
-
-  const handlers = Array.isArray(group.hooks) ? group.hooks : [];
-  return handlers.some((handler) => {
-    const entry = asRecord(handler);
-    return entry?.statusMessage === RAVI_CODEX_BASH_HOOK_STATUS;
-  });
-}
-
 function shouldMaterializeCodexHookForCommand(command: string): boolean {
   const commandName = basename(command);
   return commandName === "codex" || commandName === "codex.exe";
-}
-
-function buildRaviCodexHookCommand(): string {
-  const configuredRaviBin = process.env.RAVI_BIN?.trim();
-  if (configuredRaviBin) {
-    return [configuredRaviBin, "context", "codex-bash-hook"].map(shellEscape).join(" ");
-  }
-
-  const bundlePath = process.argv[1];
-  if (isRunnableRaviCliEntrypoint(bundlePath)) {
-    return [process.execPath, bundlePath, "context", "codex-bash-hook"].map(shellEscape).join(" ");
-  }
-
-  const sourceRaviBin = resolveSourceRaviBinPath();
-  if (sourceRaviBin) {
-    return [sourceRaviBin, "context", "codex-bash-hook"].map(shellEscape).join(" ");
-  }
-
-  return ["ravi", "context", "codex-bash-hook"].map(shellEscape).join(" ");
-}
-
-function isRunnableRaviCliEntrypoint(entrypoint?: string): entrypoint is string {
-  if (!entrypoint || !existsSync(entrypoint)) {
-    return false;
-  }
-  if (/\.test\.[cm]?[jt]sx?$/.test(entrypoint)) {
-    return false;
-  }
-  return entrypoint.endsWith("/dist/bundle/index.js") || entrypoint.endsWith("/src/cli/index.ts");
-}
-
-function resolveSourceRaviBinPath(): string | null {
-  try {
-    const modulePath = fileURLToPath(import.meta.url);
-    const candidate = join(dirname(dirname(dirname(modulePath))), "bin", "ravi");
-    return existsSync(candidate) ? candidate : null;
-  } catch {
-    return null;
-  }
 }
 
 function buildCodexAppServerEnvSignature(env: NodeJS.ProcessEnv): string {
@@ -3588,13 +3489,6 @@ function listCodexAppServerEnvSignatureKeys(env: NodeJS.ProcessEnv): string[] {
         CODEX_APP_SERVER_ENV_KEY_PREFIXES.some((prefix) => key.startsWith(prefix)),
     )
     .sort((left, right) => left.localeCompare(right));
-}
-
-function shellEscape(value: string): string {
-  if (value.length === 0) {
-    return "''";
-  }
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 const CODEX_APP_SERVER_OPTOUT_METHODS = [

--- a/src/runtime/skill-gate.test.ts
+++ b/src/runtime/skill-gate.test.ts
@@ -163,6 +163,7 @@ describe("evaluateSkillGate", () => {
       ruleId: "apps",
     });
     expect(runtimeSkillGateForCommand("bin/ravi context codex-bash-hook")).toBeUndefined();
+    expect(runtimeSkillGateForCommand("bin/ravi context codex-tool-hook")).toBeUndefined();
     expect(runtimeSkillGateForCommand('echo "ravi tasks list"')).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop Codex session `main-dm-860700` (and any other worker still calling `ravi context codex-tool-hook`) from hard-blocking every local tool, including Ravi Pages read/publish. The preferred generated command stays `codex-bash-hook`; the old name becomes a same-access alias, stale `hooks.json` groups are replaced, and a live app-server respawns when that file changes.

## Problem

Codex session `main-dm-860700` could not run local tools, including Ravi Pages list/published/publish. PreToolUse invoked `ravi context codex-tool-hook`, which the installed CLI does not register, so every matching tool was denied. Rewriting `~/.codex/hooks.json` and restarting the daemon did not help: CLI `3.260821.2` rematerialized the old command, leftover hook groups were not replaced after PR #436, and the live Codex app-server does not reload `hooks.json` without a respawn.

## Investigation

This is a Codex hook-path outage, not a `pi` isolation bug. Default runtime provider is `codex` (`src/runtime/provider-registry.ts`). `src/runtime/pi-provider.ts` has no `hooks.json` / PreToolUse path. Gustavo confirmed Codex; a diagnostic that mentioned `pi` was looking at a different harness.

### 1. Rename history

| When | Commit / PR | What happened |
| --- | --- | --- |
| 2026-04-13 | `a8f13ffd` | `codex-bash-hook` CLI + matcher `^(Bash|shell)$` shipped as bash governance. |
| 2026-05-03 | `ec977dcc` | Doctor started requiring that exact matcher + `codex-bash-hook`. |
| 2026-06-26 / 06-30 | `faed7a31` merged as PR #130 `dff9c350` | Meeting-channel branch **widened** the matcher to every `RUNTIME_BUILTIN_TOOL_HOOK_NAMES` alias (`exec_command`, `view_image`, `Read`, …) and **rewrote generated hooks to `codex-tool-hook`**. |
| 2026-07-01 | `48f29bdd` on `codex/runtime-context-safety-clean` only | Added a real `codex-tool-hook` CLI that authorized non-bash tools. **Never merged to `dev`.** No alias was intended on main. |
| 2026-06-30 → 08-21 | CLI `3.260821.2` = `27bc44f0` | Split-brain: provider **emitted** `codex-tool-hook`; installed CLI only had `codex-bash-hook`. Doctor already failed the generated file. |
| 2026-08-21 | PR #436 / `b30435d1` | “repair Codex hook”: generated command and matcher went back to bash-only. **No CLI alias.** `isRaviCodexHookGroup` then matched only the new status, so old groups were no longer replaced. |

PR #436 already stated the hook “referenced an unregistered command and matched more tools than the shell boundary intended.” It fixed generation, not leftover files or in-memory Codex workers.

### 2. Remaining `codex-tool-hook` references (before this PR)

Only `src/runtime/codex-provider.test.ts` **forbade** the old name. Nothing on `dev` still **emitted** it. No skills/docs/SDK/fixtures still generated it. The live outage came from leftover `~/.codex/hooks.json` / in-memory Codex config written by `3.260821.2`.

### 3. Hook load lifecycle

Ravi never sends hooks over app-server JSON-RPC. It writes `$CODEX_HOME/hooks.json` (global `~/.codex` or a model-broker/auth-profile dir) in `prepareSession` and again in `spawnChild`.

The Codex **child** reads that file at process start. `ensureClient` reused the child unless the Ravi env signature changed. `hooks.json` was not part of that signature. Daemon restart kills the bot and its Codex children, then the next turn rematerializes and respawns.

### 4. Who writes `hooks.json` / why rewrite + daemon restart failed

On `3.260821.2`, `ensureCodexBashHookConfig` still preferred `codex-tool-hook` + the wide matcher. Doctor told the operator to rewrite to `codex-bash-hook`. Restart ran rematerialize and **wrote the old command back**. That is why a validated rewrite plus daemon restart still invoked `codex-tool-hook`.

On current `dev` (post-#436) a second bug remains: rematerialize only recognized status `ravi codex bash permission gate`. A leftover group with `ravi codex native tool permission gate` / `codex-tool-hook` was **kept**, and a new bash group was appended. Codex still ran the stale command for every tool the old matcher covered.

Doctor inspected only `~/.codex/hooks.json` and did not rewrite. Install/setup has no separate hook writer.

### 5. Matcher

Required matcher is exactly `^(Bash|shell)$` (SPEC, doctor, this PR).

The broken session’s generated matcher was `^(${RUNTIME_BUILTIN_TOOL_HOOK_NAMES})$`, which includes `Bash`, `shell`, `exec_command`, `view_image`, `Read`, `Edit`, and the rest of the builtin alias list. Doctor already rejected that.

### 6. Blast radius (including Pages)

Codex does not expose Ravi CLI as native dynamic tools. Model-initiated work is `ravi …` through Bash/shell.

- **Pages read/publish are Bash CLI:** `ravi pages list`, `ravi pages published`, `ravi pages publish … --execute`. They die as soon as PreToolUse cannot exec the hook command, even if the matcher is already narrowed to `^(Bash|shell)$`.
- **Wide matcher** also blocked non-bash locals (`exec_command`, `view_image`, attachments/Read). That is why the incident listed those tools. Codex applied the hook to every name the matcher covered; the matcher was too wide.
- **`codex-bash-hook` itself** denies payloads without `tool_input.command`. Alias-only without matcher repair would still deny `view_image` on a stale wide matcher.

`pi` is out of scope and not on this path.

### 7. Safe fix shape

Alias **and** rematerialize/reload. Alias alone is not enough for a leftover wide matcher; rematerialize alone is not enough for a Codex child that still has the old command in memory.

## Solution

- Hidden/deprecated CLI alias: `ravi context codex-tool-hook` → same handler, access, and payload as `codex-bash-hook`. Generated hooks still emit only `codex-bash-hook`.
- Shared `src/runtime/codex-hooks.ts`: replace legacy Ravi groups (old status, old command, or non-canonical matcher) instead of appending.
- Reused app-server respawns when `hooks.json` changes; thread/resume keeps history.
- Doctor fails clearly on stale `codex-tool-hook` and on a matcher other than `^(Bash|shell)$`, then rewrites the Ravi group.

## Practical impact

Stale Codex workers and leftover `hooks.json` no longer hard-block Bash. That unblocks Pages list/published/publish and other `ravi …` shell calls. After rematerialize + respawn, non-bash tools stop hitting the hook.

## What does NOT change

Hook protocol, sandbox/NATS/`pi` isolation, Console `SERVER_UNAVAILABLE`, WhatsApp group confirmation.

## Validation

- `bun test src/runtime/codex-hooks.test.ts src/runtime/codex-provider.test.ts src/cli/commands/doctor.test.ts src/cli/commands/context.test.ts src/cli/commands/context-hook-alias.test.ts src/runtime/skill-gate.test.ts`
- Pre-push: typecheck, full test suite, SDK/OpenAPI/Swift drift

## Risks

Doctor rewrites `~/.codex/hooks.json` when it finds a stale Ravi group. A live Codex child still needs a respawn (automatic on next turn after this change). The alias must not become the preferred generated command.

## Rollback

Revert this branch. Pre-#436 leftover files would still need a manual `hooks.json` rewrite **and** a CLI that accepts `codex-tool-hook`, or the same rematerialize overwrite will return.

## Follow-ups

- Doctor currently repairs `~/.codex/hooks.json`. Per-session `$CODEX_HOME` from model-broker/auth profiles is repaired on the next Codex `prepareSession` / spawn.
- Do not fold `pi` isolation or Console availability into this hook fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51c067c5-9bcc-4052-bdb7-aaed5c16105b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51c067c5-9bcc-4052-bdb7-aaed5c16105b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

