### PR TITLE
fix(cli): let isolated media send reach the host gateway with context source

### DIFF
--- a/src/cli/media-send.test.ts
+++ b/src/cli/media-send.test.ts
@@ -9,7 +9,9 @@ mock.module("../config-store.js", () => ({
   },
 }));
 
-const { sendMediaWithOmniCli } = await import("./media-send.js");
+import { runWithContext } from "./context.js";
+
+const { sendMediaWithOmniCli, resolveMediaSendTarget } = await import("./media-send.js");
 
 const ORIGINAL_PATH = process.env.PATH ?? "";
 const tempDirs: string[] = [];
@@ -19,6 +21,30 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("resolveMediaSendTarget", () => {
+  it("resolves account and chat from tool context source without --account/--to", () => {
+    const target = runWithContext(
+      {
+        source: {
+          channel: "whatsapp-baileys",
+          accountId: "acct-media",
+          chatId: "group:120363425628305127",
+          threadId: "thread-1",
+        },
+      },
+      () => resolveMediaSendTarget(),
+    );
+
+    expect(target).toEqual({
+      channel: "whatsapp-baileys",
+      accountId: "acct-media",
+      instanceId: "acct-media",
+      chatId: "120363425628305127@g.us",
+      threadId: "thread-1",
+    });
+  });
 });
 
 describe("sendMediaWithOmniCli", () => {

--- a/src/cli/registry-snapshot.test.ts
+++ b/src/cli/registry-snapshot.test.ts
@@ -12,7 +12,7 @@ import {
   getCommandAccessMetadata,
   getReturnsMetadata,
 } from "./decorators.js";
-import { buildRegistry } from "./registry-snapshot.js";
+import { buildRegistry, omitRenderingFlags } from "./registry-snapshot.js";
 import {
   inferRaviCommandSkillGate,
   inferRaviToolSkillGate,
@@ -153,6 +153,26 @@ describe("buildRegistry", () => {
     // Non-rendering options (tag, items) survive.
     expect(optionNames).toContain("tag");
     expect(optionNames).toContain("items");
+  });
+
+  it("omits rendering flags from a remote body while keeping other fields", () => {
+    expect(
+      omitRenderingFlags({
+        file: "/tmp/img.png",
+        caption: "hello",
+        execute: true,
+        json: true,
+        asJson: true,
+        pretty: true,
+        noColor: true,
+        quiet: true,
+        verbose: true,
+      }),
+    ).toEqual({
+      file: "/tmp/img.png",
+      caption: "hello",
+      execute: true,
+    });
   });
 
   it("captures @Returns schema on the command entry", () => {

--- a/src/cli/registry-snapshot.ts
+++ b/src/cli/registry-snapshot.ts
@@ -40,10 +40,15 @@ export type CommandClass = new () => object;
  * caller speaks is structured JSON; the rendering choice is the consumer's
  * problem.
  */
-const RENDERING_FLAG_NAMES = new Set(["json", "asJson", "pretty", "noColor", "quiet", "verbose"]);
+export const RENDERING_FLAG_NAMES = new Set(["json", "asJson", "pretty", "noColor", "quiet", "verbose"]);
 
 function isRenderingFlag(opt: { name: string }): boolean {
   return RENDERING_FLAG_NAMES.has(opt.name);
+}
+
+/** Drop CLI rendering flags from a remote gateway body. Keep them locally for stdout. */
+export function omitRenderingFlags(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([key]) => !RENDERING_FLAG_NAMES.has(key)));
 }
 
 export interface ArgRegistryEntry {

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -208,6 +208,49 @@ describe("registerCommands", () => {
     ]);
   });
 
+  it("omits --json from the remote gateway body while keeping it for local rendering", async () => {
+    const program = new CommanderCommand();
+    program.exitOverride();
+    registerCommands(program, [ShadowDirectCommands]);
+
+    const previousGatewayUrl = process.env.RAVI_GATEWAY_URL;
+    const previousContextKey = process.env.RAVI_CONTEXT_KEY;
+    const previousSuppressAudit = process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+    const originalFetch = globalThis.fetch;
+    const originalLog = console.log;
+    const originalExit = process.exit;
+    const bodies: unknown[] = [];
+
+    process.env.RAVI_GATEWAY_URL = "https://gateway.example.test";
+    process.env.RAVI_CONTEXT_KEY = "rctx_remote_only";
+    process.env.RAVI_SUPPRESS_AUDIT_EVENTS = "1";
+    globalThis.fetch = (async (_input, init) => {
+      bodies.push(JSON.parse(String(init?.body ?? "{}")));
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    console.log = () => {};
+    process.exit = ((code?: number) => {
+      throw new Error(`unexpected process.exit(${code})`);
+    }) as typeof process.exit;
+
+    try {
+      await runWithContext({}, () => program.parseAsync(["node", "test", "shadow", "item", "demo", "--json"]));
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.log = originalLog;
+      process.exit = originalExit;
+      if (previousGatewayUrl === undefined) delete process.env.RAVI_GATEWAY_URL;
+      else process.env.RAVI_GATEWAY_URL = previousGatewayUrl;
+      if (previousContextKey === undefined) delete process.env.RAVI_CONTEXT_KEY;
+      else process.env.RAVI_CONTEXT_KEY = previousContextKey;
+      if (previousSuppressAudit === undefined) delete process.env.RAVI_SUPPRESS_AUDIT_EVENTS;
+      else process.env.RAVI_SUPPRESS_AUDIT_EVENTS = previousSuppressAudit;
+    }
+
+    expect(bodies).toEqual([{ id: "demo" }]);
+    expect(JSON.stringify(bodies)).not.toContain('"json"');
+  });
+
   it("renders a projected contract instead of a raw non-success remote body", async () => {
     const program = new CommanderCommand();
     program.exitOverride();

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -31,6 +31,7 @@ import { cloudErrorToContractError, commandOperation, renderCloudContractError }
 import { enforceCliCommandAuthorization, redactCommandAccessInput } from "./command-access.js";
 import { emitCliAuditEvent } from "./audit.js";
 import { getContext, runWithContext } from "./context.js";
+import { omitRenderingFlags } from "./registry-snapshot.js";
 import {
   dispatchRemote,
   resolveRemoteGatewayConfig,
@@ -391,7 +392,7 @@ async function dispatchRemoteCommand(input: DispatchRemoteCommandInput): Promise
     result = await dispatchRemote({
       groupSegments: input.groupSegments,
       command: input.command,
-      body: input.input,
+      body: omitRenderingFlags(input.input),
       config: input.config,
       contextKey,
     });

--- a/src/sdk/gateway/dispatcher.test.ts
+++ b/src/sdk/gateway/dispatcher.test.ts
@@ -104,7 +104,11 @@ class GatewayDemoCommands {
   @CommandAccess({ kind: "read", resource: "demo", action: "context", risk: "low" })
   context() {
     console.log("human CLI output should not leak through the SDK gateway");
-    return { suppressCliOutput: getContext()?.suppressCliOutput === true };
+    const ctx = getContext();
+    return {
+      suppressCliOutput: ctx?.suppressCliOutput === true,
+      ...(ctx?.source ? { source: ctx.source } : {}),
+    };
   }
 
   @Command({ name: "broken", description: "Returns wrong shape" })
@@ -961,6 +965,28 @@ describe("dispatch — CLI output", () => {
       suppressCliOutput: boolean;
     };
     expect(body.suppressCliOutput).toBe(true);
+  });
+
+  it("exposes context record source on the gateway tool context", async () => {
+    const contextWithSource = {
+      ...demoContext,
+      source: {
+        channel: "whatsapp-baileys",
+        accountId: "acct-1",
+        chatId: "group:120363425628305127",
+        threadId: "thread-1",
+      },
+    };
+    const result = await dispatch(findCmd("demo.context"), {}, {}, { contextRecord: contextWithSource });
+    const body = (await result.response.json()) as {
+      source?: { channel: string; accountId: string; chatId: string; threadId?: string };
+    };
+    expect(body.source).toEqual({
+      channel: "whatsapp-baileys",
+      accountId: "acct-1",
+      chatId: "group:120363425628305127",
+      threadId: "thread-1",
+    });
   });
 
   it("does not render a ContractError into gateway process logs", async () => {

--- a/src/sdk/gateway/dispatcher.ts
+++ b/src/sdk/gateway/dispatcher.ts
@@ -487,6 +487,14 @@ function asToolContext(scope: ScopeContext, record: ContextRecord | null): ToolC
   if (record) {
     ctx.contextId = record.contextId;
     ctx.context = record;
+    if (record.source) {
+      ctx.source = {
+        channel: record.source.channel,
+        accountId: record.source.accountId,
+        chatId: record.source.chatId,
+        ...(record.source.threadId ? { threadId: record.source.threadId } : {}),
+      };
+    }
   }
   return ctx;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Let isolated agent CLIs that auto-bridge to the host CLI gateway (`RAVI_CONTEXT_KEY` + `~/.ravi/cli-gateway.sock`) run `ravi media send <file> --caption ... --execute --json` and have the gateway accept the body while still resolving account/chat from the context record.

## Problem

- Isolated CLI `--json` was POSTed as `json: true`. The gateway snapshot already strips rendering flags, so `normalizeBody` rejected the unknown key with HTTP 400 (`Remote gateway rejected the command input`).
- `asToolContext` bound `ctx.context = record` but never copied `record.source` onto `ctx.source`. `getContext()` returns the ALS store as-is, so `resolveMediaSendTarget` threw `No target context available`.

## Solution

- Strip `RENDERING_FLAG_NAMES` (`json`, `asJson`, `pretty`, `noColor`, `quiet`, `verbose`) from the remote POST body. Keep `input.json` locally so the CLI can still render JSON. Do not add `json` back to the gateway snapshot.
- Copy `record.source` onto `ctx.source` (`channel`, `accountId`, `chatId`, `threadId`). Do not require `--account` / `--to`.

## Practical impact

- Isolated agents can send media through the host unix gateway with `--json --execute` using the context record's account/chat.

## What does NOT change

- No ravi-app channel, CORS, `from`, wait, Grok, or session-relay emit work.
- No WhatsApp/Omni adapter changes.
- `--account` / `--to` remain optional overrides, not the fix.
- `json` stays out of the gateway snapshot.
- Patch 3 (project remote `error.issues` / keep `Invalid input for ${op}.`) is omitted. `remote-gateway.test.ts` currently asserts projected envelopes must not contain `issues`, and a safe projection would need new allowlist rules plus a locked message change.

## Validation

- `bun test src/cli/registry-snapshot.test.ts src/cli/registry.test.ts src/sdk/gateway/dispatcher.test.ts src/cli/media-send.test.ts src/cli/remote-gateway.test.ts` — 97 pass
- `bun test src/cli/host-cli-gateway.test.ts` — 2 pass
- `bun test src/cli/commands/media-json.test.ts` — 22 pass
- `bun tsc --noEmit` — pass
- `GITHUB_BASE_REF=dev bun src/ci/run-quality-gate.ts` — pass
- New coverage: remote body has no `json` when `--json` was set; `asToolContext` exposes `source` from the record; media send target resolves from that source

## Risks

- Remote bodies lose rendering-only keys only. Command contract fields are unchanged.
- Tool context now exposes source when the record has one; commands that already read `getContext()?.source` pick it up.

## Rollback

Revert this PR. Isolated media send again POSTs `json: true` (HTTP 400) and `asToolContext` no longer copies `record.source`, so implicit account/chat disappear.

## Follow-ups

- Optional: project already-redacted remote `issues` (`path: "<unknown>"`) without fighting the privacy tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f402f16-7f08-4dbc-b0a2-39d63df01136?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f402f16-7f08-4dbc-b0a2-39d63df01136&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>