### PR TITLE
fix(sessions): keep operator send user rows raw

### DIFF
--- a/.ravi/specs/sessions/attach/CHECKS.md
+++ b/.ravi/specs/sessions/attach/CHECKS.md
@@ -9,10 +9,19 @@
 - An unattached inbound source MUST fail closed instead of using the default.
 - CLI-only `sessions send -w` MUST return this turn's assistant transcript
   when no `.response` is emitted. Previous-turn rows MUST NOT leak.
+- Operator CLI-only and HTTP/user `sessions.send` MUST persist and dispatch
+  the raw user text. The persisted `user.text` MUST NOT contain
+  `[session surface]`, `waiting CLI`, or `no inbound chat`.
+- Inbound WhatsApp/Slack attach turns MUST still receive the
+  `[session surface]` instruction on the user prompt.
+- HTTP operator send (`transport: "gateway"`, no `callerSessionKey`) MUST
+  NOT be treated as a waiting CLI or a source-less attach turn.
+- `sessions.send` input MUST NOT grow a `from` field. `[from:]` remains
+  only `callerSessionKey` inside `[System] Inform:`.
 - Detaching the output chat MUST clear output for that session.
 - Attach/detach during a running turn MUST NOT redirect that turn's captured
   reply target.
 - Different source chats and threads MUST run as separate serialized turns.
 - `ravi sessions mute`, `unmute`, `focus`, and related state MUST NOT exist.
-- `bun test src/router/session-attach.test.ts src/runtime/session-output-target.test.ts src/cli/commands/sessions.test.ts src/omni/consumer-context.test.ts`
+- `bun test src/router/session-attach.test.ts src/runtime/session-output-target.test.ts src/cli/commands/sessions.test.ts src/omni/consumer-context.test.ts src/runtime/session-surface-hint.test.ts src/runtime/session-trace.test.ts src/cli/session-cli-surface.test.ts`
   SHOULD pass after changing attach behavior.

--- a/.ravi/specs/sessions/attach/CHECKS.md
+++ b/.ravi/specs/sessions/attach/CHECKS.md
@@ -9,13 +9,15 @@
 - An unattached inbound source MUST fail closed instead of using the default.
 - CLI-only `sessions send -w` MUST return this turn's assistant transcript
   when no `.response` is emitted. Previous-turn rows MUST NOT leak.
-- Operator CLI-only and HTTP/user `sessions.send` MUST persist and dispatch
-  the raw user text. The persisted `user.text` MUST NOT contain
-  `[session surface]`, `waiting CLI`, or `no inbound chat`.
+- Operator CLI-only and HTTP/user `sessions.send` MUST persist the raw user
+  text. The persisted `user.text` MUST NOT contain `[session surface]`,
+  `waiting CLI`, or `no inbound chat`.
+- The provider/runtime prompt for those operator turns MUST still include
+  the `[session surface]` header (CLI-wait or no-inbound-chat) as
+  launch-prompt metadata, not as the displayed user row.
 - Inbound WhatsApp/Slack attach turns MUST still receive the
-  `[session surface]` instruction on the user prompt.
-- HTTP operator send (`transport: "gateway"`, no `callerSessionKey`) MUST
-  NOT be treated as a waiting CLI or a source-less attach turn.
+  `[session surface]` instruction on the runtime prompt and MAY keep it on
+  the persisted user prompt.
 - `sessions.send` input MUST NOT grow a `from` field. `[from:]` remains
   only `callerSessionKey` inside `[System] Inform:`.
 - Detaching the output chat MUST clear output for that session.

--- a/.ravi/specs/sessions/attach/RUNBOOK.md
+++ b/.ravi/specs/sessions/attach/RUNBOOK.md
@@ -13,7 +13,14 @@
    default.
 7. For CLI-only `sessions send -w`, read this turn's assistant transcript
    after `turn.complete`. Do not treat a dropped chat emit as empty success.
-7. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
+8. For operator CLI-only or HTTP `sessions.send`, read the persisted user
+   row. It MUST be the raw prompt. A `[session surface]` prefix, "waiting
+   CLI", or "no inbound chat" on that row is a leak.
+9. For a real WhatsApp/Slack inbound turn, the user row SHOULD start with
+   `[session surface] This turn came from a …`.
+10. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
+11. Do not add a `from` field to `sessions.send`. App identity stays on
+    `context issue`; `[from:]` is only `callerSessionKey` inside Inform.
 
 ## Validation
 

--- a/.ravi/specs/sessions/attach/RUNBOOK.md
+++ b/.ravi/specs/sessions/attach/RUNBOOK.md
@@ -16,16 +16,20 @@
 8. For operator CLI-only or HTTP `sessions.send`, read the persisted user
    row. It MUST be the raw prompt. A `[session surface]` prefix, "waiting
    CLI", or "no inbound chat" on that row is a leak.
-9. For a real WhatsApp/Slack inbound turn, the user row SHOULD start with
-   `[session surface] This turn came from a …`.
-10. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
-11. Do not add a `from` field to `sessions.send`. App identity stays on
+9. For the same operator turn, inspect launch-prompt metadata or the
+   queued runtime `user` content. The model-facing prompt MUST still start
+   with `[session surface]`.
+10. For a real WhatsApp/Slack inbound turn, the runtime prompt MUST start
+    with `[session surface] This turn came from a …`. The persisted user
+    row MAY keep that prefix.
+11. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
+12. Do not add a `from` field to `sessions.send`. App identity stays on
     `context issue`; `[from:]` is only `callerSessionKey` inside Inform.
 
 ## Validation
 
 ```bash
 bun test src/router/session-attach.test.ts src/runtime/session-output-target.test.ts src/cli/commands/sessions.test.ts src/omni/consumer-context.test.ts
-bun test src/runtime/delivery-queue.test.ts src/runtime/session-dispatcher.test.ts src/runtime/session-surface-hint.test.ts
+bun test src/runtime/delivery-queue.test.ts src/runtime/session-dispatcher.test.ts src/runtime/session-surface-hint.test.ts src/runtime/session-trace.test.ts
 bun run build
 ```

--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -86,21 +86,35 @@ serialized.
 
 ## Prompt Contract
 
-The dispatcher adds exactly one short English instruction to every new logical
-prompt:
+Inbound chat turns (WhatsApp, Slack, or another attached source that produced
+this turn) receive exactly one short English instruction on the persisted
+user prompt:
 
 ```text
 [session surface] This turn came from a Slack chat. A normal reply returns there.
 ```
 
-For a thread, it says `Slack thread`. For a CLI-only operator turn, it says
-that a normal reply returns to the waiting CLI. For other source-less turns,
-it says that the session default will be used when one is available.
+For a thread, it says `Slack thread`. The instruction MUST NOT include session
+names, chat ids, subscription lists, roles, database fields, or routing
+commands. It is added centrally so every channel uses the same contract, and
+it MUST remain idempotent across durable replay.
 
-The instruction MUST NOT include session names, chat ids, subscription lists,
-roles, database fields, or routing commands. It is added centrally so every
-channel uses the same contract, and it MUST remain idempotent across durable
-replay.
+Operator CLI-only and HTTP/user `sessions.send` MUST persist and dispatch the
+raw user text. Honor `--raw`. The dispatcher MUST NOT prefix
+`[session surface]` onto that `user.text` / `prompt.prompt`. Leftover
+`lastChannel` on a session-relay send is not an inbound chat turn.
+
+HTTP operator send (`transport: "gateway"`, no `callerSessionKey`) is neither
+a waiting CLI nor a source-less attach turn. Do not write "waiting CLI" or
+"no inbound chat" into that user row.
+
+If the model still needs a surface instruction for an operator turn, put it
+in host-only metadata or a separate system row. Do not rewrite the operator
+user row.
+
+`[from:]` is only `callerSessionKey` inside `[System] Inform:`.
+`SessionsSendInput` has no `from` field. App identity is `context issue`.
+`sessions.set-display` is a session label, not a sender.
 
 ## CLI
 
@@ -148,7 +162,9 @@ Regression coverage MUST include:
 - two Slack threads remaining separate;
 - source-less output using the default attachment;
 - an unattached inbound source failing closed;
-- replay adding the surface instruction only once.
+- replay adding the surface instruction only once;
+- operator CLI-only and HTTP `sessions.send` persisting raw user text;
+- inbound WhatsApp/Slack still receiving the surface instruction.
 
 ## Failure Modes
 

--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -86,31 +86,38 @@ serialized.
 
 ## Prompt Contract
 
-Inbound chat turns (WhatsApp, Slack, or another attached source that produced
-this turn) receive exactly one short English instruction on the persisted
-user prompt:
+Every new logical turn has two payloads:
+
+- **runtime prompt** — what the provider/model sees
+- **persisted user row** — what `sessions read`, chat display, and transcript
+  show
+
+The dispatcher adds exactly one short English instruction to the
+**runtime** prompt:
 
 ```text
 [session surface] This turn came from a Slack chat. A normal reply returns there.
 ```
 
-For a thread, it says `Slack thread`. The instruction MUST NOT include session
-names, chat ids, subscription lists, roles, database fields, or routing
-commands. It is added centrally so every channel uses the same contract, and
-it MUST remain idempotent across durable replay.
+For a thread, it says `Slack thread`. For a CLI-only operator turn, it says
+that a normal reply returns to the waiting CLI. For other source-less turns
+(including HTTP operator send with no inbound source), it says that the
+session default will be used when one is available.
 
-Operator CLI-only and HTTP/user `sessions.send` MUST persist and dispatch the
-raw user text. Honor `--raw`. The dispatcher MUST NOT prefix
-`[session surface]` onto that `user.text` / `prompt.prompt`. Leftover
-`lastChannel` on a session-relay send is not an inbound chat turn.
+The instruction MUST NOT include session names, chat ids, subscription lists,
+roles, database fields, or routing commands. It is added centrally so every
+channel uses the same contract, and it MUST remain idempotent across durable
+replay.
 
-HTTP operator send (`transport: "gateway"`, no `callerSessionKey`) is neither
-a waiting CLI nor a source-less attach turn. Do not write "waiting CLI" or
-"no inbound chat" into that user row.
+Inbound WhatsApp/Slack may keep the instruction on the persisted user prompt
+when the channel already shows the original message separately.
 
-If the model still needs a surface instruction for an operator turn, put it
-in host-only metadata or a separate system row. Do not rewrite the operator
-user row.
+Operator CLI-only and HTTP/user `sessions.send` MUST persist the raw user
+text. Honor `--raw`. Do not glue `[session surface]`, `waiting CLI`, or
+`no inbound chat` into that `user.text`. Put the header on launch-prompt
+metadata (`_sessionSurfaceHintText` / `_runtimePrompt`) and inject it into
+the model prompt. Leftover `lastChannel` on a session-relay send is not an
+inbound chat turn.
 
 `[from:]` is only `callerSessionKey` inside `[System] Inform:`.
 `SessionsSendInput` has no `from` field. App identity is `context issue`.
@@ -163,7 +170,8 @@ Regression coverage MUST include:
 - source-less output using the default attachment;
 - an unattached inbound source failing closed;
 - replay adding the surface instruction only once;
-- operator CLI-only and HTTP `sessions.send` persisting raw user text;
+- operator CLI-only and HTTP `sessions.send` persisting raw user text
+  while the runtime prompt still carries the surface header;
 - inbound WhatsApp/Slack still receiving the surface instruction.
 
 ## Failure Modes
@@ -175,3 +183,5 @@ Regression coverage MUST include:
 - Sending an inbound turn to the default output.
 - Implementing the surface instruction in one channel adapter instead of the
   central dispatcher.
+- Gluing the surface header into an operator `user.text` row, or omitting
+  it from the model-facing runtime prompt.

--- a/.ravi/specs/sessions/attach/WHY.md
+++ b/.ravi/specs/sessions/attach/WHY.md
@@ -11,9 +11,14 @@ redirecting work that is already running.
 CLI-only `sessions send` is a first-class destination: the waiting CLI reads
 this turn's transcript. Attach stays fail-closed for chat delivery.
 
-The `[session surface]` line is an inbound-chat envelope, not an operator
-rewrite. WhatsApp/Slack turns need it so the model knows where a normal
-reply returns. Operator CLI and HTTP `sessions.send` already *are* the
-user row; prefixing "waiting CLI" or "no inbound chat" onto that text
-leaks host routing into the transcript. HTTP gateway send with no caller
-session is neither a waiting CLI nor a source-less chat turn.
+The `[session surface]` line tells the model where a normal reply returns.
+That instruction is model-visible on every new logical turn, including
+operator CLI-only and HTTP `sessions.send`.
+
+The operator user row is different: `sessions read`, chat display, and
+transcript must show only what the user typed. Gluing "waiting CLI" or
+"no inbound chat" into that row leaks host routing into the displayed
+history. Two payloads, one turn: runtime prompt carries the header;
+persisted `user.text` stays raw. WhatsApp/Slack inbound can keep the
+header on the stored prompt because the channel already shows the
+original message.

--- a/.ravi/specs/sessions/attach/WHY.md
+++ b/.ravi/specs/sessions/attach/WHY.md
@@ -10,3 +10,10 @@ redirecting work that is already running.
 
 CLI-only `sessions send` is a first-class destination: the waiting CLI reads
 this turn's transcript. Attach stays fail-closed for chat delivery.
+
+The `[session surface]` line is an inbound-chat envelope, not an operator
+rewrite. WhatsApp/Slack turns need it so the model knows where a normal
+reply returns. Operator CLI and HTTP `sessions.send` already *are* the
+user row; prefixing "waiting CLI" or "no inbound chat" onto that text
+leaks host routing into the transcript. HTTP gateway send with no caller
+session is neither a waiting CLI nor a source-less chat turn.

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -762,6 +762,8 @@ describe("SessionCommands delivery barriers", () => {
     expect(publishedPrompts[0]?.payload.prompt).not.toContain("[System] Inform:");
     expect(publishedPrompts[0]?.payload.prompt).not.toContain("[from: unknown]");
     expect(publishedPrompts[0]?.payload._cliDestination).toBe(true);
+    expect(publishedPrompts[0]?.payload.prompt).not.toContain("[session surface]");
+    expect(publishedPrompts[0]?.payload).not.toHaveProperty("from");
     expect(publishedPrompts[0]?.payload.deliveryBarrier).toBe("after_response");
     expect(publishedPrompts[0]?.payload.deliveryBarrierSource).toBe("default");
     expect(publishedPrompts[0]?.payload._turnOrigin).toMatchObject({
@@ -773,6 +775,25 @@ describe("SessionCommands delivery barriers", () => {
         type: "automation",
         id: "operator:local",
       },
+    });
+  });
+
+  it("publishes HTTP operator send as raw user text without a from field", async () => {
+    toolContext = { suppressCliOutput: true, transport: "gateway" };
+    const commands = new SessionCommands();
+
+    await captureLogsAsync(async () => {
+      await commands.send("dev", "hello from gateway");
+    });
+
+    expect(publishedPrompts).toHaveLength(1);
+    expect(publishedPrompts[0]?.payload.prompt).toBe("hello from gateway");
+    expect(publishedPrompts[0]?.payload.prompt).not.toContain("[session surface]");
+    expect(publishedPrompts[0]?.payload.prompt).not.toContain("[System] Inform:");
+    expect(publishedPrompts[0]?.payload).not.toHaveProperty("from");
+    expect(publishedPrompts[0]?.payload._turnOrigin).toMatchObject({
+      producer: "session-relay",
+      action: "send",
     });
   });
 

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -412,6 +412,8 @@ mock.module("../../tags/service.js", () => ({
   }),
 }));
 
+import { getOptionsMetadata } from "../decorators.js";
+
 const { SessionCommands } = await import("./sessions.js");
 const {
   buildCurrentSessionActionsCommand,
@@ -795,6 +797,11 @@ describe("SessionCommands delivery barriers", () => {
       producer: "session-relay",
       action: "send",
     });
+    expect(
+      getOptionsMetadata(SessionCommands.prototype, "send")
+        .map((option) => option.flags)
+        .join("\n"),
+    ).not.toMatch(/(?:^|\s)--from(?:\s|$)/m);
   });
 
   it("strips historical actor identity before republishing stored channel context", async () => {

--- a/src/cli/session-cli-surface.test.ts
+++ b/src/cli/session-cli-surface.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { SessionsSendInputSchema } from "../../packages/ravi-os-sdk/src/schemas.js";
 import { CLI_SESSION_BOOTSTRAP_EFFORT, DEFAULT_RUNTIME_EFFORT } from "../runtime/effort.js";
 import {
   buildSessionSendPrompt,
@@ -21,6 +22,29 @@ describe("session CLI surface", () => {
     expect(buildSessionSendPrompt({ prompt: "hello", callerSessionKey: "agent:main:origin" })).toBe(
       "[System] Inform: [from: agent:main:origin] hello",
     );
+  });
+
+  it("does not invent a from field on sessions.send", () => {
+    expect(SessionsSendInputSchema.properties).not.toHaveProperty("from");
+    expect(Object.keys(SessionsSendInputSchema.properties).sort()).toEqual([
+      "agent",
+      "barrier",
+      "channel",
+      "effort",
+      "immediate",
+      "interactive",
+      "nameOrKey",
+      "prompt",
+      "raw",
+      "steer",
+      "thread",
+      "threadOwner",
+      "threadScope",
+      "threadSummary",
+      "threadTitle",
+      "to",
+      "wait",
+    ]);
   });
 
   it("uses --raw as an escape hatch even for in-context sends", () => {

--- a/src/cli/session-cli-surface.test.ts
+++ b/src/cli/session-cli-surface.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import { SessionsSendInputSchema } from "../../packages/ravi-os-sdk/src/schemas.js";
 import { CLI_SESSION_BOOTSTRAP_EFFORT, DEFAULT_RUNTIME_EFFORT } from "../runtime/effort.js";
 import {
   buildSessionSendPrompt,
@@ -10,6 +9,7 @@ import {
   sanitizeCliAssistantText,
   snapshotTranscriptCursor,
   waitForThisTurnAssistantText,
+  type SessionSendPromptInput,
 } from "./session-cli-surface.js";
 
 describe("session CLI surface", () => {
@@ -25,26 +25,16 @@ describe("session CLI surface", () => {
   });
 
   it("does not invent a from field on sessions.send", () => {
-    expect(SessionsSendInputSchema.properties).not.toHaveProperty("from");
-    expect(Object.keys(SessionsSendInputSchema.properties).sort()).toEqual([
-      "agent",
-      "barrier",
-      "channel",
-      "effort",
-      "immediate",
-      "interactive",
-      "nameOrKey",
-      "prompt",
-      "raw",
-      "steer",
-      "thread",
-      "threadOwner",
-      "threadScope",
-      "threadSummary",
-      "threadTitle",
-      "to",
-      "wait",
-    ]);
+    type HasFrom = "from" extends keyof SessionSendPromptInput ? true : false;
+    const hasFrom: HasFrom = false;
+    expect(hasFrom).toBe(false);
+    expect(
+      Object.keys({
+        prompt: "hello",
+        raw: true,
+        callerSessionKey: "agent:main:origin",
+      } satisfies SessionSendPromptInput).sort(),
+    ).toEqual(["callerSessionKey", "prompt", "raw"]);
   });
 
   it("uses --raw as an escape hatch even for in-context sends", () => {

--- a/src/runtime/delivery-queue.ts
+++ b/src/runtime/delivery-queue.ts
@@ -9,7 +9,7 @@ import {
   type RuntimeUserMessage,
 } from "./host-session.js";
 import type { MessageActorMetadata, RaviCommandPromptMetadata, RuntimeLaunchPrompt } from "./message-types.js";
-import { combineSessionSurfacePromptContents } from "./session-surface-hint.js";
+import { combineSessionSurfacePromptContents, resolveRuntimePromptText } from "./session-surface-hint.js";
 import type { RuntimePromptMessage } from "./types.js";
 import { isSameRuntimeTurnSurface, runtimeTurnSurfaceKey } from "./turn-surface.js";
 
@@ -29,7 +29,7 @@ export function getRuntimePromptDeliveryBarrier(prompt: RuntimePromptDeliveryMes
 export function createQueuedRuntimeUserMessage(prompt: RuntimePromptDeliveryMessage): RuntimeUserMessage {
   return {
     type: "user",
-    message: { role: "user", content: prompt.prompt },
+    message: { role: "user", content: resolveRuntimePromptText(prompt) },
     session_id: "",
     parent_tool_use_id: null,
     deliveryBarrier: getRuntimePromptDeliveryBarrier(prompt),
@@ -182,8 +182,8 @@ function channelSteeringCompatibilityKey(message: RuntimeUserMessage): string | 
     (message.commands?.length ?? 0) > 0 ||
     (prompt.commands?.length ?? 0) > 0 ||
     context.isEditedMessage === true ||
-    Boolean(context.editedMessageId) ||
-    Boolean(context.editEventId) ||
+    context.editedMessageId ||
+    context.editEventId ||
     (barrier !== "after_tool" && barrier !== "immediate_interrupt") ||
     message.taskBarrierTaskId ||
     prompt._observation ||

--- a/src/runtime/message-types.ts
+++ b/src/runtime/message-types.ts
@@ -217,6 +217,13 @@ export interface PromptMessage {
   _daemonRestartResume?: DaemonRestartResumePromptMetadata;
   /** Internal marker preventing duplicate session-surface instructions after durable replay. */
   _sessionSurfaceHint?: boolean;
+  /** Surface header line. Host metadata for the model; not the persisted user row. */
+  _sessionSurfaceHintText?: string;
+  /**
+   * Model-facing prompt when it differs from `prompt` (operator/HTTP send).
+   * `prompt` remains the displayed/persisted user text.
+   */
+  _runtimePrompt?: string;
   /**
    * Operator CLI-only turn. Chat attach stays fail-closed; the waiting CLI is
    * the reply destination via this turn's assistant transcript.

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -71,7 +71,7 @@ import {
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { isSameRuntimeTurnSurface } from "./turn-surface.js";
 import type { RuntimeRecoveryExhaustedAlertInput } from "./runtime-recovery-alert.js";
-import { withSessionSurfaceHint } from "./session-surface-hint.js";
+import { resolvePersistedUserText, resolveRuntimePromptText, withSessionSurfaceHint } from "./session-surface-hint.js";
 import { resolveRuntimeForPrompt, runtimePromptRequiresRestart } from "./task-runtime-context.js";
 import {
   buildRuntimeSessionPoolSnapshot,
@@ -955,7 +955,7 @@ export class RuntimeSessionDispatcher {
           saveMessage(
             sessionName,
             "user",
-            prompt.prompt,
+            resolvePersistedUserText(prompt),
             sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId,
             {
               agentId: sessionEntry?.agentId ?? existing.agentId,
@@ -1156,14 +1156,20 @@ export class RuntimeSessionDispatcher {
         updateRuntimeSessionMetadata(sessionEntry.sessionKey, prompt);
       }
       if (!prompt._resumeStashedMessages) {
-        saveMessage(sessionName, "user", prompt.prompt, sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId, {
-          agentId: sessionEntry?.agentId ?? agent.id,
-          channel: prompt.source?.channel ?? prompt.context?.channelId,
-          accountId: prompt.source?.accountId ?? prompt.context?.accountId,
-          chatId: prompt.source?.chatId ?? prompt.context?.chatId,
-          sourceMessageId: prompt.source?.sourceMessageId ?? prompt.context?.messageId,
-          commands: prompt.commands,
-        });
+        saveMessage(
+          sessionName,
+          "user",
+          resolvePersistedUserText(prompt),
+          sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId,
+          {
+            agentId: sessionEntry?.agentId ?? agent.id,
+            channel: prompt.source?.channel ?? prompt.context?.channelId,
+            accountId: prompt.source?.accountId ?? prompt.context?.accountId,
+            chatId: prompt.source?.chatId ?? prompt.context?.chatId,
+            sourceMessageId: prompt.source?.sourceMessageId ?? prompt.context?.messageId,
+            commands: prompt.commands,
+          },
+        );
       }
       const queued = daemonRestartMessages
         ? appendUniqueRuntimeMessagesToStash(sessionName, daemonRestartMessages, this.stashedMessages)
@@ -1220,14 +1226,20 @@ export class RuntimeSessionDispatcher {
         updateRuntimeSessionMetadata(sessionEntry.sessionKey, prompt);
       }
       if (!prompt._resumeStashedMessages) {
-        saveMessage(sessionName, "user", prompt.prompt, sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId, {
-          agentId: sessionEntry?.agentId ?? agent.id,
-          channel: prompt.source?.channel ?? prompt.context?.channelId,
-          accountId: prompt.source?.accountId ?? prompt.context?.accountId,
-          chatId: prompt.source?.chatId ?? prompt.context?.chatId,
-          sourceMessageId: prompt.source?.sourceMessageId ?? prompt.context?.messageId,
-          commands: prompt.commands,
-        });
+        saveMessage(
+          sessionName,
+          "user",
+          resolvePersistedUserText(prompt),
+          sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId,
+          {
+            agentId: sessionEntry?.agentId ?? agent.id,
+            channel: prompt.source?.channel ?? prompt.context?.channelId,
+            accountId: prompt.source?.accountId ?? prompt.context?.accountId,
+            chatId: prompt.source?.chatId ?? prompt.context?.chatId,
+            sourceMessageId: prompt.source?.sourceMessageId ?? prompt.context?.messageId,
+            commands: prompt.commands,
+          },
+        );
       }
       const queued = daemonRestartMessages
         ? appendUniqueRuntimeMessagesToStash(sessionName, daemonRestartMessages, this.stashedMessages)
@@ -1940,7 +1952,7 @@ export class RuntimeSessionDispatcher {
     const result = await existing.queryHandle
       .control?.({
         operation: "turn.steer",
-        text: prompt.prompt,
+        text: resolveRuntimePromptText(prompt),
       })
       .catch((error) => ({
         ok: false,

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -28,6 +28,7 @@ import {
 import type { RuntimeCredentialAttemptBinding } from "./credential-types.js";
 import type { RuntimeCrashRecoveryCoordinator } from "./crash-recovery.js";
 import { createQueuedRuntimeUserMessage } from "./delivery-queue.js";
+import { resolvePersistedUserText } from "./session-surface-hint.js";
 import { normalizePromptTaskBarrierTaskId } from "./host-env.js";
 import { runRuntimeEventLoop, type RuntimeSafeEmit } from "./host-event-loop.js";
 import { getRuntimeToolAccessMode } from "./host-services.js";
@@ -175,14 +176,20 @@ export async function startRuntimeSession(options: StartRuntimeSessionOptions): 
 
   updateRuntimeSessionMetadata(dbSessionKey, prompt);
   if (!resumeStashedMessages) {
-    saveMessage(sessionName, "user", prompt.prompt, canResumeStoredSession ? storedProviderSessionId : undefined, {
-      agentId: agent.id,
-      channel: resolvedSource?.channel ?? prompt.context?.channelId,
-      accountId: resolvedSource?.accountId ?? prompt.context?.accountId,
-      chatId: resolvedSource?.chatId ?? prompt.context?.chatId,
-      sourceMessageId: resolvedSource?.sourceMessageId ?? prompt.context?.messageId,
-      commands: prompt.commands,
-    });
+    saveMessage(
+      sessionName,
+      "user",
+      resolvePersistedUserText(prompt),
+      canResumeStoredSession ? storedProviderSessionId : undefined,
+      {
+        agentId: agent.id,
+        channel: resolvedSource?.channel ?? prompt.context?.channelId,
+        accountId: resolvedSource?.accountId ?? prompt.context?.accountId,
+        chatId: resolvedSource?.chatId ?? prompt.context?.chatId,
+        sourceMessageId: resolvedSource?.sourceMessageId ?? prompt.context?.messageId,
+        commands: prompt.commands,
+      },
+    );
   }
 
   const runtimeResolution = resolveRuntimeForPrompt({

--- a/src/runtime/session-surface-hint.test.ts
+++ b/src/runtime/session-surface-hint.test.ts
@@ -4,7 +4,9 @@ import {
   buildSessionSurfaceHint,
   CLI_SURFACE_HINT,
   combineSessionSurfacePromptContents,
-  shouldPrefixSessionSurfaceHint,
+  persistSessionSurfaceHintOnUserRow,
+  resolvePersistedUserText,
+  resolveRuntimePromptText,
   SOURCELESS_SURFACE_HINT,
   withSessionSurfaceHint,
 } from "./session-surface-hint.js";
@@ -37,31 +39,39 @@ describe("session surface hint", () => {
     ).toContain("WhatsApp chat");
   });
 
-  it("keeps source-less and CLI hint builders for host metadata, not operator user rows", () => {
+  it("keeps source-less and CLI hint builders for the model-facing header", () => {
     expect(buildSessionSurfaceHint(undefined)).toBe(SOURCELESS_SURFACE_HINT);
     expect(buildSessionSurfaceHint(undefined, { cliDestination: true })).toBe(CLI_SURFACE_HINT);
   });
 
-  it("does not prefix operator CLI-only or HTTP session-relay text onto the user row", () => {
+  it("keeps operator CLI-only user rows raw and puts the CLI header on the runtime prompt", () => {
     const cliOnly = withSessionSurfaceHint({
       prompt: "responde só: pong",
       _cliDestination: true,
     });
-    expect(cliOnly.prompt).toBe("responde só: pong");
+    expect(resolvePersistedUserText(cliOnly)).toBe("responde só: pong");
     expect(cliOnly.prompt).not.toContain("[session surface]");
-    expect(cliOnly._sessionSurfaceHint).toBe(true);
-    expect(shouldPrefixSessionSurfaceHint({ prompt: "responde só: pong", _cliDestination: true })).toBe(false);
+    expect(cliOnly._sessionSurfaceHintText).toBe(CLI_SURFACE_HINT);
+    expect(resolveRuntimePromptText(cliOnly)).toBe(`${CLI_SURFACE_HINT}\nresponde só: pong`);
+    expect(persistSessionSurfaceHintOnUserRow({ prompt: "responde só: pong", _cliDestination: true })).toBe(false);
+  });
 
+  it("keeps HTTP session-relay user rows raw and still sends a sourceless header to the model", () => {
     const httpOperator = withSessionSurfaceHint({
       prompt: "hello from gateway",
       _turnOrigin: buildSessionRelayTurnOrigin("send"),
     });
-    expect(httpOperator.prompt).toBe("hello from gateway");
+    expect(resolvePersistedUserText(httpOperator)).toBe("hello from gateway");
     expect(httpOperator.prompt).not.toContain("waiting CLI");
     expect(httpOperator.prompt).not.toContain("no inbound chat");
-    expect(shouldPrefixSessionSurfaceHint({ prompt: "hello from gateway", _turnOrigin: buildSessionRelayTurnOrigin("send") })).toBe(
-      false,
-    );
+    expect(httpOperator._sessionSurfaceHintText).toBe(SOURCELESS_SURFACE_HINT);
+    expect(resolveRuntimePromptText(httpOperator)).toBe(`${SOURCELESS_SURFACE_HINT}\nhello from gateway`);
+    expect(
+      persistSessionSurfaceHintOnUserRow({
+        prompt: "hello from gateway",
+        _turnOrigin: buildSessionRelayTurnOrigin("send"),
+      }),
+    ).toBe(false);
   });
 
   it("does not treat leftover lastChannel source on sessions.send as inbound chat", () => {
@@ -70,8 +80,11 @@ describe("session surface hint", () => {
       source: { channel: "slack", accountId: "main", chatId: "C123" },
       _turnOrigin: buildSessionRelayTurnOrigin("send"),
     });
-    expect(decorated.prompt).toBe("operator text");
+    expect(resolvePersistedUserText(decorated)).toBe("operator text");
     expect(decorated.prompt).not.toContain("[session surface]");
+    expect(decorated._sessionSurfaceHintText).toBe(SOURCELESS_SURFACE_HINT);
+    expect(resolveRuntimePromptText(decorated)).toBe(`${SOURCELESS_SURFACE_HINT}\noperator text`);
+    expect(resolveRuntimePromptText(decorated)).not.toContain("Slack chat");
   });
 
   it("prefixes inbound WhatsApp and Slack turns and stays idempotent", () => {
@@ -86,9 +99,11 @@ describe("session surface hint", () => {
     expect(decorated.prompt).toBe(
       "[session surface] This turn came from a WhatsApp chat. A normal reply returns there.\nhello",
     );
+    expect(resolveRuntimePromptText(decorated)).toBe(decorated.prompt);
+    expect(decorated._runtimePrompt).toBeUndefined();
     expect(withSessionSurfaceHint(decorated)).toBe(decorated);
     expect(
-      shouldPrefixSessionSurfaceHint({
+      persistSessionSurfaceHintOnUserRow({
         prompt: "hello",
         source: { channel: "slack", accountId: "workspace", chatId: "C123" },
       }),

--- a/src/runtime/session-surface-hint.test.ts
+++ b/src/runtime/session-surface-hint.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import { buildSessionRelayTurnOrigin } from "./turn-origin.js";
 import {
   buildSessionSurfaceHint,
+  CLI_SURFACE_HINT,
   combineSessionSurfacePromptContents,
+  shouldPrefixSessionSurfaceHint,
+  SOURCELESS_SURFACE_HINT,
   withSessionSurfaceHint,
 } from "./session-surface-hint.js";
 
@@ -33,25 +37,44 @@ describe("session surface hint", () => {
     ).toContain("WhatsApp chat");
   });
 
-  it("describes the source-less default without embedding mutable routing state", () => {
-    expect(buildSessionSurfaceHint(undefined)).toBe(
-      "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.",
+  it("keeps source-less and CLI hint builders for host metadata, not operator user rows", () => {
+    expect(buildSessionSurfaceHint(undefined)).toBe(SOURCELESS_SURFACE_HINT);
+    expect(buildSessionSurfaceHint(undefined, { cliDestination: true })).toBe(CLI_SURFACE_HINT);
+  });
+
+  it("does not prefix operator CLI-only or HTTP session-relay text onto the user row", () => {
+    const cliOnly = withSessionSurfaceHint({
+      prompt: "responde só: pong",
+      _cliDestination: true,
+    });
+    expect(cliOnly.prompt).toBe("responde só: pong");
+    expect(cliOnly.prompt).not.toContain("[session surface]");
+    expect(cliOnly._sessionSurfaceHint).toBe(true);
+    expect(shouldPrefixSessionSurfaceHint({ prompt: "responde só: pong", _cliDestination: true })).toBe(false);
+
+    const httpOperator = withSessionSurfaceHint({
+      prompt: "hello from gateway",
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+    });
+    expect(httpOperator.prompt).toBe("hello from gateway");
+    expect(httpOperator.prompt).not.toContain("waiting CLI");
+    expect(httpOperator.prompt).not.toContain("no inbound chat");
+    expect(shouldPrefixSessionSurfaceHint({ prompt: "hello from gateway", _turnOrigin: buildSessionRelayTurnOrigin("send") })).toBe(
+      false,
     );
   });
 
-  it("describes CLI-only turns as returning to the waiting CLI", () => {
-    expect(buildSessionSurfaceHint(undefined, { cliDestination: true })).toBe(
-      "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.",
-    );
-    expect(
-      withSessionSurfaceHint({
-        prompt: "responde só: pong",
-        _cliDestination: true,
-      }).prompt,
-    ).toBe("[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.\nresponde só: pong");
+  it("does not treat leftover lastChannel source on sessions.send as inbound chat", () => {
+    const decorated = withSessionSurfaceHint({
+      prompt: "operator text",
+      source: { channel: "slack", accountId: "main", chatId: "C123" },
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+    });
+    expect(decorated.prompt).toBe("operator text");
+    expect(decorated.prompt).not.toContain("[session surface]");
   });
 
-  it("replaces legacy headers once and stays idempotent", () => {
+  it("prefixes inbound WhatsApp and Slack turns and stays idempotent", () => {
     const decorated = withSessionSurfaceHint({
       prompt:
         "[session surfaces] session=main source_chat=chat-1\n" +
@@ -64,6 +87,12 @@ describe("session surface hint", () => {
       "[session surface] This turn came from a WhatsApp chat. A normal reply returns there.\nhello",
     );
     expect(withSessionSurfaceHint(decorated)).toBe(decorated);
+    expect(
+      shouldPrefixSessionSurfaceHint({
+        prompt: "hello",
+        source: { channel: "slack", accountId: "workspace", chatId: "C123" },
+      }),
+    ).toBe(true);
   });
 
   it("keeps one instruction when same-surface messages share a physical turn", () => {

--- a/src/runtime/session-surface-hint.ts
+++ b/src/runtime/session-surface-hint.ts
@@ -28,29 +28,38 @@ export function buildSessionSurfaceHint(
 }
 
 /**
- * Prefix `[session surface]` onto persisted user text only for real inbound
- * chat turns. Operator CLI-only and HTTP `sessions.send` stay raw: those
- * rows are the operator's text, not a channel envelope.
+ * Persist the surface header on the user row only for real inbound chat.
+ * Operator CLI-only and HTTP `sessions.send` keep raw `user.text`.
  */
-export function shouldPrefixSessionSurfaceHint(prompt: RuntimeLaunchPrompt): boolean {
-  if (prompt._sessionSurfaceHint) return false;
+export function persistSessionSurfaceHintOnUserRow(prompt: RuntimeLaunchPrompt): boolean {
   if (prompt._cliDestination) return false;
   if (isSessionRelayOperatorTurn(prompt)) return false;
   return hasInboundChatSource(prompt.source);
 }
 
+export function resolveRuntimePromptText(prompt: Pick<RuntimeLaunchPrompt, "prompt" | "_runtimePrompt">): string {
+  return prompt._runtimePrompt ?? prompt.prompt;
+}
+
+export function resolvePersistedUserText(prompt: Pick<RuntimeLaunchPrompt, "prompt">): string {
+  return prompt.prompt;
+}
+
 export function withSessionSurfaceHint(prompt: RuntimeLaunchPrompt): RuntimeLaunchPrompt {
   if (prompt._sessionSurfaceHint) return prompt;
-  if (!shouldPrefixSessionSurfaceHint(prompt)) {
-    return { ...prompt, _sessionSurfaceHint: true };
-  }
 
-  const content = stripSessionSurfacePrefixes(prompt.prompt);
+  const persistOnUserRow = persistSessionSurfaceHintOnUserRow(prompt);
+  const hintSource = persistOnUserRow ? prompt.source : undefined;
+  const hint = buildSessionSurfaceHint(hintSource, { cliDestination: prompt._cliDestination });
+  const body = persistOnUserRow ? stripSessionSurfacePrefixes(prompt.prompt) : prompt.prompt;
+  const runtimePrompt = `${hint}\n${body}`;
 
   return {
     ...prompt,
-    prompt: `${buildSessionSurfaceHint(prompt.source)}\n${content}`,
+    prompt: persistOnUserRow ? runtimePrompt : prompt.prompt,
+    _runtimePrompt: persistOnUserRow ? undefined : runtimePrompt,
     _sessionSurfaceHint: true,
+    _sessionSurfaceHintText: hint,
   };
 }
 
@@ -65,9 +74,9 @@ function isSessionRelayOperatorTurn(prompt: RuntimeLaunchPrompt): boolean {
   return resolveRuntimeTurnOrigin(prompt._turnOrigin)?.producer === "session-relay";
 }
 
-function hasInboundChatSource(source: RuntimeLaunchPrompt["source"]): source is NonNullable<
-  RuntimeLaunchPrompt["source"]
-> {
+function hasInboundChatSource(
+  source: RuntimeLaunchPrompt["source"],
+): source is NonNullable<RuntimeLaunchPrompt["source"]> {
   return Boolean(source?.channel?.trim() && source?.chatId?.trim());
 }
 

--- a/src/runtime/session-surface-hint.ts
+++ b/src/runtime/session-surface-hint.ts
@@ -1,7 +1,11 @@
 import type { RuntimeLaunchPrompt } from "./message-types.js";
+import { resolveRuntimeTurnOrigin } from "./turn-origin.js";
 
 export const CLI_SURFACE_HINT =
   "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.";
+
+export const SOURCELESS_SURFACE_HINT =
+  "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.";
 
 const SESSION_SURFACE_PREFIX = /^\[session surfaces?\][^\n]*(?:\n|$)/i;
 const CURRENT_SESSION_SURFACE_LINE = /^\[session surface\][^\n]*/i;
@@ -10,7 +14,7 @@ export function buildSessionSurfaceHint(
   source: RuntimeLaunchPrompt["source"],
   options: { cliDestination?: boolean } = {},
 ): string {
-  if (source) {
+  if (hasInboundChatSource(source)) {
     const channel = formatChannelName(source.channel);
     const place = source.threadId ? `${channel} thread` : `${channel} chat`;
     return `[session surface] This turn came from a ${place}. A normal reply returns there.`;
@@ -20,17 +24,32 @@ export function buildSessionSurfaceHint(
     return CLI_SURFACE_HINT;
   }
 
-  return "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.";
+  return SOURCELESS_SURFACE_HINT;
+}
+
+/**
+ * Prefix `[session surface]` onto persisted user text only for real inbound
+ * chat turns. Operator CLI-only and HTTP `sessions.send` stay raw: those
+ * rows are the operator's text, not a channel envelope.
+ */
+export function shouldPrefixSessionSurfaceHint(prompt: RuntimeLaunchPrompt): boolean {
+  if (prompt._sessionSurfaceHint) return false;
+  if (prompt._cliDestination) return false;
+  if (isSessionRelayOperatorTurn(prompt)) return false;
+  return hasInboundChatSource(prompt.source);
 }
 
 export function withSessionSurfaceHint(prompt: RuntimeLaunchPrompt): RuntimeLaunchPrompt {
   if (prompt._sessionSurfaceHint) return prompt;
+  if (!shouldPrefixSessionSurfaceHint(prompt)) {
+    return { ...prompt, _sessionSurfaceHint: true };
+  }
 
   const content = stripSessionSurfacePrefixes(prompt.prompt);
 
   return {
     ...prompt,
-    prompt: `${buildSessionSurfaceHint(prompt.source, { cliDestination: prompt._cliDestination })}\n${content}`,
+    prompt: `${buildSessionSurfaceHint(prompt.source)}\n${content}`,
     _sessionSurfaceHint: true,
   };
 }
@@ -40,6 +59,16 @@ export function combineSessionSurfacePromptContents(contents: string[]): string 
   const hint = contents.map((content) => content.match(CURRENT_SESSION_SURFACE_LINE)?.[0]).find(Boolean);
   const body = contents.map(stripSessionSurfacePrefixes).join("\n\n");
   return hint ? `${hint}\n${body}` : body;
+}
+
+function isSessionRelayOperatorTurn(prompt: RuntimeLaunchPrompt): boolean {
+  return resolveRuntimeTurnOrigin(prompt._turnOrigin)?.producer === "session-relay";
+}
+
+function hasInboundChatSource(source: RuntimeLaunchPrompt["source"]): source is NonNullable<
+  RuntimeLaunchPrompt["source"]
+> {
+  return Boolean(source?.channel?.trim() && source?.chatId?.trim());
 }
 
 function stripSessionSurfacePrefixes(content: string): string {

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -998,10 +998,16 @@ describe("runtime session trace instrumentation", () => {
     expect(userRows[1]).not.toContain("no inbound chat");
     expect(streaming.pendingMessages.map((message) => message.message.content)).toEqual([
       "active inbound turn",
-      "responde só: pong",
-      "hello from gateway",
+      "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.\nresponde só: pong",
+      "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.\nhello from gateway",
       "[session surface] This turn came from a Slack chat. A normal reply returns there.\nhello from slack",
     ]);
+    expect(streaming.pendingMessages[1]?.launchPrompt?.prompt).toBe("responde só: pong");
+    expect(streaming.pendingMessages[1]?.launchPrompt?._runtimePrompt).toContain("waiting CLI");
+    expect(streaming.pendingMessages[1]?.launchPrompt?._sessionSurfaceHintText).toContain("waiting CLI");
+    expect(streaming.pendingMessages[2]?.launchPrompt?.prompt).toBe("hello from gateway");
+    expect(streaming.pendingMessages[2]?.launchPrompt?._runtimePrompt).toContain("no inbound chat");
+    expect(streaming.pendingMessages[2]?.launchPrompt?._sessionSurfaceHintText).toContain("no inbound chat");
   });
 
   it("blocks invisible provider env fallback when a managed credential pool cannot resolve", async () => {

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -927,9 +927,15 @@ describe("runtime session trace instrumentation", () => {
     const streaming = makeStreamingSession({
       agentMode: "active",
       currentSource: source,
+      currentEffort: "xhigh",
       pendingMessages: [activeMessage],
       currentTurnPendingIds: [activeMessage.pendingId!],
       turnActive: true,
+      queryHandle: {
+        provider: "codex",
+        events: (async function* () {})(),
+        interrupt: async () => {},
+      },
     });
     const dispatcher = new RuntimeSessionDispatcher({
       instanceId: "trace-test",

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -42,6 +42,7 @@ import type { RuntimeRecoveryExhaustedAlertInput } from "./runtime-recovery-aler
 import { buildRuntimeStartRequest, resolveRuntimeCredentialUpstreamProvider } from "./runtime-request-builder.js";
 import { RuntimeSessionDispatcher } from "./session-dispatcher.js";
 import { resolveSessionOutputTarget } from "./session-output-target.js";
+import { buildSessionRelayTurnOrigin } from "./turn-origin.js";
 import type {
   RuntimeCapabilities,
   RuntimeEvent,
@@ -906,6 +907,94 @@ describe("runtime session trace instrumentation", () => {
       { response: "original WhatsApp response", targetChatId: whatsappChat.id },
       { response: "Slack response", targetChatId: slackChat.id },
       { response: "later WhatsApp response", targetChatId: whatsappChat.id },
+    ]);
+  });
+
+  it("persists operator/HTTP sessions.send as raw user text and keeps inbound surface hints", async () => {
+    const slackSource: RuntimeMessageTarget = {
+      channel: "slack",
+      accountId: "slack-main",
+      instanceId: "slack-main",
+      chatId: "C123",
+      canonicalChatId: "chat_slack",
+      sourceMessageId: "123.456",
+    };
+    const activeMessage = createQueuedRuntimeUserMessage({
+      prompt: "active inbound turn",
+      source,
+      deliveryBarrier: "after_tool",
+    });
+    const streaming = makeStreamingSession({
+      agentMode: "active",
+      currentSource: source,
+      pendingMessages: [activeMessage],
+      currentTurnPendingIds: [activeMessage.pendingId!],
+      turnActive: true,
+    });
+    const dispatcher = new RuntimeSessionDispatcher({
+      instanceId: "trace-test",
+      maxConcurrentSessions: 10,
+      interactiveReservedSessions: 0,
+      safeEmit: async () => {},
+      notifyRuntimeRecoveryExhausted: async () => {},
+      getConfigModel: () => MODEL,
+      crashRecovery,
+    });
+    dispatcher.streamingSessions.set(SESSION_NAME, streaming);
+
+    await dispatcher.handlePromptImmediate(SESSION_NAME, {
+      prompt: "responde só: pong",
+      _cliDestination: true,
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+      source: slackSource,
+      _agentId: AGENT_ID,
+      deliveryBarrier: "after_response",
+      deliveryBarrierSource: "default",
+    });
+
+    await dispatcher.handlePromptImmediate(SESSION_NAME, {
+      prompt: "hello from gateway",
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+      _agentId: AGENT_ID,
+      deliveryBarrier: "after_response",
+      deliveryBarrierSource: "default",
+    });
+
+    await dispatcher.handlePromptImmediate(SESSION_NAME, {
+      prompt: "hello from slack",
+      source: slackSource,
+      context: {
+        channelId: "slack",
+        channelName: "Slack",
+        accountId: slackSource.accountId,
+        instanceId: slackSource.instanceId,
+        chatId: slackSource.chatId,
+        canonicalChatId: slackSource.canonicalChatId,
+        messageId: slackSource.sourceMessageId!,
+        senderId: "U123",
+        isGroup: false,
+        timestamp: Date.now(),
+      },
+      _agentId: AGENT_ID,
+      deliveryBarrier: "after_tool",
+      deliveryBarrierSource: "default",
+    });
+
+    const history = getRecentHistory(SESSION_NAME, 10);
+    const userRows = history.filter((message) => message.role === "user").map((message) => message.content);
+    expect(userRows).toEqual([
+      "responde só: pong",
+      "hello from gateway",
+      "[session surface] This turn came from a Slack chat. A normal reply returns there.\nhello from slack",
+    ]);
+    expect(userRows[0]).not.toContain("[session surface]");
+    expect(userRows[1]).not.toContain("waiting CLI");
+    expect(userRows[1]).not.toContain("no inbound chat");
+    expect(streaming.pendingMessages.map((message) => message.message.content)).toEqual([
+      "active inbound turn",
+      "responde só: pong",
+      "hello from gateway",
+      "[session surface] This turn came from a Slack chat. A normal reply returns there.\nhello from slack",
     ]);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Keep operator CLI-only and HTTP `sessions.send` user rows as the typed prompt, while the agentic runtime still receives the `[session surface]` header so it knows where a normal reply goes. Two payloads, one turn.

## Problem

#448 stopped Inform-wrapping operator/HTTP `sessions.send`. The remaining leak was that `withSessionSurfaceHint` still glued `[session surface] This turn came from the CLI...` / `no inbound chat...` onto the same `prompt.prompt` that `saveMessage` persists as `user.text`.

The first revision of this PR omitted the hint entirely for operator/HTTP (`shouldPrefixSessionSurfaceHint` returned false). That is the wrong split: the model still needs the header.

## Solution

Split persist vs runtime on the launch prompt:

- `prompt` / `resolvePersistedUserText` = raw operator text (honor `raw`; Inform wrap still only for agent-to-agent via `callerSessionKey`)
- `_runtimePrompt` / `resolveRuntimePromptText` = hint line + raw text (what `createQueuedRuntimeUserMessage` and native steer send to the provider)
- `_sessionSurfaceHintText` = the header line as inspectable launch-prompt metadata

`saveMessage` in `session-dispatcher` / `session-launcher` writes the persisted user row. The delivery queue writes the model-facing `user` content.

Inbound WhatsApp/Slack still prefix `prompt.prompt` (persist + runtime stay the same) because the channel already shows the original message.

Leftover `lastChannel` on a session-relay send is not inbound Slack: persist stays raw; the model gets the sourceless / CLI header, not a Slack-chat header.

## Practical impact

- `sessions read`, transcript, and chat display show `responde só: pong`
- CLI `-w --json` still returns `{ response: { text: "pong", source: "transcript" } }`
- The provider still sees `[session surface] This turn came from the CLI...` / `no inbound chat...`
- Inbound WhatsApp/Slack attach turns keep today's surface prefix and reply routing

## What does NOT change

- `buildSessionSendPrompt` Inform wrap: raw if `input.raw` or no `callerSessionKey`
- `SessionsSendInput` has no `from` field. Do not invent `from`. `[from:]` is only `callerSessionKey` inside Inform
- App identity stays `context issue`. `sessions.set-display` is a session label, not a sender
- CORS, gateway auth, `rctx_*`, Grok, and daemon-restart resume are out of scope
- Inbound reply routing is unchanged

## Validation

- `bun test src/runtime/session-surface-hint.test.ts src/runtime/session-trace.test.ts src/cli/session-cli-surface.test.ts src/cli/commands/sessions.test.ts`
- Allowlisted assertion in `src/runtime/session-trace.test.ts`: persist operator/HTTP user rows raw; queued `message.content` still starts with `[session surface]`; `launchPrompt.prompt` stays raw; `_runtimePrompt` / `_sessionSurfaceHintText` carry the header
- `sessions.send` CLI options and `SessionSendPromptInput` still have no `from`
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts` — spec PASSED, coverage PASSED (`src/runtime/` via `session-trace.test.ts`)
- Pre-push (`bun test`, typecheck, SDK/OpenAPI snapshots) passed on this branch

[Two-payload test evidence](https://cursor.com/agents/bc-fccf06db-96e6-452e-a746-2fbf165ae653/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperator_session_surface_two_payloads.log)

## Risks

- Operator send with `--channel/--to` is session-relay, so the persisted row stays raw (not treated as inbound). The model still gets a sourceless/CLI header.
- Source-less cron/heartbeat/followup turns also persist raw user text. Reply routing remains host-side. The model still gets the sourceless header.

## Rollback

- Revert this branch / revert the merge commit on `dev`.

## Follow-ups

- SDK/read can later surface `_sessionSurfaceHintText` as metadata. That is not a new `from` field and is not required for this PR.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fccf06db-96e6-452e-a746-2fbf165ae653?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fccf06db-96e6-452e-a746-2fbf165ae653&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

