### PR TITLE
fix(sessions): keep session-relay emit off leftover lastChannel

### DIFF
--- a/.ravi/specs/sessions/CHECKS.md
+++ b/.ravi/specs/sessions/CHECKS.md
@@ -28,4 +28,7 @@
   when no `.response` event is emitted.
 - Default `sessions read --json` MUST omit `runtimeSessionParams.skillVisibility`.
 - Operator `sessions send` without a caller session MUST NOT wrap `[System] Inform:`.
+- Operator / HTTP / app `sessions.send` without `--channel`/`--to` MUST NOT
+  emit to leftover `lastChannel` or the default output attachment. Persist
+  MUST still store the assistant row for `sessions.read`.
 - Bare `ravi tui` MUST fail with a usage error instead of opening `main`.

--- a/.ravi/specs/sessions/RUNBOOK.md
+++ b/.ravi/specs/sessions/RUNBOOK.md
@@ -33,3 +33,6 @@
 An inbound turn returns to its attached source chat or thread. The default
 output attachment is used only for a turn with no inbound source. An
 unattached inbound source MUST fail closed instead of falling back elsewhere.
+Operator / HTTP `sessions.send` without `--channel`/`--to` MUST NOT emit to
+leftover `lastChannel` or the default attachment; read the assistant row
+from `sessions.read`.

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -19,6 +19,7 @@ applies_to:
   - src/router/resolver.ts
   - src/omni/consumer.ts
   - src/runtime/host-event-loop.ts
+  - src/runtime/runtime-request-builder.ts
   - src/cli/commands/sessions.ts
   - src/sessions/recap.ts
   - src/prompt-builder.ts
@@ -81,6 +82,7 @@ Sessions do NOT own:
 - A physical provider turn MUST keep one immutable reply surface. Different chats and threads MUST be serialized into separate turns.
 - An inbound turn MUST reply to its attached source chat or thread. The default output attachment is used only when a turn has no inbound source.
 - An unattached inbound source or a source-less turn without a default output MUST NOT emit externally.
+- Operator / HTTP / app `sessions.send` (session-relay, no `--channel`/`--to`, no real inbound chat) is a session destination for emit. Leftover `lastChannel`/`lastTo` MUST NOT become `prompt.source` / `currentSource`. The default output attachment MUST NOT be the emit target. Chat emit stays fail-closed. Persist + `sessions.read` remain the sink.
 - `ravi sessions send` and related inter-session commands inject prompt/context into a Ravi session. They MUST NOT be documented as direct external channel delivery primitives. Visible outbound channel delivery belongs to the session response path or to explicit channel/media/outbound commands.
 - Operator CLI-only `sessions send` (no `--channel`/`--to`) sends the raw user text. `[System] Inform:` is reserved for agent-to-agent / in-context sends. `--raw` is the escape hatch.
 - CLI-only `sessions send -w` waits for this turn's assistant transcript after `turn.complete`. Chat-attached `-w` still means delivered. Attach remains fail-closed for chat emit.

--- a/.ravi/specs/sessions/WHY.md
+++ b/.ravi/specs/sessions/WHY.md
@@ -15,6 +15,16 @@ notion of a session.
 `session_name` must never rewrite `session_key`, otherwise routing and provider
 continuity break for an already-running session.
 
+## Why Session-Relay Send Is Not Chat Emit
+
+Operator / HTTP / app `sessions.send` injects a prompt into a session. It is
+not inbound WhatsApp/Slack. Copying leftover `lastChannel`/`lastTo` into
+`prompt.source` made emit treat that send as a chat reply — including onto
+`main` when the leftover chat was attached. The default output attachment
+has the same leak once the leftover source is stripped. Persist already
+stores the assistant row; emit must fail closed instead of inventing a
+chat sink.
+
 ## Why Attach Is Separate From Bindings
 
 The original `session_chat_bindings` row records the primary/origin chat.

--- a/.ravi/specs/sessions/attach/CHECKS.md
+++ b/.ravi/specs/sessions/attach/CHECKS.md
@@ -5,7 +5,12 @@
 - `ravi sessions attach <session> --chat <chat>` MUST select that chat as the
   session output target.
 - Inbound from an attached source MUST emit to that source chat or thread.
-- A source-less turn MUST emit to the default attachment when one exists.
+- A source-less cron/heartbeat/follow-up turn MUST emit to the default
+  attachment when one exists.
+- Operator / HTTP / app `sessions.send` without `--channel`/`--to` MUST NOT
+  emit to leftover `lastChannel`/`lastTo` or the default output attachment.
+  Chat emit MUST fail closed. `sessions.read` / `getRecentHistory` MUST
+  still contain this turn's assistant row.
 - An unattached inbound source MUST fail closed instead of using the default.
 - CLI-only `sessions send -w` MUST return this turn's assistant transcript
   when no `.response` is emitted. Previous-turn rows MUST NOT leak.

--- a/.ravi/specs/sessions/attach/RUNBOOK.md
+++ b/.ravi/specs/sessions/attach/RUNBOOK.md
@@ -8,7 +8,9 @@
    default output marker.
 3. Confirm the trace keeps one source for the whole physical turn.
 4. Confirm messages from another chat/thread stay queued until that turn ends.
-5. For a source-less turn, inspect the default attachment.
+5. For a source-less cron/heartbeat/follow-up turn, inspect the default
+   attachment. For operator / HTTP `sessions.send` without `--channel`/`--to`,
+   leftover `lastChannel` and the default attachment MUST NOT receive emit.
 6. If an inbound source is unattached, fail closed instead of using the
    default.
 7. For CLI-only `sessions send -w`, read this turn's assistant transcript

--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -17,6 +17,7 @@ applies_to:
   - src/runtime/session-dispatcher.ts
   - src/runtime/session-output-target.ts
   - src/runtime/session-surface-hint.ts
+  - src/runtime/runtime-request-builder.ts
   - src/cli/commands/sessions.ts
 owners:
   - ravi-dev
@@ -64,8 +65,18 @@ destination. After `turn.complete`, `sessions send -w` MUST return this
 turn's assistant transcript row (persist may lag). Missing chat delivery
 is not empty success when that transcript exists.
 
+Operator / HTTP / app `sessions.send` with the same shape (session-relay,
+no `--channel`/`--to`, no real inbound chat) is a **session destination
+for emit too**. Leftover `lastChannel` / `lastTo` MUST NOT be copied into
+`prompt.source` / `currentSource`. The default output attachment MUST NOT
+be the emit target. Chat emit MUST fail closed (`Response target
+unresolved — dropping emit`). Do not invent a chat `.response` sink.
+Persist stays independent: `saveMessage` on `turn.complete` plus
+`sessions.read` / `getRecentHistory` by `session_id`.
+
 The default output is only a fallback for proactive and other source-less
-turns. It never overrides an inbound source.
+turns (cron, heartbeat, follow-up). It never overrides an inbound source
+and MUST NOT claim a session-relay operator send.
 
 ## Turn Isolation
 
@@ -100,9 +111,10 @@ The dispatcher adds exactly one short English instruction to the
 ```
 
 For a thread, it says `Slack thread`. For a CLI-only operator turn, it says
-that a normal reply returns to the waiting CLI. For other source-less turns
-(including HTTP operator send with no inbound source), it says that the
-session default will be used when one is available.
+that a normal reply returns to the waiting CLI. For HTTP / app session-relay
+send with no inbound chat, it says that a normal reply stays on this
+session. For other source-less turns (cron, heartbeat, follow-up), it says
+that the session default will be used when one is available.
 
 The instruction MUST NOT include session names, chat ids, subscription lists,
 roles, database fields, or routing commands. It is added centrally so every
@@ -168,6 +180,9 @@ Regression coverage MUST include:
 - Slack active, WhatsApp queued, then one reply to each source in order;
 - two Slack threads remaining separate;
 - source-less output using the default attachment;
+- session-relay / HTTP operator send not emitting to leftover lastChannel
+  or the default output, while persist/read still has the assistant row;
+- inbound WhatsApp/Slack still emitting to the source chat;
 - an unattached inbound source failing closed;
 - replay adding the surface instruction only once;
 - operator CLI-only and HTTP `sessions.send` persisting raw user text

--- a/.ravi/specs/sessions/attach/WHY.md
+++ b/.ravi/specs/sessions/attach/WHY.md
@@ -9,7 +9,10 @@ This keeps the normal experience automatic and prevents a later message from
 redirecting work that is already running.
 
 CLI-only `sessions send` is a first-class destination: the waiting CLI reads
-this turn's transcript. Attach stays fail-closed for chat delivery.
+this turn's transcript. HTTP / app session-relay send is the same kind of
+session destination for emit: leftover `lastChannel` and the default output
+attachment must not become WhatsApp/Slack. Attach stays fail-closed for
+chat delivery. Persist + `sessions.read` remain the sink.
 
 The `[session surface]` line tells the model where a normal reply returns.
 That instruction is model-visible on every new logical turn, including

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -827,6 +827,7 @@ describe("SessionCommands delivery barriers", () => {
       await commands.send("dev", "hello");
     });
 
+    expect(publishedPrompts[0]?.payload.source).toBeUndefined();
     expect(publishedPrompts[0]?.payload.context).toEqual({
       channelId: "slack",
       channelName: "Slack",

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -5427,19 +5427,10 @@ export class SessionCommands {
 
     if (channelOverride && toOverride) {
       source = { channel: channelOverride, accountId: "", chatId: toOverride };
-    } else if (session.lastChannel && session.lastTo) {
-      // Derive threadId from session key (lastTo doesn't carry it)
-      const derived = deriveSourceFromSessionKey(session.sessionKey);
-      source = {
-        channel: session.lastChannel,
-        accountId: session.lastAccountId ?? "",
-        chatId: session.lastTo,
-        ...(derived?.threadId ? { threadId: derived.threadId } : {}),
-      };
-    } else {
-      const derived = deriveSourceFromSessionKey(session.sessionKey);
-      if (derived) source = derived;
     }
+    // Session-relay without --channel/--to is not inbound chat. Leftover
+    // lastChannel/lastTo and session-key derivation must not become
+    // prompt.source / currentSource / emit target.
 
     if (session.lastContext) {
       try {

--- a/src/cli/session-cli-surface.test.ts
+++ b/src/cli/session-cli-surface.test.ts
@@ -68,7 +68,7 @@ describe("session CLI surface", () => {
         source: { channel: "whatsapp", chatId: "5511" },
       }),
     ).toBe(false);
-    expect(isCliWaitDestination({ hasOutputAttachment: true })).toBe(false);
+    expect(isCliWaitDestination({ hasOutputAttachment: true })).toBe(true);
   });
 
   it("does not treat @@SILENT@@ as CLI text", () => {

--- a/src/cli/session-cli-surface.ts
+++ b/src/cli/session-cli-surface.ts
@@ -47,7 +47,8 @@ export function buildSessionSendPrompt(input: SessionSendPromptInput): string {
 export function isCliWaitDestination(input: CliWaitDestinationInput): boolean {
   if (input.channelOverride?.trim() || input.toOverride?.trim()) return false;
   if (input.source?.channel?.trim() && input.source?.chatId?.trim()) return false;
-  if (input.hasOutputAttachment) return false;
+  // Default output attach is not a chat destination for operator session-relay.
+  // Persist + `sessions.read` / CLI transcript are the sink.
   return true;
 }
 
@@ -59,10 +60,7 @@ export function snapshotTranscriptCursor(messages: Array<{ id: number }>): numbe
   return messages.reduce((max, message) => Math.max(max, message.id), 0);
 }
 
-export function readThisTurnAssistantText(
-  messages: TranscriptMessageLike[],
-  afterId: number,
-): { text: string } | null {
+export function readThisTurnAssistantText(messages: TranscriptMessageLike[], afterId: number): { text: string } | null {
   const newer = messages.filter((message) => message.id > afterId);
   const lastAssistant = [...newer].reverse().find((message) => message.role === "assistant");
   if (!lastAssistant) return null;
@@ -83,9 +81,7 @@ export async function waitForThisTurnAssistantText(input: WaitForThisTurnAssista
   }
 }
 
-export function omitSkillVisibilityFromSessionJson(
-  sessionJson: Record<string, unknown>,
-): Record<string, unknown> {
+export function omitSkillVisibilityFromSessionJson(sessionJson: Record<string, unknown>): Record<string, unknown> {
   const params = sessionJson.runtimeSessionParams;
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return sessionJson;

--- a/src/runtime/runtime-request-builder.test.ts
+++ b/src/runtime/runtime-request-builder.test.ts
@@ -4,6 +4,7 @@ import { getOrCreateSession } from "../router/index.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { resolveRuntimePromptSource, rotateRuntimeProviderEnvironment } from "./runtime-request-builder.js";
+import { buildSessionRelayTurnOrigin } from "./turn-origin.js";
 
 let stateDir: string | null = null;
 
@@ -56,6 +57,69 @@ describe("resolveRuntimePromptSource", () => {
       canonicalChatId: chat.id,
       instanceId: "main",
     });
+  });
+
+  it("does not copy leftover lastChannel onto session-relay HTTP send", () => {
+    const session = getOrCreateSession("agent:main:main", "main", "/tmp/main", { name: "main" });
+    session.lastChannel = "whatsapp";
+    session.lastAccountId = "main";
+    session.lastTo = "5511999999999@s.whatsapp.net";
+
+    expect(
+      resolveRuntimePromptSource(
+        {
+          prompt: "hello from gateway",
+          source: {
+            channel: "whatsapp",
+            accountId: "main",
+            chatId: "5511999999999@s.whatsapp.net",
+          },
+          _turnOrigin: buildSessionRelayTurnOrigin("send"),
+        },
+        session,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveRuntimePromptSource(
+        {
+          prompt: "hello from gateway",
+          _turnOrigin: buildSessionRelayTurnOrigin("send"),
+        },
+        session,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("still resolves a real inbound WhatsApp source and strips tui", () => {
+    const session = getOrCreateSession("agent:main:main", "main", "/tmp/main", { name: "main" });
+    session.lastChannel = "whatsapp";
+    session.lastTo = "old@s.whatsapp.net";
+
+    const inbound = resolveRuntimePromptSource(
+      {
+        prompt: "from whatsapp",
+        source: {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "new@s.whatsapp.net",
+        },
+      },
+      session,
+    );
+    expect(inbound).toMatchObject({
+      channel: "whatsapp",
+      chatId: "new@s.whatsapp.net",
+    });
+
+    expect(
+      resolveRuntimePromptSource(
+        {
+          prompt: "local tui",
+          source: { channel: "tui", accountId: "", chatId: "" },
+        },
+        session,
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/src/runtime/runtime-request-builder.ts
+++ b/src/runtime/runtime-request-builder.ts
@@ -12,6 +12,7 @@ import {
 } from "../session-trace/runtime-trace.js";
 import type { TaskRuntimeResolution } from "../tasks/types.js";
 import { classifyTurnProvenance } from "./turn-provenance.js";
+import { isSessionRelayTurn } from "./turn-origin.js";
 import { resolveAgentSkills } from "./allowed-skills.js";
 import type { RuntimeCrashRecoveryCoordinator } from "./crash-recovery.js";
 import { createRuntimeMessageGenerator } from "./delivery-queue.js";
@@ -243,6 +244,17 @@ export function resolveRuntimePromptSource(
   prompt: RuntimeLaunchPrompt,
   session: SessionEntry,
 ): RuntimeMessageTarget | undefined {
+  if (isSessionRelayTurn(prompt)) {
+    // Session-relay operator/HTTP/app send is a session destination.
+    // Leftover lastChannel/lastTo and the origin chat binding are not inbound.
+    const explicit = prompt.source;
+    if (!explicit || isLeftoverLastChannelSource(explicit, session)) {
+      return undefined;
+    }
+    const resolved = enrichSourceFromSessionChatBinding(explicit, session);
+    return resolved.channel === "tui" ? undefined : resolved;
+  }
+
   let resolvedSource = prompt.source;
   if (resolvedSource) {
     resolvedSource = enrichSourceFromSessionChatBinding(resolvedSource, session);
@@ -259,6 +271,17 @@ export function resolveRuntimePromptSource(
   }
 
   return resolvedSource?.channel === "tui" ? undefined : resolvedSource;
+}
+
+function isLeftoverLastChannelSource(
+  source: Pick<RuntimeMessageTarget, "channel" | "chatId">,
+  session: SessionEntry,
+): boolean {
+  const channel = source.channel?.trim();
+  const chatId = source.chatId?.trim();
+  const lastChannel = session.lastChannel?.trim();
+  const lastTo = session.lastTo?.trim();
+  return Boolean(channel && chatId && lastChannel && lastTo && channel === lastChannel && chatId === lastTo);
 }
 
 function splitCanonicalPlatformChat(platformChatId: string): { chatId: string; threadId?: string } {
@@ -796,11 +819,12 @@ async function buildRuntimeStartRequestInternal(
     beforeTurnStart: (input) => {
       const queuedTurnPrompt = findRuntimeTurnPrompt(input.deliverableMessages);
       const turnPrompt = queuedTurnPrompt ?? prompt;
-      const turnSource = queuedTurnPrompt ? queuedTurnPrompt.source : resolvedSource;
+      const turnSource = queuedTurnPrompt ? resolveRuntimePromptSource(turnPrompt, session) : resolvedSource;
       streamingSession.currentSource = turnSource ? { ...turnSource } : undefined;
       const replyResolution = resolveSessionOutputTarget({
         sessionKey: dbSessionKey,
         fallback: streamingSession.currentSource,
+        allowDefaultOutput: !isSessionRelayTurn(turnPrompt),
       });
       streamingSession.currentReplyTarget = replyResolution.target ? { ...replyResolution.target } : null;
       streamingSession.currentChannelBackend = turnPrompt._channelBackend;

--- a/src/runtime/session-output-target.test.ts
+++ b/src/runtime/session-output-target.test.ts
@@ -120,6 +120,21 @@ describe("resolveSessionOutputTarget", () => {
     });
   });
 
+  it("does not use the default output for a session-relay destination turn", () => {
+    const session = getOrCreateSession("agent:dev:s-relay-dest", "dev", "/tmp/dev");
+    const outputChat = makeChat("relay-default-output");
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: outputChat.id, setOutputTarget: true });
+
+    const result = resolveSessionOutputTarget({
+      sessionKey: session.sessionKey,
+      fallback: undefined,
+      allowDefaultOutput: false,
+    });
+
+    expect(result.source).toBe("unresolved");
+    expect(result.target).toBeNull();
+  });
+
   it("returns the default output for a source-less turn", () => {
     const session = getOrCreateSession("agent:dev:s-default", "dev", "/tmp/dev");
     const outputChat = makeChat("default-output");

--- a/src/runtime/session-output-target.ts
+++ b/src/runtime/session-output-target.ts
@@ -21,6 +21,13 @@ const log = logger.child("session-output-target");
 export interface ResolveSessionOutputTargetInput {
   sessionKey: string;
   fallback: MessageTarget | undefined;
+  /**
+   * Source-less turns may use the session default output attachment.
+   * Session-relay operator/HTTP/app send is a session destination: persist
+   * and `sessions.read` are the sink. Pass false so leftover lastChannel
+   * stripping cannot fall through to WhatsApp/Slack.
+   */
+  allowDefaultOutput?: boolean;
 }
 
 export type ResolveSource = "source-chat" | "attached-output" | "unresolved";
@@ -51,6 +58,10 @@ export function resolveSessionOutputTarget(input: ResolveSessionOutputTargetInpu
         chatId: sourceSubscription.chatId,
       });
     }
+    return { target: null, source: "unresolved" };
+  }
+
+  if (input.allowDefaultOutput === false) {
     return { target: null, source: "unresolved" };
   }
 

--- a/src/runtime/session-surface-hint.test.ts
+++ b/src/runtime/session-surface-hint.test.ts
@@ -7,6 +7,7 @@ import {
   persistSessionSurfaceHintOnUserRow,
   resolvePersistedUserText,
   resolveRuntimePromptText,
+  SESSION_RELAY_SURFACE_HINT,
   SOURCELESS_SURFACE_HINT,
   withSessionSurfaceHint,
 } from "./session-surface-hint.js";
@@ -42,6 +43,7 @@ describe("session surface hint", () => {
   it("keeps source-less and CLI hint builders for the model-facing header", () => {
     expect(buildSessionSurfaceHint(undefined)).toBe(SOURCELESS_SURFACE_HINT);
     expect(buildSessionSurfaceHint(undefined, { cliDestination: true })).toBe(CLI_SURFACE_HINT);
+    expect(buildSessionSurfaceHint(undefined, { sessionRelay: true })).toBe(SESSION_RELAY_SURFACE_HINT);
   });
 
   it("keeps operator CLI-only user rows raw and puts the CLI header on the runtime prompt", () => {
@@ -64,8 +66,8 @@ describe("session surface hint", () => {
     expect(resolvePersistedUserText(httpOperator)).toBe("hello from gateway");
     expect(httpOperator.prompt).not.toContain("waiting CLI");
     expect(httpOperator.prompt).not.toContain("no inbound chat");
-    expect(httpOperator._sessionSurfaceHintText).toBe(SOURCELESS_SURFACE_HINT);
-    expect(resolveRuntimePromptText(httpOperator)).toBe(`${SOURCELESS_SURFACE_HINT}\nhello from gateway`);
+    expect(httpOperator._sessionSurfaceHintText).toBe(SESSION_RELAY_SURFACE_HINT);
+    expect(resolveRuntimePromptText(httpOperator)).toBe(`${SESSION_RELAY_SURFACE_HINT}\nhello from gateway`);
     expect(
       persistSessionSurfaceHintOnUserRow({
         prompt: "hello from gateway",
@@ -82,8 +84,8 @@ describe("session surface hint", () => {
     });
     expect(resolvePersistedUserText(decorated)).toBe("operator text");
     expect(decorated.prompt).not.toContain("[session surface]");
-    expect(decorated._sessionSurfaceHintText).toBe(SOURCELESS_SURFACE_HINT);
-    expect(resolveRuntimePromptText(decorated)).toBe(`${SOURCELESS_SURFACE_HINT}\noperator text`);
+    expect(decorated._sessionSurfaceHintText).toBe(SESSION_RELAY_SURFACE_HINT);
+    expect(resolveRuntimePromptText(decorated)).toBe(`${SESSION_RELAY_SURFACE_HINT}\noperator text`);
     expect(resolveRuntimePromptText(decorated)).not.toContain("Slack chat");
   });
 

--- a/src/runtime/session-surface-hint.ts
+++ b/src/runtime/session-surface-hint.ts
@@ -1,8 +1,11 @@
 import type { RuntimeLaunchPrompt } from "./message-types.js";
-import { resolveRuntimeTurnOrigin } from "./turn-origin.js";
+import { isSessionRelayTurn } from "./turn-origin.js";
 
 export const CLI_SURFACE_HINT =
   "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.";
+
+export const SESSION_RELAY_SURFACE_HINT =
+  "[session surface] This turn has no inbound chat. A normal reply stays on this session.";
 
 export const SOURCELESS_SURFACE_HINT =
   "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.";
@@ -12,7 +15,7 @@ const CURRENT_SESSION_SURFACE_LINE = /^\[session surface\][^\n]*/i;
 
 export function buildSessionSurfaceHint(
   source: RuntimeLaunchPrompt["source"],
-  options: { cliDestination?: boolean } = {},
+  options: { cliDestination?: boolean; sessionRelay?: boolean } = {},
 ): string {
   if (hasInboundChatSource(source)) {
     const channel = formatChannelName(source.channel);
@@ -24,6 +27,10 @@ export function buildSessionSurfaceHint(
     return CLI_SURFACE_HINT;
   }
 
+  if (options.sessionRelay) {
+    return SESSION_RELAY_SURFACE_HINT;
+  }
+
   return SOURCELESS_SURFACE_HINT;
 }
 
@@ -33,7 +40,7 @@ export function buildSessionSurfaceHint(
  */
 export function persistSessionSurfaceHintOnUserRow(prompt: RuntimeLaunchPrompt): boolean {
   if (prompt._cliDestination) return false;
-  if (isSessionRelayOperatorTurn(prompt)) return false;
+  if (isSessionRelayTurn(prompt)) return false;
   return hasInboundChatSource(prompt.source);
 }
 
@@ -50,7 +57,10 @@ export function withSessionSurfaceHint(prompt: RuntimeLaunchPrompt): RuntimeLaun
 
   const persistOnUserRow = persistSessionSurfaceHintOnUserRow(prompt);
   const hintSource = persistOnUserRow ? prompt.source : undefined;
-  const hint = buildSessionSurfaceHint(hintSource, { cliDestination: prompt._cliDestination });
+  const hint = buildSessionSurfaceHint(hintSource, {
+    cliDestination: prompt._cliDestination,
+    sessionRelay: isSessionRelayTurn(prompt),
+  });
   const body = persistOnUserRow ? stripSessionSurfacePrefixes(prompt.prompt) : prompt.prompt;
   const runtimePrompt = `${hint}\n${body}`;
 
@@ -68,10 +78,6 @@ export function combineSessionSurfacePromptContents(contents: string[]): string 
   const hint = contents.map((content) => content.match(CURRENT_SESSION_SURFACE_LINE)?.[0]).find(Boolean);
   const body = contents.map(stripSessionSurfacePrefixes).join("\n\n");
   return hint ? `${hint}\n${body}` : body;
-}
-
-function isSessionRelayOperatorTurn(prompt: RuntimeLaunchPrompt): boolean {
-  return resolveRuntimeTurnOrigin(prompt._turnOrigin)?.producer === "session-relay";
 }
 
 function hasInboundChatSource(

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -9,6 +9,7 @@ import {
   getOrCreateSession,
   getSession,
   updateSessionName,
+  updateSessionSource,
   updateRuntimeProviderState,
   type AgentConfig,
   type SessionEntry,
@@ -39,7 +40,11 @@ import type { ModelBrokerAttemptFeedback } from "./model-broker.js";
 import { registerModelBroker, unregisterModelBroker } from "./model-broker-registry.js";
 import { getRuntimeLiveStateForSession } from "./live-state.js";
 import type { RuntimeRecoveryExhaustedAlertInput } from "./runtime-recovery-alert.js";
-import { buildRuntimeStartRequest, resolveRuntimeCredentialUpstreamProvider } from "./runtime-request-builder.js";
+import {
+  buildRuntimeStartRequest,
+  resolveRuntimeCredentialUpstreamProvider,
+  resolveRuntimePromptSource,
+} from "./runtime-request-builder.js";
 import { RuntimeSessionDispatcher } from "./session-dispatcher.js";
 import { resolveSessionOutputTarget } from "./session-output-target.js";
 import { buildSessionRelayTurnOrigin } from "./turn-origin.js";
@@ -1004,15 +1009,213 @@ describe("runtime session trace instrumentation", () => {
     expect(streaming.pendingMessages.map((message) => message.message.content)).toEqual([
       "active inbound turn",
       "[session surface] This turn came from the CLI. A normal reply returns to the waiting CLI.\nresponde só: pong",
-      "[session surface] This turn has no inbound chat. A normal reply uses the session default, if available.\nhello from gateway",
+      "[session surface] This turn has no inbound chat. A normal reply stays on this session.\nhello from gateway",
       "[session surface] This turn came from a Slack chat. A normal reply returns there.\nhello from slack",
     ]);
     expect(streaming.pendingMessages[1]?.launchPrompt?.prompt).toBe("responde só: pong");
     expect(streaming.pendingMessages[1]?.launchPrompt?._runtimePrompt).toContain("waiting CLI");
     expect(streaming.pendingMessages[1]?.launchPrompt?._sessionSurfaceHintText).toContain("waiting CLI");
     expect(streaming.pendingMessages[2]?.launchPrompt?.prompt).toBe("hello from gateway");
-    expect(streaming.pendingMessages[2]?.launchPrompt?._runtimePrompt).toContain("no inbound chat");
-    expect(streaming.pendingMessages[2]?.launchPrompt?._sessionSurfaceHintText).toContain("no inbound chat");
+    expect(streaming.pendingMessages[2]?.launchPrompt?._runtimePrompt).toContain("stays on this session");
+    expect(streaming.pendingMessages[2]?.launchPrompt?._sessionSurfaceHintText).toContain("stays on this session");
+  });
+
+  it("does not emit session-relay HTTP send to leftover lastChannel or default output", async () => {
+    const leftoverChat = dbUpsertChat({
+      channel: "whatsapp",
+      instanceId: "main",
+      platformChatId: "leftover-emit@s.whatsapp.net",
+      chatType: "dm",
+      title: "leftover lastChannel",
+    });
+    const inboundChat = dbUpsertChat({
+      channel: "slack",
+      instanceId: "slack-main",
+      platformChatId: "C-inbound-emit",
+      chatType: "group",
+      title: "inbound slack",
+    });
+    attachChatToSession({ sessionKey: SESSION_KEY, chatId: leftoverChat.id, setOutputTarget: true });
+    attachChatToSession({ sessionKey: SESSION_KEY, chatId: inboundChat.id, setOutputTarget: false });
+    updateSessionSource(SESSION_KEY, {
+      channel: "whatsapp",
+      accountId: "main",
+      chatId: leftoverChat.platformChatId,
+    });
+    const session = getSession(SESSION_KEY)!;
+    const leftoverSource: RuntimeMessageTarget = {
+      channel: "whatsapp",
+      accountId: "main",
+      instanceId: "main",
+      chatId: leftoverChat.platformChatId,
+      canonicalChatId: leftoverChat.id,
+    };
+    const inboundSource: RuntimeMessageTarget = {
+      channel: "slack",
+      accountId: "slack-main",
+      instanceId: "slack-main",
+      chatId: inboundChat.platformChatId,
+      canonicalChatId: inboundChat.id,
+    };
+    const relayPrompt = {
+      prompt: "hello from gateway",
+      source: leftoverSource,
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+    };
+    expect(resolveRuntimePromptSource(relayPrompt, session)).toBeUndefined();
+    expect(
+      resolveSessionOutputTarget({
+        sessionKey: SESSION_KEY,
+        fallback: leftoverSource,
+      }).source,
+    ).toBe("source-chat");
+    expect(
+      resolveSessionOutputTarget({
+        sessionKey: SESSION_KEY,
+        fallback: undefined,
+      }).target?.canonicalChatId,
+    ).toBe(leftoverChat.id);
+
+    const relayStreaming = makeStreamingSession({
+      agentMode: "active",
+      currentSource: leftoverSource,
+      pendingMessages: [createQueuedRuntimeUserMessage(relayPrompt)],
+    });
+    const provider: SessionRuntimeProvider = {
+      id: PROVIDER,
+      getCapabilities: () => capabilities,
+      startSession: () => makeRuntimeSession([]),
+    };
+    const runtimeResolution = {
+      options: { model: MODEL },
+      sources: { model: "agent_default" as const, effort: null, thinking: null },
+      hasTaskRuntimeContext: false,
+    };
+    const { runtimeRequest } = await buildRuntimeStartRequest({
+      runId: "run-session-relay-emit",
+      sessionName: SESSION_NAME,
+      prompt: relayPrompt,
+      session,
+      agent: makeAgent(),
+      runtimeProviderId: PROVIDER,
+      runtimeProvider: provider,
+      runtimeCapabilities: capabilities,
+      sessionCwd: stateDir ?? "/tmp",
+      dbSessionKey: SESSION_KEY,
+      model: MODEL,
+      runtimeResolution,
+      storedRuntimeSessionParams: undefined,
+      canResumeStoredSession: false,
+      resolvedSource: resolveRuntimePromptSource(relayPrompt, session),
+      streamingSession: relayStreaming,
+      stashedMessages: new Map(),
+      defaultRuntimeProviderId: "claude",
+      crashRecovery,
+    });
+
+    expect((await runtimeRequest.prompt.next()).done).toBe(false);
+    expect(relayStreaming.currentSource).toBeUndefined();
+    expect(relayStreaming.currentReplyTarget).toBeNull();
+
+    const relayEmits: Array<{ response?: unknown; target?: RuntimeMessageTarget }> = [];
+    const relayEmitSpy = spyOn(nats, "emit").mockImplementation(async (topic: string, data: unknown) => {
+      if (topic === `ravi.session.${SESSION_NAME}.response` && data && typeof data === "object") {
+        relayEmits.push(data as (typeof relayEmits)[number]);
+      }
+    });
+    try {
+      await runTraceLoop(
+        relayStreaming,
+        makeRuntimeSession([
+          { type: "assistant.message", text: "pong from session" },
+          {
+            type: "turn.complete",
+            providerSessionId: "provider-relay",
+            usage: { inputTokens: 1, outputTokens: 1 },
+          },
+        ]),
+      );
+    } finally {
+      relayEmitSpy.mockRestore();
+      relayStreaming.done = true;
+      relayStreaming.onTurnComplete?.();
+      await runtimeRequest.prompt.return?.(undefined);
+    }
+
+    expect(relayEmits).toEqual([]);
+    const assistantRows = getRecentHistory(SESSION_NAME, 10).filter((message) => message.role === "assistant");
+    expect(assistantRows.map((message) => message.content)).toEqual(["pong from session"]);
+
+    const inboundPrompt = {
+      prompt: "hello from slack",
+      source: inboundSource,
+    };
+    const inboundStreaming = makeStreamingSession({
+      agentMode: "active",
+      currentSource: inboundSource,
+      pendingMessages: [createQueuedRuntimeUserMessage(inboundPrompt)],
+    });
+    const inboundRequest = await buildRuntimeStartRequest({
+      runId: "run-inbound-emit",
+      sessionName: SESSION_NAME,
+      prompt: inboundPrompt,
+      session,
+      agent: makeAgent(),
+      runtimeProviderId: PROVIDER,
+      runtimeProvider: provider,
+      runtimeCapabilities: capabilities,
+      sessionCwd: stateDir ?? "/tmp",
+      dbSessionKey: SESSION_KEY,
+      model: MODEL,
+      runtimeResolution,
+      storedRuntimeSessionParams: undefined,
+      canResumeStoredSession: false,
+      resolvedSource: resolveRuntimePromptSource(inboundPrompt, session),
+      streamingSession: inboundStreaming,
+      stashedMessages: new Map(),
+      defaultRuntimeProviderId: "claude",
+      crashRecovery,
+    });
+
+    expect((await inboundRequest.runtimeRequest.prompt.next()).done).toBe(false);
+    expect(inboundStreaming.currentSource?.canonicalChatId).toBe(inboundChat.id);
+    expect(inboundStreaming.currentReplyTarget?.canonicalChatId).toBe(inboundChat.id);
+
+    const inboundEmits: Array<{ response?: unknown; target?: RuntimeMessageTarget }> = [];
+    const inboundEmitSpy = spyOn(nats, "emit").mockImplementation(async (topic: string, data: unknown) => {
+      if (topic === `ravi.session.${SESSION_NAME}.response` && data && typeof data === "object") {
+        inboundEmits.push(data as (typeof inboundEmits)[number]);
+      }
+    });
+    try {
+      await runTraceLoop(
+        inboundStreaming,
+        makeRuntimeSession([
+          { type: "assistant.message", text: "inbound slack reply" },
+          {
+            type: "turn.complete",
+            providerSessionId: "provider-inbound",
+            usage: { inputTokens: 1, outputTokens: 1 },
+          },
+        ]),
+      );
+    } finally {
+      inboundEmitSpy.mockRestore();
+      inboundStreaming.done = true;
+      inboundStreaming.onTurnComplete?.();
+      await inboundRequest.runtimeRequest.prompt.return?.(undefined);
+    }
+
+    expect(inboundEmits).toHaveLength(1);
+    expect(inboundEmits[0]).toMatchObject({
+      response: "inbound slack reply",
+      target: { canonicalChatId: inboundChat.id },
+    });
+    expect(
+      getRecentHistory(SESSION_NAME, 10)
+        .filter((message) => message.role === "assistant")
+        .map((message) => message.content),
+    ).toEqual(["pong from session", "inbound slack reply"]);
   });
 
   it("blocks invisible provider env fallback when a managed credential pool cannot resolve", async () => {

--- a/src/runtime/turn-origin.test.ts
+++ b/src/runtime/turn-origin.test.ts
@@ -3,6 +3,7 @@ import {
   buildChannelTurnOrigin,
   buildRuntimeCallerPrincipal,
   buildSessionRelayTurnOrigin,
+  isSessionRelayTurn,
   resolveRuntimeTurnOrigin,
 } from "./turn-origin.js";
 
@@ -37,6 +38,8 @@ describe("runtime turn origin", () => {
         id: "operator:local",
       },
     });
+    expect(isSessionRelayTurn({ _turnOrigin: buildSessionRelayTurnOrigin("send") })).toBe(true);
+    expect(isSessionRelayTurn({})).toBe(false);
   });
 
   it("derives the same authenticated caller principal for any internal producer", () => {

--- a/src/runtime/turn-origin.ts
+++ b/src/runtime/turn-origin.ts
@@ -70,6 +70,10 @@ export function buildChannelTurnOrigin(
  * shape, not producer identity: authenticity comes from restricting the
  * internal session-prompt bus to trusted Ravi producers.
  */
+export function isSessionRelayTurn(prompt: { _turnOrigin?: unknown } | null | undefined): boolean {
+  return resolveRuntimeTurnOrigin(prompt?._turnOrigin)?.producer === "session-relay";
+}
+
 export function resolveRuntimeTurnOrigin(value: unknown): RuntimeTurnOriginMetadata | null {
   if (!isRecord(value)) return null;
   if (value.protocol !== RUNTIME_TURN_ORIGIN_PROTOCOL || value.schemaVersion !== RUNTIME_TURN_ORIGIN_SCHEMA_VERSION) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Apply the leftover-`lastChannel` correction to **emit**, matching what #448/#451 already did for persist/hint. Operator / HTTP / app `sessions.send` (session-relay, no `--channel`/`--to`, no real inbound chat) is a **session destination** for emit too.

## Problem

#451 stopped treating leftover `lastChannel` as inbound for persist/hint, but emit still used it:

- CLI/HTTP `resolveSource` copied `session.lastChannel` + `lastTo` into `prompt.source`.
- `resolveRuntimePromptSource` fell back to `lastChannel`, which became `streaming.currentSource` and the `emitResponse` fallback.
- If that chat was attached, the reply went to WhatsApp/Slack (including production `main`).
- If there was no leftover source but the session had a default output attach, source-less emit still went there.

`tui` was already stripped so it never became an outbound target. Session-relay HTTP/app send needed the same treatment.

## Solution

- Stop copying leftover `lastChannel`/`lastTo` (and session-key derivation) into `prompt.source` unless `--channel`/`--to` is explicit.
- In `resolveRuntimePromptSource`, strip leftover lastChannel for session-relay the same way `tui` is stripped. Do not fall back to the origin chat binding.
- Resolve queued turn sources through the same function, and skip default output attach for session-relay (`allowDefaultOutput: false`).
- Chat emit stays fail-closed (`Response target unresolved — dropping emit`). Persist on `turn.complete` is unchanged.
- CLI `-w` without `--channel`/`--to` is a transcript destination even when a default output attach exists.
- HTTP session-relay surface hint now says a normal reply stays on this session.

## Practical impact

- Operator / HTTP / app `sessions.send` no longer replies to leftover WhatsApp/Slack or the default output attach.
- After the send, `sessions.read` / `getRecentHistory` still has the assistant row.
- Real inbound WhatsApp/Slack still emits to the source chat.
- CLI-only `-w` reads this turn's transcript when there is no chat emit.

## What does NOT change

- No `ravi-app` / `app` / `gateway` channel, driver, chatId, attach, or `/_stream/chats` inbox.
- No invented `from` on `SessionsSendInput`.
- No CORS, `rctx_*`, or wait:true / SSE as the destination.
- WhatsApp/Slack adapters unchanged. Sentinel unchanged.
- Persist remains independent of emit. Cron/heartbeat/follow-up source-less turns still use the default output attach.
- Explicit `--channel`/`--to` remains a chat-wait / delivered path when the source is not leftover lastChannel.

## Validation

- `bun test src/runtime/session-trace.test.ts src/runtime/runtime-request-builder.test.ts src/runtime/session-output-target.test.ts src/runtime/session-surface-hint.test.ts src/cli/session-cli-surface.test.ts src/cli/commands/sessions.test.ts`
- Allowlisted assertion in `src/runtime/session-trace.test.ts`: session-relay HTTP send does not emit to leftover lastChannel or default output; inbound Slack still emits to the source chat; persist/read still has the assistant row.
- `bun run typecheck`
- `CHANGED_FILES="$(git diff --name-only origin/dev...HEAD)" bun src/ci/run-quality-gate.ts` — spec PASSED (`sessions`, `sessions/attach`), coverage PASSED (`src/runtime/` via `session-trace.test.ts`)

## Risks

- Explicit `--channel`/`--to` that happens to equal leftover `lastChannel`+`lastTo` is treated as leftover and fail-closes for emit.
- CLI `-w` on a session that only has a default output attach now waits for transcript instead of delivered chat. That matches the new emit contract.

## Rollback

- Revert this branch / revert the merge commit on `dev`.

## Follow-ups

- None required for this correction. SDK/read can later surface session-destination metadata; that is not a new `from` field.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cac0dc4-ce88-421d-87de-5b42d3238025?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cac0dc4-ce88-421d-87de-5b42d3238025&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

