### PR TITLE
fix(runtime): recover from fatal ownership loss without trace floods

### DIFF
--- a/.ravi/specs/runtime/cloud-trace-export/CHECKS.md
+++ b/.ravi/specs/runtime/cloud-trace-export/CHECKS.md
@@ -38,6 +38,8 @@ normative: true
   by default instead of replaying unbounded historical `session_events`.
 - Cursor metadata records skipped historical ranges when the exporter advances
   past old local-only history.
+- A disabled, unlinked, or stale export cursor does not block local trace TTL
+  pruning after the configured retention window.
 - The sync runner can enqueue and upload multiple bounded trace batches per tick
   so interleaved sessions catch up fast enough for current Console visibility.
 - Automatic trace export is disabled by default because the daemon sync runner

--- a/.ravi/specs/runtime/cloud-trace-export/SPEC.md
+++ b/.ravi/specs/runtime/cloud-trace-export/SPEC.md
@@ -164,8 +164,12 @@ messages. It should only map the row owned by the resolved session/run to
 ## Export Efficiency
 
 The exporter SHOULD maintain a local export cursor or trace-export outbox so
-local trace TTL pruning cannot delete unexported accepted events without an
-explicit policy decision.
+local trace TTL pruning cannot delete unexported accepted events inside the
+configured local retention window without an explicit policy decision. TTL
+expiry is that policy boundary: a disabled, unlinked, or stale exporter MUST
+NOT pin an unbounded local SQLite backlog after the local retention window.
+The exporter MUST tolerate deleted id gaps and resume from the first surviving
+event above its cursor.
 
 Local installations often contain historical `session_events` rows from before
 cloud trace export was enabled. The exporter MUST NOT replay an unbounded old

--- a/src/bot.live.fixture.ts
+++ b/src/bot.live.fixture.ts
@@ -308,6 +308,9 @@ async function runBotRoundTrip(
       model,
       logLevel: "error",
     } as any,
+    onFatalRuntimeError: (error) => {
+      throw error;
+    },
   });
 
   const sessionName = `agent:main:live:${provider}`;

--- a/src/bot.runtime-guards.fixture.ts
+++ b/src/bot.runtime-guards.fixture.ts
@@ -94,6 +94,7 @@ type RuntimeHandle = {
 const emittedEvents: Array<{ topic: string; data: any }> = [];
 const sessions = new Map<string, SessionState>();
 const createdBots: Array<{ stop(): Promise<void> }> = [];
+const fatalRuntimeErrors: Error[] = [];
 let activeProvider: RuntimeProviderId = "claude";
 let runtimeStartCalls: RuntimeStartRequest[] = [];
 let runtimePrepareImpl: (
@@ -752,6 +753,7 @@ function createBot(options: { startCrashRecovery?: boolean } = {}) {
       logLevel: "error",
       apiKey: "fake",
     } as any,
+    onFatalRuntimeError: (error) => fatalRuntimeErrors.push(error),
   });
   if (options.startCrashRecovery !== false) {
     (bot as any).crashRecovery.start();
@@ -941,6 +943,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<voi
 describe("RaviBot runtime guards", () => {
   beforeEach(async () => {
     emittedEvents.length = 0;
+    fatalRuntimeErrors.length = 0;
     sessions.clear();
     clearProviderSession.mockClear();
     delete process.env.RAVI_BIN;
@@ -2129,6 +2132,7 @@ describe("RaviBot runtime guards", () => {
 describe("RaviBot streaming session lifecycle", () => {
   beforeEach(async () => {
     emittedEvents.length = 0;
+    fatalRuntimeErrors.length = 0;
     sessions.clear();
     clearProviderSession.mockClear();
     activeProvider = "claude";
@@ -2224,7 +2228,7 @@ describe("RaviBot streaming session lifecycle", () => {
     createdBots.splice(createdBots.indexOf(bot), 1);
   });
 
-  it("fences intake and closes runtime sessions when crash recovery ownership is lost", async () => {
+  it("fences intake, closes runtime sessions, and requests a supervised restart when ownership is lost", async () => {
     const bot = createBot({ startCrashRecovery: false });
     await bot.start();
     const abortController = new AbortController();
@@ -2250,15 +2254,19 @@ describe("RaviBot streaming session lifecycle", () => {
       pendingAbort: false,
     });
 
+    const crashRecovery = (bot as any).crashRecovery;
     expect((bot as any).promptSubscription.healthTimer).not.toBeNull();
-    (bot as any).crashRecovery.enterFailClosed("test ownership loss");
+    crashRecovery.now = () => crashRecovery.boot.leaseExpiresAt;
+    expect(() => crashRecovery.heartbeatNow()).toThrow("Crash recovery boot lease expired before heartbeat");
+    const ownershipError = crashRecovery.ownershipFailure;
 
     expect(bot.canAcceptRuntimePrompt()).toBe(false);
     expect((bot as any).promptSubscription.healthTimer).toBeNull();
     expect((bot as any).streamingSessions.size).toBe(0);
     expect(abortController.signal.aborted).toBe(true);
     expect(interrupt).toHaveBeenCalledTimes(1);
-    expect((bot as any).crashRecovery.boot).toMatchObject({ status: "active" });
+    expect(crashRecovery.boot).toMatchObject({ status: "active" });
+    expect(fatalRuntimeErrors).toEqual([ownershipError]);
 
     await bot.stop();
     createdBots.splice(createdBots.indexOf(bot), 1);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -32,6 +32,12 @@ type StreamingSession = RuntimeHostStreamingSession;
 
 export interface RaviBotOptions {
   config: Config;
+  /**
+   * Called after the runtime has fenced prompt intake and closed every provider
+   * because crash-recovery ownership can no longer be proven. The process host
+   * must terminate non-zero so its supervisor can start a fresh boot epoch.
+   */
+  onFatalRuntimeError: (error: RuntimeCrashRecoveryOwnershipLostError) => void;
 }
 
 export interface RaviBotStopOptions {
@@ -49,6 +55,7 @@ export class RaviBot {
   private readonly crashRecovery: RuntimeCrashRecoveryCoordinator;
   private readonly hostSubscriptions: RuntimeHostSubscriptions;
   private readonly promptSubscription: RuntimePromptSubscription;
+  private readonly onFatalRuntimeError: RaviBotOptions["onFatalRuntimeError"];
   /** Unique instance ID to trace responses back to this daemon instance */
   readonly instanceId = Math.random().toString(36).slice(2, 8);
   /** Resolves when the JetStream consumer is active and ready to receive messages */
@@ -61,6 +68,7 @@ export class RaviBot {
       this.resolveConsumerReady = resolve;
     });
     this.config = options.config;
+    this.onFatalRuntimeError = options.onFatalRuntimeError;
     logger.setLevel(options.config.logLevel);
     const maxConcurrentSessions = resolveRuntimeSessionPoolMax();
     const interactiveReservedSessions = resolveRuntimeInteractiveReservedSlots(undefined, maxConcurrentSessions);
@@ -131,6 +139,14 @@ export class RaviBot {
       log.error("Failed to close runtime sessions after crash recovery ownership loss", {
         instanceId: this.instanceId,
         error: shutdownError,
+      });
+    }
+    try {
+      this.onFatalRuntimeError(error);
+    } catch (fatalHandlerError) {
+      log.error("Fatal runtime error handler failed after crash recovery ownership loss", {
+        instanceId: this.instanceId,
+        error: fatalHandlerError,
       });
     }
   }

--- a/src/channels/outbound-consumer.test.ts
+++ b/src/channels/outbound-consumer.test.ts
@@ -22,6 +22,9 @@ import type { ChannelOutboundJob } from "./outbound-stream.js";
 function processChannelOutboundJob(job: ChannelOutboundJob, options: ChannelOutboundConsumerOptions) {
   return processChannelOutboundJobWithNats(job, {
     flushNats: async () => {},
+    // Unit tests must never write delivery traces into the operator's live
+    // Ravi database. Tests that exercise trace behavior pass an explicit spy.
+    recordDeliveryTrace: () => null,
     ...options,
   });
 }
@@ -173,6 +176,41 @@ describe("channel outbound consumer", () => {
         reason: "send_error",
         error: "slack unavailable",
       }),
+    );
+  });
+
+  it("emits retry telemetry without persisting duplicate failure traces", async () => {
+    const emitEvent = mock(async () => {});
+    const recordDeliveryTrace = mock(() => null);
+    const delivery: NativeTextDelivery = {
+      channelId: "slack",
+      supports: () => true,
+      deliverText: mock(async () => {
+        throw new Error("slack unavailable");
+      }),
+    };
+
+    const first = await processChannelOutboundJob(makeJob(), {
+      deliveries: [delivery],
+      emitEvent,
+      persistDelivery: false,
+      deliveryAttempt: 1,
+      recordDeliveryTrace,
+    });
+    const retry = await processChannelOutboundJob(makeJob(), {
+      deliveries: [delivery],
+      emitEvent,
+      persistDelivery: false,
+      deliveryAttempt: 2,
+      recordDeliveryTrace,
+    });
+
+    expect(first).toMatchObject({ disposition: "nak", retryable: true, phase: "send" });
+    expect(retry).toMatchObject({ disposition: "nak", retryable: true, phase: "send" });
+    expect(recordDeliveryTrace).toHaveBeenCalledTimes(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      "ravi.session.ravi-channels.delivery",
+      expect.objectContaining({ status: "failed", reason: "send_error", retryable: true }),
     );
   });
 

--- a/src/channels/outbound-consumer.ts
+++ b/src/channels/outbound-consumer.ts
@@ -231,7 +231,7 @@ export async function processChannelOutboundJob(
   const adapter = findNativeOutboundAdapter(job, options);
   if (options.persistDelivery === false) {
     if (!adapter) return emitMissingAdapter(emitEvent, recordTrace, job, t0, deliveryAttempt);
-    return processWithoutReceiptLedger(job, adapter, emitEvent, recordTrace, t0);
+    return processWithoutReceiptLedger(job, adapter, emitEvent, recordTrace, t0, deliveryAttempt);
   }
 
   const receiptStore = options.receiptStore ?? sqliteChannelOutboundReceiptStore;
@@ -374,7 +374,7 @@ export async function processChannelOutboundJob(
         });
       }
       try {
-        await emitDelivery(emitEvent, recordTrace, job, {
+        await emitDelivery(emitEvent, traceRecorderForAttempt(recordTrace, deliveryAttempt), job, {
           status: "failed",
           reason: "send_error",
           error: message,
@@ -475,6 +475,7 @@ async function processWithoutReceiptLedger(
   emitEvent: typeof nats.emit,
   recordTrace: typeof recordDeliveryTrace,
   t0: number,
+  deliveryAttempt?: number,
 ): Promise<ChannelOutboundProcessingResult> {
   const emitId = job.request.origin.emitId;
   const target = job.request.target;
@@ -485,7 +486,7 @@ async function processWithoutReceiptLedger(
   } catch (error) {
     const message = errorMessage(error);
     const failure = classifyNativeOutboundFailure(job, message);
-    await emitDelivery(emitEvent, recordTrace, job, {
+    await emitDelivery(emitEvent, traceRecorderForAttempt(recordTrace, deliveryAttempt), job, {
       status: "failed",
       reason: "send_error",
       error: message,
@@ -900,7 +901,7 @@ async function emitMissingAdapter(
 ): Promise<ChannelOutboundProcessingResult> {
   const error = `No native delivery adapter registered for channel: ${job.request.channelId}`;
   const retryDelayMs = missingAdapterRetryDelayMs(deliveryAttempt);
-  await emitDelivery(emitEvent, recordTrace, job, {
+  await emitDelivery(emitEvent, traceRecorderForAttempt(recordTrace, deliveryAttempt), job, {
     status: "failed",
     reason: "missing_adapter",
     error,
@@ -933,6 +934,18 @@ export function missingAdapterRetryDelayMs(deliveryAttempt: number | undefined):
     CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_BASE_MS * 2 ** exponent,
     CHANNEL_OUTBOUND_MISSING_ADAPTER_RETRY_MAX_MS,
   );
+}
+
+function traceRecorderForAttempt(
+  recordTrace: typeof recordDeliveryTrace,
+  deliveryAttempt: number | undefined,
+): typeof recordDeliveryTrace {
+  // JetStream redeliveries still emit live delivery telemetry, but persisting
+  // the same failure on every retry can turn a provider outage into an
+  // unbounded SQLite write amplifier. The first failure plus the eventual
+  // terminal delivery are sufficient for the durable trace.
+  if (deliveryAttempt === undefined || deliveryAttempt <= 1) return recordTrace;
+  return () => null;
 }
 
 function deliveryResultFromReceipt(receipt: ChannelOutboundReceipt): NativeOutboundDeliveryResult {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -195,7 +195,7 @@ export function getBotInstance(): RaviBot | null {
   return bot;
 }
 
-async function shutdown(signal: string) {
+async function shutdown(signal: string, exitCode = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
 
@@ -291,7 +291,15 @@ async function shutdown(signal: string) {
 
   clearTimeout(shutdownTimeout);
   log.info("Daemon stopped", { pid: process.pid });
-  process.exit(0);
+  process.exit(exitCode);
+}
+
+function restartAfterFatalRuntimeError(error: Error): void {
+  log.error("Fatal runtime ownership error; exiting for supervised restart", {
+    pid: process.pid,
+    error,
+  });
+  void shutdown("fatal runtime ownership error", 1);
 }
 
 export async function startDaemon() {
@@ -333,7 +341,7 @@ export async function startDaemon() {
   log.info("RAVI_EVENTS stream ready");
 
   // Step 5: Start bot
-  bot = new RaviBot({ config });
+  bot = new RaviBot({ config, onFatalRuntimeError: restartAfterFatalRuntimeError });
   await bot.start();
   log.info("Bot started");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,13 @@ async function main(): Promise<void> {
     const config = loadConfig();
     logger.setLevel(config.logLevel);
 
-    const bot = new RaviBot({ config });
+    const bot = new RaviBot({
+      config,
+      onFatalRuntimeError: (error) => {
+        logger.error("Fatal runtime ownership error; exiting for supervised restart", error);
+        process.exit(1);
+      },
+    });
 
     // Handle shutdown signals
     const shutdown = async () => {

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -10332,25 +10332,6 @@ const SESSION_EVENTS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — daily rollu
 const SESSION_TRACE_BLOBS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — keep blob TTL aligned with events
 const AUDIT_LOG_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
 const COST_EVENTS_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
-const TRACE_EXPORT_CURSOR_DOMAIN = "runtime_trace";
-const TRACE_EXPORT_SESSION_EVENTS_CURSOR = "session_events_enqueued";
-
-function getTraceExportSessionEventsCursor(db: Database): number | null {
-  const row = db
-    .prepare("SELECT cursor_value FROM sync_cursors WHERE domain = ? AND cursor_key = ?")
-    .get(TRACE_EXPORT_CURSOR_DOMAIN, TRACE_EXPORT_SESSION_EVENTS_CURSOR) as { cursor_value: string | null } | undefined;
-  if (!row?.cursor_value) return null;
-  const cursor = Number(row.cursor_value);
-  return Number.isFinite(cursor) && cursor >= 0 ? cursor : null;
-}
-
-function hasSessionEventsAtOrBeforeCursor(db: Database, cursor: number): boolean {
-  const row = db.prepare("SELECT 1 AS found FROM session_events WHERE id <= ? LIMIT 1").get(cursor) as
-    | { found: number }
-    | undefined;
-  return Boolean(row);
-}
-
 /**
  * Delete message metadata older than 7 days.
  * Returns number of rows deleted.
@@ -10404,7 +10385,6 @@ export interface DbPruneOptions {
 export function dbPruneStaleRows(options: DbPruneOptions = {}): DbPruneResult {
   const db = getDb();
   const now = options.now ?? Date.now();
-  const traceExportCursor = getTraceExportSessionEventsCursor(db);
   const result: DbPruneResult = {
     messageMetadata: 0,
     sessionEvents: 0,
@@ -10419,28 +10399,18 @@ export function dbPruneStaleRows(options: DbPruneOptions = {}): DbPruneResult {
   if (options.dryRun) {
     const count = (sql: string, threshold: number): number =>
       Number((db.prepare(sql).get(threshold) as { c: number }).c ?? 0);
-    const countSessionEvents = (): number => {
-      if (traceExportCursor === null) {
-        return count("SELECT COUNT(*) AS c FROM session_events WHERE timestamp < ?", now - SESSION_EVENTS_TTL_MS);
-      }
-      if (!hasSessionEventsAtOrBeforeCursor(db, traceExportCursor)) {
-        return 0;
-      }
-      return Number(
-        (
-          db
-            .prepare("SELECT COUNT(*) AS c FROM session_events WHERE timestamp < ? AND id <= ?")
-            .get(now - SESSION_EVENTS_TTL_MS, traceExportCursor) as {
-            c: number;
-          }
-        ).c ?? 0,
-      );
-    };
     result.messageMetadata = count(
       "SELECT COUNT(*) AS c FROM message_metadata WHERE created_at < ?",
       now - MESSAGE_META_TTL_MS,
     );
-    result.sessionEvents = countSessionEvents();
+    // The local TTL is a hard retention boundary. An optional cloud-export
+    // cursor must not pin an unbounded local backlog when export is disabled,
+    // unlinked, or stale. The exporter already tolerates gaps and resumes from
+    // the first surviving id above its cursor.
+    result.sessionEvents = count(
+      "SELECT COUNT(*) AS c FROM session_events WHERE timestamp < ?",
+      now - SESSION_EVENTS_TTL_MS,
+    );
     result.sessionTraceBlobs = count(
       "SELECT COUNT(*) AS c FROM session_trace_blobs WHERE created_at < ?",
       now - SESSION_TRACE_BLOBS_TTL_MS,
@@ -10461,22 +10431,8 @@ export function dbPruneStaleRows(options: DbPruneOptions = {}): DbPruneResult {
     db.prepare(sql).run(threshold);
     return getDbChanges();
   };
-  const deleteSessionEvents = (): number => {
-    if (traceExportCursor === null) {
-      return runDelete("DELETE FROM session_events WHERE timestamp < ?", now - SESSION_EVENTS_TTL_MS);
-    }
-    if (!hasSessionEventsAtOrBeforeCursor(db, traceExportCursor)) {
-      return 0;
-    }
-    db.prepare("DELETE FROM session_events WHERE timestamp < ? AND id <= ?").run(
-      now - SESSION_EVENTS_TTL_MS,
-      traceExportCursor,
-    );
-    return getDbChanges();
-  };
-
   result.messageMetadata = runDelete("DELETE FROM message_metadata WHERE created_at < ?", now - MESSAGE_META_TTL_MS);
-  result.sessionEvents = deleteSessionEvents();
+  result.sessionEvents = runDelete("DELETE FROM session_events WHERE timestamp < ?", now - SESSION_EVENTS_TTL_MS);
   result.sessionTraceBlobs = runDelete(
     "DELETE FROM session_trace_blobs WHERE created_at < ?",
     now - SESSION_TRACE_BLOBS_TTL_MS,

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Database } from "bun:sqlite";
 import { join } from "node:path";
+import { enqueueTraceExportBatch } from "../session-trace/cloud-trace-export.js";
+import { recordSessionEvent } from "../session-trace/session-trace-db.js";
+import { getSyncCursor } from "../sync/db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import {
   dbCreateAgent,
@@ -14,6 +17,7 @@ import {
   dbListChannels,
   dbListContexts,
   dbPruneContexts,
+  dbPruneStaleRows,
   dbUpdateAgent,
   dbUpdateChannel,
   dbUpsertChannel,
@@ -135,6 +139,25 @@ describe("router context queries", () => {
         .map((context) => context.contextId)
         .sort(),
     ).toEqual(["active", "expired-recent"]);
+  });
+
+  it("does not let a stale trace export cursor block the local retention TTL", () => {
+    recordSessionEvent({
+      sessionKey: "agent:dev",
+      eventType: "turn.complete",
+      eventGroup: "runtime",
+      timestamp: 1,
+    });
+    recordSessionEvent({
+      sessionKey: "agent:dev",
+      eventType: "turn.complete",
+      eventGroup: "runtime",
+      timestamp: 2,
+    });
+    enqueueTraceExportBatch({ limit: 1, now: 3 });
+
+    expect(getSyncCursor("runtime_trace", "session_events_enqueued")?.cursorValue).toBe("1");
+    expect(dbPruneStaleRows({ dryRun: true, now: 10 * DAY }).sessionEvents).toBe(2);
   });
 
   it("creates trace indexes, shell trigger columns, and the reaction ledger during schema bootstrap", () => {

--- a/src/session-trace/cloud-trace-export.test.ts
+++ b/src/session-trace/cloud-trace-export.test.ts
@@ -507,7 +507,7 @@ describe("cloud trace export", () => {
     expect(inspectSyncRecord(second.outboxId!)?.record.status).toBe("acked");
   });
 
-  it("moves the export cursor before TTL pruning can delete exported event rows", () => {
+  it("does not let a stale export cursor block the local trace TTL", () => {
     recordSessionEvent({
       sessionKey: "agent:dev",
       eventType: "turn.complete",
@@ -523,7 +523,7 @@ describe("cloud trace export", () => {
     enqueueTraceExportBatch({ limit: 1, now: 3 });
     expect(getSyncCursor("runtime_trace", "session_events_enqueued")?.cursorValue).toBe("1");
     const prune = dbPruneStaleRows({ dryRun: true, now: 10 * 24 * 60 * 60 * 1000 });
-    expect(prune.sessionEvents).toBe(1);
+    expect(prune.sessionEvents).toBe(2);
   });
 });
 

--- a/src/session-trace/cloud-trace-export.test.ts
+++ b/src/session-trace/cloud-trace-export.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { dbPruneStaleRows } from "../router/router-db.js";
 import type { CloudCredentials } from "../cloud-auth/types.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import { getOutboxById, getSyncCursor, inspectSyncRecord } from "../sync/db.js";
@@ -505,25 +504,6 @@ describe("cloud trace export", () => {
     expect(calls).toHaveLength(2);
     expect(inspectSyncRecord(first.outboxId!)?.record.status).toBe("acked");
     expect(inspectSyncRecord(second.outboxId!)?.record.status).toBe("acked");
-  });
-
-  it("does not let a stale export cursor block the local trace TTL", () => {
-    recordSessionEvent({
-      sessionKey: "agent:dev",
-      eventType: "turn.complete",
-      eventGroup: "runtime",
-      timestamp: 1,
-    });
-    recordSessionEvent({
-      sessionKey: "agent:dev",
-      eventType: "turn.complete",
-      eventGroup: "runtime",
-      timestamp: 2,
-    });
-    enqueueTraceExportBatch({ limit: 1, now: 3 });
-    expect(getSyncCursor("runtime_trace", "session_events_enqueued")?.cursorValue).toBe("1");
-    const prune = dbPruneStaleRows({ dryRun: true, now: 10 * 24 * 60 * 60 * 1000 });
-    expect(prune.sessionEvents).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Objective

Keep Ravi responsive and self-recovering when crash-recovery ownership is lost, while bounding local delivery-trace storage under repeated channel failures.

## Problem

A permanent Slack `invalid_auth` failure was retried as transient. The same 1,047 outbound jobs generated about 1.6 million duplicate `delivery.failed` rows and grew the operator database to 3.3 GB.

SQLite and disk contention then starved the crash-recovery heartbeat beyond its 30-second lease. Ownership loss is correctly fatal because continuing could duplicate a turn, but the daemon only fenced prompt intake and remained online under PM2. The result was a zombie process that looked healthy but could no longer answer.

A stale optional cloud-export cursor also prevented the seven-day local trace TTL from pruning newer expired rows, allowing the backlog to remain unbounded.

## Solution

- Exit the daemon with code 1 after crash-recovery ownership loss so PM2 replaces the fenced process.
- Persist a delivery failure trace only for the first JetStream attempt while continuing to emit live telemetry for each retry.
- Keep eventual terminal delivery traces durable.
- Make local trace TTL a hard retention boundary independent of stale or disabled cloud export.
- Isolate outbound-consumer unit tests from the operator database.
- Document retention-window and export-gap behavior.

The permanent Slack error classification that stopped the live `invalid_auth` retry avalanche is already present on `dev`; this PR closes the remaining recovery and retention gaps.

## Practical impact

A fatal ownership loss now causes an automatic supervised restart instead of permanent silence. Repeated deliveries remain observable live without writing an unbounded duplicate trace for every attempt, and expired local traces can be pruned even when cloud export is disabled or stale.

## What does NOT change

The ownership fence remains fail-closed, Slack delivery idempotency remains intact, live retry telemetry is still emitted for every attempt, and terminal delivery outcomes remain durable. This PR does not compact the existing operator database or change the configured seven-day retention window.

## Validation

- Full pre-push quality gate passed.
- Focused regression suite: 160 tests passed, 0 failed.
- Typecheck, production build, and Biome checks passed.
- Regression coverage verifies fatal shutdown, retry trace deduplication, cursor-independent TTL pruning, and test isolation from the operator database.

## Risks

Suppressing durable traces after the first retry reduces historical per-attempt detail, but live telemetry is preserved and the first failure plus terminal outcome remain stored. TTL pruning may create ID gaps for exporters; the exporter already advances from the first surviving ID above its cursor and now has regression coverage for this policy.

## Rollback

Revert commits `4d1a4cbf` and `e43f0eca`, then rebuild and restart the daemon. No schema migration is introduced, so rollback does not require database transformation.
