### PR TITLE
fix(publish): pin ws so npm publish no longer hits EOVERRIDE

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.4",
         "reflect-metadata": "^0.2.2",
-        "ws": "^8.21.3",
+        "ws": "8.21.3",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "qrcode-terminal": "^0.12.0",
     "react": "^19.2.4",
     "reflect-metadata": "^0.2.2",
-    "ws": "^8.21.3",
+    "ws": "8.21.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Unblock the automatic `next` CLI publish on `filipexyz/ravi`. `Version And Publish` has failed at **Publish to npm** since the `ws` security pin landed, so `ravi.bot@next` is stuck on `3.260821.2`.

## Problem

- Workflow `.github/workflows/version.yml` versions, tags, and builds successfully, then `npm publish` (npm, not bun) exits with:
  - `EOVERRIDE`
  - `Override for ws@^8.21.3 conflicts with direct dependency`
- Example failed run after the Pages merge: https://github.com/filipexyz/ravi/actions/runs/32919366180
- CI itself is green. `bun install` works. The publish job is what rejects the package.
- On `dev`, `dependencies.ws` was `^8.21.3` while `overrides.ws` was the exact pin `8.21.3`. npm 10 treats that pair as a conflict.
- Failed publishes already pushed version bumps/tags on `dev` (`v3.260826.1`, and `package.json` on `dev` is already `3.260826.2`). This PR does not invent a new versioning scheme and does not delete those tags.

## Solution

- Pin `dependencies.ws` to `8.21.3` so it agrees with `overrides.ws`.
- Keep the exact security pin. Do not loosen `ws` to a floating range.
- Sync the same specifier in `bun.lock`.
- Other overrides in the same block (`protobufjs`, `hono`, `qs`, …) are not also direct dependencies, so they do not trip the same npm rule.

## Practical impact

- After merge to `dev`, CI + `Version And Publish` should fire again automatically and be able to publish `ravi.bot@next`.
- Transitive `ws` stays pinned at `8.21.3`.

## What does NOT change

- Publish workflow trigger, versioning scheme, or existing tags.
- Codex hooks, Pages isolation, NATS, `pi`.
- The rest of the security override set.

## Validation

- Before (npm 10.9.7): `npm publish --dry-run --ignore-scripts` failed with `EOVERRIDE` / `Override for ws@^8.21.3 conflicts with direct dependency`.
- After: the same command packed `ravi.bot@3.260826.2` and did not emit `EOVERRIDE`.
- After: `npm publish --dry-run --tag next --access public` (with `prepack` / build) also succeeded: `ravi.bot-3.260826.2.tgz`, 8 files, no `EOVERRIDE`.
- `npm pack --dry-run --ignore-scripts` and `npm install --package-lock-only` also succeed after the pin.
- `bun install --frozen-lockfile` is consistent.

## Risks

- Low. Specifier-only change; resolved `ws@8.21.3` is unchanged.
- The next successful publish will consume the next date/build number. Older failed tags remain.

## Rollback

- Revert this PR. Publish will fail closed on `EOVERRIDE` again; `ravi.bot@next` stays on the last successful version.

## Follow-ups

- None required. After merge, let CI + Version And Publish run. Do not delete the already-pushed version tags unless someone explicitly asks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5026dd6-2d03-44fb-bd1c-41ea4af7fd79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5026dd6-2d03-44fb-bd1c-41ea4af7fd79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

