### PR TITLE
fix(runtime): do not drop stored inbound after fence or stale channels

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "974539f51e40ffb4"
+    "version": "5539f5bb9a134678"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -17907,6 +17907,9 @@
                         }
                       ]
                     },
+                    "previousPid": {
+                      "type": "number"
+                    },
                     "reason": {
                       "type": "string"
                     },
@@ -18710,6 +18713,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "previousPid": {
+                      "type": "number"
                     },
                     "reason": {
                       "type": "string"
@@ -19630,6 +19636,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "previousPid": {
+                      "type": "number"
                     },
                     "reason": {
                       "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "974539f51e40ffb4"
+    "version": "5539f5bb9a134678"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -17907,6 +17907,9 @@
                         }
                       ]
                     },
+                    "previousPid": {
+                      "type": "number"
+                    },
                     "reason": {
                       "type": "string"
                     },
@@ -18710,6 +18713,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "previousPid": {
+                      "type": "number"
                     },
                     "reason": {
                       "type": "string"
@@ -19630,6 +19636,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "previousPid": {
+                      "type": "number"
                     },
                     "reason": {
                       "type": "string"

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -15860,6 +15860,9 @@ export const ChannelsRestartReturnSchema = {
         }
       ]
     },
+    "previousPid": {
+      "type": "number"
+    },
     "reason": {
       "type": "string"
     },
@@ -16549,6 +16552,9 @@ export const ChannelsStartReturnSchema = {
           "type": "null"
         }
       ]
+    },
+    "previousPid": {
+      "type": "number"
     },
     "reason": {
       "type": "string"
@@ -17417,6 +17423,9 @@ export const ChannelsStopReturnSchema = {
           "type": "null"
         }
       ]
+    },
+    "previousPid": {
+      "type": "number"
     },
     "reason": {
       "type": "string"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -2838,6 +2838,7 @@ export type ChannelsRestartReturn = {
   action: string;
   changed: boolean;
   pm2Status?: number | null;
+  previousPid?: number;
   reason?: string;
   runnerEnv?: {
     consumeOutbound: string;
@@ -2971,6 +2972,7 @@ export type ChannelsStartReturn = {
   action: string;
   changed: boolean;
   pm2Status?: number | null;
+  previousPid?: number;
   reason?: string;
   runnerEnv?: {
     consumeOutbound: string;
@@ -3138,6 +3140,7 @@ export type ChannelsStopReturn = {
   action: string;
   changed: boolean;
   pm2Status?: number | null;
+  previousPid?: number;
   reason?: string;
   runnerEnv?: {
     consumeOutbound: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:f79d1275bfa98ff5d9f904761bb4febf81cd0337c7255337dd3c7dcefa515dd6";
+export const REGISTRY_HASH = "sha256:bf7da02e9a16dbc2b49b256797b02eef5654ee1745259f23bf595ee4de0d7227";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "d3f0cf2f2521";
+export const GIT_SHA = "5761bfb4aea0";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -15984,6 +15984,9 @@ public enum RaviSchemas {
           }
         ]
       },
+      "previousPid": {
+        "type": "number"
+      },
       "reason": {
         "type": "string"
       },
@@ -16679,6 +16682,9 @@ public enum RaviSchemas {
             "type": "null"
           }
         ]
+      },
+      "previousPid": {
+        "type": "number"
       },
       "reason": {
         "type": "string"
@@ -17551,6 +17557,9 @@ public enum RaviSchemas {
             "type": "null"
           }
         ]
+      },
+      "previousPid": {
+        "type": "number"
       },
       "reason": {
         "type": "string"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -3646,15 +3646,17 @@ public struct ChannelsRestartReturn: Codable, Sendable {
   public var action: String
   public var changed: Bool
   public var pm2Status: RaviJSON?
+  public var previousPid: Double?
   public var reason: String?
   public var runnerEnv: RaviJSON?
   public var status: RaviJSON?
   public var target: RaviJSON?
 
-  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, previousPid: Double? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
     self.action = action
     self.changed = changed
     self.pm2Status = pm2Status
+    self.previousPid = previousPid
     self.reason = reason
     self.runnerEnv = runnerEnv
     self.status = status
@@ -3665,6 +3667,7 @@ public struct ChannelsRestartReturn: Codable, Sendable {
     case action = "action"
     case changed = "changed"
     case pm2Status = "pm2Status"
+    case previousPid = "previousPid"
     case reason = "reason"
     case runnerEnv = "runnerEnv"
     case status = "status"
@@ -3745,15 +3748,17 @@ public struct ChannelsStartReturn: Codable, Sendable {
   public var action: String
   public var changed: Bool
   public var pm2Status: RaviJSON?
+  public var previousPid: Double?
   public var reason: String?
   public var runnerEnv: RaviJSON?
   public var status: RaviJSON?
   public var target: RaviJSON?
 
-  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, previousPid: Double? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
     self.action = action
     self.changed = changed
     self.pm2Status = pm2Status
+    self.previousPid = previousPid
     self.reason = reason
     self.runnerEnv = runnerEnv
     self.status = status
@@ -3764,6 +3769,7 @@ public struct ChannelsStartReturn: Codable, Sendable {
     case action = "action"
     case changed = "changed"
     case pm2Status = "pm2Status"
+    case previousPid = "previousPid"
     case reason = "reason"
     case runnerEnv = "runnerEnv"
     case status = "status"
@@ -3802,15 +3808,17 @@ public struct ChannelsStopReturn: Codable, Sendable {
   public var action: String
   public var changed: Bool
   public var pm2Status: RaviJSON?
+  public var previousPid: Double?
   public var reason: String?
   public var runnerEnv: RaviJSON?
   public var status: RaviJSON?
   public var target: RaviJSON?
 
-  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
+  public init(action: String, changed: Bool, pm2Status: RaviJSON? = nil, previousPid: Double? = nil, reason: String? = nil, runnerEnv: RaviJSON? = nil, status: RaviJSON? = nil, target: RaviJSON? = nil) {
     self.action = action
     self.changed = changed
     self.pm2Status = pm2Status
+    self.previousPid = previousPid
     self.reason = reason
     self.runnerEnv = runnerEnv
     self.status = status
@@ -3821,6 +3829,7 @@ public struct ChannelsStopReturn: Codable, Sendable {
     case action = "action"
     case changed = "changed"
     case pm2Status = "pm2Status"
+    case previousPid = "previousPid"
     case reason = "reason"
     case runnerEnv = "runnerEnv"
     case status = "status"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:f79d1275bfa98ff5d9f904761bb4febf81cd0337c7255337dd3c7dcefa515dd6"
-public let RAVI_GIT_SHA = "d3f0cf2f2521"
+public let RAVI_REGISTRY_HASH = "sha256:bf7da02e9a16dbc2b49b256797b02eef5654ee1745259f23bf595ee4de0d7227"
+public let RAVI_GIT_SHA = "5761bfb4aea0"

--- a/src/bot.runtime-guards.fixture.ts
+++ b/src/bot.runtime-guards.fixture.ts
@@ -2218,6 +2218,7 @@ describe("RaviBot streaming session lifecycle", () => {
     }
 
     expect(stopError).toMatchObject({ name: "RuntimeCrashRecoveryOwnershipLostError" });
+    expect(fatalRuntimeErrors[0]).toBe(stopError as Error);
     expect(crashRecovery.ownershipFailure).toBe(stopError);
     expect(crashRecovery.heartbeatTimer).toBeNull();
     expect(crashRecovery.boot).toMatchObject({ status: "active" });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -14,6 +14,7 @@ import { RuntimeHostSubscriptions } from "./runtime/host-subscriptions.js";
 import { RuntimePromptSubscription } from "./runtime/prompt-subscription.js";
 import { notifyRuntimeRecoveryExhausted } from "./runtime/runtime-recovery-alert.js";
 import { safeEmit } from "./runtime/safe-emit.js";
+import { recordPromptIntakeFencedTrace } from "./session-trace/channel-trace.js";
 import { RuntimeSessionDispatcher, type RuntimeAbortProvenance } from "./runtime/session-dispatcher.js";
 import { resolveRuntimeInteractiveReservedSlots, resolveRuntimeSessionPoolMax } from "./runtime/session-pool.js";
 import { resolveGlobalRuntimeModel } from "./runtime/runtime-defaults.js";
@@ -100,6 +101,25 @@ export class RaviBot {
       getRuntimeSessionPoolSnapshot: () => this.sessionDispatcher.getRuntimeSessionPoolSnapshot(),
       markConsumerReady: () => this.markConsumerReady(),
       handlePrompt: (sessionName, prompt) => this.handlePrompt(sessionName, prompt),
+      onIntakeFenced: (event) => {
+        recordPromptIntakeFencedTrace({
+          sessionName: event.sessionName,
+          reason: event.reason,
+          subject: event.subject,
+        });
+        safeEmit(`ravi.session.${event.sessionName}.runtime`, {
+          type: "prompt.intake_fenced",
+          sessionName: event.sessionName,
+          reason: event.reason,
+          subject: event.subject,
+          timestamp: new Date().toISOString(),
+        }).catch((error) => {
+          log.warn("Failed to emit prompt intake fence event", {
+            sessionName: event.sessionName,
+            error,
+          });
+        });
+      },
     });
   }
 
@@ -124,22 +144,18 @@ export class RaviBot {
     });
     this.running = false;
     this.promptSubscription.stopHealthCheck();
-    if (this.stopping) {
-      // stop() already owns a full dispatcher sweep. Re-entering shutdownAll
-      // from a terminal ledger failure would interrupt the same provider twice
-      // and could clear the map underneath the outer sweep.
-      return;
-    }
-    try {
-      // Per-attempt ownership callbacks run before this host callback and
-      // detach their ledger bindings. Dispatcher shutdown can therefore close
-      // providers without attempting a stale terminal write.
-      this.sessionDispatcher.shutdownAll();
-    } catch (shutdownError) {
-      log.error("Failed to close runtime sessions after crash recovery ownership loss", {
-        instanceId: this.instanceId,
-        error: shutdownError,
-      });
+    if (!this.stopping) {
+      try {
+        // Per-attempt ownership callbacks run before this host callback and
+        // detach their ledger bindings. Dispatcher shutdown can therefore close
+        // providers without attempting a stale terminal write.
+        this.sessionDispatcher.shutdownAll();
+      } catch (shutdownError) {
+        log.error("Failed to close runtime sessions after crash recovery ownership loss", {
+          instanceId: this.instanceId,
+          error: shutdownError,
+        });
+      }
     }
     try {
       this.onFatalRuntimeError(error);

--- a/src/channels/backend.test.ts
+++ b/src/channels/backend.test.ts
@@ -343,6 +343,7 @@ describe("channel backend ingress", () => {
       prompt: resolved.prompt,
     });
     expect(publishPrompt).toHaveBeenCalledTimes(1);
+    expect(publishPrompt.mock.calls[0]?.[0]).toBe(resolved.session.name);
     expect(publishPrompt.mock.calls[0]?.[1]).toMatchObject({
       ...resolved.prompt,
       _channelBackend: {

--- a/src/channels/runner-liveness.test.ts
+++ b/src/channels/runner-liveness.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  bounceManagedChannelRunnerProcess,
+  decideChannelRunnerStartAction,
+  isStaleChannelRunnerHealthReason,
+  reconcileManagedChannelRunner,
+  STALE_CHANNEL_RUNNER_HEALTH_REASONS,
+} from "./runner-liveness.js";
+import { createChannelRunnerHealthSnapshot } from "./health.js";
+
+const HEALTHY_SNAPSHOT = createChannelRunnerHealthSnapshot({
+  running: true,
+  startedAt: 1,
+  pid: 5661,
+  outbound: {
+    stream: "CHANNEL_OUTBOUND",
+    consumer: "ravi-channels-outbound",
+    enabled: true,
+    infrastructureReady: true,
+    consuming: true,
+  },
+  adapters: [{ id: "slack:main", channelId: "slack", status: "connected" }],
+});
+
+describe("channel runner liveness", () => {
+  it("treats timeout, no_responders, and pid_mismatch as stale health", () => {
+    expect(STALE_CHANNEL_RUNNER_HEALTH_REASONS).toEqual(["timeout", "no_responders", "pid_mismatch"]);
+    expect(isStaleChannelRunnerHealthReason("timeout")).toBe(true);
+    expect(isStaleChannelRunnerHealthReason("no_responders")).toBe(true);
+    expect(isStaleChannelRunnerHealthReason("pid_mismatch")).toBe(true);
+    expect(isStaleChannelRunnerHealthReason("nats_unavailable")).toBe(false);
+  });
+
+  it("starts when PM2 is not online and keeps a healthy runner", () => {
+    expect(decideChannelRunnerStartAction()).toEqual({ action: "start" });
+    expect(
+      decideChannelRunnerStartAction({
+        pm2Online: true,
+        pid: 5661,
+        health: { reachable: true, snapshot: HEALTHY_SNAPSHOT },
+      }),
+    ).toEqual({ action: "already_running" });
+  });
+
+  it("bounces stale health and refuses to no-op when NATS is unavailable", () => {
+    expect(
+      decideChannelRunnerStartAction({
+        pm2Online: true,
+        pid: 5661,
+        health: { reachable: false, reason: "timeout" },
+      }),
+    ).toEqual({ action: "bounce", pid: 5661, reason: "timeout" });
+    expect(
+      decideChannelRunnerStartAction({
+        pm2Online: true,
+        pid: 5661,
+        health: { reachable: false, reason: "nats_unavailable" },
+      }),
+    ).toEqual({ action: "unconfirmed", reason: "nats_unavailable" });
+  });
+
+  it("reconciles an online-but-stale runner by bouncing it", async () => {
+    const bounce = mock(() => ({
+      ok: true,
+      pm2Status: 0,
+      previousPid: 5661,
+      reason: "stale_timeout",
+    }));
+    const result = await reconcileManagedChannelRunner({
+      isAvailable: () => true,
+      getProcess: () =>
+        ({
+          name: "ravi-channels",
+          pm_id: 2,
+          pid: 5661,
+          status: "online",
+          cpu: 0,
+          memory: 0,
+          args: ["/tmp/bundle/index.js", "channels", "run"],
+          cwd: "/tmp/bundle",
+        }) as never,
+      probe: async () => ({ reachable: false, reason: "timeout" }),
+      bounce,
+      resolveTarget: () => ({ bundlePath: "/tmp/bundle/index.js", cwd: "/tmp/bundle" }),
+    });
+
+    expect(result).toEqual({ action: "bounced", previousPid: 5661, reason: "stale_timeout" });
+    expect(bounce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "stale_timeout",
+        previousPid: 5661,
+      }),
+    );
+  });
+
+  it("does not bounce a healthy runner and reports unconfirmed NATS", async () => {
+    const bounce = mock(() => ({ ok: true, pm2Status: 0, reason: "unused" }));
+    const healthy = await reconcileManagedChannelRunner({
+      isAvailable: () => true,
+      getProcess: () => ({ name: "ravi-channels", pm_id: 2, pid: 5661, status: "online", cpu: 0, memory: 0 }) as never,
+      probe: async () => ({ reachable: true, snapshot: HEALTHY_SNAPSHOT }),
+      bounce,
+    });
+    expect(healthy).toEqual({ action: "healthy", pid: 5661 });
+    expect(bounce).not.toHaveBeenCalled();
+
+    const unconfirmed = await reconcileManagedChannelRunner({
+      isAvailable: () => true,
+      getProcess: () => ({ name: "ravi-channels", pm_id: 2, pid: 5661, status: "online", cpu: 0, memory: 0 }) as never,
+      probe: async () => ({ reachable: false, reason: "nats_unavailable" }),
+      bounce,
+      emit: async () => {},
+    });
+    expect(unconfirmed).toEqual({ action: "unconfirmed", reason: "nats_unavailable" });
+  });
+
+  it("reports bounce_failed when PM2 delete/start fails", async () => {
+    const result = await reconcileManagedChannelRunner({
+      isAvailable: () => true,
+      getProcess: () =>
+        ({
+          name: "ravi-channels",
+          pm_id: 2,
+          pid: 5661,
+          status: "online",
+          cpu: 0,
+          memory: 0,
+        }) as never,
+      probe: async () => ({ reachable: false, reason: "no_responders" }),
+      bounce: () => ({ ok: false, pm2Status: 1, previousPid: 5661, reason: "stale_no_responders" }),
+      resolveTarget: () => ({ bundlePath: "/tmp/bundle/index.js", cwd: "/tmp/bundle" }),
+    });
+    expect(result).toEqual({
+      action: "bounce_failed",
+      previousPid: 5661,
+      reason: "stale_no_responders",
+    });
+  });
+
+  it("bounces via PM2 delete + start bun --name ravi-channels", () => {
+    const runPm2 = mock((_args: string[]) => {
+      return { status: 0 };
+    });
+    const persistPm2 = mock(() => 0);
+    const emit = mock(async () => {});
+
+    const result = bounceManagedChannelRunnerProcess({
+      target: { bundlePath: "/repo/dist/bundle/index.js", cwd: "/repo" },
+      reason: "stale_timeout",
+      previousPid: 5661,
+      persist: true,
+      runPm2,
+      persistPm2,
+      emit,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      pm2Status: 0,
+      previousPid: 5661,
+      reason: "stale_timeout",
+    });
+    expect(runPm2.mock.calls.map((call) => call[0])).toEqual([
+      ["delete", "ravi-channels"],
+      ["start", "bun", "--name", "ravi-channels", "--", "/repo/dist/bundle/index.js", "channels", "run"],
+    ]);
+    expect(persistPm2).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(
+      "ravi.channels.runner.reconcile",
+      expect.objectContaining({ action: "bounced", previousPid: 5661 }),
+    );
+  });
+});

--- a/src/channels/runner-liveness.ts
+++ b/src/channels/runner-liveness.ts
@@ -1,0 +1,242 @@
+import { spawnSync } from "node:child_process";
+import { nats } from "../nats.js";
+import { CHANNELS_PM2_PROCESS_NAME, buildPm2Env, getPm2Process, isPm2Available, type Pm2Process } from "../pm2.js";
+import { logger } from "../utils/logger.js";
+import { buildRunnerPm2Env } from "./pm2-env.js";
+import {
+  probeChannelRunnerHealth,
+  type ChannelRunnerHealthProbeFailureReason,
+  type ChannelRunnerHealthProbeResult,
+} from "./health.js";
+
+const log = logger.child("channels:runner-liveness");
+
+export const STALE_CHANNEL_RUNNER_HEALTH_REASONS = ["timeout", "no_responders", "pid_mismatch"] as const;
+
+export type StaleChannelRunnerHealthReason = (typeof STALE_CHANNEL_RUNNER_HEALTH_REASONS)[number];
+
+export type ChannelRunnerStartDecision =
+  | { action: "start" }
+  | { action: "already_running" }
+  | { action: "bounce"; pid: number; reason: StaleChannelRunnerHealthReason }
+  | { action: "unconfirmed"; reason: "nats_unavailable" };
+
+export type ChannelRunnerReconcileResult =
+  | { action: "none"; reason?: string }
+  | { action: "healthy"; pid: number }
+  | { action: "bounced"; previousPid: number; reason: string }
+  | { action: "unconfirmed"; reason: "nats_unavailable" }
+  | { action: "bounce_failed"; previousPid?: number; reason: string };
+
+export function isStaleChannelRunnerHealthReason(
+  reason: ChannelRunnerHealthProbeFailureReason | string,
+): reason is StaleChannelRunnerHealthReason {
+  return (STALE_CHANNEL_RUNNER_HEALTH_REASONS as readonly string[]).includes(reason);
+}
+
+export function decideChannelRunnerStartAction(
+  options: { pm2Online?: boolean; pid?: number | null; health?: ChannelRunnerHealthProbeResult | null } = {},
+): ChannelRunnerStartDecision {
+  if (!options.pm2Online) return { action: "start" };
+  const health = options.health;
+  if (!health) return { action: "unconfirmed", reason: "nats_unavailable" };
+  if (health.reachable) return { action: "already_running" };
+  if (health.reason === "nats_unavailable") return { action: "unconfirmed", reason: "nats_unavailable" };
+  if (isStaleChannelRunnerHealthReason(health.reason)) {
+    return { action: "bounce", pid: options.pid ?? 0, reason: health.reason };
+  }
+  return { action: "unconfirmed", reason: "nats_unavailable" };
+}
+
+export function bounceManagedChannelRunnerProcess(options: {
+  target: { bundlePath: string; cwd: string };
+  reason: string;
+  previousPid?: number | null;
+  persist?: boolean;
+  runPm2?: (args: string[], opts?: { cwd?: string; envOverrides?: Record<string, string> }) => { status: number };
+  persistPm2?: () => number;
+  emit?: (topic: string, payload: Record<string, unknown>) => Promise<void>;
+  runnerEnv?: Record<string, string>;
+}): { ok: boolean; pm2Status: number; previousPid?: number; reason: string } {
+  const runPm2 = options.runPm2 ?? defaultRunPm2;
+  const persistPm2 = options.persistPm2 ?? defaultPersistPm2;
+  const emit = options.emit ?? ((topic, payload) => nats.emit(topic, payload));
+  const runnerEnv = options.runnerEnv ?? buildRunnerPm2Env();
+  const previousPid = options.previousPid ?? undefined;
+
+  const deleted = runPm2(["delete", CHANNELS_PM2_PROCESS_NAME]);
+  if (deleted.status !== 0) {
+    const result = {
+      ok: false,
+      pm2Status: deleted.status,
+      previousPid,
+      reason: options.reason,
+    };
+    void emit("ravi.channels.runner.reconcile", {
+      action: "bounce_failed",
+      phase: "delete",
+      ...result,
+    }).catch((error) => {
+      log.warn("Failed to emit channel runner reconcile event", { error });
+    });
+    return result;
+  }
+
+  const startArgs = [
+    "start",
+    "bun",
+    "--name",
+    CHANNELS_PM2_PROCESS_NAME,
+    "--",
+    options.target.bundlePath,
+    "channels",
+    "run",
+  ];
+  const started = runPm2(startArgs, { cwd: options.target.cwd, envOverrides: runnerEnv });
+  if (started.status !== 0) {
+    const result = {
+      ok: false,
+      pm2Status: started.status,
+      previousPid,
+      reason: options.reason,
+    };
+    void emit("ravi.channels.runner.reconcile", {
+      action: "bounce_failed",
+      phase: "start",
+      ...result,
+    }).catch((error) => {
+      log.warn("Failed to emit channel runner reconcile event", { error });
+    });
+    return result;
+  }
+
+  if (options.persist !== false) {
+    const saveStatus = persistPm2();
+    if (saveStatus !== 0) {
+      const result = {
+        ok: false,
+        pm2Status: started.status,
+        previousPid,
+        reason: options.reason,
+      };
+      void emit("ravi.channels.runner.reconcile", {
+        action: "bounce_failed",
+        phase: "save",
+        ...result,
+      }).catch((error) => {
+        log.warn("Failed to emit channel runner reconcile event", { error });
+      });
+      return result;
+    }
+  }
+
+  const result = {
+    ok: true,
+    pm2Status: started.status,
+    previousPid,
+    reason: options.reason,
+  };
+  void emit("ravi.channels.runner.reconcile", {
+    action: "bounced",
+    ...result,
+  }).catch((error) => {
+    log.warn("Failed to emit channel runner reconcile event", { error });
+  });
+  return result;
+}
+
+export async function reconcileManagedChannelRunner(
+  options: {
+    getProcess?: () => Pm2Process | undefined;
+    isAvailable?: () => boolean;
+    probe?: (input: { pid: number }) => Promise<ChannelRunnerHealthProbeResult>;
+    bounce?: typeof bounceManagedChannelRunnerProcess;
+    resolveTarget?: () => { bundlePath: string; cwd: string } | null;
+    emit?: (topic: string, payload: Record<string, unknown>) => Promise<void>;
+    persist?: boolean;
+  } = {},
+): Promise<ChannelRunnerReconcileResult> {
+  const isAvailable = options.isAvailable ?? isPm2Available;
+  if (!isAvailable()) {
+    return { action: "none", reason: "pm2_unavailable" };
+  }
+
+  const processInfo = (options.getProcess ?? (() => getPm2Process(CHANNELS_PM2_PROCESS_NAME)))();
+  if (!processInfo || processInfo.status !== "online") {
+    return { action: "none", reason: "not_running" };
+  }
+
+  const pid = processInfo.pid;
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return { action: "none", reason: "invalid_pid" };
+  }
+
+  const health = await (options.probe ?? probeChannelRunnerHealth)({ pid });
+  const decision = decideChannelRunnerStartAction({
+    pm2Online: true,
+    pid,
+    health,
+  });
+
+  if (decision.action === "already_running") {
+    return { action: "healthy", pid };
+  }
+  if (decision.action === "unconfirmed") {
+    void (options.emit ?? ((topic, payload) => nats.emit(topic, payload)))("ravi.channels.runner.reconcile", {
+      action: "unconfirmed",
+      reason: decision.reason,
+      pid,
+    }).catch((error) => {
+      log.warn("Failed to emit channel runner reconcile event", { error });
+    });
+    return { action: "unconfirmed", reason: decision.reason };
+  }
+  if (decision.action !== "bounce") {
+    return { action: "none" };
+  }
+
+  const target = options.resolveTarget?.() ?? resolveManagedChannelRunnerTarget(processInfo);
+  if (!target) {
+    return { action: "bounce_failed", previousPid: pid, reason: "missing_runtime_target" };
+  }
+
+  const bounced = (options.bounce ?? bounceManagedChannelRunnerProcess)({
+    target,
+    reason: `stale_${decision.reason}`,
+    previousPid: decision.pid,
+    persist: options.persist ?? false,
+    emit: options.emit,
+  });
+  if (!bounced.ok) {
+    return {
+      action: "bounce_failed",
+      previousPid: pid,
+      reason: bounced.reason,
+    };
+  }
+  return { action: "bounced", previousPid: pid, reason: bounced.reason };
+}
+
+function resolveManagedChannelRunnerTarget(processInfo: Pm2Process): { bundlePath: string; cwd: string } | null {
+  const bundlePath = processInfo.args?.[0];
+  const cwd = processInfo.cwd;
+  if (!bundlePath || !cwd) return null;
+  return { bundlePath, cwd };
+}
+
+function defaultRunPm2(
+  args: string[],
+  options: { cwd?: string; envOverrides?: Record<string, string> } = {},
+): { status: number } {
+  const result = spawnSync("pm2", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+    cwd: options.cwd,
+    env: buildPm2Env(options.envOverrides),
+  });
+  return { status: result.status ?? 1 };
+}
+
+function defaultPersistPm2(): number {
+  return defaultRunPm2(["save", "--force"]).status;
+}

--- a/src/cli/commands/channels.test.ts
+++ b/src/cli/commands/channels.test.ts
@@ -22,6 +22,50 @@ mock.module("../context.js", () => ({
   },
 }));
 
+const actualHealth = await import("../../channels/health.js");
+const healthProbeOverride: {
+  current:
+    | ((options: { pid: number }) => Promise<import("../../channels/health.js").ChannelRunnerHealthProbeResult>)
+    | null;
+} = { current: null };
+mock.module("../../channels/health.js", () => ({
+  ...actualHealth,
+  probeChannelRunnerHealth: async (options: { pid: number }) => {
+    if (healthProbeOverride.current) return healthProbeOverride.current(options);
+    return actualHealth.probeChannelRunnerHealth(options);
+  },
+}));
+
+const actualPm2 = await import("../../pm2.js");
+const pm2Override: {
+  running: boolean;
+  process: ReturnType<typeof actualPm2.getPm2Process>;
+} = { running: false, process: undefined };
+mock.module("../../pm2.js", () => ({
+  ...actualPm2,
+  isPm2Available: () => true,
+  isPm2ProcessRunning: (name: string) =>
+    name === "ravi-channels" ? pm2Override.running : actualPm2.isPm2ProcessRunning(name),
+  getPm2Process: (name: string) =>
+    name === "ravi-channels" && pm2Override.process !== undefined ? pm2Override.process : actualPm2.getPm2Process(name),
+}));
+
+const actualLiveness = await import("../../channels/runner-liveness.js");
+const bounceOverride = {
+  current: null as
+    | null
+    | ((
+        ...args: Parameters<typeof actualLiveness.bounceManagedChannelRunnerProcess>
+      ) => ReturnType<typeof actualLiveness.bounceManagedChannelRunnerProcess>),
+};
+mock.module("../../channels/runner-liveness.js", () => ({
+  ...actualLiveness,
+  bounceManagedChannelRunnerProcess: (...args: Parameters<typeof actualLiveness.bounceManagedChannelRunnerProcess>) => {
+    if (bounceOverride.current) return bounceOverride.current(...args);
+    return actualLiveness.bounceManagedChannelRunnerProcess(...args);
+  },
+}));
+
 const {
   buildChannelsLiveStatusJson,
   ChannelsCommands,
@@ -44,6 +88,10 @@ afterEach(async () => {
   await cleanupIsolatedRaviState(stateDir);
   stateDir = null;
   process.env = { ...ORIGINAL_ENV };
+  healthProbeOverride.current = null;
+  pm2Override.running = false;
+  pm2Override.process = undefined;
+  bounceOverride.current = null;
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) rmSync(dir, { recursive: true, force: true });
@@ -128,6 +176,50 @@ describe("channels runner lifecycle", () => {
     expect(pm2Log).toContain(`start bun --name ravi-channels -- ${realpathSync(bundlePath)} channels run`);
     expect(pm2Log).toContain("save --force");
   }, 20_000);
+
+  it("bounces an online-but-unreachable runner instead of no-op already_running", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ravi-channels-start-bounce-"));
+    tempDirs.push(root);
+    const bundlePath = join(root, "dist", "bundle", "index.js");
+    mkdirSync(join(bundlePath, ".."), { recursive: true });
+    writeFileSync(bundlePath, "", "utf8");
+    process.env.RAVI_BUNDLE = bundlePath;
+    process.env.RAVI_DAEMON_CWD = root;
+
+    pm2Override.running = true;
+    pm2Override.process = {
+      name: "ravi-channels",
+      pm_id: 2,
+      pid: 5661,
+      status: "online",
+      cpu: 0,
+      memory: 0,
+    };
+    healthProbeOverride.current = async () => ({ reachable: false, reason: "timeout" });
+    const bounce = mock((input: { reason: string; previousPid?: number | null }) => ({
+      ok: true,
+      pm2Status: 0,
+      previousPid: input.previousPid ?? 5661,
+      reason: input.reason,
+    }));
+    bounceOverride.current = bounce as never;
+
+    const commands = new ChannelsCommands();
+    const payload = await commands.start(undefined, true);
+
+    expect(payload).toMatchObject({
+      action: "start",
+      changed: true,
+      reason: "stale_timeout",
+      previousPid: 5661,
+    });
+    expect(bounce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "stale_timeout",
+        previousPid: 5661,
+      }),
+    );
+  });
 });
 
 describe("channels config commands", () => {

--- a/src/cli/commands/channels.ts
+++ b/src/cli/commands/channels.ts
@@ -11,6 +11,7 @@ import {
   type ChannelRunnerHealthProbeResult,
   type ChannelRunnerHealthSnapshot,
 } from "../../channels/health.js";
+import { bounceManagedChannelRunnerProcess, decideChannelRunnerStartAction } from "../../channels/runner-liveness.js";
 import { ChannelRunner, runChannelRunnerFromEnv } from "../../channels/runner.js";
 import { buildRunnerPm2Env } from "../../channels/pm2-env.js";
 import { getCredentialConnection, listCredentialConnections } from "../../credentials/index.js";
@@ -146,6 +147,7 @@ const channelsMutationReturnSchema = z
     runnerEnv: runnerEnvReturnSchema.optional(),
     status: channelsStatusReturnSchema.optional(),
     reason: z.string().optional(),
+    previousPid: z.number().optional(),
   })
   .strict();
 
@@ -638,21 +640,75 @@ export class ChannelsCommands {
   @Command({ name: "start", description: "Start the channel runner via PM2" })
   @CommandAccess({ kind: "mutate", resource: "channels", action: "start", risk: "high" })
   @Returns(channelsMutationReturnSchema)
-  start(
+  async start(
     @Option({ flags: "-b, --build", description: "Use dist bundle from source repo" }) build?: boolean,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     requirePm2();
 
     if (isPm2ProcessRunning(CHANNELS_PM2_PROCESS_NAME)) {
+      const running = getPm2Process(CHANNELS_PM2_PROCESS_NAME);
+      const pid = running?.pid;
+      const health =
+        Number.isSafeInteger(pid) && (pid ?? 0) > 0
+          ? await probeChannelRunnerHealth({ pid: pid as number })
+          : ({ reachable: false, reason: "pid_mismatch" } as const);
+      const decision = decideChannelRunnerStartAction({
+        pm2Online: true,
+        pid,
+        health,
+      });
+      if (decision.action === "already_running") {
+        const payload = {
+          action: "start" as const,
+          changed: false,
+          reason: "already_running",
+          status: await buildChannelsLiveStatusJson(),
+        };
+        if (asJson) printJson(payload);
+        else console.log("Channel runner is already running");
+        return payload;
+      }
+      if (decision.action === "unconfirmed") {
+        fail(
+          "Channel runner PM2 process is online but health could not be confirmed (NATS unavailable). Refusing to no-op.",
+        );
+      }
+      if (decision.action !== "bounce") {
+        return { action: "not_managed" as const, changed: false };
+      }
+
+      const target = requireRuntimeTarget(build);
+      const runnerEnv = buildRunnerPm2Env();
+      const bounced = bounceManagedChannelRunnerProcess({
+        target,
+        reason: `stale_${decision.reason}`,
+        previousPid: decision.pid,
+        persist: true,
+        runnerEnv,
+        runPm2: (args, opts) =>
+          asJson
+            ? runPm2Quiet(args, { cwd: opts?.cwd ?? target.cwd, envOverrides: opts?.envOverrides ?? runnerEnv })
+            : runPm2(args, opts?.envOverrides ?? runnerEnv, { cwd: opts?.cwd ?? target.cwd }),
+        persistPm2: persistPm2ProcessList,
+      });
       const payload = {
         action: "start" as const,
-        changed: false,
-        reason: "already_running",
-        status: buildChannelsStatusJson(),
+        changed: bounced.ok,
+        reason: `stale_${decision.reason}`,
+        previousPid: decision.pid,
+        pm2Status: bounced.pm2Status,
+        target,
+        runnerEnv: publicRunnerEnv(runnerEnv),
+        status: await buildChannelsLiveStatusJson(),
       };
-      if (asJson) printJson(payload);
-      else console.log("Channel runner is already running");
+      if (asJson) {
+        printJson(payload);
+        if (!bounced.ok) fail("Failed to bounce stale channel runner");
+        return payload;
+      }
+      if (!bounced.ok) fail("Failed to bounce stale channel runner");
+      console.log(`Channel runner bounced (stale ${decision.reason}, previous PID ${decision.pid})`);
       return payload;
     }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -57,6 +57,7 @@ import {
   watchForLeadershipVacancy,
   releaseLeadership,
 } from "./leader/index.js";
+import { reconcileManagedChannelRunner } from "./channels/runner-liveness.js";
 
 const log = logger.child("daemon");
 
@@ -294,11 +295,25 @@ async function shutdown(signal: string, exitCode = 0) {
   process.exit(exitCode);
 }
 
+async function reconcileChannelRunnerAfterDaemonStart(): Promise<void> {
+  try {
+    const result = await reconcileManagedChannelRunner();
+    if (result.action === "bounce_failed" || result.action === "unconfirmed") {
+      log.error("Channel runner reconcile after daemon start did not confirm Slack transport", result);
+    }
+  } catch (error) {
+    log.error("Channel runner reconcile after daemon start failed", { error });
+  }
+}
+
 function restartAfterFatalRuntimeError(error: Error): void {
   log.error("Fatal runtime ownership error; exiting for supervised restart", {
     pid: process.pid,
     error,
   });
+  if (shuttingDown) {
+    process.exit(1);
+  }
   void shutdown("fatal runtime ownership error", 1);
 }
 
@@ -379,6 +394,7 @@ export async function startDaemon() {
 
   await gateway.start();
   log.info("Gateway started");
+  await reconcileChannelRunnerAfterDaemonStart();
 
   // Step 7: Start runners — leader election ensures only one daemon runs heartbeat/cron
   // Trigger, ephemeral, and inbox are per-daemon (each daemon handles its own).

--- a/src/runtime/prompt-subscription.test.ts
+++ b/src/runtime/prompt-subscription.test.ts
@@ -6,6 +6,7 @@ const emitCalls: Array<{ topic: string; payload: Record<string, unknown> }> = []
 
 let running = false;
 let consumedMessages: FakePromptMessage[] = [];
+let stopRunningAfterConsume = true;
 
 interface FakePromptMessage {
   data: Uint8Array;
@@ -18,11 +19,14 @@ const fakeConsumer = {
   consume: mock(async (options: Record<string, unknown>) => {
     consumeCalls.push(options);
     const messages = [...consumedMessages];
+    consumedMessages = [];
     return (async function* () {
       try {
         yield* messages;
       } finally {
-        running = false;
+        if (stopRunningAfterConsume) {
+          running = false;
+        }
       }
     })();
   }),
@@ -63,6 +67,7 @@ afterAll(() => {
 
 beforeEach(() => {
   running = true;
+  stopRunningAfterConsume = true;
   consumedMessages = [];
   consumeCalls.length = 0;
   emitCalls.length = 0;
@@ -169,6 +174,69 @@ describe("RuntimePromptSubscription", () => {
     expect(message.ack).not.toHaveBeenCalled();
     expect(handlePrompt).not.toHaveBeenCalled();
     expect(subscription.promptsReceived).toBe(0);
+  });
+
+  it("records onIntakeFenced when crash-recovery intake is closed", async () => {
+    const message = makePromptMessage("ravi.session.main.prompt", { prompt: "stored after fence" });
+    consumedMessages = [message];
+    const onIntakeFenced = mock(() => {});
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => false,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt: mock(async () => {}),
+      onIntakeFenced,
+    });
+
+    subscription.subscribe();
+    await waitUntil(() => !subscription.active);
+
+    expect(onIntakeFenced).toHaveBeenCalledWith({
+      sessionName: "main",
+      subject: "ravi.session.main.prompt",
+      reason: "crash_recovery_not_accepting",
+    });
+    expect(message.nak).toHaveBeenCalledTimes(1);
+    expect(message.ack).not.toHaveBeenCalled();
+  });
+
+  it("resubscribes after a transient fence and dispatches Slack-sourced inbound", async () => {
+    stopRunningAfterConsume = false;
+    const fenced = makePromptMessage("ravi.session.main.prompt", { prompt: "held during fence" });
+    const slack = makePromptMessage("ravi.session.main.prompt", {
+      prompt: "@ravi ping",
+      source: { channel: "slack", accountId: "ravi-slack", chatId: "C123" },
+    });
+    consumedMessages = [fenced];
+    let accept = false;
+    const handlePrompt = mock(async () => {
+      running = false;
+    });
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => accept,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt,
+      intakeFenceRetryMs: 20,
+    });
+
+    subscription.subscribe();
+    await waitUntil(() => fenced.nak.mock.calls.length === 1 && consumeCalls.length === 1);
+
+    accept = true;
+    consumedMessages = [slack];
+    await waitUntil(() => handlePrompt.mock.calls.length === 1);
+
+    expect(handlePrompt).toHaveBeenCalledWith("main", {
+      prompt: "@ravi ping",
+      source: { channel: "slack", accountId: "ravi-slack", chatId: "C123" },
+    });
+    expect(slack.ack).toHaveBeenCalledTimes(1);
+    expect(fenced.ack).not.toHaveBeenCalled();
   });
 });
 

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -13,6 +13,14 @@ import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
 
 const log = logger.child("runtime:prompt-subscription");
 const PROMPT_DISPATCH_RETRY_DELAY_MS = 5_000;
+export const DEFAULT_PROMPT_INTAKE_FENCE_RETRY_MS = 5_000;
+export const PROMPT_INTAKE_FENCED_REASON = "crash_recovery_not_accepting";
+
+export interface PromptIntakeFencedEvent {
+  sessionName: string;
+  subject: string;
+  reason: typeof PROMPT_INTAKE_FENCED_REASON;
+}
 
 export interface RuntimePromptSubscriptionOptions {
   isRunning(): boolean;
@@ -22,6 +30,8 @@ export interface RuntimePromptSubscriptionOptions {
   ensurePromptInfrastructure?(options?: EnsureSessionPromptInfrastructureOptions): Promise<void>;
   markConsumerReady(): void;
   handlePrompt(sessionName: string, prompt: RuntimeLaunchPrompt): Promise<void>;
+  onIntakeFenced?(event: PromptIntakeFencedEvent): void;
+  intakeFenceRetryMs?: number;
 }
 
 export class RuntimePromptSubscription {
@@ -136,10 +146,20 @@ export class RuntimePromptSubscription {
             }
             if (!canAcceptPrompt) {
               intakeFenced = true;
-              log.warn("Runtime prompt intake fenced before acknowledgement", {
+              const event = {
                 sessionName,
                 subject: msg.subject,
-              });
+                reason: PROMPT_INTAKE_FENCED_REASON,
+              } as const;
+              log.warn("Runtime prompt intake fenced before acknowledgement", event);
+              try {
+                this.options.onIntakeFenced?.(event);
+              } catch (error) {
+                log.warn("Failed to record runtime prompt intake fence", {
+                  sessionName,
+                  error,
+                });
+              }
               msg.nak();
               break;
             }
@@ -221,8 +241,9 @@ export class RuntimePromptSubscription {
         running: this.options.isRunning(),
         promptsReceived: this.promptsReceived,
       });
-      if (this.options.isRunning() && !intakeFenced) {
-        setTimeout(() => this.subscribe(), 1000);
+      if (this.options.isRunning()) {
+        const retryMs = intakeFenced ? (this.options.intakeFenceRetryMs ?? DEFAULT_PROMPT_INTAKE_FENCE_RETRY_MS) : 1000;
+        setTimeout(() => this.subscribe(), retryMs);
       }
     }
   }

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { nats } from "../nats.js";
+import { configStore } from "../config-store.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import {
   RuntimeSessionDispatcher,
@@ -2508,6 +2509,92 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
 
     expect(dispatcher.streamingSessions.has("task-blocked-work")).toBe(false);
     expect(dispatcher.streamingSessions.has("main")).toBe(true);
+  });
+
+  it("throws a visible intake failure instead of silently dropping a prompt with no agent", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-no-agent-intake-");
+    try {
+      getOrCreateSession("agent:main:main", "main", stateDir, { name: "main" });
+      configStore.refresh();
+      const dispatcher = createDispatcher();
+      const getConfig = spyOn(configStore, "getConfig").mockReturnValue({
+        ...configStore.getConfig(),
+        agents: {},
+        defaultAgent: "missing",
+      });
+
+      await expect(
+        dispatcher.handlePrompt("main", {
+          prompt: "hello after reroute",
+          source: { channel: "whatsapp", accountId: "main", chatId: "5511999999999" },
+        }),
+      ).rejects.toThrow("Runtime prompt intake failed (no_agent)");
+
+      getConfig.mockRestore();
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+
+  it("cold-starts Slack inbound after an idle-complete runtime session", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-idle-complete-");
+    try {
+      getOrCreateSession("agent:main:main", "main", stateDir, { name: "main" });
+      configStore.refresh();
+      const dispatcher = createDispatcher();
+      const startStreamingSession = spyOn(dispatcher, "startStreamingSession").mockResolvedValue();
+      dispatcher.streamingSessions.set(
+        "main",
+        createActiveSession({
+          agentId: "main",
+          done: true,
+        }),
+      );
+
+      await dispatcher.handlePromptImmediate("main", {
+        prompt: "@ravi ping",
+        source: { channel: "slack", accountId: "ravi-slack", chatId: "C123" },
+      });
+
+      expect(startStreamingSession).toHaveBeenCalledTimes(1);
+      expect(startStreamingSession.mock.calls[0]?.[1]._daemonRestartResume).toBeUndefined();
+      expect(dispatcher.streamingSessions.has("main")).toBe(false);
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+
+  it("cold-starts WhatsApp inbound after a missing_snapshot skip-resume", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-skip-resume-inbound-");
+    try {
+      const sessionKey = "agent:main:main";
+      getOrCreateSession(sessionKey, "main", stateDir, { name: "main" });
+      configStore.refresh();
+      dbUpsertDaemonRestartEpoch({
+        restartEpoch: "epoch-missing-snapshot",
+        reason: "crash-recovery-fenced snapshot",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      dbMarkDaemonRestartResumeDelivered({
+        restartEpoch: "epoch-missing-snapshot",
+        sessionKey,
+        sessionName: "main",
+      });
+      const dispatcher = createDispatcher();
+      const startStreamingSession = spyOn(dispatcher, "startStreamingSession").mockResolvedValue();
+
+      await dispatcher.handlePromptImmediate("main", {
+        prompt: "oi",
+        source: { channel: "whatsapp", accountId: "main", chatId: "5511999999999" },
+        _daemonRestartResume: undefined,
+      });
+
+      expect(startStreamingSession).toHaveBeenCalledTimes(1);
+      expect(startStreamingSession.mock.calls[0]?.[1]._daemonRestartResume).toBeUndefined();
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
   });
 
   it("keeps queued runtime starts parked when model change caller immediately restarts the same session", async () => {

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -691,8 +691,7 @@ export class RuntimeSessionDispatcher {
     const agentId = prompt._agentId ?? sessionEntry?.agentId ?? routerConfig.defaultAgent;
     const agent = routerConfig.agents[agentId] ?? routerConfig.agents[routerConfig.defaultAgent];
     if (!agent) {
-      log.error("No agent found for prompt", { sessionName, agentId });
-      return;
+      this.failPromptIntake(sessionName, prompt, "no_agent", { agentId });
     }
 
     const isGroup = sessionEntry?.chatType === "group" || sessionName.includes(":group:");
@@ -792,8 +791,7 @@ export class RuntimeSessionDispatcher {
     const agentId = prompt._agentId ?? sessionEntry?.agentId ?? routerConfig.defaultAgent;
     const agent = routerConfig.agents[agentId] ?? routerConfig.agents[routerConfig.defaultAgent];
     if (!agent) {
-      log.error("No agent found for prompt", { sessionName, agentId });
-      return;
+      this.failPromptIntake(sessionName, prompt, "no_agent", { agentId });
     }
     const modelBrokerTurnId = prompt._modelBrokerTurnId ?? createSessionTraceTurnId();
     const modelBrokerPlan = await planRuntimeModelBrokerRoute({
@@ -1147,6 +1145,7 @@ export class RuntimeSessionDispatcher {
     }
 
     if (existing?.done) {
+      log.info("Streaming: relaunching after idle-complete runtime session", { sessionName });
       this.releaseRuntimeSessionSlot(sessionName);
     }
 
@@ -1313,6 +1312,30 @@ export class RuntimeSessionDispatcher {
       },
     });
     await this.startStreamingSession(sessionName, prompt, { retainReleasedSlot });
+  }
+
+  private failPromptIntake(
+    sessionName: string,
+    prompt: RuntimeLaunchPrompt,
+    reason: string,
+    extra: Record<string, unknown> = {},
+  ): never {
+    const sessionEntry = getSessionByName(sessionName);
+    const message = `Runtime prompt intake failed (${reason})`;
+    log.error(message, { sessionName, reason, ...extra });
+    recordRuntimeTraceEvent({
+      sessionKey: sessionEntry?.sessionKey ?? sessionName,
+      sessionName,
+      agentId: prompt._agentId ?? sessionEntry?.agentId,
+      eventType: "dispatch.intake_failed",
+      eventGroup: "dispatch",
+      status: "failed",
+      source: prompt.source,
+      messageId: prompt.context?.messageId,
+      error: message,
+      payloadJson: { reason, ...extra },
+    });
+    throw new Error(message);
   }
 
   private prepareDaemonRestartResumePrompt(

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -100,7 +100,9 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
   const resumeStashedMessages = prompt._resumeStashedMessages === true;
 
   const sessionIdentity = resolveRuntimeSessionIdentity({ sessionName, prompt });
-  if (!sessionIdentity) return;
+  if (!sessionIdentity) {
+    throw new Error("Runtime prompt intake failed (unresolved_identity)");
+  }
   let modelBrokerPlanClaim: ClaimedRuntimeModelBrokerPlan | undefined;
   if (prompt._modelBrokerTurnId) {
     const selection = resolveRequiredRuntimeModelBrokerSelection(
@@ -144,7 +146,7 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
     throw error;
   }
   if (!resolvedSession) {
-    return;
+    throw new Error("Runtime prompt intake failed (unresolved_session)");
   }
 
   const {

--- a/src/session-trace/channel-trace.test.ts
+++ b/src/session-trace/channel-trace.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeSessionTraceSource,
   recordChannelMessageReceivedTrace,
   recordDeliveryTrace,
+  recordPromptIntakeFencedTrace,
   recordPromptPublishedTrace,
   recordResponseEmittedTrace,
   recordRouteResolvedTrace,
@@ -210,6 +211,33 @@ describe("channel session trace", () => {
       actorType: "agent",
       actorAgentId: "main",
       contactId: null,
+    });
+  });
+
+  it("records a dedicated prompt.intake_fenced event", () => {
+    const sessionKey = "agent:main:main";
+    const sessionName = "main";
+    getOrCreateSession(sessionKey, "main", "/tmp/ravi-agent");
+    updateSessionName(sessionKey, sessionName);
+
+    const recorded = recordPromptIntakeFencedTrace({
+      sessionName,
+      reason: "crash_recovery_not_accepting",
+      subject: "ravi.session.main.prompt",
+      timestamp: 42,
+    });
+    expect(recorded).not.toBeNull();
+
+    const events = listSessionEvents(sessionKey);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: "prompt.intake_fenced",
+      eventGroup: "prompt",
+      status: "fenced",
+      payloadJson: {
+        reason: "crash_recovery_not_accepting",
+        subject: "ravi.session.main.prompt",
+      },
     });
   });
 });

--- a/src/session-trace/channel-trace.ts
+++ b/src/session-trace/channel-trace.ts
@@ -72,6 +72,13 @@ export interface RecordPromptPublishedTraceInput {
   timestamp?: number;
 }
 
+export interface RecordPromptIntakeFencedTraceInput {
+  sessionName: string;
+  reason: string;
+  subject?: string;
+  timestamp?: number;
+}
+
 export interface RecordResponseEmittedTraceInput {
   sessionName: string;
   response: ResponseMessage;
@@ -442,6 +449,25 @@ export function recordRouteRejectedTrace(input: RecordRouteRejectedTraceInput): 
     timestamp: input.timestamp,
     source: input.source,
     payloadJson: payload,
+  });
+}
+
+export function recordPromptIntakeFencedTrace(input: RecordPromptIntakeFencedTraceInput): SessionEventRecord | null {
+  const session = getSessionByName(input.sessionName);
+  if (!session) return null;
+
+  return recordSessionEvent({
+    sessionKey: session.sessionKey,
+    sessionName: input.sessionName,
+    agentId: session.agentId,
+    eventType: "prompt.intake_fenced",
+    eventGroup: "prompt",
+    status: "fenced",
+    timestamp: input.timestamp,
+    payloadJson: {
+      reason: input.reason,
+      subject: input.subject ?? null,
+    },
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop stored+rerouted inbound from dying silently after a crash-recovery fence or idle-complete session, and bounce a stale `ravi-channels` process left behind by a ravi-only restart.

## Problem

Production mute on 2026-08-27 (America/Sao_Paulo): inbound was stored and rerouted, then no runtime turn started. The mute was not WhatsApp-only — Slack `@ravi` also stopped on the same host.

### Facts

- WhatsApp/Omni/NATS/router were up. Instance `main` was connected, not logged out.
- Last successful WhatsApp reply: 2026-08-26 20:35:47 BRT on session `main`.
- 2026-08-26 20:40 idle-evict of `main` (5 min).
- 2026-08-27 11:00:05 inbound stored in `chat_messages` **and** Omni consumer rerouted to `agent:main:main`.
- After that: no `startRuntimeSession`, no dispatcher push, no new `runtime_prompt_queue` row, no outbound. Typing heartbeat: `inactive session sessionName=main`.
- Earlier: 2026-08-25 22:24 `RuntimeCrashRecoveryOwnershipLostError` (fencing prompt intake, boot lease expired). 22:59 ravi PM2 respawn; Omni consumer started; **skipped restart resume** for `agent:main:main` (`crash-recovery-fenced snapshot`, `reason=missing_snapshot`).
- Slack `@ravi` also stopped. After ops restarted only PM2 `ravi` (new PID 73571 at 11:11 BRT), they left `ravi-channels` (Slack Socket Mode runner, PID 5661, ~42h) untouched. Channel-runner health had been unreachable/timeout.

### Inference

- Stored+rerouted inbound can be dropped after a crash-recovery fence / idle-complete: `RuntimePromptSubscription` NAKs and stops pulling when `canAcceptPrompt` is false, then does not resubscribe while the process still claims to be running. SESSION_PROMPTS is an in-memory 60s workqueue, so unpublished/unconsumed prompts expire with no turn.
- `handlePrompt` / `handlePromptImmediate` logged and returned when no agent (ACK after “success”). `session-launcher` silently returned when identity/session could not be resolved.
- Ownership-loss fatal handling returned early if `stopping`, and `shutdown()` was a no-op if already `shuttingDown`. Hung shutdown + live publishers = mute.
- A ravi-only restart leaves stale `ravi-channels`. PID-scoped health (`_RAVI.channels.health.{pid}`) times out; Slack Socket Mode inbound/outbound stay dead even if runtime intake is fixed.

## Solution

- `failPromptIntake` instead of silent return (JetStream NAK + `dispatch.intake_failed` trace).
- Cold-start after idle-complete (`Streaming: relaunching after idle-complete runtime session`).
- Prompt subscription always resubscribes while the daemon is alive; fence emits durable `prompt.intake_fenced`.
- Fatal ownership always exits (`onFatalRuntimeError` even while stopping; `process.exit(1)` if shutdown is already in progress).
- Bounce a stale channel runner (`timeout` / `no_responders` / `pid_mismatch`) from `channels start` and after daemon start. `nats_unavailable` is a visible failure, not a no-op.

## Practical impact

- WhatsApp Omni and native Slack inbound that is stored+rerouted now either starts a turn or emits a durable, visible failure.
- After idle-evict, new inbound cold-starts instead of sitting on a `done` session.
- After a ravi-only restart, a stale Slack Socket Mode runner is bounced instead of reported as already running.

## What does NOT change

- WhatsApp login, Omni transport, or NATS stream TTL.
- Sandbox / permission provider runtime.
- #442 hooks, #443 Pages isolation, #444 ownership-loss restart (this PR makes that exit path fail closed).

## Validation

- `bun test src/runtime/prompt-subscription.test.ts src/runtime/session-dispatcher.test.ts src/session-trace/channel-trace.test.ts src/channels/runner-liveness.test.ts src/cli/commands/channels.test.ts src/channels/backend.test.ts src/bot.runtime-guards.test.ts` — 102 pass, 0 fail.
- `bun run typecheck` passed.
- Pre-push (`sdk:check`, build, typecheck, full `bun run test` including OpenAPI + Swift check) passed after regenerating TS/OpenAPI/Swift artifacts for `previousPid`.

[Focused inbound-mute tests](https://cursor.com/agents/bc-93720ec0-151a-4328-b906-421131099910/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbound-mute-focused-tests.log)
[Pre-push SDK and Swift check](https://cursor.com/agents/bc-93720ec0-151a-4328-b906-421131099910/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpre-push-sdk-check.log)

## Risks

- Ownership loss during an already-running shutdown now forces `process.exit(1)` instead of waiting for the graceful path.
- Bouncing `ravi-channels` on stale health briefly drops Slack Socket Mode; WhatsApp Omni continues.
- Daemon start logs and continues if channel-runner bounce fails or NATS health is unconfirmed.

## Rollback

- Revert this PR. Intake returns to silent drop on fence / no-agent, and `channels start` no-ops when PM2 says the runner is online.

## Follow-ups

- Persist crash-recovery fences across process restart (the in-memory fence is still not a durable table).
- Supervisor should treat `ravi` + `ravi-channels` as one restart unit so ops cannot leave Slack dead after a ravi-only bounce.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93720ec0-151a-4328-b906-421131099910?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93720ec0-151a-4328-b906-421131099910&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

