### PR TITLE
feat(sessions): CLI-only send -w returns this turn's transcript

### DIFF
--- a/.ravi/specs/sessions/CHECKS.md
+++ b/.ravi/specs/sessions/CHECKS.md
@@ -21,4 +21,9 @@
 ## Commands
 
 - `bun test src/router/sessions.test.ts src/router/sessions.rename.test.ts`
-- `bun test src/cli/commands/sessions.test.ts`
+- `bun test src/cli/commands/sessions.test.ts src/cli/session-cli-surface.test.ts`
+- CLI-only `sessions send -w --json` MUST return this turn's transcript text
+  when no `.response` event is emitted.
+- Default `sessions read --json` MUST omit `runtimeSessionParams.skillVisibility`.
+- Operator `sessions send` without a caller session MUST NOT wrap `[System] Inform:`.
+- Bare `ravi tui` MUST fail with a usage error instead of opening `main`.

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -82,6 +82,11 @@ Sessions do NOT own:
 - An inbound turn MUST reply to its attached source chat or thread. The default output attachment is used only when a turn has no inbound source.
 - An unattached inbound source or a source-less turn without a default output MUST NOT emit externally.
 - `ravi sessions send` and related inter-session commands inject prompt/context into a Ravi session. They MUST NOT be documented as direct external channel delivery primitives. Visible outbound channel delivery belongs to the session response path or to explicit channel/media/outbound commands.
+- Operator CLI-only `sessions send` (no `--channel`/`--to`) sends the raw user text. `[System] Inform:` is reserved for agent-to-agent / in-context sends. `--raw` is the escape hatch.
+- CLI-only `sessions send -w` waits for this turn's assistant transcript after `turn.complete`. Chat-attached `-w` still means delivered. Attach remains fail-closed for chat emit.
+- Default `sessions read --json` is session + messages. The advertised skill catalog stays on `sessions visibility` or `sessions read --visibility`.
+- Bare `ravi tui` MUST require a session name (usage error). It MUST NOT default to `main`.
+- CLI-only session bootstrap MUST NOT inherit hardcoded `DEFAULT_RUNTIME_EFFORT = xhigh`. `sessions send --effort` sets an explicit override. The Ravi system prompt remains large.
 - Session reset MUST clear provider continuity state (per `runtime/session-continuity`) but MUST NOT silently drop attach subscriptions — those are routing/wiring, not provider state.
 - `ravi sessions set-effort <session> <level>` MUST persist an effort override using `none|minimal|low|medium|high|xhigh|max|ultra`; `clear` MUST remove only the session override.
 - Session effort is separate from thinking. `ravi sessions set-thinking` MUST NOT accept effort values such as `max` or `ultra`, and `ravi sessions set-effort` MUST NOT mutate `thinking_level`.

--- a/.ravi/specs/sessions/attach/CHECKS.md
+++ b/.ravi/specs/sessions/attach/CHECKS.md
@@ -7,6 +7,8 @@
 - Inbound from an attached source MUST emit to that source chat or thread.
 - A source-less turn MUST emit to the default attachment when one exists.
 - An unattached inbound source MUST fail closed instead of using the default.
+- CLI-only `sessions send -w` MUST return this turn's assistant transcript
+  when no `.response` is emitted. Previous-turn rows MUST NOT leak.
 - Detaching the output chat MUST clear output for that session.
 - Attach/detach during a running turn MUST NOT redirect that turn's captured
   reply target.

--- a/.ravi/specs/sessions/attach/RUNBOOK.md
+++ b/.ravi/specs/sessions/attach/RUNBOOK.md
@@ -11,6 +11,8 @@
 5. For a source-less turn, inspect the default attachment.
 6. If an inbound source is unattached, fail closed instead of using the
    default.
+7. For CLI-only `sessions send -w`, read this turn's assistant transcript
+   after `turn.complete`. Do not treat a dropped chat emit as empty success.
 7. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
 
 ## Validation

--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -55,7 +55,14 @@ surface when the turn starts.
 2. A turn with no inbound source replies to the default output attachment.
 3. An inbound source that is not attached MUST fail closed. It MUST NOT fall
    back to the default output.
-4. A source-less turn with no default output MUST fail closed.
+4. A source-less turn with no default output MUST fail closed for *chat*
+   delivery. It MUST NOT invent a chat `.response` sink.
+
+CLI-only `sessions send` (no `--channel`/`--to`, no inbound chat, named
+session) is **not** a source-less attach turn. The waiting CLI is the
+destination. After `turn.complete`, `sessions send -w` MUST return this
+turn's assistant transcript row (persist may lag). Missing chat delivery
+is not empty success when that transcript exists.
 
 The default output is only a fallback for proactive and other source-less
 turns. It never overrides an inbound source.
@@ -86,8 +93,9 @@ prompt:
 [session surface] This turn came from a Slack chat. A normal reply returns there.
 ```
 
-For a thread, it says `Slack thread`. For a source-less turn, it says that the
-session default will be used when one is available.
+For a thread, it says `Slack thread`. For a CLI-only operator turn, it says
+that a normal reply returns to the waiting CLI. For other source-less turns,
+it says that the session default will be used when one is available.
 
 The instruction MUST NOT include session names, chat ids, subscription lists,
 roles, database fields, or routing commands. It is added centrally so every
@@ -100,7 +108,12 @@ replay.
 ravi sessions attach <session> --chat <chat-id> [--reason "..."]
 ravi sessions detach <session> --chat <chat-id>
 ravi sessions subscriptions <session>
+ravi sessions send <session> "<prompt>" -w --json
 ```
+
+Operator CLI-only `sessions send` (no channel) sends the raw user text.
+`[System] Inform:` remains for agent-to-agent / in-context sends. `--raw`
+is the escape hatch. Chat-attached `-w` still means delivered.
 
 - `attach` adds/reactivates the subscription and selects it as the default
   output.

--- a/.ravi/specs/sessions/attach/WHY.md
+++ b/.ravi/specs/sessions/attach/WHY.md
@@ -7,3 +7,6 @@ thread that produced that turn.
 The default attachment exists only for proactive turns with no inbound chat.
 This keeps the normal experience automatic and prevents a later message from
 redirecting work that is already running.
+
+CLI-only `sessions send` is a first-class destination: the waiting CLI reads
+this turn's transcript. Attach stays fail-closed for chat delivery.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "974539f51e40ffb4"
+    "version": "ed4eadad24f79552"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -72289,6 +72289,10 @@
                     "description": "Optional session name/key override (defaults to current session)",
                     "type": "string"
                   },
+                  "visibility": {
+                    "description": "Include the skill catalog from runtimeSessionParams.skillVisibility",
+                    "type": "boolean"
+                  },
                   "workspace": {
                     "description": "Return workspace projection: merged provider+chat history with flat timeline (history-only)",
                     "type": "boolean"
@@ -73578,6 +73582,10 @@
                     "description": "Override delivery channel",
                     "type": "string"
                   },
+                  "effort": {
+                    "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
+                    "type": "string"
+                  },
                   "immediate": {
                     "description": "Deliver immediately instead of queueing as a follow-up",
                     "type": "boolean"
@@ -73593,6 +73601,10 @@
                   "prompt": {
                     "description": "Prompt to send (omit for interactive mode)",
                     "type": "string"
+                  },
+                  "raw": {
+                    "description": "Send the prompt without [System] Inform wrapping",
+                    "type": "boolean"
                   },
                   "steer": {
                     "description": "Steer the active turn after safe tool barriers",
@@ -73623,7 +73635,7 @@
                     "type": "string"
                   },
                   "wait": {
-                    "description": "Wait for response (chat mode)",
+                    "description": "Wait for this turn's reply (CLI transcript or delivered chat)",
                     "type": "boolean"
                   }
                 },

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "974539f51e40ffb4"
+    "version": "ed4eadad24f79552"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -72289,6 +72289,10 @@
                     "description": "Optional session name/key override (defaults to current session)",
                     "type": "string"
                   },
+                  "visibility": {
+                    "description": "Include the skill catalog from runtimeSessionParams.skillVisibility",
+                    "type": "boolean"
+                  },
                   "workspace": {
                     "description": "Return workspace projection: merged provider+chat history with flat timeline (history-only)",
                     "type": "boolean"
@@ -73578,6 +73582,10 @@
                     "description": "Override delivery channel",
                     "type": "string"
                   },
+                  "effort": {
+                    "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
+                    "type": "string"
+                  },
                   "immediate": {
                     "description": "Deliver immediately instead of queueing as a follow-up",
                     "type": "boolean"
@@ -73593,6 +73601,10 @@
                   "prompt": {
                     "description": "Prompt to send (omit for interactive mode)",
                     "type": "string"
+                  },
+                  "raw": {
+                    "description": "Send the prompt without [System] Inform wrapping",
+                    "type": "boolean"
                   },
                   "steer": {
                     "description": "Steer the active turn after safe tool barriers",
@@ -73623,7 +73635,7 @@
                     "type": "string"
                   },
                   "wait": {
-                    "description": "Wait for response (chat mode)",
+                    "description": "Wait for this turn's reply (CLI transcript or delivered chat)",
                     "type": "boolean"
                   }
                 },

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -5685,6 +5685,7 @@ export class RaviClient {
     read: async (nameOrKey?: string, options?: {
       count?: string;
       messageId?: string;
+      visibility?: boolean;
       workspace?: boolean;
     }): Promise<SessionsReadReturn> => {
       return this.transport.call({
@@ -5811,8 +5812,10 @@ export class RaviClient {
       agent?: string;
       barrier?: string;
       channel?: string;
+      effort?: string;
       immediate?: boolean;
       interactive?: boolean;
+      raw?: boolean;
       steer?: boolean;
       thread?: string;
       threadOwner?: string;

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -57828,6 +57828,10 @@ export const SessionsReadInputSchema = {
       "description": "Optional session name/key override (defaults to current session)",
       "type": "string"
     },
+    "visibility": {
+      "description": "Include the skill catalog from runtimeSessionParams.skillVisibility",
+      "type": "boolean"
+    },
     "workspace": {
       "description": "Return workspace projection: merged provider+chat history with flat timeline (history-only)",
       "type": "boolean"
@@ -58739,6 +58743,10 @@ export const SessionsSendInputSchema = {
       "description": "Override delivery channel",
       "type": "string"
     },
+    "effort": {
+      "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
+      "type": "string"
+    },
     "immediate": {
       "description": "Deliver immediately instead of queueing as a follow-up",
       "type": "boolean"
@@ -58754,6 +58762,10 @@ export const SessionsSendInputSchema = {
     "prompt": {
       "description": "Prompt to send (omit for interactive mode)",
       "type": "string"
+    },
+    "raw": {
+      "description": "Send the prompt without [System] Inform wrapping",
+      "type": "boolean"
     },
     "steer": {
       "description": "Steer the active turn after safe tool barriers",
@@ -58784,7 +58796,7 @@ export const SessionsSendInputSchema = {
       "type": "string"
     },
     "wait": {
-      "description": "Wait for response (chat mode)",
+      "description": "Wait for this turn's reply (CLI transcript or delivered chat)",
       "type": "boolean"
     }
   },

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -11842,6 +11842,7 @@ export type SessionsReadInput = {
   count?: string;
   messageId?: string;
   nameOrKey?: string;
+  visibility?: boolean;
   workspace?: boolean;
 };
 
@@ -12088,10 +12089,12 @@ export type SessionsSendInput = {
   agent?: string;
   barrier?: string;
   channel?: string;
+  effort?: string;
   immediate?: boolean;
   interactive?: boolean;
   nameOrKey: string;
   prompt?: string;
+  raw?: boolean;
   steer?: boolean;
   thread?: string;
   threadOwner?: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:f79d1275bfa98ff5d9f904761bb4febf81cd0337c7255337dd3c7dcefa515dd6";
+export const REGISTRY_HASH = "sha256:11ef19b803ee18fa8ac537a9ead12b2c6afcc7e69a3221547485a7063b523f6d";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "d3f0cf2f2521";
+export const GIT_SHA = "173474127a9d";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -58743,6 +58743,10 @@ public enum RaviSchemas {
         "description": "Optional session name/key override (defaults to current session)",
         "type": "string"
       },
+      "visibility": {
+        "description": "Include the skill catalog from runtimeSessionParams.skillVisibility",
+        "type": "boolean"
+      },
       "workspace": {
         "description": "Return workspace projection: merged provider+chat history with flat timeline (history-only)",
         "type": "boolean"
@@ -59676,6 +59680,10 @@ public enum RaviSchemas {
         "description": "Override delivery channel",
         "type": "string"
       },
+      "effort": {
+        "description": "Runtime effort: none|minimal|low|medium|high|xhigh|max|ultra",
+        "type": "string"
+      },
       "immediate": {
         "description": "Deliver immediately instead of queueing as a follow-up",
         "type": "boolean"
@@ -59691,6 +59699,10 @@ public enum RaviSchemas {
       "prompt": {
         "description": "Prompt to send (omit for interactive mode)",
         "type": "string"
+      },
+      "raw": {
+        "description": "Send the prompt without [System] Inform wrapping",
+        "type": "boolean"
       },
       "steer": {
         "description": "Steer the active turn after safe tool barriers",
@@ -59721,7 +59733,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "wait": {
-        "description": "Wait for response (chat mode)",
+        "description": "Wait for this turn's reply (CLI transcript or delivered chat)",
         "type": "boolean"
       }
     },

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -19365,17 +19365,20 @@ public typealias SessionsPruneReturn = [String: RaviJSON]
 public struct SessionsReadOptions: Codable, Sendable {
   public var count: String?
   public var messageId: String?
+  public var visibility: Bool?
   public var workspace: Bool?
 
-  public init(count: String? = nil, messageId: String? = nil, workspace: Bool? = nil) {
+  public init(count: String? = nil, messageId: String? = nil, visibility: Bool? = nil, workspace: Bool? = nil) {
     self.count = count
     self.messageId = messageId
+    self.visibility = visibility
     self.workspace = workspace
   }
 
   enum CodingKeys: String, CodingKey {
     case count = "count"
     case messageId = "messageId"
+    case visibility = "visibility"
     case workspace = "workspace"
   }
 
@@ -19385,6 +19388,9 @@ public struct SessionsReadOptions: Codable, Sendable {
     }
     if let value = self.messageId {
       body["messageId"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.visibility {
+      body["visibility"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.workspace {
       body["workspace"] = try RaviJSON.fromEncodable(value)
@@ -19831,8 +19837,10 @@ public struct SessionsSendOptions: Codable, Sendable {
   public var agent: String?
   public var barrier: String?
   public var channel: String?
+  public var effort: String?
   public var immediate: Bool?
   public var interactive: Bool?
+  public var raw: Bool?
   public var steer: Bool?
   public var thread: String?
   public var threadOwner: String?
@@ -19842,12 +19850,14 @@ public struct SessionsSendOptions: Codable, Sendable {
   public var to: String?
   public var wait: Bool?
 
-  public init(agent: String? = nil, barrier: String? = nil, channel: String? = nil, immediate: Bool? = nil, interactive: Bool? = nil, steer: Bool? = nil, thread: String? = nil, threadOwner: String? = nil, threadScope: String? = nil, threadSummary: String? = nil, threadTitle: String? = nil, to: String? = nil, wait: Bool? = nil) {
+  public init(agent: String? = nil, barrier: String? = nil, channel: String? = nil, effort: String? = nil, immediate: Bool? = nil, interactive: Bool? = nil, raw: Bool? = nil, steer: Bool? = nil, thread: String? = nil, threadOwner: String? = nil, threadScope: String? = nil, threadSummary: String? = nil, threadTitle: String? = nil, to: String? = nil, wait: Bool? = nil) {
     self.agent = agent
     self.barrier = barrier
     self.channel = channel
+    self.effort = effort
     self.immediate = immediate
     self.interactive = interactive
+    self.raw = raw
     self.steer = steer
     self.thread = thread
     self.threadOwner = threadOwner
@@ -19862,8 +19872,10 @@ public struct SessionsSendOptions: Codable, Sendable {
     case agent = "agent"
     case barrier = "barrier"
     case channel = "channel"
+    case effort = "effort"
     case immediate = "immediate"
     case interactive = "interactive"
+    case raw = "raw"
     case steer = "steer"
     case thread = "thread"
     case threadOwner = "threadOwner"
@@ -19884,11 +19896,17 @@ public struct SessionsSendOptions: Codable, Sendable {
     if let value = self.channel {
       body["channel"] = try RaviJSON.fromEncodable(value)
     }
+    if let value = self.effort {
+      body["effort"] = try RaviJSON.fromEncodable(value)
+    }
     if let value = self.immediate {
       body["immediate"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.interactive {
       body["interactive"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.raw {
+      body["raw"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.steer {
       body["steer"] = try RaviJSON.fromEncodable(value)

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:f79d1275bfa98ff5d9f904761bb4febf81cd0337c7255337dd3c7dcefa515dd6"
-public let RAVI_GIT_SHA = "d3f0cf2f2521"
+public let RAVI_REGISTRY_HASH = "sha256:11ef19b803ee18fa8ac537a9ead12b2c6afcc7e69a3221547485a7063b523f6d"
+public let RAVI_GIT_SHA = "e4e82e610047"

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -37,6 +37,8 @@ let routerConfig: {
   agents: {},
 };
 let chatHistory: Array<Record<string, unknown>> = [];
+let chatHistoryAfterSnapshot: Array<Record<string, unknown>> | null = null;
+let chatHistoryReads = 0;
 let chatHistoryByChat: Array<Record<string, unknown>> = [];
 let messageMetadataRows: Array<Record<string, unknown>> = [];
 const chatRecords = new Map<string, Record<string, unknown>>();
@@ -320,7 +322,11 @@ mock.module("../../stickers/catalog.js", () => ({
 }));
 
 mock.module("../../db.js", () => ({
-  getRecentHistory: (_sessionId: string, limit: number) => chatHistory.slice(-limit),
+  getRecentHistory: (_sessionId: string, limit: number) => {
+    chatHistoryReads += 1;
+    const rows = chatHistoryReads > 1 && chatHistoryAfterSnapshot ? chatHistoryAfterSnapshot : chatHistory;
+    return rows.slice(-limit);
+  },
   countHistory: () => chatHistory.length,
   getRecentHistoryByChatIds: (chatIds: string[], limit: number, agentId?: string | null) =>
     chatHistoryByChat
@@ -465,6 +471,8 @@ beforeEach(() => {
   canAccess = true;
   sessionGoal = null;
   chatHistory = [];
+  chatHistoryAfterSnapshot = null;
+  chatHistoryReads = 0;
   chatHistoryByChat = [];
   messageMetadataRows = [];
   chatRecords.clear();
@@ -582,6 +590,126 @@ describe("SessionCommands wait mode", () => {
     }
   });
 
+  it("returns transcript text from CLI-only send -w --json without a .response sink", async () => {
+    toolContext = { suppressCliOutput: true };
+    runtimeEvents = [{ type: "turn.complete" }];
+    resolvedSession = {
+      sessionKey: "agent:grok-cli-probe:main",
+      name: "grok-cli-probe",
+      agentId: "grok-cli-probe",
+      agentCwd: "/tmp/grok-cli-probe",
+    };
+    chatHistory = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+    ];
+    chatHistoryAfterSnapshot = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+      { id: 3, role: "user", content: "responde só: pong" },
+      { id: 4, role: "assistant", content: "pong" },
+    ];
+
+    const commands = new SessionCommands();
+    const payload = (await commands.send("grok-cli-probe", "responde só: pong", false, true)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(payload).toMatchObject({
+      action: "send",
+      mode: "wait",
+      response: { text: "pong", source: "transcript" },
+    });
+    expect(publishedPrompts[0]?.payload.prompt).toBe("responde só: pong");
+    expect(publishedPrompts[0]?.payload._cliDestination).toBe(true);
+  });
+
+  it("returns this turn's transcript for CLI-only -w when no .response is emitted", async () => {
+    runtimeEvents = [{ type: "turn.complete" }];
+    chatHistory = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+    ];
+    chatHistoryAfterSnapshot = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+      { id: 3, role: "user", content: "responde só: pong" },
+      { id: 4, role: "assistant", content: "pong" },
+    ];
+
+    const commands = new SessionCommands();
+    let responseText = "";
+    const chars = await (commands as any).streamToSession(
+      "grok-cli-probe",
+      "responde só: pong",
+      {
+        sessionKey: "agent:grok-cli-probe:main",
+        name: "grok-cli-probe",
+        agentId: "grok-cli-probe",
+        agentCwd: "/tmp/grok-cli-probe",
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        silent: true,
+        cliDestination: true,
+        onResponse: (chunk: string) => {
+          responseText += chunk;
+        },
+      },
+    );
+
+    expect(chars).toBe(4);
+    expect(responseText).toBe("pong");
+    expect(publishedPrompts[0]?.payload._cliDestination).toBe(true);
+    expect(publishedPrompts[0]?.payload.prompt).toBe("responde só: pong");
+  });
+
+  it("does not leak a previous-turn assistant row when CLI-only persist lags", async () => {
+    runtimeEvents = [{ type: "turn.complete" }];
+    chatHistory = [
+      { id: 10, role: "user", content: "first" },
+      { id: 11, role: "assistant", content: "old-pong" },
+    ];
+    chatHistoryAfterSnapshot = [
+      { id: 10, role: "user", content: "first" },
+      { id: 11, role: "assistant", content: "old-pong" },
+      { id: 12, role: "user", content: "responde só: pong" },
+      { id: 13, role: "assistant", content: "@@SILENT@@ pong" },
+    ];
+
+    const commands = new SessionCommands();
+    let responseText = "";
+    await (commands as any).streamToSession(
+      "grok-cli-probe",
+      "responde só: pong",
+      {
+        sessionKey: "agent:grok-cli-probe:main",
+        name: "grok-cli-probe",
+        agentId: "grok-cli-probe",
+        agentCwd: "/tmp/grok-cli-probe",
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        silent: true,
+        cliDestination: true,
+        onResponse: (chunk: string) => {
+          responseText += chunk;
+        },
+      },
+    );
+
+    expect(responseText).toBe("pong");
+    expect(responseText).not.toBe("old-pong");
+    expect(responseText).not.toContain("@@SILENT@@");
+  });
+
   it("throws on timeout instead of treating the wait as success", async () => {
     const commands = new SessionCommands();
     const originalSetTimeout = globalThis.setTimeout;
@@ -630,6 +758,10 @@ describe("SessionCommands delivery barriers", () => {
     });
 
     expect(publishedPrompts).toHaveLength(1);
+    expect(publishedPrompts[0]?.payload.prompt).toBe("hello");
+    expect(publishedPrompts[0]?.payload.prompt).not.toContain("[System] Inform:");
+    expect(publishedPrompts[0]?.payload.prompt).not.toContain("[from: unknown]");
+    expect(publishedPrompts[0]?.payload._cliDestination).toBe(true);
     expect(publishedPrompts[0]?.payload.deliveryBarrier).toBe("after_response");
     expect(publishedPrompts[0]?.payload.deliveryBarrierSource).toBe("default");
     expect(publishedPrompts[0]?.payload._turnOrigin).toMatchObject({
@@ -831,6 +963,65 @@ describe("SessionCommands delivery barriers", () => {
 
     expect(publishedPrompts.at(-1)?.payload.deliveryBarrier).toBe("after_tool");
     expect(publishedPrompts.at(-1)?.payload.deliveryBarrierSource).toBe("explicit");
+  });
+
+  it("keeps Inform wrapping for in-context agent sends unless --raw", async () => {
+    toolContext = { suppressCliOutput: true, sessionKey: "agent:origin-agent:main" };
+    const commands = new SessionCommands();
+
+    await commands.send("dev", "hello");
+    expect(publishedPrompts[0]?.payload.prompt).toBe("[System] Inform: [from: agent:origin-agent:main] hello");
+
+    publishedPrompts.length = 0;
+    await commands.send(
+      "dev",
+      "hello",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(publishedPrompts[0]?.payload.prompt).toBe("hello");
+  });
+
+  it("applies --effort on sessions send without changing the global default", async () => {
+    const commands = new SessionCommands();
+
+    await captureLogsAsync(async () => {
+      await commands.send(
+        "dev",
+        "hello",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "low",
+      );
+    });
+
+    expect(effortUpdates).toEqual([{ sessionKey: "agent:dev:main", effort: "low" }]);
   });
 
   it("answers as follow-up by default", async () => {
@@ -2015,6 +2206,69 @@ describe("SessionCommands read", () => {
       chatId: "63295117615153@lid",
       sourceMessageId: "wamid-1",
     });
+  });
+
+  it("omits the advertised skill catalog from default read --json", () => {
+    resolvedSession = {
+      ...resolvedSession!,
+      runtimeSessionParams: {
+        sessionId: "sess-1",
+        skillVisibility: {
+          skills: [{ id: "ravi-system-events", state: "advertised" }],
+          loadedSkills: [],
+        },
+      },
+    };
+    chatHistory = [
+      {
+        id: 1,
+        session_id: "main-dm-615153",
+        role: "assistant",
+        content: "pong",
+        created_at: "2026-04-20 04:29:35",
+      },
+    ];
+
+    const payload = JSON.parse(
+      captureLogs(() => {
+        new SessionCommands().read("main-dm-615153", "10", true);
+      }),
+    );
+
+    expect(payload.session.name ?? payload.session.label).toBeTruthy();
+    expect(payload.messages).toEqual([expect.objectContaining({ text: "pong" })]);
+    expect(JSON.stringify(payload)).not.toContain("skillVisibility");
+    expect(JSON.stringify(payload)).not.toContain("ravi-system-events");
+  });
+
+  it("includes the skill catalog on read --json --visibility", () => {
+    resolvedSession = {
+      ...resolvedSession!,
+      runtimeSessionParams: {
+        sessionId: "sess-1",
+        skillVisibility: {
+          skills: [{ id: "ravi-system-events", state: "advertised" }],
+          loadedSkills: [],
+        },
+      },
+    };
+    chatHistory = [
+      {
+        id: 1,
+        session_id: "main-dm-615153",
+        role: "assistant",
+        content: "pong",
+        created_at: "2026-04-20 04:29:35",
+      },
+    ];
+
+    const payload = JSON.parse(
+      captureLogs(() => {
+        new SessionCommands().read("main-dm-615153", "10", true, undefined, undefined, true);
+      }),
+    );
+
+    expect(payload.session.runtimeSessionParams.skillVisibility.skills[0].id).toBe("ravi-system-events");
   });
 
   it("returns normalized history when invoked through the SDK gateway context", () => {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -104,6 +104,15 @@ import {
 } from "../../router/router-db.js";
 import type { SessionEntry } from "../../router/types.js";
 import { RUNTIME_EFFORT_LEVELS, formatRuntimeEffortLevels, parseRuntimeEffort } from "../../runtime/effort.js";
+import { getSessionsSendRuntimeMismatchWarning, inspectCliRuntimeTarget } from "../runtime-target.js";
+import {
+  buildSessionSendPrompt,
+  isCliWaitDestination,
+  omitSkillVisibilityFromSessionJson,
+  resolveCliSessionBootstrapEffort,
+  snapshotTranscriptCursor,
+  waitForThisTurnAssistantText,
+} from "../session-cli-surface.js";
 import type { RuntimeProviderId } from "../../runtime/types.js";
 import { publicRuntimeFailureDetail } from "../../runtime/public-failure.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
@@ -4163,7 +4172,7 @@ export class SessionCommands {
     interactive?: boolean,
     @Option({
       flags: "-w, --wait",
-      description: "Wait for response (chat mode)",
+      description: "Wait for this turn's reply (CLI transcript or delivered chat)",
     })
     wait?: boolean,
     @Option({
@@ -4220,10 +4229,20 @@ export class SessionCommands {
     immediate?: boolean,
     @Option({ flags: "--json", description: "Print raw JSON result" })
     asJson?: boolean,
+    @Option({
+      flags: "--raw",
+      description: "Send the prompt without [System] Inform wrapping",
+    })
+    raw?: boolean,
+    @Option({
+      flags: "--effort <level>",
+      description: `Runtime effort: ${formatRuntimeEffortLevels()}`,
+    })
+    effort?: string,
   ) {
     const structuredResult = shouldReturnStructuredResult(asJson);
     let createdSession = false;
-    const session = this.resolveTarget(nameOrKey, agentId, {
+    let session = this.resolveTarget(nameOrKey, agentId, {
       silent: structuredResult,
       onCreated: () => {
         createdSession = true;
@@ -4269,10 +4288,40 @@ export class SessionCommands {
       return this.interactiveMode(sessionName, session, channel, to);
     }
 
-    const origin = getContext()?.sessionKey ?? "unknown";
+    const callerSessionKey = getContext()?.sessionKey;
+    const origin = callerSessionKey ?? "unknown";
     const { source, context } = this.resolveSource(session, channel, to);
+    const cliDestination =
+      !callerSessionKey &&
+      isCliWaitDestination({
+        channelOverride: channel,
+        toOverride: to,
+        source,
+        hasOutputAttachment: listSessionSubscriptions(session.sessionKey).some(
+          (subscription) => subscription.outputAttachedAt !== undefined,
+        ),
+      });
+    const explicitEffort = effort === undefined ? undefined : parseRuntimeEffort(effort);
+    const bootstrapEffort = resolveCliSessionBootstrapEffort({
+      createdSession,
+      cliDestination,
+      explicitEffort,
+    });
+    if (bootstrapEffort) {
+      updateSessionEffortOverride(session.sessionKey, bootstrapEffort);
+      session =
+        resolveSession(session.sessionKey) ??
+        ({
+          ...session,
+          effortOverride: bootstrapEffort,
+        } as SessionEntry);
+    }
     const deliveryJson = buildDeliveryJson(session, deliveryBarrier, delivery.source, source, context);
-    let fullPrompt = `[System] Inform: [from: ${origin}] ${prompt}`;
+    let fullPrompt = buildSessionSendPrompt({
+      prompt,
+      raw,
+      callerSessionKey,
+    });
     let preparedThread: PreparedThreadHandoff | undefined;
     let promptPayload: Record<string, unknown> | undefined;
 
@@ -4307,6 +4356,10 @@ export class SessionCommands {
     }
 
     if (wait) {
+      const runtimeMismatch = getSessionsSendRuntimeMismatchWarning(inspectCliRuntimeTarget());
+      if (runtimeMismatch && !structuredResult) {
+        console.warn(runtimeMismatch);
+      }
       if (structuredResult) {
         let responseText = "";
         let chars = 0;
@@ -4322,6 +4375,7 @@ export class SessionCommands {
             {
               silent: true,
               promptPayload,
+              cliDestination,
               onResponse: (chunk) => {
                 responseText += chunk;
               },
@@ -4349,7 +4403,9 @@ export class SessionCommands {
           response: {
             length: chars,
             text: responseText,
+            source: cliDestination ? "transcript" : "delivered",
           },
+          ...(runtimeMismatch ? { runtimeMismatch } : {}),
         };
         return returnStructuredResult(payload, asJson);
       }
@@ -4369,6 +4425,7 @@ export class SessionCommands {
           delivery.source,
           {
             promptPayload,
+            cliDestination,
           },
         );
         if (preparedThread) {
@@ -4395,6 +4452,7 @@ export class SessionCommands {
           deliveryBarrier,
           delivery.source,
           promptPayload,
+          cliDestination,
         );
         if (preparedThread) {
           preparedThread = {
@@ -4765,6 +4823,11 @@ export class SessionCommands {
       description: "Return metadata for a single message (transcription, mediaType) using session history as fallback",
     })
     messageId?: string,
+    @Option({
+      flags: "--visibility",
+      description: "Include the skill catalog from runtimeSessionParams.skillVisibility",
+    })
+    includeVisibility?: boolean,
   ) {
     const structuredResult = shouldReturnStructuredResult(asJson);
     const target = nameOrKey?.trim() || resolveCurrentSessionRef();
@@ -4790,8 +4853,9 @@ export class SessionCommands {
     const sessionLabel = session.name ?? target;
     const loaded = loadSessionReadTranscript(session, maxMessages);
     if (structuredResult) {
+      const sessionJson = buildSessionJson(session);
       const payload = {
-        session: buildSessionJson(session),
+        session: includeVisibility ? sessionJson : omitSkillVisibilityFromSessionJson(sessionJson),
         transcript: loaded.transcript,
         messages: loaded.messages,
         totalMessages: loaded.totalMessages,
@@ -5441,6 +5505,7 @@ export class SessionCommands {
     deliveryBarrier: DeliveryBarrier = DEFAULT_DELIVERY_BARRIER,
     deliveryBarrierSource: DeliveryBarrierSource = "default",
     promptPayload?: Record<string, unknown>,
+    cliDestination = false,
   ): Promise<void> {
     const { source, context } = this.resolveSource(session, channelOverride, toOverride);
 
@@ -5455,6 +5520,7 @@ export class SessionCommands {
       deliveryBarrier,
       deliveryBarrierSource,
       ...(promptPayload ?? {}),
+      ...(cliDestination ? { _cliDestination: true } : {}),
       _turnOrigin: buildSessionRelayTurnOrigin(action, getContext()),
     } as Record<string, unknown>);
   }
@@ -5474,11 +5540,13 @@ export class SessionCommands {
       silent?: boolean;
       onResponse?: (chunk: string) => void;
       promptPayload?: Record<string, unknown>;
+      cliDestination?: boolean;
     } = {},
   ): Promise<number> {
     let responseLength = 0;
     let settled = false;
     let settleCompletion: ((state: StreamTerminalState) => void) | undefined;
+    const transcriptCursor = snapshotTranscriptCursor(getRecentHistory(sessionName, 1));
 
     const runtimeStream = nats.subscribe(`ravi.session.${sessionName}.runtime`);
     const claudeStream = nats.subscribe(`ravi.session.${sessionName}.claude`);
@@ -5560,6 +5628,9 @@ export class SessionCommands {
             break;
           }
           if (data.response) {
+            if (options.cliDestination) {
+              continue;
+            }
             if (!options.silent) {
               process.stdout.write(data.response);
             }
@@ -5582,6 +5653,7 @@ export class SessionCommands {
       deliveryBarrier,
       deliveryBarrierSource,
       ...(options.promptPayload ?? {}),
+      ...(options.cliDestination ? { _cliDestination: true } : {}),
       _turnOrigin: buildSessionRelayTurnOrigin("send", getContext()),
     } as Record<string, unknown>);
 
@@ -5595,6 +5667,21 @@ export class SessionCommands {
     }
     if (completionState.kind === "timeout") {
       throw new Error(formatWaitTimeoutError(sessionName));
+    }
+
+    if (options.cliDestination) {
+      const transcriptText = await waitForThisTurnAssistantText({
+        afterId: transcriptCursor,
+        readMessages: () => getRecentHistory(sessionName, 50),
+      });
+      if (transcriptText !== null) {
+        if (!options.silent && transcriptText) {
+          process.stdout.write(transcriptText);
+        }
+        options.onResponse?.(transcriptText);
+        return transcriptText.length;
+      }
+      return 0;
     }
 
     return responseLength;

--- a/src/cli/commands/usage-exit.smoke.test.ts
+++ b/src/cli/commands/usage-exit.smoke.test.ts
@@ -45,8 +45,8 @@ describe("usage exit taxonomy smoke", () => {
   it("exits 2 when bare ravi tui is missing a session name", () => {
     const result = runCli(["tui"], { RAVI_AGENT_ID: undefined });
     expect(result.status).toBe(2);
-    expect(result.stderr + result.stdout).toMatch(/tui|session|required|missing|Usage/i);
-    expect(result.stderr + result.stdout).not.toMatch(/\bmain\b.*default/i);
+    expect(result.stderr).toContain("Usage: ravi tui <session>");
+    expect(result.stdout).toBe("");
   });
 
   it("exits 2 with one USAGE_ERROR envelope for an unknown root command", () => {

--- a/src/cli/commands/usage-exit.smoke.test.ts
+++ b/src/cli/commands/usage-exit.smoke.test.ts
@@ -42,6 +42,13 @@ function runCli(
 }
 
 describe("usage exit taxonomy smoke", () => {
+  it("exits 2 when bare ravi tui is missing a session name", () => {
+    const result = runCli(["tui"], { RAVI_AGENT_ID: undefined });
+    expect(result.status).toBe(2);
+    expect(result.stderr + result.stdout).toMatch(/tui|session|required|missing|Usage/i);
+    expect(result.stderr + result.stdout).not.toMatch(/\bmain\b.*default/i);
+  });
+
   it("exits 2 with one USAGE_ERROR envelope for an unknown root command", () => {
     const result = runCli(["task", "list", "--json"], { RAVI_AGENT_ID: undefined });
     expect(result.status).toBe(2);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,9 @@ import { dirname, join } from "node:path";
 import { registerCommands } from "./registry.js";
 import * as allCommands from "./commands/index.js";
 import {
+  CONTRACT_EXIT_USAGE,
   ContractError,
+  contractFail,
   contractFailureOutcome,
   installRootUsageContract,
   installUsageContract,
@@ -267,18 +269,28 @@ program
 program
   .command("tui")
   .description("Open the terminal UI for a session")
-  .argument("<session>", "Session name or key")
-  .action(async (session: string) => {
+  .argument("[session]", "Session name or key")
+  .action(async (session?: string) => {
+    const sessionName = session?.trim();
+    if (!sessionName) {
+      contractFail("tui", "USAGE_ERROR", "Usage: ravi tui <session>", {
+        exitCode: CONTRACT_EXIT_USAGE,
+        details: {
+          suggestedAction: "Pass a session name: ravi tui <session>",
+          usage: "ravi tui <session>",
+        },
+      });
+    }
     await runWithCliAudit(
       {
         group: "_root",
         name: "tui",
         tool: "root_tui",
-        input: { session },
+        input: { session: sessionName },
         closeLazyConnection: true,
       },
       async () => {
-        await spawnDirectTui(requireTuiSessionName(session), projectRoot);
+        await spawnDirectTui(requireTuiSessionName(sessionName), projectRoot);
       },
     );
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -34,6 +34,7 @@ import { runCloudAuthRootCommand, runLogin, runLogout, runWhoami } from "./comma
 import { emitCliAuditEvent, runWithCliAudit, wasContractErrorAudited } from "./audit.js";
 import { configureCliLogging } from "./logging.js";
 import { spawnDirectTui } from "./tui-launcher.js";
+import { requireTuiSessionName } from "../tui/session-arg.js";
 import { maybeRunAppAliasRoute } from "../apps/router.js";
 import { buildRootOperationalHelp } from "../runtime/runtime-operational-context.js";
 
@@ -266,7 +267,7 @@ program
 program
   .command("tui")
   .description("Open the terminal UI for a session")
-  .argument("[session]", "Session name or key", "main")
+  .argument("<session>", "Session name or key")
   .action(async (session: string) => {
     await runWithCliAudit(
       {
@@ -277,7 +278,7 @@ program
         closeLazyConnection: true,
       },
       async () => {
-        await spawnDirectTui(session, projectRoot);
+        await spawnDirectTui(requireTuiSessionName(session), projectRoot);
       },
     );
   });

--- a/src/cli/runtime-target.test.ts
+++ b/src/cli/runtime-target.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { matchesLiveDaemonRuntime } from "./runtime-target.js";
+import { getSessionsSendRuntimeMismatchWarning, matchesLiveDaemonRuntime } from "./runtime-target.js";
 
 describe("matchesLiveDaemonRuntime", () => {
   it("accepts an in-process gateway invocation hosted by the live daemon", () => {
@@ -42,6 +42,44 @@ describe("matchesLiveDaemonRuntime", () => {
         daemonProcessPid: null,
         cliBundlePath: null,
         daemonBundlePath: "/repo/dist/bundle/index.js",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getSessionsSendRuntimeMismatchWarning", () => {
+  it("warns without blocking PATH CLI publish to the live daemon", () => {
+    const warning = getSessionsSendRuntimeMismatchWarning({
+      cliExecPath: "/usr/local/bin/ravi",
+      cliBundlePath: "/global/dist/bundle/index.js",
+      dbPath: "/tmp/ravi.db",
+      daemon: {
+        online: true,
+        execPath: "/repo/dist/bundle/index.js",
+        cwd: "/repo",
+        matchesCli: false,
+      },
+      instance: null,
+    });
+
+    expect(warning).toContain("CLI/runtime mismatch detected.");
+    expect(warning).toContain("sessions send still publishes to the live daemon via NATS.");
+    expect(warning).toContain("this-turn transcript");
+  });
+
+  it("stays quiet when the CLI bundle matches the live daemon", () => {
+    expect(
+      getSessionsSendRuntimeMismatchWarning({
+        cliExecPath: "/repo/bin/ravi",
+        cliBundlePath: "/repo/dist/bundle/index.js",
+        dbPath: "/tmp/ravi.db",
+        daemon: {
+          online: true,
+          execPath: "/repo/dist/bundle/index.js",
+          cwd: "/repo",
+          matchesCli: true,
+        },
+        instance: null,
       }),
     ).toBeNull();
   });

--- a/src/cli/runtime-target.ts
+++ b/src/cli/runtime-target.ts
@@ -152,3 +152,17 @@ export function getCliRuntimeMismatchMessage(summary: CliRuntimeTargetSummary): 
     "Use the repo CLI/runtime instead of the outdated PATH/global bundle.",
   ].join("\n");
 }
+
+export function getSessionsSendRuntimeMismatchWarning(summary: CliRuntimeTargetSummary): string | null {
+  if (!summary.daemon.online || summary.daemon.matchesCli !== false) {
+    return null;
+  }
+
+  return [
+    "CLI/runtime mismatch detected.",
+    `CLI bundle: ${summary.cliBundlePath ?? "-"}`,
+    `Daemon bundle: ${summary.daemon.execPath ?? "-"}`,
+    "sessions send still publishes to the live daemon via NATS.",
+    "sessions send -w uses this CLI's wait logic (this-turn transcript for CLI-only).",
+  ].join("\n");
+}

--- a/src/cli/session-cli-surface.test.ts
+++ b/src/cli/session-cli-surface.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import { CLI_SESSION_BOOTSTRAP_EFFORT, DEFAULT_RUNTIME_EFFORT } from "../runtime/effort.js";
+import {
+  buildSessionSendPrompt,
+  isCliWaitDestination,
+  omitSkillVisibilityFromSessionJson,
+  readThisTurnAssistantText,
+  resolveCliSessionBootstrapEffort,
+  sanitizeCliAssistantText,
+  snapshotTranscriptCursor,
+  waitForThisTurnAssistantText,
+} from "./session-cli-surface.js";
+
+describe("session CLI surface", () => {
+  it("sends operator CLI-only prompts as raw user text", () => {
+    expect(buildSessionSendPrompt({ prompt: "responde só: pong" })).toBe("responde só: pong");
+    expect(buildSessionSendPrompt({ prompt: "hello", callerSessionKey: undefined })).toBe("hello");
+  });
+
+  it("keeps Inform wrapping for in-context agent-to-agent sends", () => {
+    expect(buildSessionSendPrompt({ prompt: "hello", callerSessionKey: "agent:main:origin" })).toBe(
+      "[System] Inform: [from: agent:main:origin] hello",
+    );
+  });
+
+  it("uses --raw as an escape hatch even for in-context sends", () => {
+    expect(
+      buildSessionSendPrompt({
+        prompt: "hello",
+        callerSessionKey: "agent:main:origin",
+        raw: true,
+      }),
+    ).toBe("hello");
+  });
+
+  it("treats named CLI-only sessions as the wait destination", () => {
+    expect(
+      isCliWaitDestination({
+        source: undefined,
+        hasOutputAttachment: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps chat-attached waits on delivered channel output", () => {
+    expect(
+      isCliWaitDestination({
+        channelOverride: "slack",
+        toOverride: "C123",
+      }),
+    ).toBe(false);
+    expect(
+      isCliWaitDestination({
+        source: { channel: "whatsapp", chatId: "5511" },
+      }),
+    ).toBe(false);
+    expect(isCliWaitDestination({ hasOutputAttachment: true })).toBe(false);
+  });
+
+  it("does not treat @@SILENT@@ as CLI text", () => {
+    expect(sanitizeCliAssistantText("@@SILENT@@")).toBe("");
+    expect(sanitizeCliAssistantText("@@SILENT@@ pong")).toBe("pong");
+  });
+
+  it("reads this turn's assistant transcript and ignores previous turns", () => {
+    const messages = [
+      { id: 1, role: "user", content: "old" },
+      { id: 2, role: "assistant", content: "previous" },
+      { id: 3, role: "user", content: "responde só: pong" },
+      { id: 4, role: "assistant", content: "pong" },
+    ];
+    expect(snapshotTranscriptCursor(messages.slice(0, 2))).toBe(2);
+    expect(readThisTurnAssistantText(messages, 2)).toEqual({ text: "pong" });
+    expect(readThisTurnAssistantText(messages.slice(0, 2), 2)).toBeNull();
+  });
+
+  it("waits when persist lags after turn.complete", async () => {
+    const prior = [
+      { id: 1, role: "user", content: "old" },
+      { id: 2, role: "assistant", content: "previous" },
+    ];
+    const current = [
+      ...prior,
+      { id: 3, role: "user", content: "responde só: pong" },
+      { id: 4, role: "assistant", content: "pong" },
+    ];
+    let reads = 0;
+
+    const text = await waitForThisTurnAssistantText({
+      afterId: 2,
+      timeoutMs: 200,
+      pollMs: 1,
+      sleep: async () => {},
+      readMessages: () => {
+        reads += 1;
+        return reads < 3 ? prior : current;
+      },
+    });
+
+    expect(text).toBe("pong");
+    expect(reads).toBeGreaterThanOrEqual(3);
+  });
+
+  it("strips the advertised skill catalog from default session JSON", () => {
+    const session = omitSkillVisibilityFromSessionJson({
+      sessionKey: "agent:grok-cli-probe:main",
+      name: "grok-cli-probe",
+      runtimeSessionParams: {
+        sessionId: "sess-1",
+        skillVisibility: {
+          skills: [{ id: "ravi-system-events", state: "advertised" }],
+          loadedSkills: [],
+        },
+      },
+    });
+
+    expect(session.runtimeSessionParams).toEqual({ sessionId: "sess-1" });
+    expect(JSON.stringify(session)).not.toContain("skillVisibility");
+    expect(JSON.stringify(session)).not.toContain("ravi-system-events");
+  });
+
+  it("does not inherit hardcoded xhigh for CLI-only bootstrap", () => {
+    expect(DEFAULT_RUNTIME_EFFORT).toBe("xhigh");
+    expect(CLI_SESSION_BOOTSTRAP_EFFORT).not.toBe(DEFAULT_RUNTIME_EFFORT);
+    expect(
+      resolveCliSessionBootstrapEffort({
+        createdSession: true,
+        cliDestination: true,
+      }),
+    ).toBe(CLI_SESSION_BOOTSTRAP_EFFORT);
+    expect(
+      resolveCliSessionBootstrapEffort({
+        createdSession: true,
+        cliDestination: true,
+        explicitEffort: "low",
+      }),
+    ).toBe("low");
+    expect(
+      resolveCliSessionBootstrapEffort({
+        createdSession: false,
+        cliDestination: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/cli/session-cli-surface.ts
+++ b/src/cli/session-cli-surface.ts
@@ -1,0 +1,114 @@
+import { SILENT_TOKEN } from "../prompt-builder.js";
+import type { RuntimeEffort } from "../runtime/effort.js";
+import { CLI_SESSION_BOOTSTRAP_EFFORT } from "../runtime/effort.js";
+
+export const CLI_TRANSCRIPT_PERSIST_TIMEOUT_MS = 5_000;
+export const CLI_TRANSCRIPT_PERSIST_POLL_MS = 25;
+
+export interface SessionSendPromptInput {
+  prompt: string;
+  raw?: boolean;
+  callerSessionKey?: string;
+}
+
+export interface CliWaitDestinationInput {
+  channelOverride?: string;
+  toOverride?: string;
+  source?: { channel?: string; chatId?: string } | null;
+  hasOutputAttachment?: boolean;
+}
+
+export interface TranscriptMessageLike {
+  id: number;
+  role: string;
+  content: string;
+}
+
+export interface WaitForThisTurnAssistantInput {
+  afterId: number;
+  readMessages: () => TranscriptMessageLike[];
+  timeoutMs?: number;
+  pollMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export function isOperatorCliSend(input: SessionSendPromptInput): boolean {
+  return !input.callerSessionKey && !input.raw;
+}
+
+export function buildSessionSendPrompt(input: SessionSendPromptInput): string {
+  if (input.raw) return input.prompt;
+  if (input.callerSessionKey) {
+    return `[System] Inform: [from: ${input.callerSessionKey}] ${input.prompt}`;
+  }
+  return input.prompt;
+}
+
+export function isCliWaitDestination(input: CliWaitDestinationInput): boolean {
+  if (input.channelOverride?.trim() || input.toOverride?.trim()) return false;
+  if (input.source?.channel?.trim() && input.source?.chatId?.trim()) return false;
+  if (input.hasOutputAttachment) return false;
+  return true;
+}
+
+export function sanitizeCliAssistantText(text: string): string {
+  return text.split(SILENT_TOKEN).join("").trim();
+}
+
+export function snapshotTranscriptCursor(messages: Array<{ id: number }>): number {
+  return messages.reduce((max, message) => Math.max(max, message.id), 0);
+}
+
+export function readThisTurnAssistantText(
+  messages: TranscriptMessageLike[],
+  afterId: number,
+): { text: string } | null {
+  const newer = messages.filter((message) => message.id > afterId);
+  const lastAssistant = [...newer].reverse().find((message) => message.role === "assistant");
+  if (!lastAssistant) return null;
+  return { text: sanitizeCliAssistantText(lastAssistant.content) };
+}
+
+export async function waitForThisTurnAssistantText(input: WaitForThisTurnAssistantInput): Promise<string | null> {
+  const timeoutMs = input.timeoutMs ?? CLI_TRANSCRIPT_PERSIST_TIMEOUT_MS;
+  const pollMs = input.pollMs ?? CLI_TRANSCRIPT_PERSIST_POLL_MS;
+  const sleep = input.sleep ?? defaultSleep;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const found = readThisTurnAssistantText(input.readMessages(), input.afterId);
+    if (found) return found.text;
+    if (Date.now() >= deadline) return null;
+    await sleep(pollMs);
+  }
+}
+
+export function omitSkillVisibilityFromSessionJson(
+  sessionJson: Record<string, unknown>,
+): Record<string, unknown> {
+  const params = sessionJson.runtimeSessionParams;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return sessionJson;
+  }
+  const { skillVisibility: _skillVisibility, ...rest } = params as Record<string, unknown>;
+  return {
+    ...sessionJson,
+    runtimeSessionParams: Object.keys(rest).length > 0 ? rest : undefined,
+  };
+}
+
+export function resolveCliSessionBootstrapEffort(input: {
+  createdSession: boolean;
+  cliDestination: boolean;
+  explicitEffort?: RuntimeEffort;
+}): RuntimeEffort | undefined {
+  if (input.explicitEffort) return input.explicitEffort;
+  if (input.createdSession && input.cliDestination) return CLI_SESSION_BOOTSTRAP_EFFORT;
+  return undefined;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/runtime/codex-provider.test.ts
+++ b/src/runtime/codex-provider.test.ts
@@ -1717,6 +1717,41 @@ process.on("SIGTERM", () => {
     expect(skillVisibility.skills.map((skill: any) => skill.state)).toEqual(["advertised", "advertised"]);
   });
 
+  it("omits the advertised skill-name catalog on CLI-only Codex starts", async () => {
+    const { calls, transport } = createMockTransport([
+      () => ({
+        events: (async function* () {
+          yield { type: "thread.started", thread_id: "thread_cli_catalog" };
+          yield { type: "turn.started" };
+          yield { type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } };
+        })(),
+      }),
+    ]);
+
+    const provider = createCodexRuntimeProvider({
+      transport: transport as any,
+      defaultModel: "gpt-5",
+      syncSkills: () => ["ravi-system-events", "ravi-system-agents-manager"],
+    });
+
+    provider.prepareSession?.({
+      agentId: "main",
+      cwd: "/tmp/ravi-codex",
+      plugins: [{ type: "local", path: "/tmp/ravi/plugins/ravi-system" }],
+    });
+
+    const session = provider.startSession(
+      makeStartRequest(["hello"], { omitAdvertisedSkillCatalog: true, effort: "high" }),
+    );
+    await collectEvents(session.events);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.systemPromptAppend).not.toContain("Ravi synchronized these Codex skills for this session:");
+    expect(calls[0]?.systemPromptAppend).not.toContain("- ravi-system-events");
+    expect(calls[0]?.systemPromptAppend).not.toContain("- ravi-system-agents-manager");
+    expect(calls[0]?.effort).toBe("high");
+  });
+
   it("marks Codex skills loaded from app-server instruction sources", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "ravi-codex-skills-"));
     const originalCodexHome = process.env.CODEX_HOME;

--- a/src/runtime/codex-provider.ts
+++ b/src/runtime/codex-provider.ts
@@ -565,7 +565,11 @@ async function* normalizeCodexEvents(
   let previousSessionId = resolveCodexResumeId(input.resumeSession, input.resume, input.cwd);
   let forkFromSessionId = input.forkSession ? previousSessionId : undefined;
   const outerAbortSignal = input.abortController.signal;
-  const systemPromptAppend = await buildCodexSystemPromptAppend(input.cwd, input.systemPromptAppend, syncedSkillNames);
+  const systemPromptAppend = await buildCodexSystemPromptAppend(
+    input.cwd,
+    input.systemPromptAppend,
+    input.omitAdvertisedSkillCatalog ? [] : syncedSkillNames,
+  );
   const effort = toCodexRuntimeEffort(input.effort);
 
   try {

--- a/src/runtime/effort.test.ts
+++ b/src/runtime/effort.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  CLI_SESSION_BOOTSTRAP_EFFORT,
   DEFAULT_RUNTIME_EFFORT,
   RUNTIME_EFFORT_LEVELS,
   formatRuntimeEffortLevels,
@@ -15,6 +16,8 @@ describe("runtime effort", () => {
     expect(RUNTIME_EFFORT_LEVELS).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
     expect(formatRuntimeEffortLevels()).toBe("none|minimal|low|medium|high|xhigh|max|ultra");
     expect(DEFAULT_RUNTIME_EFFORT).toBe("xhigh");
+    expect(CLI_SESSION_BOOTSTRAP_EFFORT).toBe("high");
+    expect(CLI_SESSION_BOOTSTRAP_EFFORT).not.toBe(DEFAULT_RUNTIME_EFFORT);
   });
 
   it("normalizes max and ultra", () => {

--- a/src/runtime/effort.ts
+++ b/src/runtime/effort.ts
@@ -4,6 +4,9 @@ export type RuntimeEffort = (typeof RUNTIME_EFFORT_LEVELS)[number];
 
 export const DEFAULT_RUNTIME_EFFORT: RuntimeEffort = "xhigh";
 
+/** CLI-only session bootstrap. Do not change the global WhatsApp/Slack default. */
+export const CLI_SESSION_BOOTSTRAP_EFFORT: RuntimeEffort = "high";
+
 export type StrongestCompatibleRuntimeEffort = "low" | "medium" | "high" | "max";
 
 const STRONGEST_COMPATIBLE_BY_EFFORT: Record<RuntimeEffort, StrongestCompatibleRuntimeEffort> = {

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -217,6 +217,11 @@ export interface PromptMessage {
   _daemonRestartResume?: DaemonRestartResumePromptMetadata;
   /** Internal marker preventing duplicate session-surface instructions after durable replay. */
   _sessionSurfaceHint?: boolean;
+  /**
+   * Operator CLI-only turn. Chat attach stays fail-closed; the waiting CLI is
+   * the reply destination via this turn's assistant transcript.
+   */
+  _cliDestination?: boolean;
   /** Provider-neutral identity for prompts accepted through a channel backend. */
   _channelBackend?: ChannelBackendPromptMetadata;
   /** Validated provenance asserted by a trusted internal producer; not a credential. */

--- a/src/runtime/pi-provider.ts
+++ b/src/runtime/pi-provider.ts
@@ -246,7 +246,9 @@ export function createPiRuntimeProvider(options: CreatePiRuntimeProviderOptions 
       });
       const request: RuntimeStartRequest = {
         ...input,
-        systemPromptAppend: buildPiSkillCatalogSystemPrompt(input.systemPromptAppend, skillVisibility),
+        systemPromptAppend: input.omitAdvertisedSkillCatalog
+          ? input.systemPromptAppend
+          : buildPiSkillCatalogSystemPrompt(input.systemPromptAppend, skillVisibility),
       };
       const state: PiSessionRuntimeState = {
         activeTurn: false,

--- a/src/runtime/runtime-request-builder.ts
+++ b/src/runtime/runtime-request-builder.ts
@@ -857,6 +857,7 @@ async function buildRuntimeStartRequestInternal(
       ...(hooks ? { hooks } : {}),
       ...(runtimePlugins.length > 0 ? { plugins: runtimePlugins } : {}),
       ...(allowedSkills ? { allowedSkills } : {}),
+      ...(prompt._cliDestination ? { omitAdvertisedSkillCatalog: true } : {}),
       ...(remoteSpawn ? { remoteSpawn } : {}),
       ...(modelBroker ? { modelBroker } : {}),
     },

--- a/src/runtime/session-surface-hint.test.ts
+++ b/src/runtime/session-surface-hint.test.ts
@@ -39,6 +39,18 @@ describe("session surface hint", () => {
     );
   });
 
+  it("describes CLI-only turns as returning to the waiting CLI", () => {
+    expect(buildSessionSurfaceHint(undefined, { cliDestination: true })).toBe(
+      "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.",
+    );
+    expect(
+      withSessionSurfaceHint({
+        prompt: "responde só: pong",
+        _cliDestination: true,
+      }).prompt,
+    ).toBe("[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.\nresponde só: pong");
+  });
+
   it("replaces legacy headers once and stays idempotent", () => {
     const decorated = withSessionSurfaceHint({
       prompt:

--- a/src/runtime/session-surface-hint.ts
+++ b/src/runtime/session-surface-hint.ts
@@ -1,13 +1,23 @@
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 
+export const CLI_SURFACE_HINT =
+  "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.";
+
 const SESSION_SURFACE_PREFIX = /^\[session surfaces?\][^\n]*(?:\n|$)/i;
 const CURRENT_SESSION_SURFACE_LINE = /^\[session surface\][^\n]*/i;
 
-export function buildSessionSurfaceHint(source: RuntimeLaunchPrompt["source"]): string {
+export function buildSessionSurfaceHint(
+  source: RuntimeLaunchPrompt["source"],
+  options: { cliDestination?: boolean } = {},
+): string {
   if (source) {
     const channel = formatChannelName(source.channel);
     const place = source.threadId ? `${channel} thread` : `${channel} chat`;
     return `[session surface] This turn came from a ${place}. A normal reply returns there.`;
+  }
+
+  if (options.cliDestination) {
+    return CLI_SURFACE_HINT;
   }
 
   return "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.";
@@ -20,7 +30,7 @@ export function withSessionSurfaceHint(prompt: RuntimeLaunchPrompt): RuntimeLaun
 
   return {
     ...prompt,
-    prompt: `${buildSessionSurfaceHint(prompt.source)}\n${content}`,
+    prompt: `${buildSessionSurfaceHint(prompt.source, { cliDestination: prompt._cliDestination })}\n${content}`,
     _sessionSurfaceHint: true,
   };
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -447,6 +447,11 @@ export interface RuntimeStartRequest {
    * "load every discovered skill" behavior (Invariant F — grandfather).
    */
   allowedSkills?: string[];
+  /**
+   * CLI-only bootstrap: skip the advertised skill-name catalog. The Ravi system
+   * prompt remains large; this does not claim a 23k-token reduction.
+   */
+  omitAdvertisedSkillCatalog?: boolean;
 }
 
 export type RuntimeEvent =

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -20,8 +20,9 @@ import { resolveRuntimeDisplayLabel } from "./hooks/runtime-display.js";
 import { applyAgentRuntimeSelection } from "./runtime-config.js";
 import { publish } from "../nats.js";
 import { resetSession } from "../router/sessions.js";
+import { resolveTuiSessionArg } from "./session-arg.js";
 
-const sessionName = process.argv[2] || "main";
+const sessionName = resolveTuiSessionArg();
 type ActiveView = "chat" | "cockpit";
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];

--- a/src/tui/session-arg.test.ts
+++ b/src/tui/session-arg.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { TUI_SESSION_USAGE, requireTuiSessionName, resolveTuiSessionArg } from "./session-arg.js";
+
+describe("TUI session argument", () => {
+  it("requires a session name instead of defaulting to main", () => {
+    expect(() => requireTuiSessionName(undefined)).toThrow(TUI_SESSION_USAGE);
+    expect(() => requireTuiSessionName("")).toThrow(TUI_SESSION_USAGE);
+    expect(() => requireTuiSessionName("   ")).toThrow(TUI_SESSION_USAGE);
+    expect(() => resolveTuiSessionArg(["bun", "src/tui/index.tsx"])).toThrow(TUI_SESSION_USAGE);
+  });
+
+  it("accepts an explicit session name", () => {
+    expect(requireTuiSessionName("grok-cli-probe")).toBe("grok-cli-probe");
+    expect(resolveTuiSessionArg(["bun", "src/tui/index.tsx", "grok-cli-probe"])).toBe("grok-cli-probe");
+  });
+});

--- a/src/tui/session-arg.ts
+++ b/src/tui/session-arg.ts
@@ -1,0 +1,13 @@
+export const TUI_SESSION_USAGE = "Usage: ravi tui <session>";
+
+export function requireTuiSessionName(session?: string | null): string {
+  const trimmed = session?.trim();
+  if (!trimmed) {
+    throw new Error(TUI_SESSION_USAGE);
+  }
+  return trimmed;
+}
+
+export function resolveTuiSessionArg(argv: string[] = process.argv): string {
+  return requireTuiSessionName(argv[2]);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Make CLI-only `sessions send` a first-class session surface: the waiting CLI is the destination of the reply. `-w --json` returns this turn's assistant transcript text instead of empty success when chat attach has no target.

## Problem

- Operator `sessions send grok-cli-probe "responde só: pong" -w --json` wrote `pong` in the transcript, then returned `response.text=""` because wait collected `.response` and attach fail-closed dropped the emit.
- Missing chat delivery was treated as empty success.
- Operator CLI-only send was wrapped as `[System] Inform: [from: unknown]`.
- Default `sessions read --json` leaked the advertised skill catalog via `runtimeSessionParams.skillVisibility`.
- Bare `ravi tui` defaulted to `main`.

## Solution

- CLI-only `sessions send` (no `--channel`/`--to`, no inbound chat) is not a source-less attach turn. The CLI is the destination.
- Do not invent a chat `.response` sink. Attach stays fail-closed: no chat target → do not emit to a channel.
- `sessions send -w` waits for `turn.complete`, then reads **this turn's** assistant transcript row (persist may lag). That text is `response.text`.
- Chat-attached `-w` still means delivered `.response`.
- Operator CLI-only send publishes raw user text. Agent-to-agent / in-context keeps `[System] Inform:`. `--raw` is the escape hatch.
- Default `sessions read --json` is session + messages. Catalog stays on `sessions visibility` or `--visibility`.
- Bare `ravi tui` requires a session name (usage error, exit 2).
- Bundle-path mismatch warns; it does not block `sessions send`.
- `sessions send --effort` plus CLI-only bootstrap `high` (global `DEFAULT_RUNTIME_EFFORT` stays `xhigh` for WhatsApp/Slack). Advertised skill-name catalog is omitted on CLI-only starts. The Ravi system prompt is still large.

## Practical impact

- Operator `sessions send <named-session> "..." -w --json` returns the model reply as `response.text` with `response.source="transcript"`.
- Chat-attached wait still reports delivered text (`response.source="delivered"`).
- `sessions read --json` is one screen: session + messages, no skill catalog unless `--visibility`.
- `ravi tui` without a session name fails closed with usage.

## What does NOT change

- Attach fail-closed for *chat* delivery (no invented `.response` sink).
- Global `DEFAULT_RUNTIME_EFFORT = xhigh` for WhatsApp/Slack.
- `main`, WhatsApp, Slack, `.env`, or the `grok-cli-probe` session.
- PATH CLI still publishes to the live daemon via NATS.

## Validation

- `bun test src/cli/session-cli-surface.test.ts src/cli/commands/sessions.test.ts src/tui/session-arg.test.ts src/runtime/session-surface-hint.test.ts src/cli/runtime-target.test.ts src/runtime/effort.test.ts src/runtime/session-output-target.test.ts src/cli/commands/usage-exit.smoke.test.ts`
- Allowlisted focused test: `src/runtime/codex-provider.test.ts` asserts CLI-only Codex starts omit the advertised skill-name catalog and accept `effort: "high"`.
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts` — spec PASSED, coverage PASSED.
- Covers: CLI-only `-w` with no `.response` + transcript row → non-empty text; no previous-turn leak; operator send is not Inform-wrapped; `read --json` omits catalog; bare `ravi tui` exits 2; attach fail-closed unchanged.
- Pre-push: `bun test` + SDK/OpenAPI/Swift snapshot checks passed.

## Risks

- Silent turns with no assistant row after the persist window still return empty text (not the old dropped-emit empty success).
- Stale PATH CLI vs daemon wait logic can still diverge; mismatch is a warning, not a block, so a stale CLI may still mis-wait.
- CLI-only bootstrap effort `high` does not shrink the Ravi system prompt.

## Rollback

- Revert this branch / revert the merge commit on `dev`.

## Follow-ups

- Honest token-budget work on the Ravi system prompt (not claimed here).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee22e239-03a0-4b0a-9483-9f42bf66f1a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee22e239-03a0-4b0a-9483-9f42bf66f1a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

