### PR TITLE
fix(runtime): prevent prompt head-of-line blocking

### DIFF
--- a/src/runtime/prompt-subscription.test.ts
+++ b/src/runtime/prompt-subscription.test.ts
@@ -12,6 +12,7 @@ interface FakePromptMessage {
   subject: string;
   ack: ReturnType<typeof mock>;
   nak: ReturnType<typeof mock>;
+  working: ReturnType<typeof mock>;
 }
 
 const fakeConsumer = {
@@ -113,7 +114,7 @@ describe("RuntimePromptSubscription", () => {
     });
 
     subscription.subscribe();
-    await waitUntil(() => !subscription.active);
+    await waitUntil(() => message.ack.mock.calls.length === 1);
 
     expect(canAcceptPrompt).toHaveBeenCalledWith("dev");
     expect(message.ack).toHaveBeenCalledTimes(1);
@@ -139,12 +140,117 @@ describe("RuntimePromptSubscription", () => {
     });
 
     subscription.subscribe();
-    await waitUntil(() => !subscription.active);
+    await waitUntil(() => message.nak.mock.calls.length === 1);
 
     expect(handlePrompt).toHaveBeenCalledTimes(1);
     expect(message.nak).toHaveBeenCalledWith(5_000);
     expect(message.ack).not.toHaveBeenCalled();
     expect(subscription.promptsReceived).toBe(0);
+  });
+
+  it("does not let a blocked background session stall prompts for another session", async () => {
+    const background = makePromptMessage("ravi.session.obs:blocked.prompt", { prompt: "background" });
+    const interactive = makePromptMessage("ravi.session.main.prompt", { prompt: "interactive" });
+    consumedMessages = [background, interactive];
+
+    let releaseBackground!: () => void;
+    const backgroundAccepted = new Promise<void>((resolve) => {
+      releaseBackground = resolve;
+    });
+    const handlePrompt = mock(async (sessionName: string) => {
+      if (sessionName === "obs:blocked") {
+        await backgroundAccepted;
+      }
+    });
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => true,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt,
+    });
+
+    subscription.subscribe();
+    const interactiveBypassedBlockedBackground = await waitUntil(() => interactive.ack.mock.calls.length === 1, 100)
+      .then(() => true)
+      .catch(() => false);
+
+    releaseBackground();
+    await waitUntil(() => background.ack.mock.calls.length === 1 && interactive.ack.mock.calls.length === 1);
+
+    expect(interactiveBypassedBlockedBackground).toBe(true);
+    expect(handlePrompt).toHaveBeenCalledWith("main", { prompt: "interactive" });
+    expect(background.nak).not.toHaveBeenCalled();
+    expect(interactive.nak).not.toHaveBeenCalled();
+  });
+
+  it("preserves prompt order within the same session while dispatch is blocked", async () => {
+    const first = makePromptMessage("ravi.session.main.prompt", { prompt: "first" });
+    const second = makePromptMessage("ravi.session.main.prompt", { prompt: "second" });
+    consumedMessages = [first, second];
+
+    let releaseFirst!: () => void;
+    const firstAccepted = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const handledPrompts: string[] = [];
+    const handlePrompt = mock(async (_sessionName: string, prompt: { prompt: string }) => {
+      handledPrompts.push(prompt.prompt);
+      if (prompt.prompt === "first") {
+        await firstAccepted;
+      }
+    });
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => true,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      markConsumerReady: mock(() => {}),
+      handlePrompt,
+    });
+
+    subscription.subscribe();
+    await waitUntil(() => handledPrompts.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(handledPrompts).toEqual(["first"]);
+    expect(second.ack).not.toHaveBeenCalled();
+
+    releaseFirst();
+    await waitUntil(() => first.ack.mock.calls.length === 1 && second.ack.mock.calls.length === 1);
+
+    expect(handledPrompts).toEqual(["first", "second"]);
+  });
+
+  it("renews the JetStream ACK deadline while dispatcher admission is pending", async () => {
+    const message = makePromptMessage("ravi.session.obs:blocked.prompt", { prompt: "background" });
+    consumedMessages = [message];
+
+    let acceptPrompt!: () => void;
+    const accepted = new Promise<void>((resolve) => {
+      acceptPrompt = resolve;
+    });
+    const subscription = new RuntimePromptSubscription({
+      isRunning: () => running,
+      canAcceptPrompt: () => true,
+      getStreamingSessionCount: () => 0,
+      ensurePromptInfrastructure: ensureInfrastructureMock,
+      promptAckProgressIntervalMs: 5,
+      markConsumerReady: mock(() => {}),
+      handlePrompt: async () => accepted,
+    });
+
+    subscription.subscribe();
+    await waitUntil(() => message.working.mock.calls.length > 0);
+
+    expect(message.ack).not.toHaveBeenCalled();
+    acceptPrompt();
+    await waitUntil(() => message.ack.mock.calls.length === 1);
+    const renewalsAfterAck = message.working.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    expect(message.working).toHaveBeenCalledTimes(renewalsAfterAck);
   });
 
   it("NAKs and stops the pull before ACK or dispatch when intake is fenced", async () => {
@@ -178,6 +284,7 @@ function makePromptMessage(subject: string, prompt: Record<string, unknown>): Fa
     data: new TextEncoder().encode(JSON.stringify(prompt)),
     ack: mock(() => {}),
     nak: mock(() => {}),
+    working: mock(() => {}),
   };
 }
 

--- a/src/runtime/prompt-subscription.ts
+++ b/src/runtime/prompt-subscription.ts
@@ -1,4 +1,4 @@
-import { StringCodec } from "nats";
+import { StringCodec, type JsMsg } from "nats";
 import { getNats, nats } from "../nats.js";
 import {
   SESSION_STREAM,
@@ -13,6 +13,7 @@ import type { RuntimeSessionPoolSnapshot } from "./session-pool.js";
 
 const log = logger.child("runtime:prompt-subscription");
 const PROMPT_DISPATCH_RETRY_DELAY_MS = 5_000;
+const PROMPT_ACK_PROGRESS_INTERVAL_MS = 30_000;
 
 export interface RuntimePromptSubscriptionOptions {
   isRunning(): boolean;
@@ -20,6 +21,7 @@ export interface RuntimePromptSubscriptionOptions {
   getStreamingSessionCount(): number;
   getRuntimeSessionPoolSnapshot?(): RuntimeSessionPoolSnapshot;
   ensurePromptInfrastructure?(options?: EnsureSessionPromptInfrastructureOptions): Promise<void>;
+  promptAckProgressIntervalMs?: number;
   markConsumerReady(): void;
   handlePrompt(sessionName: string, prompt: RuntimeLaunchPrompt): Promise<void>;
 }
@@ -29,6 +31,7 @@ export class RuntimePromptSubscription {
   promptsReceived = 0;
   private healthTimer: ReturnType<typeof setInterval> | null = null;
   private healthProbeInFlight = false;
+  private readonly sessionDispatchTails = new Map<string, Promise<void>>();
 
   constructor(private readonly options: RuntimePromptSubscriptionOptions) {}
 
@@ -144,49 +147,10 @@ export class RuntimePromptSubscription {
               break;
             }
 
-            try {
-              // Keep the JetStream work item durable until the dispatcher has
-              // accepted the prompt. Provider/bootstrap failures can happen
-              // before a turn exists, so acknowledging earlier loses the only
-              // retryable copy.
-              await this.options.handlePrompt(sessionName, prompt);
-            } catch (error) {
-              log.error("Failed to handle prompt before acknowledgement", {
-                sessionName,
-                subject: msg.subject,
-                retryDelayMs: PROMPT_DISPATCH_RETRY_DELAY_MS,
-                error,
-              });
-              msg.nak(PROMPT_DISPATCH_RETRY_DELAY_MS);
-              continue;
-            }
-
-            msg.ack();
-            this.promptsReceived++;
-
-            nats
-              .emit(`ravi.session.${sessionName}.runtime`, {
-                type: "prompt.received",
-                sessionName,
-                prompt: prompt.prompt,
-                source: prompt.source,
-                context: prompt.context,
-                deliveryBarrier: prompt.deliveryBarrier,
-                deliveryBarrierSource: prompt.deliveryBarrierSource,
-                taskBarrierTaskId: prompt.taskBarrierTaskId,
-                commands: prompt.commands,
-                observation: prompt._observation,
-                turnProvenance: classifyTurnProvenance({ prompt }),
-                thread: prompt._thread,
-                _agentId: prompt._agentId,
-                timestamp: new Date().toISOString(),
-              })
-              .catch((error) => {
-                log.warn("Failed to emit prompt audit event", {
-                  sessionName,
-                  error,
-                });
-              });
+            // Dispatcher admission can wait indefinitely for a runtime slot.
+            // Keep ordering within one session, but never let that wait block
+            // unrelated interactive sessions behind it in the shared consumer.
+            this.schedulePromptDispatch(sessionName, prompt, msg);
           }
 
           if (!this.options.isRunning() || intakeFenced) {
@@ -237,6 +201,119 @@ export class RuntimePromptSubscription {
       .catch((error) => {
         log.warn("Failed to emit runtime session pool gauge", { error });
       });
+  }
+
+  private schedulePromptDispatch(sessionName: string, prompt: RuntimeLaunchPrompt, msg: JsMsg): void {
+    const previous = this.sessionDispatchTails.get(sessionName) ?? Promise.resolve();
+    const progressTimer = setInterval(() => {
+      try {
+        msg.working();
+      } catch (error) {
+        log.warn("Failed to renew pending prompt acknowledgement", {
+          sessionName,
+          subject: msg.subject,
+          error,
+        });
+      }
+    }, this.options.promptAckProgressIntervalMs ?? PROMPT_ACK_PROGRESS_INTERVAL_MS);
+    progressTimer.unref?.();
+
+    let dispatch!: Promise<void>;
+    dispatch = previous
+      .then(() => this.dispatchPrompt(sessionName, prompt, msg))
+      .catch((error) => {
+        log.error("Unexpected prompt dispatch lane failure", {
+          sessionName,
+          subject: msg.subject,
+          error,
+        });
+        try {
+          msg.nak(PROMPT_DISPATCH_RETRY_DELAY_MS);
+        } catch (nakError) {
+          log.warn("Failed to NAK prompt after dispatch lane failure", {
+            sessionName,
+            subject: msg.subject,
+            error: nakError,
+          });
+        }
+      })
+      .finally(() => {
+        clearInterval(progressTimer);
+        if (this.sessionDispatchTails.get(sessionName) === dispatch) {
+          this.sessionDispatchTails.delete(sessionName);
+        }
+      });
+    this.sessionDispatchTails.set(sessionName, dispatch);
+    void dispatch;
+  }
+
+  private async dispatchPrompt(sessionName: string, prompt: RuntimeLaunchPrompt, msg: JsMsg): Promise<void> {
+    try {
+      // Keep the JetStream work item durable until the dispatcher has accepted
+      // it. Provider/bootstrap failures can happen before a turn exists, so
+      // acknowledging earlier loses the only retryable copy.
+      await this.options.handlePrompt(sessionName, prompt);
+    } catch (error) {
+      log.error("Failed to handle prompt before acknowledgement", {
+        sessionName,
+        subject: msg.subject,
+        retryDelayMs: PROMPT_DISPATCH_RETRY_DELAY_MS,
+        error,
+      });
+      try {
+        msg.nak(PROMPT_DISPATCH_RETRY_DELAY_MS);
+      } catch (nakError) {
+        log.warn("Failed to NAK rejected prompt", {
+          sessionName,
+          subject: msg.subject,
+          error: nakError,
+        });
+      }
+      return;
+    }
+
+    try {
+      msg.ack();
+    } catch (error) {
+      log.warn("Failed to ACK accepted prompt", {
+        sessionName,
+        subject: msg.subject,
+        error,
+      });
+      return;
+    }
+    this.promptsReceived++;
+
+    try {
+      nats
+        .emit(`ravi.session.${sessionName}.runtime`, {
+          type: "prompt.received",
+          sessionName,
+          prompt: prompt.prompt,
+          source: prompt.source,
+          context: prompt.context,
+          deliveryBarrier: prompt.deliveryBarrier,
+          deliveryBarrierSource: prompt.deliveryBarrierSource,
+          taskBarrierTaskId: prompt.taskBarrierTaskId,
+          commands: prompt.commands,
+          observation: prompt._observation,
+          turnProvenance: classifyTurnProvenance({ prompt }),
+          thread: prompt._thread,
+          _agentId: prompt._agentId,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((error) => {
+          log.warn("Failed to emit prompt audit event", {
+            sessionName,
+            error,
+          });
+        });
+    } catch (error) {
+      log.warn("Failed to emit prompt audit event", {
+        sessionName,
+        error,
+      });
+    }
   }
 
   private ensurePromptInfrastructureForHealthCheck(): void {


### PR DESCRIPTION
## Objective

Prevent a runtime prompt waiting for session-pool capacity from freezing every prompt behind it in the shared JetStream consumer. This fixes the production failure where Slack inbound reached `prompt.published` but never reached `adapter.request` until the daemon restarted.

## Problem

- The prompt subscription awaited `handlePrompt()` inline inside the single shared consumer loop.
- A background observer cold start can wait indefinitely in `reserveRuntimeSessionStart()` when the background pool is saturated.
- That wait caused global head-of-line blocking: unrelated interactive Slack prompts remained unconsumed even though routing, Slack sockets, and NATS were healthy.
- In the incident, an observer queued at 14:31 and later Slack prompts stayed at `prompt.published` for more than 20 minutes.

## Solution

- Dispatch prompts through independent per-session promise lanes instead of awaiting dispatcher admission in the global consumer loop.
- Preserve strict ordering within each session while allowing unrelated sessions to continue.
- Keep each JetStream message unacknowledged until its dispatcher call succeeds.
- Send JetStream progress ACKs while admission is pending so long waits do not trigger duplicate redelivery.
- NAK failures with the existing retry delay and contain unexpected lane failures.

## Practical impact

- A saturated observer/task/background session can no longer make all Slack and other channel sessions appear offline.
- Interactive prompts continue to reach the provider while background work waits for capacity.

## What does NOT change

- Prompt order within a session.
- ACK-after-dispatch durability semantics.
- Runtime pool limits, reserved interactive capacity, routing, provider selection, or Slack behavior.

## Validation

- Added a regression that fails on the previous implementation by blocking a background session ahead of an interactive session.
- Added coverage for same-session ordering and JetStream ACK deadline renewal.
- `bun test src/runtime/prompt-subscription.test.ts src/runtime/session-dispatcher.test.ts src/bot.runtime-guards.test.ts` — 64 passed.
- `bun run typecheck` — passed.
- `bun run build` — passed.
- Pre-push full test suite — passed.
- Biome check for both changed files — passed.
- `make quality` still reports 16 pre-existing Biome failures on unchanged `origin/dev` files.

## Risks

- Prompts for different sessions can now enter dispatcher admission concurrently; runtime pool admission remains the authority for actual starts.
- JetStream can hold more in-flight unacknowledged messages, bounded by the consumer's existing `max_ack_pending` setting.

## Rollback

- Revert this commit to restore the previous sequential consumer behavior. A daemon restart remains the operational mitigation if head-of-line blocking recurs after rollback.

## Follow-ups

- Add a production health signal for the age and count of pending per-session dispatch lanes.
