### PR TITLE
fix(cli): Codex Pages isolation without blaming unused pi

### DIFF
--- a/.ravi/specs/cli/cloud-auth/SPEC.md
+++ b/.ravi/specs/cli/cloud-auth/SPEC.md
@@ -178,6 +178,7 @@ Recognized auth/publish errors include:
 - `PAYLOAD_INVALID`
 - `RATE_LIMITED`
 - `SERVER_UNAVAILABLE`
+- `HOST_UNREACHABLE` — Console HTTPS failed from a provider sandbox. The host CLI can still reach Console. This is not a generic Console outage and MUST NOT be inferred from unused runtime providers such as `pi`.
 
 Human output SHOULD show the next useful action. JSON output MUST include the
 safe error code.

--- a/.ravi/specs/cli/pages/SPEC.md
+++ b/.ravi/specs/cli/pages/SPEC.md
@@ -72,7 +72,13 @@ contract errors rethrow first, recognizable Console not-found failures map to
 8. `pages list` and `pages published` MUST accept `--fields a,b,c`.
 9. A thrown `ContractError` MUST pass through `runPagesCommand`'s
    CloudAuthError funnel untouched (rethrow-first, model: mail.ts).
-10. `pages domains --execute` MUST be one idempotent setup command. When
+10. When Console HTTPS fails from a provider sandbox, `pages published`,
+    `pages list`, and `pages publish` MUST surface `HOST_UNREACHABLE` rather
+    than `SERVER_UNAVAILABLE`. The host CLI remaining able to publish/read
+    proves Console is up. Isolated CLIs MAY use the host unix-socket CLI
+    gateway when `RAVI_CONTEXT_KEY` is set and `~/.ravi/cli-gateway.sock` is
+    reachable. They MUST NOT auto-open raw `127.0.0.1`.
+11. `pages domains --execute` MUST be one idempotent setup command. When
     ownership or Pages DNS is not ready, the CLI MUST recognize
     `DOMAIN_SETUP_REQUIRED`, surface the Console-authored DNS instruction, exit
     1, and tell the operator to rerun the same command after propagation. This
@@ -103,6 +109,7 @@ is added it MUST arrive braked.
 | Console route not found | `ROUTE_NOT_FOUND` + listing suggestedAction | 1 |
 | braked write without `--execute` | `WRITE_REQUIRES_EXECUTE` + plan | 3 |
 | domain setup saved but waiting for DNS/provider readiness | `DOMAIN_SETUP_REQUIRED` + exact safe DNS action | 1 |
+| Console HTTPS failed from a provider sandbox | `HOST_UNREACHABLE` + host CLI suggestedAction | 1 |
 | other Console failures (auth, payload, rate limit) | stable CloudAuthError code | `2` for `PAYLOAD_INVALID`; otherwise `1` |
 
 ## Internal consumers

--- a/.ravi/specs/doctor/check-catalog/SPEC.md
+++ b/.ravi/specs/doctor/check-catalog/SPEC.md
@@ -124,6 +124,7 @@ usage accounting.
 Initial checks:
 
 - `runtime.daemon_offline`
+- `runtime.isolation`
 - `runtime.bundle_mismatch`
 - `runtime.branch_drift`
 - `runtime.dirty_worktree`
@@ -134,6 +135,31 @@ Initial checks:
 Runtime checks MUST normalize process names and known aliases before reporting
 failures. For example, renamed Omni process names MUST not be reported as
 missing when the replacement process is healthy.
+
+### Execution plane (`runtime.isolation`)
+
+Provider sandboxes (Codex shell and other isolated CLIs) can see host state
+files while being unable to see `pm2` or reach Console. Doctor MUST report
+that plane without blaming unused built-in providers.
+
+- `id`: `runtime.isolation` (domain `runtime`).
+- `defaultSeverity`: `info` on the host plane, `warn` inside a provider
+  sandbox. This check MUST NOT fail the host because a sandbox probe is
+  isolated.
+- Evidence MUST include `plane`, host-evidence booleans, and sandbox markers.
+  Evidence MUST NOT name unused providers such as `pi`.
+
+`runtime.providers` MUST check only providers used by registered agents
+(or the default provider when no agents exist). A built-in provider that is
+registered but unused, including `pi`, MUST NOT fail doctor.
+
+`runtime.daemon` MUST distinguish "daemon offline on the host" from "daemon
+not visible from this provider sandbox while host `ravi.db` is present". The
+sandbox case is `skip`/`warn`, not a host-offline error.
+
+`permissions.provider_runtime_boundaries` MUST skip when cwd is not a Ravi
+source tree (agent/sandbox workspace), and MUST fail only when the source
+tree is present and the boundary file is missing or imports a retired engine.
 
 Dirty worktree SHOULD be `info` in development contexts and `warn` or `error`
 only in release/deploy contexts.

--- a/src/artifacts/publish-client.ts
+++ b/src/artifacts/publish-client.ts
@@ -5,7 +5,8 @@ import { basename, extname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { file as bunFile } from "bun";
 import { ConsoleApiClient, getMeWithAutoRefresh, normalizeConsoleUrl } from "../cloud-auth/client.js";
-import { CloudAuthError } from "../cloud-auth/errors.js";
+import { CloudAuthError, classifyConsoleNetworkError } from "../cloud-auth/errors.js";
+import { inspectExecutionPlane } from "../isolation/execution-plane.js";
 import { deleteCloudCredentials, readCloudCredentials, writeCloudCredentials } from "../cloud-auth/storage.js";
 import type { CloudCredentials } from "../cloud-auth/types.js";
 import {
@@ -671,11 +672,16 @@ async function uploadPackageFiles(input: {
     const body = bunFile(file.absolutePath, {
       type: headers.get("content-type") ?? file.contentType,
     });
-    const response = await (input.fetch ?? fetch)(request.url, {
-      method: request.method,
-      headers,
-      body,
-    });
+    let response: Response;
+    try {
+      response = await (input.fetch ?? fetch)(request.url, {
+        method: request.method,
+        headers,
+        body,
+      });
+    } catch (error) {
+      throw classifyConsoleNetworkError(error, inspectExecutionPlane());
+    }
     if (!response.ok) {
       throw new CloudAuthError("SERVER_UNAVAILABLE", `Console upload failed for ${file.path}.`, {
         status: response.status,

--- a/src/cli/cloud-error-contract.ts
+++ b/src/cli/cloud-error-contract.ts
@@ -49,6 +49,8 @@ function publicMessage(code: CloudAuthError["code"], sourceMessage: string): str
       return "Console request was rate limited.";
     case "SERVER_UNAVAILABLE":
       return "Console service is unavailable.";
+    case "HOST_UNREACHABLE":
+      return "Console is unreachable from this provider sandbox. The host CLI can reach Console.";
     case "CREDENTIALS_INVALID":
       return "Console credentials are invalid.";
     case "CLOUD_PUBLISH_NOT_IMPLEMENTED":
@@ -90,6 +92,8 @@ function suggestedAction(code: CloudAuthError["code"]): string {
       return "wait for the provider rate limit to reset, then retry";
     case "SERVER_UNAVAILABLE":
       return "retry when the provider is available";
+    case "HOST_UNREACHABLE":
+      return "run the same `ravi pages` command on the host, or retry after the host CLI gateway socket is available";
     case "CLOUD_PUBLISH_NOT_IMPLEMENTED":
       return "use a supported publish path";
   }

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -94,6 +94,15 @@ function makeHealthyDeps() {
       ] as any,
     getRuntimeCompatibilityIssues: () => [],
     listRegisteredRuntimeProviderIds: () => ["codex", "claude"] as any,
+    inspectExecutionPlane: () =>
+      ({
+        plane: "host",
+        runtimeContext: false,
+        hostEvidence: { stateDir: true, sqliteDb: true, cloudCredentials: true, cliGatewaySocket: false },
+        markers: [],
+        daemonIsolationLikely: false,
+        sourceTree: true,
+      }) as any,
     getConfiguredPermissionProviders: () => [{ id: "operator-control" }, { id: "context-capabilities" }] as any,
     getConfiguredCapabilityMaterializers: () =>
       [
@@ -320,6 +329,15 @@ describe("inspectDoctor", () => {
               },
             ]
           : [],
+      inspectExecutionPlane: () =>
+        ({
+          plane: "host",
+          runtimeContext: false,
+          hostEvidence: { stateDir: true, sqliteDb: true, cloudCredentials: false, cliGatewaySocket: false },
+          markers: [],
+          daemonIsolationLikely: false,
+          sourceTree: false,
+        }) as any,
       checkAppManifests: () => [] as any,
       discoverAppManifests: () => [] as any,
       getRegistry: () => ({ commands: [] }) as any,
@@ -567,6 +585,86 @@ describe("inspectDoctor", () => {
     const cronCheck = report.checks.find((check) => check.id === "cron.targets");
     expect(cronCheck).toBeDefined();
     expect(cronCheck!.status).toBe("pass");
+  });
+
+  it("does not fail restricted providers for unused built-in pi", () => {
+    const deps = makeHealthyDeps();
+    const report = inspectDoctor({
+      ...deps,
+      listRegisteredRuntimeProviderIds: () => ["codex", "claude", "pi"] as any,
+      dbListAgents: () => [{ id: "main", cwd: "/agents/main", provider: "codex" }] as any,
+      getRuntimeCompatibilityIssues: (provider) =>
+        provider === "pi"
+          ? [
+              {
+                code: "restricted_tool_access_unsupported",
+                message: "Runtime provider 'pi' requires full tool and executable access because Ravi permission hooks are unsupported",
+              },
+            ]
+          : [],
+    });
+
+    expect(report.checks.find((check) => check.id === "runtime.providers")?.status).toBe("pass");
+    expect(JSON.stringify(report.checks.find((check) => check.id === "runtime.providers"))).not.toContain("pi");
+  });
+
+  it("does not treat a sandboxed daemon probe as host-offline", () => {
+    const deps = makeHealthyDeps();
+    const report = inspectDoctor({
+      ...deps,
+      inspectCliRuntimeTarget: () => ({
+        ...deps.inspectCliRuntimeTarget(),
+        daemon: { online: false, execPath: null, cwd: null, matchesCli: null },
+      }),
+      inspectExecutionPlane: () =>
+        ({
+          plane: "provider-sandbox",
+          runtimeContext: true,
+          hostEvidence: { stateDir: true, sqliteDb: true, cloudCredentials: true, cliGatewaySocket: true },
+          markers: ["codex-sandbox", "runtime-context-key"],
+          daemonIsolationLikely: true,
+          sourceTree: false,
+        }) as any,
+    });
+
+    const daemon = report.checks.find((check) => check.id === "runtime.daemon");
+    const isolation = report.checks.find((check) => check.id === "runtime.isolation");
+    expect(daemon?.status).toBe("skip");
+    expect(daemon?.severity).toBe("warn");
+    expect(daemon?.data).toMatchObject({ isolated: true, plane: "provider-sandbox" });
+    expect(isolation?.status).toBe("pass");
+    expect(isolation?.severity).toBe("warn");
+    expect(JSON.stringify(isolation)).not.toContain("pi");
+  });
+
+  it("skips provider-runtime source checks outside a Ravi source tree", () => {
+    const deps = makeHealthyDeps();
+    const report = inspectDoctor({
+      ...deps,
+      cwd: () => "/agents/main",
+      exists: (path: string) => path === deps.getRaviStateDir() || path === deps.getRaviDbPath(),
+    });
+
+    expect(report.checks.find((check) => check.id === "permissions.provider_runtime_boundaries")?.status).toBe(
+      "skip",
+    );
+  });
+
+  it("fails provider-runtime boundaries only inside a Ravi source tree", () => {
+    const deps = makeHealthyDeps();
+    const report = inspectDoctor({
+      ...deps,
+      cwd: () => "/repo",
+      exists: (path: string) =>
+        path === "/repo/src/cli/commands/doctor.ts" ||
+        path === "/repo/src/cli/commands/pages.ts" ||
+        path === deps.getRaviStateDir() ||
+        path === deps.getRaviDbPath(),
+    });
+
+    expect(report.checks.find((check) => check.id === "permissions.provider_runtime_boundaries")?.status).toBe(
+      "fail",
+    );
   });
 });
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -25,7 +25,11 @@ import {
   materializeSubjectCapabilities,
 } from "../../permissions/provider-runtime.js";
 import { inspectAgentInstructionFiles, type AgentInstructionState } from "../../runtime/agent-instructions.js";
-import { inspectExecutionPlane, looksLikeRaviSourceTree, type ExecutionPlaneSnapshot } from "../../isolation/execution-plane.js";
+import {
+  inspectExecutionPlane,
+  looksLikeRaviSourceTree,
+  type ExecutionPlaneSnapshot,
+} from "../../isolation/execution-plane.js";
 import {
   DEFAULT_RUNTIME_PROVIDER_ID,
   getRuntimeCompatibilityIssues,
@@ -2592,7 +2596,10 @@ function providersUsedByRegisteredAgents(deps: DoctorDeps): RuntimeProviderId[] 
       used.add(DEFAULT_RUNTIME_PROVIDER_ID);
     }
     for (const agent of agents) {
-      const provider = typeof agent.provider === "string" && agent.provider.trim() ? agent.provider.trim() : DEFAULT_RUNTIME_PROVIDER_ID;
+      const provider =
+        typeof agent.provider === "string" && agent.provider.trim()
+          ? agent.provider.trim()
+          : DEFAULT_RUNTIME_PROVIDER_ID;
       used.add(provider);
     }
   } catch {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -25,7 +25,12 @@ import {
   materializeSubjectCapabilities,
 } from "../../permissions/provider-runtime.js";
 import { inspectAgentInstructionFiles, type AgentInstructionState } from "../../runtime/agent-instructions.js";
-import { getRuntimeCompatibilityIssues, listRegisteredRuntimeProviderIds } from "../../runtime/provider-registry.js";
+import { inspectExecutionPlane, looksLikeRaviSourceTree, type ExecutionPlaneSnapshot } from "../../isolation/execution-plane.js";
+import {
+  DEFAULT_RUNTIME_PROVIDER_ID,
+  getRuntimeCompatibilityIssues,
+  listRegisteredRuntimeProviderIds,
+} from "../../runtime/provider-registry.js";
 import type { RuntimeCompatibilityIssue, RuntimeProviderId } from "../../runtime/types.js";
 import {
   dbGetAgent,
@@ -190,6 +195,12 @@ type DoctorDeps = {
     },
   ) => RuntimeCompatibilityIssue[];
   listRegisteredRuntimeProviderIds: typeof listRegisteredRuntimeProviderIds;
+  inspectExecutionPlane: (input?: {
+    env?: NodeJS.ProcessEnv;
+    cwd?: string;
+    stateDir?: string;
+    exists?: (path: string) => boolean;
+  }) => ExecutionPlaneSnapshot;
   getConfiguredPermissionProviders: typeof getConfiguredPermissionProviders;
   getConfiguredCapabilityMaterializers: typeof getConfiguredCapabilityMaterializers;
   authorizePermission: typeof authorizePermission;
@@ -242,6 +253,7 @@ const DEFAULT_DEPS: DoctorDeps = {
   listTaskAutomations,
   getRuntimeCompatibilityIssues,
   listRegisteredRuntimeProviderIds,
+  inspectExecutionPlane,
   getConfiguredPermissionProviders,
   getConfiguredCapabilityMaterializers,
   authorizePermission,
@@ -415,7 +427,8 @@ export function inspectDoctor(overrides: Partial<DoctorDeps> = {}, options: Insp
   const insightsDbPath = join(stateDir, "insights.db");
   const codexHooksPath = join(deps.homeDir(), ".codex", "hooks.json");
 
-  addCheck(checks, () => buildDaemonCheck(runtimeTarget));
+  addCheck(checks, () => buildDaemonCheck(runtimeTarget, deps));
+  addCheck(checks, () => buildIsolationCheck(deps));
   addCheck(checks, () => buildRuntimeMatchCheck(runtimeTarget));
   addCheck(checks, () => buildDaemonCwdCheck(runtimeTarget));
   addCheck(checks, () => buildStateDirCheck(stateDir, deps));
@@ -750,7 +763,7 @@ function inferDomain(id: string): string {
   return "runtime";
 }
 
-function buildDaemonCheck(summary: CliRuntimeTargetSummary): LegacyDoctorCheck {
+function buildDaemonCheck(summary: CliRuntimeTargetSummary, deps: DoctorDeps): LegacyDoctorCheck {
   if (summary.daemon.online) {
     return {
       id: "runtime.daemon",
@@ -766,6 +779,29 @@ function buildDaemonCheck(summary: CliRuntimeTargetSummary): LegacyDoctorCheck {
     };
   }
 
+  const isolation = inspectIsolation(deps);
+  if (isolation.daemonIsolationLikely) {
+    return {
+      id: "runtime.daemon",
+      title: "Live daemon",
+      status: "skip",
+      severity: "warn",
+      summary: "live daemon is not visible from this provider sandbox; host state is present",
+      details: [
+        `execution plane: ${isolation.plane}`,
+        `host sqlite: ${isolation.hostEvidence.sqliteDb ? "present" : "missing"}`,
+        `cli bundle: ${summary.cliBundlePath ?? "-"}`,
+      ],
+      fixHint: "inspect the daemon from a host terminal, not from the provider sandbox",
+      data: {
+        online: false,
+        isolated: true,
+        plane: isolation.plane,
+        cliBundle: summary.cliBundlePath,
+      },
+    };
+  }
+
   return {
     id: "runtime.daemon",
     title: "Live daemon",
@@ -776,6 +812,68 @@ function buildDaemonCheck(summary: CliRuntimeTargetSummary): LegacyDoctorCheck {
     data: {
       online: false,
       cliBundle: summary.cliBundlePath,
+    },
+  };
+}
+
+function inspectIsolation(deps: DoctorDeps): ExecutionPlaneSnapshot {
+  return deps.inspectExecutionPlane({
+    cwd: deps.cwd(),
+    stateDir: deps.getRaviStateDir(),
+    exists: deps.exists,
+  });
+}
+
+function buildIsolationCheck(deps: DoctorDeps): LegacyDoctorCheck {
+  const isolation = inspectIsolation(deps);
+  const details = [
+    `execution plane: ${isolation.plane}`,
+    `runtime context: ${isolation.runtimeContext ? "yes" : "no"}`,
+    `source tree: ${isolation.sourceTree ? "yes" : "no"}`,
+    `host state dir: ${isolation.hostEvidence.stateDir ? "present" : "missing"}`,
+    `host sqlite: ${isolation.hostEvidence.sqliteDb ? "present" : "missing"}`,
+    `host credentials: ${isolation.hostEvidence.cloudCredentials ? "present" : "missing"}`,
+    `host cli gateway socket: ${isolation.hostEvidence.cliGatewaySocket ? "present" : "missing"}`,
+    ...(isolation.markers.length > 0 ? [`markers: ${isolation.markers.join(", ")}`] : []),
+  ];
+
+  if (isolation.plane === "provider-sandbox") {
+    return {
+      id: "runtime.isolation",
+      domain: "runtime",
+      title: "Execution plane",
+      status: "ok",
+      severity: "warn",
+      summary: "this CLI is running inside a provider sandbox; host Pages/daemon probes may be unreachable",
+      details,
+      fixHint:
+        "use the host CLI or the host unix-socket CLI gateway for Pages publish/read; do not treat unused providers as the cause",
+      data: {
+        plane: isolation.plane,
+        runtimeContext: isolation.runtimeContext,
+        hostEvidence: isolation.hostEvidence,
+        markers: isolation.markers,
+        daemonIsolationLikely: isolation.daemonIsolationLikely,
+        sourceTree: isolation.sourceTree,
+        stateDirPresent: isolation.hostEvidence.stateDir,
+      },
+    };
+  }
+
+  return {
+    id: "runtime.isolation",
+    domain: "runtime",
+    title: "Execution plane",
+    status: "ok",
+    summary: "this CLI is running on the host execution plane",
+    details,
+    data: {
+      plane: isolation.plane,
+      runtimeContext: isolation.runtimeContext,
+      hostEvidence: isolation.hostEvidence,
+      markers: isolation.markers,
+      daemonIsolationLikely: isolation.daemonIsolationLikely,
+      sourceTree: isolation.sourceTree,
     },
   };
 }
@@ -2194,6 +2292,20 @@ function buildPermissionProviderRuntimeChainCheck(deps: DoctorDeps): LegacyDocto
 }
 
 function buildPermissionProviderRuntimeBoundaryCheck(deps: DoctorDeps): LegacyDoctorCheck {
+  if (!looksLikeRaviSourceTree(deps.cwd(), deps.exists)) {
+    return {
+      id: "permissions.provider_runtime_boundaries",
+      domain: "permissions",
+      title: "Permission provider runtime boundaries",
+      status: "skip",
+      severity: "info",
+      summary: "cwd is not a Ravi source tree; skipped provider-runtime source check",
+      details: ["agent or sandbox cwd is not the Ravi repository"],
+      fixHint: "run this check from the Ravi source checkout, not from an agent workspace",
+      data: { skipped: true, reason: "not_source_tree" },
+    };
+  }
+
   const providerRuntimePath = join(deps.cwd(), "src", "permissions", "provider-runtime.ts");
   const enginePath = join(deps.cwd(), "src", "permissions", "engine.ts");
   const providerRuntimeSource = deps.exists(providerRuntimePath) ? deps.readFile(providerRuntimePath) : "";
@@ -2434,7 +2546,7 @@ function buildUnexpectedFailureCheck(id: string, title: string, error: unknown):
 }
 
 function buildProviderCompatibilityCheck(deps: DoctorDeps): LegacyDoctorCheck {
-  const providers = deps.listRegisteredRuntimeProviderIds();
+  const providers = providersUsedByRegisteredAgents(deps);
   const results = providers.map((provider) => ({
     provider,
     issues: deps.getRuntimeCompatibilityIssues(provider, { toolAccessMode: "restricted" }),
@@ -2446,14 +2558,15 @@ function buildProviderCompatibilityCheck(deps: DoctorDeps): LegacyDoctorCheck {
       id: "runtime.providers",
       title: "Restricted provider compatibility",
       status: "fail",
-      summary: `${failing.length} runtime providers do not support restricted tool access`,
+      summary: `${failing.length} used runtime providers do not support restricted tool access`,
       details: failing.flatMap((entry) => entry.issues.map((issue) => `${entry.provider}: ${issue.message}`)),
-      fixHint: "bring provider capabilities back in sync before relying on restricted sessions",
+      fixHint: "bring the providers used by registered agents back in sync before relying on restricted sessions",
       data: {
         failing: failing.map((entry) => ({
           provider: entry.provider,
           issues: entry.issues.map((issue) => issue.code),
         })),
+        checked: providers,
       },
     };
   }
@@ -2462,12 +2575,30 @@ function buildProviderCompatibilityCheck(deps: DoctorDeps): LegacyDoctorCheck {
     id: "runtime.providers",
     title: "Restricted provider compatibility",
     status: "ok",
-    summary: "registered runtime providers support restricted tool access",
+    summary: "runtime providers used by registered agents support restricted tool access",
     details: results.map((entry) => `${entry.provider}: restricted tool access supported`),
     data: {
       providers: results.map((entry) => entry.provider),
     },
   };
+}
+
+function providersUsedByRegisteredAgents(deps: DoctorDeps): RuntimeProviderId[] {
+  const registered = deps.listRegisteredRuntimeProviderIds();
+  const used = new Set<string>();
+  try {
+    const agents = deps.dbListAgents();
+    if (agents.length === 0) {
+      used.add(DEFAULT_RUNTIME_PROVIDER_ID);
+    }
+    for (const agent of agents) {
+      const provider = typeof agent.provider === "string" && agent.provider.trim() ? agent.provider.trim() : DEFAULT_RUNTIME_PROVIDER_ID;
+      used.add(provider);
+    }
+  } catch {
+    used.add(DEFAULT_RUNTIME_PROVIDER_ID);
+  }
+  return registered.filter((id) => used.has(id));
 }
 
 const CRON_TARGET_STATUS: Record<CronTargetState, LegacyDoctorCheckStatus> = {

--- a/src/cli/host-cli-gateway.test.ts
+++ b/src/cli/host-cli-gateway.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dispatchRemote } from "./remote-gateway.js";
+import { startHostCliGateway, type HostCliGatewayHandle } from "./host-cli-gateway.js";
+
+const tempDirs: string[] = [];
+const handles: HostCliGatewayHandle[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ravi-host-cli-gateway-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (handles.length > 0) {
+    const handle = handles.pop();
+    if (handle) await handle.stop();
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("host CLI gateway", () => {
+  it("listens on a 0600 unix socket and serves authenticated CLI posts", async () => {
+    const socketPath = join(tempDir(), "cli-gateway.sock");
+    const handle = await startHostCliGateway({
+      socketPath,
+      handleRequest: async (request) => {
+        const url = new URL(request.url);
+        const body = (await request.json()) as { project?: string };
+        return Response.json({
+          ok: true,
+          path: url.pathname,
+          authorization: request.headers.get("authorization"),
+          project: body.project,
+        });
+      },
+    });
+    expect(handle).not.toBeNull();
+    handles.push(handle!);
+    expect(statSync(socketPath).mode & 0o777).toBe(0o600);
+
+    const result = await dispatchRemote({
+      groupSegments: ["pages"],
+      command: "published",
+      body: { project: "rbbt-lab", json: true },
+      config: { url: `unix://${socketPath}`, source: "host-socket", socketPath },
+      contextKey: "rctx_test",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(result.body)).toEqual({
+      ok: true,
+      path: "/api/v1/pages/published",
+      authorization: "Bearer rctx_test",
+      project: "rbbt-lab",
+    });
+  });
+
+  it("stays disabled when RAVI_HOST_CLI_GATEWAY=0", async () => {
+    const handle = await startHostCliGateway({
+      socketPath: join(tempDir(), "cli-gateway.sock"),
+      env: { RAVI_HOST_CLI_GATEWAY: "0" },
+    });
+    expect(handle).toBeNull();
+  });
+});

--- a/src/cli/host-cli-gateway.ts
+++ b/src/cli/host-cli-gateway.ts
@@ -14,11 +14,7 @@ import { chmodSync, existsSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { getRaviStateDir } from "../utils/paths.js";
 import { logger } from "../utils/logger.js";
-import {
-  HOST_CLI_GATEWAY_ENV,
-  getHostCliGatewaySocketPath,
-  probeUnixSocket,
-} from "../isolation/execution-plane.js";
+import { HOST_CLI_GATEWAY_ENV, getHostCliGatewaySocketPath, probeUnixSocket } from "../isolation/execution-plane.js";
 import { createGatewayHandlerContext, handleGatewayRequest } from "../sdk/gateway/server.js";
 import type { GatewayConfig, GatewayHandlerContext } from "../sdk/gateway/server.js";
 
@@ -112,9 +108,7 @@ export async function startHostCliGateway(
   };
 }
 
-export async function hostCliGatewayReachable(
-  socketPath = getHostCliGatewaySocketPath(),
-): Promise<boolean> {
+export async function hostCliGatewayReachable(socketPath = getHostCliGatewaySocketPath()): Promise<boolean> {
   return probeUnixSocket(socketPath);
 }
 
@@ -154,11 +148,7 @@ async function handleUnixRequest(
   });
 
   const response =
-    (handleRequest
-      ? await handleRequest(request)
-      : ctx
-        ? await handleGatewayRequest(request, ctx)
-        : null) ??
+    (handleRequest ? await handleRequest(request) : ctx ? await handleGatewayRequest(request, ctx) : null) ??
     new Response(JSON.stringify({ error: "NotFound" }), {
       status: 404,
       headers: { "content-type": "application/json" },

--- a/src/cli/host-cli-gateway.ts
+++ b/src/cli/host-cli-gateway.ts
@@ -1,0 +1,174 @@
+/**
+ * Host-side unix-socket CLI gateway.
+ *
+ * Isolated provider sandboxes (Codex shell, and other restricted CLIs) cannot
+ * be given a raw loopback hole. They MAY reach this socket when the host
+ * daemon created it at `~/.ravi/cli-gateway.sock` (mode 0600) and the caller
+ * presents a live `RAVI_CONTEXT_KEY`.
+ *
+ * The HTTP listener on `RAVI_HTTP_PORT` stays optional and loopback-bound.
+ * This unix listener is independent of that port.
+ */
+
+import { chmodSync, existsSync, unlinkSync } from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { getRaviStateDir } from "../utils/paths.js";
+import { logger } from "../utils/logger.js";
+import {
+  HOST_CLI_GATEWAY_ENV,
+  getHostCliGatewaySocketPath,
+  probeUnixSocket,
+} from "../isolation/execution-plane.js";
+import { createGatewayHandlerContext, handleGatewayRequest } from "../sdk/gateway/server.js";
+import type { GatewayConfig, GatewayHandlerContext } from "../sdk/gateway/server.js";
+
+const log = logger.child("cli:host-gateway");
+
+export { HOST_CLI_GATEWAY_ENV, HOST_CLI_GATEWAY_INTERNAL_ENV } from "../isolation/execution-plane.js";
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+export interface HostCliGatewayHandle {
+  socketPath: string;
+  stop(): Promise<void>;
+}
+
+export interface StartHostCliGatewayOptions {
+  socketPath?: string;
+  gateway?: GatewayConfig;
+  env?: NodeJS.ProcessEnv;
+  handleRequest?: (request: Request) => Promise<Response> | Response;
+}
+
+export function isHostCliGatewayEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[HOST_CLI_GATEWAY_ENV]?.trim();
+  return raw !== "0" && raw?.toLowerCase() !== "false" && raw?.toLowerCase() !== "off";
+}
+
+export async function startHostCliGateway(
+  options: StartHostCliGatewayOptions = {},
+): Promise<HostCliGatewayHandle | null> {
+  const env = options.env ?? process.env;
+  if (!isHostCliGatewayEnabled(env)) {
+    log.info("Host CLI gateway disabled");
+    return null;
+  }
+
+  const socketPath = options.socketPath ?? getHostCliGatewaySocketPath(getRaviStateDir(env));
+  const ctx = options.handleRequest ? null : createGatewayHandlerContext(options.gateway ?? {});
+  const handleRequest = options.handleRequest;
+
+  if (existsSync(socketPath)) {
+    try {
+      unlinkSync(socketPath);
+    } catch (error) {
+      log.warn("Failed to remove stale host CLI gateway socket", { socketPath, error });
+    }
+  }
+
+  const server = createServer((req, res) => {
+    void handleUnixRequest(req, res, ctx, handleRequest).catch((error) => {
+      log.error("Host CLI gateway request failed", { error });
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+      }
+      res.end(JSON.stringify({ error: "InternalError" }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  try {
+    chmodSync(socketPath, 0o600);
+  } catch (error) {
+    log.warn("Failed to restrict host CLI gateway socket mode", { socketPath, error });
+  }
+
+  log.info("Host CLI gateway ready", { socketPath });
+
+  return {
+    socketPath,
+    async stop() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((closeError) => {
+          if (closeError) reject(closeError);
+          else resolve();
+        });
+      });
+      if (existsSync(socketPath)) {
+        try {
+          unlinkSync(socketPath);
+        } catch {
+          // Best-effort cleanup; a replacement daemon will unlink on start.
+        }
+      }
+      log.info("Host CLI gateway stopped", { socketPath });
+    },
+  };
+}
+
+export async function hostCliGatewayReachable(
+  socketPath = getHostCliGatewaySocketPath(),
+): Promise<boolean> {
+  return probeUnixSocket(socketPath);
+}
+
+async function handleUnixRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: GatewayHandlerContext | null,
+  handleRequest?: (request: Request) => Promise<Response> | Response,
+): Promise<void> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) {
+      res.writeHead(413, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "PayloadTooLarge", limitBytes: MAX_BODY_BYTES }));
+      req.destroy();
+      return;
+    }
+    chunks.push(buffer);
+  }
+
+  const rawBody = Buffer.concat(chunks).toString("utf8");
+  const method = req.method ?? "GET";
+  const target = req.url ?? "/";
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === "string") headers.set(key, value);
+    else if (Array.isArray(value)) headers.set(key, value.join(", "));
+  }
+
+  const request = new Request(`http://ravi-cli-gateway.local${target}`, {
+    method,
+    headers,
+    ...(method !== "GET" && method !== "HEAD" && rawBody.length > 0 ? { body: rawBody } : {}),
+  });
+
+  const response =
+    (handleRequest
+      ? await handleRequest(request)
+      : ctx
+        ? await handleGatewayRequest(request, ctx)
+        : null) ??
+    new Response(JSON.stringify({ error: "NotFound" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+
+  const body = Buffer.from(await response.arrayBuffer());
+  const outHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    outHeaders[key] = value;
+  });
+  res.writeHead(response.status, outHeaders);
+  res.end(body);
+}

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -33,7 +33,7 @@ import { emitCliAuditEvent } from "./audit.js";
 import { getContext, runWithContext } from "./context.js";
 import {
   dispatchRemote,
-  getRemoteGatewayConfig,
+  resolveRemoteGatewayConfig,
   remoteGatewayErrorToContractError,
   remoteGatewayExitCode,
   remoteDispatchOutput,
@@ -226,7 +226,7 @@ function registerCommand(
 
     let remoteConfig: RemoteGatewayConfig | null;
     try {
-      remoteConfig = getRemoteGatewayConfig(process.env, commandOperation(groupName, cmdMeta.name));
+      remoteConfig = await resolveRemoteGatewayConfig(process.env, commandOperation(groupName, cmdMeta.name));
     } catch (error) {
       if (!(error instanceof ContractError)) throw error;
       renderContractError(error, input.json === true);

--- a/src/cli/remote-gateway.test.ts
+++ b/src/cli/remote-gateway.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   dispatchRemote,
   getRemoteGatewayConfig,
+  resolveRemoteGatewayConfig,
   remoteDispatchOutput,
   remoteGatewayErrorToContractError,
   remoteGatewayExitCode,
@@ -44,7 +45,7 @@ describe("remote gateway response bytes", () => {
 describe("remote gateway configuration", () => {
   it("distinguishes an unset gateway from an invalid configured URL", () => {
     expect(getRemoteGatewayConfig({})).toBeNull();
-    for (const value of ["not a URL", "file:///tmp/ravi"]) {
+    for (const value of ["not a URL", "file:///tmp/ravi", "unix:relative.sock"]) {
       let failure: unknown;
       try {
         getRemoteGatewayConfig({ RAVI_GATEWAY_URL: value });
@@ -53,6 +54,60 @@ describe("remote gateway configuration", () => {
       }
       expect(failure).toMatchObject({ code: "REMOTE_GATEWAY_INVALID", exitCode: 2 });
     }
+  });
+
+  it("accepts an explicit unix socket URL without opening loopback HTTP", () => {
+    expect(getRemoteGatewayConfig({ RAVI_GATEWAY_URL: "unix:///home/user/.ravi/cli-gateway.sock" })).toEqual({
+      url: "unix:///home/user/.ravi/cli-gateway.sock",
+      source: "env",
+      socketPath: "/home/user/.ravi/cli-gateway.sock",
+    });
+  });
+
+  it("auto-bridges isolated CLIs to a reachable host unix socket", async () => {
+    const config = await resolveRemoteGatewayConfig(
+      { RAVI_CONTEXT_KEY: "rctx_test" },
+      "pages published",
+      {
+        stateDir: "/home/user/.ravi",
+        probeSocket: async (socketPath) => socketPath === "/home/user/.ravi/cli-gateway.sock",
+      },
+    );
+
+    expect(config).toEqual({
+      url: "unix:///home/user/.ravi/cli-gateway.sock",
+      source: "host-socket",
+      socketPath: "/home/user/.ravi/cli-gateway.sock",
+    });
+  });
+
+  it("does not auto-bridge without a context key, a reachable socket, or when disabled", async () => {
+    expect(
+      await resolveRemoteGatewayConfig({}, "pages published", {
+        stateDir: "/home/user/.ravi",
+        probeSocket: async () => true,
+      }),
+    ).toBeNull();
+    expect(
+      await resolveRemoteGatewayConfig(
+        { RAVI_CONTEXT_KEY: "rctx_test", RAVI_HOST_CLI_GATEWAY: "0" },
+        "pages published",
+        { stateDir: "/home/user/.ravi", probeSocket: async () => true },
+      ),
+    ).toBeNull();
+    expect(
+      await resolveRemoteGatewayConfig({ RAVI_CONTEXT_KEY: "rctx_test" }, "pages published", {
+        stateDir: "/home/user/.ravi",
+        probeSocket: async () => false,
+      }),
+    ).toBeNull();
+    expect(
+      await resolveRemoteGatewayConfig(
+        { RAVI_CONTEXT_KEY: "rctx_test", RAVI_GATEWAY_URL: "https://gateway.example" },
+        "pages published",
+        { stateDir: "/home/user/.ravi", probeSocket: async () => true },
+      ),
+    ).toEqual({ url: "https://gateway.example", source: "env" });
   });
 });
 

--- a/src/cli/remote-gateway.test.ts
+++ b/src/cli/remote-gateway.test.ts
@@ -65,14 +65,10 @@ describe("remote gateway configuration", () => {
   });
 
   it("auto-bridges isolated CLIs to a reachable host unix socket", async () => {
-    const config = await resolveRemoteGatewayConfig(
-      { RAVI_CONTEXT_KEY: "rctx_test" },
-      "pages published",
-      {
-        stateDir: "/home/user/.ravi",
-        probeSocket: async (socketPath) => socketPath === "/home/user/.ravi/cli-gateway.sock",
-      },
-    );
+    const config = await resolveRemoteGatewayConfig({ RAVI_CONTEXT_KEY: "rctx_test" }, "pages published", {
+      stateDir: "/home/user/.ravi",
+      probeSocket: async (socketPath) => socketPath === "/home/user/.ravi/cli-gateway.sock",
+    });
 
     expect(config).toEqual({
       url: "unix:///home/user/.ravi/cli-gateway.sock",
@@ -108,6 +104,25 @@ describe("remote gateway configuration", () => {
         { stateDir: "/home/user/.ravi", probeSocket: async () => true },
       ),
     ).toEqual({ url: "https://gateway.example", source: "env" });
+  });
+
+  it("does not throw when an isolated CLI probes a missing host socket", async () => {
+    await expect(
+      resolveRemoteGatewayConfig({ RAVI_CONTEXT_KEY: "rctx_test" }, "pages published", {
+        stateDir: "/tmp/ravi-missing-host-cli-gateway-state",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("treats a throwing socket probe as unreachable instead of crashing the CLI", async () => {
+    await expect(
+      resolveRemoteGatewayConfig({ RAVI_CONTEXT_KEY: "rctx_test" }, "pages published", {
+        stateDir: "/home/user/.ravi",
+        probeSocket: async () => {
+          throw Object.assign(new Error("connect ENOENT"), { code: "ENOENT" });
+        },
+      }),
+    ).resolves.toBeNull();
   });
 });
 
@@ -235,35 +250,38 @@ describe("remote gateway exit taxonomy", () => {
     [1, "denied", "PERMISSION_DENIED", "Remote gateway denied the command."],
     [2, "usage_error", "USAGE_ERROR", "Remote gateway rejected the command input."],
     [3, "blocked", "WRITE_REQUIRES_EXECUTE", "Remote command was blocked by policy."],
-  ] as const)("projects a complete exit %i/%s response into a safe local contract", (exitCode, outcome, code, message) => {
-    const error = remoteGatewayErrorToContractError(
-      "commands list",
-      result({
-        status: 409,
-        body: JSON.stringify({
-          success: false,
-          op: "commands list",
-          exitCode,
-          outcome,
-          providerBody: "PRIVATE_MESSAGE_8K2R",
-          plan: { token: "SENTINEL_SECRET_7M4Q" },
-          error: {
-            code,
-            message: "PRIVATE_MESSAGE_8K2R",
-            retryable: true,
-            metadata: { secret: "SENTINEL_SECRET_7M4Q" },
-          },
+  ] as const)(
+    "projects a complete exit %i/%s response into a safe local contract",
+    (exitCode, outcome, code, message) => {
+      const error = remoteGatewayErrorToContractError(
+        "commands list",
+        result({
+          status: 409,
+          body: JSON.stringify({
+            success: false,
+            op: "commands list",
+            exitCode,
+            outcome,
+            providerBody: "PRIVATE_MESSAGE_8K2R",
+            plan: { token: "SENTINEL_SECRET_7M4Q" },
+            error: {
+              code,
+              message: "PRIVATE_MESSAGE_8K2R",
+              retryable: true,
+              metadata: { secret: "SENTINEL_SECRET_7M4Q" },
+            },
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(error).toMatchObject({ op: "commands list", code, exitCode, message, details: { retryable: true } });
-    const serialized = JSON.stringify(error?.envelope());
-    expect(serialized).not.toContain("PRIVATE_MESSAGE_8K2R");
-    expect(serialized).not.toContain("SENTINEL_SECRET_7M4Q");
-    expect(serialized).not.toContain("providerBody");
-    expect(serialized).not.toContain("metadata");
-  });
+      expect(error).toMatchObject({ op: "commands list", code, exitCode, message, details: { retryable: true } });
+      const serialized = JSON.stringify(error?.envelope());
+      expect(serialized).not.toContain("PRIVATE_MESSAGE_8K2R");
+      expect(serialized).not.toContain("SENTINEL_SECRET_7M4Q");
+      expect(serialized).not.toContain("providerBody");
+      expect(serialized).not.toContain("metadata");
+    },
+  );
 
   it("rejects an invalid remote error code instead of reflecting it", () => {
     const error = remoteGatewayErrorToContractError(

--- a/src/cli/remote-gateway.ts
+++ b/src/cli/remote-gateway.ts
@@ -3,10 +3,13 @@
  *
  * Spec: `runtime/context-keys`, `sdk/auth`, `sdk/gateway`.
  *
- * When `RAVI_GATEWAY_URL` is set (or, in the future, `gateway.url` from
- * `~/.ravi/config.toml`), every decorated CLI command transparently turns into
- * a `POST /api/v1/<group-segments>/<command>` request authenticated with the
- * resolved runtime context-key (`rctx_*`).
+ * When `RAVI_GATEWAY_URL` is set (http(s) or `unix://`), every decorated CLI
+ * command transparently turns into a `POST /api/v1/<group-segments>/<command>`
+ * request authenticated with the resolved runtime context-key (`rctx_*`).
+ *
+ * Isolated CLIs (`RAVI_CONTEXT_KEY` set) also auto-bridge to the host unix
+ * socket at `~/.ravi/cli-gateway.sock` when that socket is connectable. They
+ * MUST NOT auto-open raw loopback HTTP.
  *
  * The remote dispatcher is intentionally minimal: it builds a flat JSON body
  * (matching `src/sdk/gateway/dispatcher.ts`), forwards successful responses
@@ -15,6 +18,13 @@
  * local mode without trusting arbitrary remote error fields.
  */
 
+import { request as httpRequest } from "node:http";
+import {
+  HOST_CLI_GATEWAY_ENV,
+  HOST_CLI_GATEWAY_INTERNAL_ENV,
+  getHostCliGatewaySocketPath,
+  probeUnixSocket,
+} from "../isolation/execution-plane.js";
 import { resolveRuntimeContext } from "../runtime/context-registry.js";
 import { readCredentialsFile, selectDefaultCredentialsKey } from "../runtime/credentials-store.js";
 import {
@@ -27,6 +37,7 @@ import { sanitizePublicValue } from "./redaction.js";
 
 export const REMOTE_GATEWAY_URL_ENV = "RAVI_GATEWAY_URL";
 export const REMOTE_GATEWAY_DEFAULT_TIMEOUT_MS = 30_000;
+export const HOST_CLI_GATEWAY_URL_PREFIX = "unix://";
 // The authenticated target gateway owns the protocol code. Preserve it for
 // transport parity, but reject free-form strings; a shared code catalog would
 // be a broader contract change than this boundary repair.
@@ -88,12 +99,17 @@ const REMOTE_PLAN_MAX_PROPERTIES = 64;
 export interface RemoteGatewayConfig {
   url: string;
   /** Source of the configuration value, used for log/error messages. */
-  source: "env";
+  source: "env" | "host-socket";
+  socketPath?: string;
 }
 
 export function getRemoteGatewayConfig(env: NodeJS.ProcessEnv = process.env, op = "cli"): RemoteGatewayConfig | null {
   const raw = env[REMOTE_GATEWAY_URL_ENV]?.trim();
   if (!raw) return null;
+  const unix = parseUnixGatewayUrl(raw);
+  if (unix) {
+    return { url: `${HOST_CLI_GATEWAY_URL_PREFIX}${unix}`, source: "env", socketPath: unix };
+  }
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -104,11 +120,63 @@ export function getRemoteGatewayConfig(env: NodeJS.ProcessEnv = process.env, op 
   return { url: raw.replace(/\/+$/, ""), source: "env" };
 }
 
+export interface ResolveRemoteGatewayConfigOptions {
+  probeSocket?: (socketPath: string) => Promise<boolean>;
+  stateDir?: string;
+}
+
+/**
+ * Resolve an explicit HTTP(S)/unix gateway, or auto-bridge to the host unix
+ * socket when this process is an isolated CLI (`RAVI_CONTEXT_KEY`) and the
+ * socket is actually connectable. Never auto-sets a loopback HTTP URL.
+ */
+export async function resolveRemoteGatewayConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  op = "cli",
+  options: ResolveRemoteGatewayConfigOptions = {},
+): Promise<RemoteGatewayConfig | null> {
+  const explicit = getRemoteGatewayConfig(env, op);
+  if (explicit) return explicit;
+  return resolveAutoHostCliGateway(env, options);
+}
+
+export async function resolveAutoHostCliGateway(
+  env: NodeJS.ProcessEnv = process.env,
+  options: ResolveRemoteGatewayConfigOptions = {},
+): Promise<RemoteGatewayConfig | null> {
+  if (!shouldAutoUseHostCliGateway(env)) return null;
+  const socketPath = getHostCliGatewaySocketPath(options.stateDir);
+  const probe = options.probeSocket ?? probeUnixSocket;
+  if (!(await probe(socketPath))) return null;
+  return {
+    url: `${HOST_CLI_GATEWAY_URL_PREFIX}${socketPath}`,
+    source: "host-socket",
+    socketPath,
+  };
+}
+
+export function shouldAutoUseHostCliGateway(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env[REMOTE_GATEWAY_URL_ENV]?.trim()) return false;
+  const disabled = env[HOST_CLI_GATEWAY_ENV]?.trim();
+  if (disabled === "0" || disabled?.toLowerCase() === "false" || disabled?.toLowerCase() === "off") return false;
+  if (env[HOST_CLI_GATEWAY_INTERNAL_ENV]?.trim() === "1") return false;
+  return Boolean(env.RAVI_CONTEXT_KEY?.trim());
+}
+
+export function parseUnixGatewayUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("unix:")) return null;
+  let rest = trimmed.slice("unix:".length);
+  if (rest.startsWith("//")) rest = rest.slice(2);
+  if (!rest.startsWith("/")) return null;
+  return rest.replace(/\/+$/, "") || null;
+}
+
 function invalidRemoteGatewayError(op: string): ContractError {
   return new ContractError(
     op,
     "REMOTE_GATEWAY_INVALID",
-    `${REMOTE_GATEWAY_URL_ENV} must be a valid HTTP(S) URL.`,
+    `${REMOTE_GATEWAY_URL_ENV} must be a valid HTTP(S) or unix socket URL.`,
     CONTRACT_EXIT_USAGE,
     { suggestedAction: `Correct or unset ${REMOTE_GATEWAY_URL_ENV} before retrying` },
   );
@@ -374,32 +442,88 @@ function isCompleteContractErrorBody(value: unknown, expectedOp?: string): value
 
 export async function dispatchRemote(input: RemoteDispatchInput): Promise<RemoteDispatchResult> {
   const path = `/api/v1/${[...input.groupSegments, input.command].join("/")}`;
-  const url = `${input.config.url}${path}`;
+  const socketPath = input.config.socketPath ?? parseUnixGatewayUrl(input.config.url);
+  const url = socketPath ? `http://ravi-cli-gateway.local${path}` : `${input.config.url}${path}`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    authorization: `Bearer ${input.contextKey}`,
+    ...(socketPath ? { "x-ravi-gateway-internal": "1" } : {}),
+  };
+  const body = JSON.stringify(input.body);
+  const timeoutMs = input.timeoutMs ?? REMOTE_GATEWAY_DEFAULT_TIMEOUT_MS;
+
+  if (socketPath && !input.fetchImpl) {
+    return fetchViaUnixSocket({ socketPath, path, headers, body, timeoutMs });
+  }
+
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), input.timeoutMs ?? REMOTE_GATEWAY_DEFAULT_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const fetchFn = input.fetchImpl ?? fetch;
     const response = await fetchFn(url, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${input.contextKey}`,
-      },
-      body: JSON.stringify(input.body),
+      headers,
+      body,
       signal: controller.signal,
-    });
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    const text = new TextDecoder().decode(bytes);
-    return {
-      status: response.status,
-      ok: response.ok,
-      body: text,
-      bodyBytes: bytes,
-      contentType: response.headers.get("content-type"),
-    };
+      ...(socketPath ? { unix: socketPath } : {}),
+    } as RequestInit);
+    return await remoteResultFromResponse(response);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+async function fetchViaUnixSocket(input: {
+  socketPath: string;
+  path: string;
+  headers: Record<string, string>;
+  body: string;
+  timeoutMs: number;
+}): Promise<RemoteDispatchResult> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        socketPath: input.socketPath,
+        path: input.path,
+        method: "POST",
+        headers: input.headers,
+        timeout: input.timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          const bytes = new Uint8Array(Buffer.concat(chunks));
+          resolve({
+            status: res.statusCode ?? 500,
+            ok: (res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300,
+            body: new TextDecoder().decode(bytes),
+            bodyBytes: bytes,
+            contentType: typeof res.headers["content-type"] === "string" ? res.headers["content-type"] : null,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy(new Error("Host CLI gateway request timed out"));
+    });
+    req.write(input.body);
+    req.end();
+  });
+}
+
+async function remoteResultFromResponse(response: Response): Promise<RemoteDispatchResult> {
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return {
+    status: response.status,
+    ok: response.ok,
+    body: new TextDecoder().decode(bytes),
+    bodyBytes: bytes,
+    contentType: response.headers.get("content-type"),
+  };
 }
 
 /**

--- a/src/cli/remote-gateway.ts
+++ b/src/cli/remote-gateway.ts
@@ -147,7 +147,11 @@ export async function resolveAutoHostCliGateway(
   if (!shouldAutoUseHostCliGateway(env)) return null;
   const socketPath = getHostCliGatewaySocketPath(options.stateDir);
   const probe = options.probeSocket ?? probeUnixSocket;
-  if (!(await probe(socketPath))) return null;
+  try {
+    if (!(await probe(socketPath))) return null;
+  } catch {
+    return null;
+  }
   return {
     url: `${HOST_CLI_GATEWAY_URL_PREFIX}${socketPath}`,
     source: "host-socket",

--- a/src/cloud-auth/client.test.ts
+++ b/src/cloud-auth/client.test.ts
@@ -324,6 +324,46 @@ describe("ConsoleApiClient", () => {
     }
   });
 
+  it("maps sandbox Console fetch failures to HOST_UNREACHABLE", async () => {
+    const previousPlane = process.env.RAVI_EXECUTION_PLANE;
+    process.env.RAVI_EXECUTION_PLANE = "provider-sandbox";
+    const client = new ConsoleApiClient({
+      consoleUrl: "https://console.example",
+      fetch: async () => {
+        throw Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" });
+      },
+    });
+
+    try {
+      await expect(client.requestJson("GET", "/api/cli/projects/rbbt-lab/pages/published")).rejects.toMatchObject({
+        code: "HOST_UNREACHABLE",
+      });
+    } finally {
+      if (previousPlane === undefined) delete process.env.RAVI_EXECUTION_PLANE;
+      else process.env.RAVI_EXECUTION_PLANE = previousPlane;
+    }
+  });
+
+  it("keeps host Console fetch failures as SERVER_UNAVAILABLE", async () => {
+    const previousPlane = process.env.RAVI_EXECUTION_PLANE;
+    process.env.RAVI_EXECUTION_PLANE = "host";
+    const client = new ConsoleApiClient({
+      consoleUrl: "https://console.example",
+      fetch: async () => {
+        throw Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" });
+      },
+    });
+
+    try {
+      await expect(client.requestJson("GET", "/api/cli/projects/rbbt-lab/pages/published")).rejects.toMatchObject({
+        code: "SERVER_UNAVAILABLE",
+      });
+    } finally {
+      if (previousPlane === undefined) delete process.env.RAVI_EXECUTION_PLANE;
+      else process.env.RAVI_EXECUTION_PLANE = previousPlane;
+    }
+  });
+
   it("maps OAuth device authorization pending responses", async () => {
     const client = new ConsoleApiClient({
       consoleUrl: "https://console.example",

--- a/src/cloud-auth/client.ts
+++ b/src/cloud-auth/client.ts
@@ -1,5 +1,6 @@
+import { inspectExecutionPlane } from "../isolation/execution-plane.js";
 import { fetchWithTimeout } from "../utils/paths.js";
-import { CloudAuthError, normalizeCloudAuthErrorCode } from "./errors.js";
+import { CloudAuthError, classifyConsoleNetworkError, normalizeCloudAuthErrorCode } from "./errors.js";
 import type {
   CloudAuthOrganization,
   CloudAuthUser,
@@ -133,9 +134,7 @@ export class ConsoleApiClient {
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       });
     } catch (error) {
-      throw new CloudAuthError("SERVER_UNAVAILABLE", `Console request failed: ${errorMessage(error)}`, {
-        cause: error,
-      });
+      throw classifyConsoleNetworkError(error, inspectExecutionPlane());
     }
 
     const payload = await readJsonBody(response);

--- a/src/cloud-auth/errors.test.ts
+++ b/src/cloud-auth/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { cloudErrorToContractError } from "../cli/cloud-error-contract.js";
-import { CloudAuthError, cloudAuthErrorFromUnknown } from "./errors.js";
+import { CloudAuthError, classifyConsoleNetworkError, cloudAuthErrorFromUnknown } from "./errors.js";
 
 describe("cloudAuthErrorFromUnknown", () => {
   it("preserves an already classified cloud error", () => {
@@ -22,6 +22,32 @@ describe("cloudAuthErrorFromUnknown", () => {
   });
 });
 
+describe("classifyConsoleNetworkError", () => {
+  it("keeps host Console outages as SERVER_UNAVAILABLE", () => {
+    const error = Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" });
+    expect(classifyConsoleNetworkError(error, { plane: "host" })).toMatchObject({
+      code: "SERVER_UNAVAILABLE",
+    });
+  });
+
+  it("maps sandbox network failures to HOST_UNREACHABLE without mentioning pi", () => {
+    const error = Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" });
+    const classified = classifyConsoleNetworkError(error, { plane: "provider-sandbox" });
+
+    expect(classified).toMatchObject({
+      code: "HOST_UNREACHABLE",
+      message: "Console is unreachable from this provider sandbox. The host CLI can reach Console.",
+    });
+    const contract = cloudErrorToContractError("pages published", classified);
+    expect(contract).toMatchObject({
+      code: "HOST_UNREACHABLE",
+      details: { retryable: false },
+    });
+    expect(contract.details.suggestedAction).toContain("host");
+    expect(JSON.stringify(contract.envelope())).not.toContain("pi");
+  });
+});
+
 describe("cloudErrorToContractError", () => {
   it.each([
     ["AUTH_REQUIRED", "Console authentication is required.", false],
@@ -34,6 +60,7 @@ describe("cloudErrorToContractError", () => {
     ["PAYLOAD_INVALID", "Console request input was invalid.", false],
     ["RATE_LIMITED", "Console request was rate limited.", true],
     ["SERVER_UNAVAILABLE", "Console service is unavailable.", true],
+    ["HOST_UNREACHABLE", "Console is unreachable from this provider sandbox. The host CLI can reach Console.", false],
     ["CREDENTIALS_INVALID", "Console credentials are invalid.", false],
     ["CLOUD_PUBLISH_NOT_IMPLEMENTED", "Console publishing is unavailable for this command.", false],
   ] as const)("maps %s to a stable public message", (code, publicMessage, retryable) => {

--- a/src/cloud-auth/errors.ts
+++ b/src/cloud-auth/errors.ts
@@ -1,3 +1,5 @@
+import { isNetworkIsolationError, type ExecutionPlaneSnapshot } from "../isolation/execution-plane.js";
+
 export const CLOUD_AUTH_ERROR_CODES = [
   "AUTH_REQUIRED",
   "AUTH_PENDING",
@@ -10,6 +12,7 @@ export const CLOUD_AUTH_ERROR_CODES = [
   "PAYLOAD_INVALID",
   "RATE_LIMITED",
   "SERVER_UNAVAILABLE",
+  "HOST_UNREACHABLE",
   "CREDENTIALS_INVALID",
   "CLOUD_PUBLISH_NOT_IMPLEMENTED",
 ] as const;
@@ -62,6 +65,36 @@ export function cloudAuthErrorFromUnknown(error: unknown): CloudAuthError {
   return new CloudAuthError("SERVER_UNAVAILABLE", "Cloud service request failed.", {
     cause: error,
   });
+}
+
+/**
+ * Classify a Console HTTPS/fetch failure. Provider sandboxes that cannot
+ * reach Console get `HOST_UNREACHABLE` instead of a misleading "Console is
+ * down" `SERVER_UNAVAILABLE`. Host processes keep `SERVER_UNAVAILABLE`.
+ *
+ * Isolation is an explicit snapshot so unused built-in providers such as `pi`
+ * never influence this code.
+ */
+export function classifyConsoleNetworkError(
+  error: unknown,
+  isolation: Pick<ExecutionPlaneSnapshot, "plane"> = { plane: "host" },
+): CloudAuthError {
+  if (isCloudAuthError(error)) return error;
+  if (isolation.plane === "provider-sandbox" && isNetworkIsolationError(error)) {
+    return new CloudAuthError(
+      "HOST_UNREACHABLE",
+      "Console is unreachable from this provider sandbox. The host CLI can reach Console.",
+      { cause: error, exitCode: 1 },
+    );
+  }
+  return new CloudAuthError("SERVER_UNAVAILABLE", `Console request failed: ${consoleErrorMessage(error)}`, {
+    cause: error,
+  });
+}
+
+function consoleErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
 
 export function formatCloudAuthError(error: CloudAuthError): {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -41,6 +41,7 @@ import { resolveOmniConnection } from "./omni-config.js";
 import { ensureSessionPromptsStream, publishSessionPrompt } from "./omni/session-stream.js";
 import { ensureRaviEventsStream } from "./events/audit-stream.js";
 import { startWebhookHttpServerFromEnv, type WebhookHttpServerHandle } from "./webhooks/http-server.js";
+import { startHostCliGateway, type HostCliGatewayHandle } from "./cli/host-cli-gateway.js";
 import type { MessageTarget } from "./runtime/message-types.js";
 import {
   buildDaemonRestartResumePrompt,
@@ -186,6 +187,7 @@ let sessionAdapterBus: ReturnType<typeof createSessionAdapterBus> | null = null;
 let shuttingDown = false;
 let omniConsumer: OmniConsumer | null = null;
 let webhookHttpServer: WebhookHttpServerHandle | null = null;
+let hostCliGateway: HostCliGatewayHandle | null = null;
 let workObjectNatsService: WorkObjectNatsServiceHandle | null = null;
 
 /** Get the bot instance (for in-process access like /reset) */
@@ -260,6 +262,11 @@ async function shutdown(signal: string) {
 
     if (webhookHttpServer) {
       await webhookHttpServer.stop();
+    }
+
+    if (hostCliGateway) {
+      await hostCliGateway.stop();
+      hostCliGateway = null;
     }
 
     // Stop omni consumer
@@ -422,6 +429,16 @@ export async function startDaemon() {
     log.info("Webhook HTTP server ready", { url: webhookHttpServer.url });
   } else {
     log.info("Webhook HTTP server disabled (set RAVI_HTTP_PORT to enable)");
+  }
+
+  try {
+    hostCliGateway = await startHostCliGateway();
+    if (hostCliGateway) {
+      log.info("Host CLI gateway ready", { socketPath: hostCliGateway.socketPath });
+    }
+  } catch (error) {
+    log.error("Host CLI gateway failed to start", error);
+    hostCliGateway = null;
   }
 
   log.info("Daemon ready");

--- a/src/isolation/execution-plane.test.ts
+++ b/src/isolation/execution-plane.test.ts
@@ -92,9 +92,7 @@ describe("inspectExecutionPlane", () => {
 
 describe("looksLikeRaviSourceTree", () => {
   it("accepts a tree that has provider-runtime source", () => {
-    expect(
-      looksLikeRaviSourceTree("/repo", existsFrom(["/repo/src/permissions/provider-runtime.ts"])),
-    ).toBe(true);
+    expect(looksLikeRaviSourceTree("/repo", existsFrom(["/repo/src/permissions/provider-runtime.ts"]))).toBe(true);
   });
 
   it("accepts a tree that has doctor and pages sources", () => {
@@ -113,9 +111,7 @@ describe("looksLikeRaviSourceTree", () => {
 
 describe("isNetworkIsolationError", () => {
   it("recognizes fetch and socket failures", () => {
-    expect(isNetworkIsolationError(Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" }))).toBe(
-      true,
-    );
+    expect(isNetworkIsolationError(Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" }))).toBe(true);
     expect(isNetworkIsolationError(new Error("unable to connect"))).toBe(true);
     expect(isNetworkIsolationError(new Error("payload was invalid"))).toBe(false);
   });

--- a/src/isolation/execution-plane.test.ts
+++ b/src/isolation/execution-plane.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import {
+  inspectExecutionPlane,
+  isNetworkIsolationError,
+  looksLikeRaviSourceTree,
+  probeUnixSocket,
+} from "./execution-plane.js";
+
+function existsFrom(paths: string[]): (path: string) => boolean {
+  const set = new Set(paths);
+  return (path) => set.has(path);
+}
+
+describe("inspectExecutionPlane", () => {
+  it("treats an ordinary host process as host, even when unused providers exist", () => {
+    const stateDir = "/home/user/.ravi";
+    const snapshot = inspectExecutionPlane({
+      env: {},
+      cwd: "/home/user/project",
+      stateDir,
+      exists: existsFrom([stateDir, join(stateDir, "ravi.db")]),
+    });
+
+    expect(snapshot.plane).toBe("host");
+    expect(snapshot.runtimeContext).toBe(false);
+    expect(snapshot.daemonIsolationLikely).toBe(false);
+    expect(snapshot.markers.join(" ")).not.toContain("pi");
+  });
+
+  it("does not infer provider pi from isolation markers", () => {
+    const stateDir = "/home/user/.ravi";
+    const snapshot = inspectExecutionPlane({
+      env: {
+        RAVI_EXECUTION_PLANE: "provider-sandbox",
+        RAVI_CONTEXT_KEY: "rctx_test",
+        CODEX_SANDBOX: "danger-full-access",
+      },
+      cwd: "/workspace/agent",
+      stateDir,
+      exists: existsFrom([stateDir, join(stateDir, "ravi.db"), "/.dockerenv"]),
+    });
+
+    expect(snapshot.plane).toBe("provider-sandbox");
+    expect(snapshot.runtimeContext).toBe(true);
+    expect(snapshot.daemonIsolationLikely).toBe(true);
+    expect(snapshot.markers).toContain("codex-sandbox");
+    expect(snapshot.markers.some((marker) => marker.includes("pi"))).toBe(false);
+  });
+
+  it("classifies Codex sandbox env as provider-sandbox without a container", () => {
+    const snapshot = inspectExecutionPlane({
+      env: { CODEX_SANDBOX_NETWORK: "restricted" },
+      cwd: "/tmp/agent",
+      stateDir: "/tmp/missing",
+      exists: () => false,
+    });
+
+    expect(snapshot.plane).toBe("provider-sandbox");
+    expect(snapshot.markers).toContain("codex-sandbox-network");
+  });
+
+  it("requires runtime context plus a container before assuming a sandbox", () => {
+    const containerOnly = inspectExecutionPlane({
+      env: {},
+      cwd: "/repo",
+      stateDir: "/repo/.ravi",
+      exists: existsFrom(["/.dockerenv", "/repo/.ravi", "/repo/.ravi/ravi.db"]),
+    });
+    const isolatedContainer = inspectExecutionPlane({
+      env: { RAVI_CONTEXT_KEY: "rctx_test" },
+      cwd: "/repo",
+      stateDir: "/repo/.ravi",
+      exists: existsFrom(["/.dockerenv", "/repo/.ravi", "/repo/.ravi/ravi.db"]),
+    });
+
+    expect(containerOnly.plane).toBe("host");
+    expect(isolatedContainer.plane).toBe("provider-sandbox");
+  });
+
+  it("lets an explicit host plane win over Codex markers", () => {
+    const snapshot = inspectExecutionPlane({
+      env: { RAVI_EXECUTION_PLANE: "host", CODEX_SANDBOX: "1" },
+      cwd: "/repo",
+      stateDir: "/tmp/missing",
+      exists: () => false,
+    });
+
+    expect(snapshot.plane).toBe("host");
+  });
+});
+
+describe("looksLikeRaviSourceTree", () => {
+  it("accepts a tree that has provider-runtime source", () => {
+    expect(
+      looksLikeRaviSourceTree("/repo", existsFrom(["/repo/src/permissions/provider-runtime.ts"])),
+    ).toBe(true);
+  });
+
+  it("accepts a tree that has doctor and pages sources", () => {
+    expect(
+      looksLikeRaviSourceTree(
+        "/repo",
+        existsFrom(["/repo/src/cli/commands/doctor.ts", "/repo/src/cli/commands/pages.ts"]),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an agent workspace cwd", () => {
+    expect(looksLikeRaviSourceTree("/agents/main", () => false)).toBe(false);
+  });
+});
+
+describe("isNetworkIsolationError", () => {
+  it("recognizes fetch and socket failures", () => {
+    expect(isNetworkIsolationError(Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" }))).toBe(
+      true,
+    );
+    expect(isNetworkIsolationError(new Error("unable to connect"))).toBe(true);
+    expect(isNetworkIsolationError(new Error("payload was invalid"))).toBe(false);
+  });
+});
+
+describe("probeUnixSocket", () => {
+  it("returns false for a missing socket", async () => {
+    expect(await probeUnixSocket("/tmp/ravi-missing-cli-gateway.sock")).toBe(false);
+  });
+});

--- a/src/isolation/execution-plane.test.ts
+++ b/src/isolation/execution-plane.test.ts
@@ -118,7 +118,7 @@ describe("isNetworkIsolationError", () => {
 });
 
 describe("probeUnixSocket", () => {
-  it("returns false for a missing socket", async () => {
-    expect(await probeUnixSocket("/tmp/ravi-missing-cli-gateway.sock")).toBe(false);
+  it("returns false for a missing socket without rejecting", async () => {
+    await expect(probeUnixSocket("/tmp/ravi-missing-cli-gateway.sock")).resolves.toBe(false);
   });
 });

--- a/src/isolation/execution-plane.ts
+++ b/src/isolation/execution-plane.ts
@@ -47,14 +47,10 @@ export function getHostCliGatewaySocketPath(stateDir = getRaviStateDir()): strin
   return join(stateDir, HOST_CLI_GATEWAY_SOCKET_NAME);
 }
 
-export function looksLikeRaviSourceTree(
-  cwd: string,
-  exists: (path: string) => boolean = existsSync,
-): boolean {
+export function looksLikeRaviSourceTree(cwd: string, exists: (path: string) => boolean = existsSync): boolean {
   if (exists(join(cwd, "src", "permissions", "provider-runtime.ts"))) return true;
   return (
-    exists(join(cwd, "src", "cli", "commands", "doctor.ts")) &&
-    exists(join(cwd, "src", "cli", "commands", "pages.ts"))
+    exists(join(cwd, "src", "cli", "commands", "doctor.ts")) && exists(join(cwd, "src", "cli", "commands", "pages.ts"))
   );
 }
 

--- a/src/isolation/execution-plane.ts
+++ b/src/isolation/execution-plane.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { createConnection } from "node:net";
+import { Socket } from "node:net";
 import { join } from "node:path";
 import { getRaviStateDir } from "../utils/paths.js";
 
@@ -118,22 +118,26 @@ export function inspectExecutionPlane(input: InspectExecutionPlaneInput = {}): E
 }
 
 export async function probeUnixSocket(socketPath: string, timeoutMs = 250): Promise<boolean> {
+  if (!socketPath || !existsSync(socketPath)) return false;
   return new Promise((resolve) => {
-    const socket = createConnection({ path: socketPath });
-    const timer = setTimeout(() => {
-      socket.destroy();
-      resolve(false);
-    }, timeoutMs);
-    socket.once("connect", () => {
+    let settled = false;
+    const socket = new Socket();
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
-      socket.end();
-      resolve(true);
-    });
-    socket.once("error", () => {
-      clearTimeout(timer);
+      socket.removeAllListeners();
       socket.destroy();
-      resolve(false);
-    });
+      resolve(ok);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    socket.once("error", () => finish(false));
+    socket.once("connect", () => finish(true));
+    try {
+      socket.connect({ path: socketPath });
+    } catch {
+      finish(false);
+    }
   });
 }
 

--- a/src/isolation/execution-plane.ts
+++ b/src/isolation/execution-plane.ts
@@ -1,0 +1,164 @@
+/**
+ * Detect whether this CLI process is running on the host or inside a provider
+ * sandbox, and whether host-side Ravi state is visible.
+ *
+ * Used by doctor and Console/Pages error classification. Do not infer provider
+ * identity from unused registry entries (especially built-in `pi`).
+ */
+
+import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { getRaviStateDir } from "../utils/paths.js";
+
+export const RAVI_EXECUTION_PLANE_ENV = "RAVI_EXECUTION_PLANE";
+export const HOST_CLI_GATEWAY_ENV = "RAVI_HOST_CLI_GATEWAY";
+export const HOST_CLI_GATEWAY_INTERNAL_ENV = "RAVI_GATEWAY_INTERNAL";
+export const HOST_CLI_GATEWAY_SOCKET_NAME = "cli-gateway.sock";
+
+export type ExecutionPlane = "host" | "provider-sandbox";
+
+export interface HostEvidence {
+  stateDir: boolean;
+  sqliteDb: boolean;
+  cloudCredentials: boolean;
+  cliGatewaySocket: boolean;
+}
+
+export interface ExecutionPlaneSnapshot {
+  plane: ExecutionPlane;
+  runtimeContext: boolean;
+  hostEvidence: HostEvidence;
+  markers: string[];
+  daemonIsolationLikely: boolean;
+  sourceTree: boolean;
+}
+
+export interface InspectExecutionPlaneInput {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  stateDir?: string;
+  exists?: (path: string) => boolean;
+}
+
+const CODEX_SANDBOX_ENV_KEYS = ["CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK", "CODEX_THREAD_SANDBOX"] as const;
+
+export function getHostCliGatewaySocketPath(stateDir = getRaviStateDir()): string {
+  return join(stateDir, HOST_CLI_GATEWAY_SOCKET_NAME);
+}
+
+export function looksLikeRaviSourceTree(
+  cwd: string,
+  exists: (path: string) => boolean = existsSync,
+): boolean {
+  if (exists(join(cwd, "src", "permissions", "provider-runtime.ts"))) return true;
+  return (
+    exists(join(cwd, "src", "cli", "commands", "doctor.ts")) &&
+    exists(join(cwd, "src", "cli", "commands", "pages.ts"))
+  );
+}
+
+export function isNetworkIsolationError(error: unknown): boolean {
+  const parts = [errorMessage(error)];
+  if (typeof error === "object" && error && "code" in error) {
+    parts.push(String((error as { code: unknown }).code));
+  }
+  if (error instanceof Error && error.cause !== undefined) {
+    parts.push(errorMessage(error.cause));
+    if (typeof error.cause === "object" && error.cause && "code" in error.cause) {
+      parts.push(String((error.cause as { code: unknown }).code));
+    }
+  }
+  const haystack = parts.join(" ").toLowerCase();
+  return /econnrefused|enotfound|eai_again|enetunreach|ehostunreach|etimedout|econnreset|eperm|eacces|cert|ssl|tls|fetch failed|network|aborted|unable to connect|socket/.test(
+    haystack,
+  );
+}
+
+export function inspectExecutionPlane(input: InspectExecutionPlaneInput = {}): ExecutionPlaneSnapshot {
+  const env = input.env ?? process.env;
+  const exists = input.exists ?? existsSync;
+  const cwd = input.cwd ?? process.cwd();
+  const stateDir = input.stateDir ?? getRaviStateDir(env);
+  const markers: string[] = [];
+
+  const runtimeContext = Boolean(env.RAVI_CONTEXT_KEY?.trim() || env.RAVI_SESSION_NAME?.trim());
+  if (env.RAVI_CONTEXT_KEY?.trim()) markers.push("runtime-context-key");
+  if (env.RAVI_SESSION_NAME?.trim()) markers.push("runtime-session-name");
+
+  const explicit = env[RAVI_EXECUTION_PLANE_ENV]?.trim();
+  if (explicit === "provider-sandbox") markers.push("ravi-execution-plane");
+  if (explicit === "host") markers.push("ravi-execution-plane-host");
+
+  for (const key of CODEX_SANDBOX_ENV_KEYS) {
+    if (env[key]?.trim()) markers.push(codexMarkerName(key));
+  }
+
+  const inContainer = exists("/.dockerenv") || exists("/run/.containerenv");
+  if (inContainer) markers.push("container");
+
+  const hostEvidence: HostEvidence = {
+    stateDir: exists(stateDir),
+    sqliteDb: exists(join(stateDir, "ravi.db")),
+    cloudCredentials: exists(join(stateDir, "cloud-auth", "credentials.json")),
+    cliGatewaySocket: exists(getHostCliGatewaySocketPath(stateDir)),
+  };
+
+  const plane = resolvePlane({
+    explicit,
+    hasCodexSandbox: CODEX_SANDBOX_ENV_KEYS.some((key) => Boolean(env[key]?.trim())),
+    runtimeContext,
+    inContainer,
+  });
+
+  return {
+    plane,
+    runtimeContext,
+    hostEvidence,
+    markers,
+    daemonIsolationLikely: hostEvidence.sqliteDb && (plane === "provider-sandbox" || runtimeContext),
+    sourceTree: looksLikeRaviSourceTree(cwd, exists),
+  };
+}
+
+export async function probeUnixSocket(socketPath: string, timeoutMs = 250): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ path: socketPath });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      socket.end();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function resolvePlane(input: {
+  explicit: string | undefined;
+  hasCodexSandbox: boolean;
+  runtimeContext: boolean;
+  inContainer: boolean;
+}): ExecutionPlane {
+  if (input.explicit === "host") return "host";
+  if (input.explicit === "provider-sandbox") return "provider-sandbox";
+  if (input.hasCodexSandbox) return "provider-sandbox";
+  if (input.runtimeContext && input.inContainer) return "provider-sandbox";
+  return "host";
+}
+
+function codexMarkerName(key: string): string {
+  return key.toLowerCase().replaceAll("_", "-");
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return `${error.name} ${error.message}`;
+  return String(error);
+}

--- a/src/pages/client.ts
+++ b/src/pages/client.ts
@@ -1,5 +1,6 @@
 import { ConsoleApiClient, getMeWithAutoRefresh, normalizeConsoleUrl } from "../cloud-auth/client.js";
-import { CloudAuthError } from "../cloud-auth/errors.js";
+import { CloudAuthError, classifyConsoleNetworkError } from "../cloud-auth/errors.js";
+import { inspectExecutionPlane } from "../isolation/execution-plane.js";
 import { deleteCloudCredentials, readCloudCredentials, writeCloudCredentials } from "../cloud-auth/storage.js";
 import type { CloudCredentials } from "../cloud-auth/types.js";
 
@@ -427,9 +428,7 @@ function requireStoredCredentials(credentials: CloudCredentials | null, consoleU
 
 function normalizePagesError(error: unknown): CloudAuthError {
   if (error instanceof CloudAuthError) return error;
-  return new CloudAuthError("SERVER_UNAVAILABLE", error instanceof Error ? error.message : String(error), {
-    cause: error,
-  });
+  return classifyConsoleNetworkError(error, inspectExecutionPlane());
 }
 
 function normalizeSiteListPayload(payload: unknown): PageSitePayload[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop Codex sessions from failing `ravi pages` publish/read with a generic `SERVER_UNAVAILABLE`, and stop doctor from blaming unused built-in `pi`. Isolated CLIs should either run Pages on the host through a unix-socket gateway or fail with `HOST_UNREACHABLE`.

## Problem

- Gustavo could not publish or read Ravi Pages from a Codex session. The same commands worked in a host terminal.
- Doctor/session reports mentioned provider `pi` even though he was not testing `pi` and did not know what it is.
- `ravi pages` talks to Console HTTPS, not host NATS. Any fetch failure was flattened to `SERVER_UNAVAILABLE` / "Console service is unavailable."
- Doctor checked every registered runtime provider for restricted-tool compatibility, so unused built-in `pi` always failed.
- From an agent cwd, doctor also treated missing repo source (`provider-runtime.ts`) and an invisible `pm2` daemon as host breakage.

## Solution

- Detect host vs provider-sandbox execution plane from explicit env, Codex sandbox markers, or runtime context plus a container. Do not infer `pi`.
- Auto-bridge isolated CLIs (`RAVI_CONTEXT_KEY` set) to a host unix-socket CLI gateway at `~/.ravi/cli-gateway.sock` when that socket is connectable. Never auto-open raw `127.0.0.1`.
- Classify sandbox Console network failures as `HOST_UNREACHABLE` (not retryable). Host Console outages stay `SERVER_UNAVAILABLE`.
- Doctor `runtime.providers` checks only providers used by registered agents.
- Doctor `runtime.daemon` reports sandbox invisibility as skip/warn, not host-offline.
- Doctor `permissions.provider_runtime_boundaries` skips non-source-tree cwds.
- New `runtime.isolation` check reports the execution plane without unused-provider wording.
- Unix socket probes fail closed: missing sockets return unreachable instead of throwing `ENOENT` (Bun 1.3.11 CI).

## Practical impact

- Codex/`ravi pages published` and `ravi pages publish` either succeed via the host gateway or fail with a host-vs-sandbox error.
- Doctor no longer marks a healthy Codex install broken because unused `pi` cannot do restricted access.
- Daemon always starts the unix-socket gateway unless `RAVI_HOST_CLI_GATEWAY=0`. HTTP gateway on `RAVI_HTTP_PORT` stays optional.

## What does NOT change

- Codex still keeps CLI registry commands on the shell path. This does not re-enable Codex dynamic tools.
- Sandbox security is unchanged: no raw loopback hole.
- Host terminal Pages is unchanged.
- The obsolete `codex-tool-hook` rename remains a separate PR.
- Unused `pi` remains a registered provider; it is just not a doctor failure unless an agent actually uses it.

## Validation

- `bun test src/isolation/execution-plane.test.ts src/cli/host-cli-gateway.test.ts src/cli/remote-gateway.test.ts src/cloud-auth/errors.test.ts src/cloud-auth/client.test.ts src/cli/commands/doctor.test.ts` — 86 pass
- `bun test src/cli/commands/pages.test.ts src/artifacts/publish-client.test.ts src/cli/registry.test.ts` — 52 pass
- `bun test src/cli/transport-contract.test.ts src/cli/remote-gateway.test.ts src/isolation/execution-plane.test.ts` — includes the CI-failing PERMISSION_DENIED transport case
- Pre-push hook (`sdk:check` + related SDK tests) passed

## Risks

- Auto-bridge requires a live daemon (socket) and a valid `RAVI_CONTEXT_KEY`. If the socket is missing, Pages still runs locally and may return `HOST_UNREACHABLE`.
- Unix-socket mode is 0600 under `~/.ravi`. A sandbox that can see that directory and the context key can invoke host CLI commands already authorized for that key.
- Doctor check catalog adds `runtime.isolation`; consumers that snapshot check ids need to accept the new check.

## Rollback

- Revert this branch. Operators can also set `RAVI_HOST_CLI_GATEWAY=0` to disable the unix listener without reverting error classification.

## Follow-ups

- Confirm Pages still fails with `HOST_UNREACHABLE` from Codex after the separate hook-rename PR makes hooks writable.
- WhatsApp group create confirmation/rollback is out of scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb7ebf45-c180-4004-a777-3be687bf495d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb7ebf45-c180-4004-a777-3be687bf495d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

