### PR TITLE
fix(whatsapp): ignore Status before DM canonicalization

### DIFF
--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -992,6 +992,50 @@ describe("OmniConsumer channel context", () => {
     });
   });
 
+  it("ignores WhatsApp Status before chat or contact persistence", async () => {
+    contactIntakeMode = "pending";
+    const sender = {
+      send: mock(async () => {}),
+      sendTyping: mock(async () => {}),
+      markRead: mock(async () => {}),
+    };
+    const consumer = new OmniConsumer(sender as never, "http://omni.local", "test-key", {
+      resolveGroupMetadata: async () => null,
+    });
+
+    await consumer["handleMessageEvent"]("message.received.whatsapp-baileys.instance-1", {
+      id: "evt-status-broadcast",
+      type: "message.received",
+      payload: {
+        externalId: "msg-status-broadcast",
+        chatId: "status@broadcast",
+        from: "5511999904321@s.whatsapp.net",
+        content: {
+          type: "image",
+          text: "status must not become a private chat",
+        },
+        rawPayload: {
+          pushName: "Status Author",
+          resolvedSenderPhone: "5511999904321",
+          isGroup: false,
+        },
+      },
+      metadata: {
+        instanceId: "instance-1",
+        channelType: "whatsapp-baileys",
+        ingestMode: "history-sync",
+      },
+      timestamp: 1_777_777_777_000,
+    });
+
+    expect(ensureContactFromInboundCalls).toHaveLength(0);
+    expect(chatMessageCalls).toHaveLength(0);
+    expect(chatParticipantCalls).toHaveLength(0);
+    expect(messageMetaSaveCalls).toHaveLength(0);
+    expect(promptCalls).toHaveLength(0);
+    expect(sessionParticipantCalls).toHaveLength(0);
+  });
+
   it("captures old timestamp messages without replaying them to runtime", async () => {
     contactIntakeMode = "pending";
     const sender = {

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -68,6 +68,7 @@ import {
 } from "../session-trace/channel-trace.js";
 import { recordRuntimeTraceEvent } from "../session-trace/runtime-trace.js";
 import { logger } from "../utils/logger.js";
+import { isBroadcastJid } from "../utils/phone.js";
 import type {
   MessageActorMetadata,
   MessageContext,
@@ -603,6 +604,20 @@ export class OmniConsumer {
 
     // Skip reaction messages — these are handled by the REACTION stream consumer
     if (payload.content.type === "reaction") return;
+
+    // WhatsApp Status and broadcast-list feeds are not conversations. Treating
+    // their shared chat id as a DM makes different authors repeatedly
+    // canonicalize the same chat into their own contact history. Besides mixing
+    // unrelated histories, that merge is synchronous and can starve daemon
+    // heartbeats. Filter before any chat/contact persistence as defense in depth
+    // even when the channel plugin emits a broadcast event.
+    if (channelType.replace(/-baileys$/, "") === "whatsapp" && isBroadcastJid(payload.chatId)) {
+      log.debug("Ignoring WhatsApp broadcast feed", {
+        instanceId,
+        broadcastKind: payload.chatId.toLowerCase() === "status@broadcast" ? "status" : "broadcast",
+      });
+      return;
+    }
 
     const handlerStartedAt = Date.now();
     const pluginReceivedAtMs = resolvePluginReceivedAtMs(event, payload);

--- a/src/utils/phone.test.ts
+++ b/src/utils/phone.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { isBroadcastJid } from "./phone.js";
+
+describe("isBroadcastJid", () => {
+  it("recognizes WhatsApp status and broadcast-list feeds", () => {
+    expect(isBroadcastJid("status@broadcast")).toBe(true);
+    expect(isBroadcastJid("  STATUS@BROADCAST  ")).toBe(true);
+    expect(isBroadcastJid("123456@broadcast")).toBe(true);
+  });
+
+  it("does not classify users, LIDs, or groups as broadcasts", () => {
+    expect(isBroadcastJid("5511999999999@s.whatsapp.net")).toBe(false);
+    expect(isBroadcastJid("123456@lid")).toBe(false);
+    expect(isBroadcastJid("120363424772797713@g.us")).toBe(false);
+  });
+});

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -126,6 +126,15 @@ export function isGroup(jid: string): boolean {
   return GROUP_JID_RE.test(jid) || jid.startsWith("group:");
 }
 
+/**
+ * WhatsApp broadcast identifiers are transport feeds, not peer chats.
+ * In particular, `status@broadcast` must never enter DM/contact
+ * canonicalization because every status author shares that chat id.
+ */
+export function isBroadcastJid(jid: string): boolean {
+  return jid.trim().toLowerCase().endsWith("@broadcast");
+}
+
 export function isLid(jid: string): boolean {
   return LID_JID_RE.test(jid) || jid.startsWith("lid:");
 }


### PR DESCRIPTION
## Objective

Prevent WhatsApp Status and broadcast feeds from blocking Ravi prompt intake.

## Problem

Broadcast feeds share transport identifiers across authors. Ravi treated them as private chats, repeatedly canonicalized the shared history, and could starve runtime heartbeats.

## Solution

Reject WhatsApp `@broadcast` feeds before any contact, chat, participant, metadata, or prompt persistence. Add focused JID and consumer regression coverage.

## Practical impact

Status ingestion can no longer mix unrelated contact histories or perform the synchronous merge that contributed to the daemon becoming operationally mute.

## What does NOT change

Normal WhatsApp direct messages and groups retain their existing routing, persistence, authorization, and prompt behavior.

## Validation

Typecheck and Biome passed. All mandatory pre-push checks passed, including the complete repository test suite; 79 focused Omni/runtime tests also passed.

## Risks

Messages addressed to WhatsApp broadcast-list identifiers will be ignored intentionally because they are transport feeds rather than peer conversations.

## Rollback

Revert the single patch commit to restore previous broadcast handling. No schema migration or stored-data rollback is required.