### PR TITLE
feat(context): allow admin identity delegation

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "291f4dbeee37152e"
+    "version": "22c5ed4d95d64f27"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -29251,6 +29251,18 @@
                 "properties": {
                   "allow": {
                     "description": "Comma-separated permission:objectType:objectId entries to lease to the child context",
+                    "type": "string"
+                  },
+                  "asAgent": {
+                    "description": "Admin-only: delegate the child context to an explicit agent identity",
+                    "type": "string"
+                  },
+                  "asSessionKey": {
+                    "description": "Admin-only: bind the delegated identity to an explicit session key",
+                    "type": "string"
+                  },
+                  "asSessionName": {
+                    "description": "Admin-only: bind the delegated identity to an explicit session name",
                     "type": "string"
                   },
                   "cliName": {

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "291f4dbeee37152e"
+    "version": "22c5ed4d95d64f27"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -29251,6 +29251,18 @@
                 "properties": {
                   "allow": {
                     "description": "Comma-separated permission:objectType:objectId entries to lease to the child context",
+                    "type": "string"
+                  },
+                  "asAgent": {
+                    "description": "Admin-only: delegate the child context to an explicit agent identity",
+                    "type": "string"
+                  },
+                  "asSessionKey": {
+                    "description": "Admin-only: bind the delegated identity to an explicit session key",
+                    "type": "string"
+                  },
+                  "asSessionName": {
+                    "description": "Admin-only: bind the delegated identity to an explicit session name",
                     "type": "string"
                   },
                   "cliName": {

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
@@ -25163,6 +25163,18 @@ class RaviSchemas {
       "description": "Comma-separated permission:objectType:objectId entries to lease to the child context",
       "type": "string"
     },
+    "asAgent": {
+      "description": "Admin-only: delegate the child context to an explicit agent identity",
+      "type": "string"
+    },
+    "asSessionKey": {
+      "description": "Admin-only: bind the delegated identity to an explicit session key",
+      "type": "string"
+    },
+    "asSessionName": {
+      "description": "Admin-only: bind the delegated identity to an explicit session name",
+      "type": "string"
+    },
     "cliName": {
       "description": "Logical CLI name for audit and lineage",
       "type": "string"

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_types.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_types.generated.dart
@@ -5168,15 +5168,27 @@ class ContextInfoReturn {
 ContextInfoReturn contextInfoReturnFromJson(Object? json) => ContextInfoReturn.fromJsonValue(json);
 
 class ContextIssueOptions {
-  const ContextIssueOptions({this.allow, this.inherit, this.ttl});
+  const ContextIssueOptions({this.allow, this.asAgent, this.asSessionKey, this.asSessionName, this.inherit, this.ttl});
 
   final String? allow;
+  final String? asAgent;
+  final String? asSessionKey;
+  final String? asSessionName;
   final bool? inherit;
   final String? ttl;
 
   void encodeBody(Map<String, RaviJson> into) {
     if (allow != null) {
       into["allow"] = RaviJson.from(allow);
+    }
+    if (asAgent != null) {
+      into["asAgent"] = RaviJson.from(asAgent);
+    }
+    if (asSessionKey != null) {
+      into["asSessionKey"] = RaviJson.from(asSessionKey);
+    }
+    if (asSessionName != null) {
+      into["asSessionName"] = RaviJson.from(asSessionName);
     }
     if (inherit != null) {
       into["inherit"] = RaviJson.from(inherit);

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk dart check`.
 
 const raviSdkVersion = "0.1.0";
-const raviRegistryHash = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce";
-const raviGitSha = "3b8c64919d3d";
+const raviRegistryHash = "sha256:d3d3c1908ac7fab33f38840a491da6c6a9cdc8daa557e589eba93e80c6dfce0f";
+const raviGitSha = "f44cc9e9c8f0";

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -1754,6 +1754,9 @@ export class RaviClient {
     /** Issue a least-privilege child context for an external CLI */
     issue: async (cliName: string, options?: {
       allow?: string;
+      asAgent?: string;
+      asSessionKey?: string;
+      asSessionName?: string;
       inherit?: boolean;
       ttl?: string;
     }): Promise<ContextIssueReturn> => {

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -24896,6 +24896,18 @@ export const ContextIssueInputSchema = {
       "description": "Comma-separated permission:objectType:objectId entries to lease to the child context",
       "type": "string"
     },
+    "asAgent": {
+      "description": "Admin-only: delegate the child context to an explicit agent identity",
+      "type": "string"
+    },
+    "asSessionKey": {
+      "description": "Admin-only: bind the delegated identity to an explicit session key",
+      "type": "string"
+    },
+    "asSessionName": {
+      "description": "Admin-only: bind the delegated identity to an explicit session name",
+      "type": "string"
+    },
     "cliName": {
       "description": "Logical CLI name for audit and lineage",
       "type": "string"

--- a/packages/ravi-os-sdk/src/types.ts
+++ b/packages/ravi-os-sdk/src/types.ts
@@ -4740,6 +4740,9 @@ export type ContextInfoReturn = {
 /** Input shape for `context.issue`. */
 export type ContextIssueInput = {
   allow?: string;
+  asAgent?: string;
+  asSessionKey?: string;
+  asSessionName?: string;
   cliName: string;
   inherit?: boolean;
   ttl?: string;

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce";
+export const REGISTRY_HASH = "sha256:d3d3c1908ac7fab33f38840a491da6c6a9cdc8daa557e589eba93e80c6dfce0f";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "3b8c64919d3d";
+export const GIT_SHA = "d00fb909b401";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -25163,6 +25163,18 @@ public enum RaviSchemas {
         "description": "Comma-separated permission:objectType:objectId entries to lease to the child context",
         "type": "string"
       },
+      "asAgent": {
+        "description": "Admin-only: delegate the child context to an explicit agent identity",
+        "type": "string"
+      },
+      "asSessionKey": {
+        "description": "Admin-only: bind the delegated identity to an explicit session key",
+        "type": "string"
+      },
+      "asSessionName": {
+        "description": "Admin-only: bind the delegated identity to an explicit session name",
+        "type": "string"
+      },
       "cliName": {
         "description": "Logical CLI name for audit and lineage",
         "type": "string"

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviTypes.generated.swift
@@ -6128,17 +6128,26 @@ public struct ContextInfoReturn: Codable, Sendable {
 
 public struct ContextIssueOptions: Codable, Sendable {
   public var allow: String?
+  public var asAgent: String?
+  public var asSessionKey: String?
+  public var asSessionName: String?
   public var inherit: Bool?
   public var ttl: String?
 
-  public init(allow: String? = nil, inherit: Bool? = nil, ttl: String? = nil) {
+  public init(allow: String? = nil, asAgent: String? = nil, asSessionKey: String? = nil, asSessionName: String? = nil, inherit: Bool? = nil, ttl: String? = nil) {
     self.allow = allow
+    self.asAgent = asAgent
+    self.asSessionKey = asSessionKey
+    self.asSessionName = asSessionName
     self.inherit = inherit
     self.ttl = ttl
   }
 
   enum CodingKeys: String, CodingKey {
     case allow = "allow"
+    case asAgent = "asAgent"
+    case asSessionKey = "asSessionKey"
+    case asSessionName = "asSessionName"
     case inherit = "inherit"
     case ttl = "ttl"
   }
@@ -6146,6 +6155,15 @@ public struct ContextIssueOptions: Codable, Sendable {
   func encodeBody(into body: inout [String: RaviJSON]) throws {
     if let value = self.allow {
       body["allow"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.asAgent {
+      body["asAgent"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.asSessionKey {
+      body["asSessionKey"] = try RaviJSON.fromEncodable(value)
+    }
+    if let value = self.asSessionName {
+      body["asSessionName"] = try RaviJSON.fromEncodable(value)
     }
     if let value = self.inherit {
       body["inherit"] = try RaviJSON.fromEncodable(value)

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:0f033390bab0a2919f04ab0722e0ee33f8985f71da53c9461337dfebb8d79bce"
-public let RAVI_GIT_SHA = "3b8c64919d3d"
+public let RAVI_REGISTRY_HASH = "sha256:d3d3c1908ac7fab33f38840a491da6c6a9cdc8daa557e589eba93e80c6dfce0f"
+public let RAVI_GIT_SHA = "4d65c8e6237c"

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -31,7 +31,13 @@ import {
   getContextLineage,
   RAVI_CONTEXT_KEY_ENV,
 } from "../../runtime/context-registry.js";
-import { dbGetContext, dbListContexts, dbPruneContexts, type ContextRecord } from "../../router/router-db.js";
+import {
+  dbGetAgent,
+  dbGetContext,
+  dbListContexts,
+  dbPruneContexts,
+  type ContextRecord,
+} from "../../router/router-db.js";
 import { listSessions, resolveSession } from "../../router/sessions.js";
 import { buildRuntimeSessionVisibilityPayload } from "../../runtime/session-visibility.js";
 import {
@@ -389,14 +395,31 @@ export class ContextCommands {
     ttl?: string,
     @Option({ flags: "--inherit", description: "Inherit all capabilities from the current context" }) inherit = false,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson = false,
+    @Option({
+      flags: "--as-agent <id>",
+      description: "Admin-only: delegate the child context to an explicit agent identity",
+    })
+    asAgent?: string,
+    @Option({
+      flags: "--as-session-key <key>",
+      description: "Admin-only: bind the delegated identity to an explicit session key",
+    })
+    asSessionKey?: string,
+    @Option({
+      flags: "--as-session-name <name>",
+      description: "Admin-only: bind the delegated identity to an explicit session name",
+    })
+    asSessionName?: string,
   ) {
     const parent = this.requireResolvedContext();
+    const identity = parseDelegatedIdentity(asAgent, asSessionKey, asSessionName);
     const child = issueRuntimeContext({
       parent,
       cliName,
       capabilities: parseCapabilityList(allow),
       ttlMs: parseDurationMs(ttl),
       inheritCapabilities: inherit,
+      identity,
     });
 
     const payload: ContextIssuePayload = {
@@ -1276,6 +1299,34 @@ function parseDurationMs(input: string | undefined): number | undefined {
   if (unit === "d") return value * 86_400_000;
 
   fail(`Invalid duration: "${input}". Expected 30m, 2h or 1d`);
+}
+
+function parseDelegatedIdentity(
+  agentInput: string | undefined,
+  sessionKeyInput: string | undefined,
+  sessionNameInput: string | undefined,
+): { agentId: string; sessionKey?: string; sessionName?: string } | undefined {
+  const agentId = agentInput?.trim();
+  const sessionKey = sessionKeyInput?.trim();
+  const sessionName = sessionNameInput?.trim();
+  if (!agentId && !sessionKey && !sessionName) return undefined;
+  if (!agentId) fail("--as-agent is required when delegating a context identity");
+  if (Boolean(sessionKey) !== Boolean(sessionName)) {
+    fail("--as-session-key and --as-session-name must be provided together");
+  }
+  if (!dbGetAgent(agentId)) fail(`Agent not found: ${agentId}`);
+  if (sessionKey && !sessionKey.startsWith(`agent:${agentId}:`)) {
+    fail(`Delegated session key must belong to agent ${agentId}`);
+  }
+  const existingSession = sessionKey ? resolveSession(sessionKey) : sessionName ? resolveSession(sessionName) : null;
+  if (existingSession && existingSession.agentId !== agentId) {
+    fail(`Delegated session does not belong to agent ${agentId}`);
+  }
+  return {
+    agentId,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(sessionName ? { sessionName } : {}),
+  };
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/runtime/context-registry.test.ts
+++ b/src/runtime/context-registry.test.ts
@@ -300,6 +300,59 @@ describe("runtime context registry", () => {
     ).toThrow("Capability not granted by parent context");
   });
 
+  it("lets an admin parent delegate an explicit service identity", () => {
+    getOrCreateSession("agent:main:main", "main", "/tmp/ravi-main", { name: "main" });
+    const parent = createRuntimeContext({
+      kind: ADMIN_BOOTSTRAP_KIND,
+      agentId: TEST_AGENT_ID,
+      capabilities: [
+        { permission: "admin", objectType: "system", objectId: "*" },
+        { permission: "access", objectType: "session", objectId: "main" },
+      ],
+    });
+
+    const child = issueRuntimeContext({
+      parent,
+      cliName: "hub-client-issuer",
+      capabilities: [{ permission: "access", objectType: "session", objectId: "main" }],
+      identity: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionName: "main",
+      },
+    });
+
+    expect(child.agentId).toBe("main");
+    expect(child.sessionKey).toBe("agent:main:main");
+    expect(child.sessionName).toBe("main");
+    expect(child.source).toBeUndefined();
+    expect(child.metadata).toMatchObject({
+      parentContextId: parent.contextId,
+      issuedFor: "hub-client-issuer",
+      identityDelegation: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionName: "main",
+      },
+    });
+  });
+
+  it("rejects identity delegation from a non-admin parent", () => {
+    const parent = createRuntimeContext({
+      agentId: TEST_AGENT_ID,
+      capabilities: [{ permission: "access", objectType: "session", objectId: "main" }],
+    });
+
+    expect(() =>
+      issueRuntimeContext({
+        parent,
+        cliName: "hub-client-issuer",
+        capabilities: [{ permission: "access", objectType: "session", objectId: "main" }],
+        identity: { agentId: "main" },
+      }),
+    ).toThrow("Identity delegation requires admin:system:*");
+  });
+
   it("cascades revocation to descendants with a single shared revokedAt", () => {
     const parent = createRuntimeContext({
       kind: "agent-runtime",

--- a/src/runtime/context-registry.ts
+++ b/src/runtime/context-registry.ts
@@ -52,6 +52,15 @@ export interface IssueRuntimeContextInput {
   metadata?: Record<string, unknown>;
   ttlMs?: number;
   inheritCapabilities?: boolean;
+  /**
+   * Explicit identity delegation for a service issuer. This is intentionally
+   * admin-only: ordinary child contexts always inherit the parent identity.
+   */
+  identity?: {
+    agentId: string;
+    sessionKey?: string;
+    sessionName?: string;
+  };
 }
 
 export function createRuntimeContext(input: CreateRuntimeContextInput): ContextRecord {
@@ -224,6 +233,12 @@ export function getRuntimeContextFromEnv(env: NodeJS.ProcessEnv = process.env): 
 
 export function issueRuntimeContext(input: IssueRuntimeContextInput): ContextRecord {
   const now = Date.now();
+  const delegatedIdentity = input.identity ? resolveDelegatedIdentity(input.parent, input.identity) : undefined;
+  const identity = delegatedIdentity ?? {
+    agentId: input.parent.agentId,
+    sessionKey: input.parent.sessionKey,
+    sessionName: input.parent.sessionName,
+  };
   const requestedCapabilities = dedupeCapabilities([
     ...(input.inheritCapabilities ? input.parent.capabilities : []),
     ...(input.capabilities ?? []),
@@ -239,12 +254,19 @@ export function issueRuntimeContext(input: IssueRuntimeContextInput): ContextRec
 
   return createRuntimeContext({
     kind: input.kind ?? "cli-runtime",
-    agentId: input.parent.agentId,
-    sessionKey: input.parent.sessionKey,
-    sessionName: input.parent.sessionName,
-    source: input.parent.source,
+    agentId: identity.agentId,
+    sessionKey: identity.sessionKey,
+    sessionName: identity.sessionName,
+    source: input.identity ? undefined : input.parent.source,
     capabilities: requestedCapabilities,
-    metadata: buildDerivedContextMetadata(input.parent, input.cliName, input.metadata, input.inheritCapabilities, now),
+    metadata: buildDerivedContextMetadata(
+      input.parent,
+      input.cliName,
+      input.metadata,
+      input.inheritCapabilities,
+      now,
+      delegatedIdentity,
+    ),
     expiresAt: resolveChildExpiresAt(input.parent.expiresAt, input.ttlMs, now),
   });
 }
@@ -363,6 +385,11 @@ function buildDerivedContextMetadata(
   metadata: Record<string, unknown> | undefined,
   inheritCapabilities: boolean | undefined,
   now: number,
+  delegatedIdentity?: {
+    agentId: string;
+    sessionKey?: string;
+    sessionName?: string;
+  },
 ): Record<string, unknown> {
   const derived: Record<string, unknown> = {
     parentContextId: parent.contextId,
@@ -371,6 +398,14 @@ function buildDerivedContextMetadata(
     issuedAt: now,
     issuanceMode: inheritCapabilities ? "inherit" : "explicit",
   };
+
+  if (delegatedIdentity) {
+    derived.identityDelegation = {
+      agentId: delegatedIdentity.agentId,
+      sessionKey: delegatedIdentity.sessionKey ?? null,
+      sessionName: delegatedIdentity.sessionName ?? null,
+    };
+  }
 
   const approvalSource = parent.metadata?.approvalSource;
   if (approvalSource !== undefined) {
@@ -384,6 +419,33 @@ function buildDerivedContextMetadata(
   }
 
   return derived;
+}
+
+function resolveDelegatedIdentity(
+  parent: ContextRecord,
+  requested: {
+    agentId: string;
+    sessionKey?: string;
+    sessionName?: string;
+  },
+): { agentId: string; sessionKey?: string; sessionName?: string } {
+  if (!canWithCapabilityContext(parent, "admin", "system", "*")) {
+    throw new Error("Identity delegation requires admin:system:* on the parent context");
+  }
+
+  const agentId = requested.agentId.trim();
+  const sessionKey = requested.sessionKey?.trim();
+  const sessionName = requested.sessionName?.trim();
+  if (!agentId) throw new Error("Delegated agentId is required");
+  if (Boolean(sessionKey) !== Boolean(sessionName)) {
+    throw new Error("Delegated sessionKey and sessionName must be provided together");
+  }
+
+  return {
+    agentId,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(sessionName ? { sessionName } : {}),
+  };
 }
 
 function resolveChildExpiresAt(


### PR DESCRIPTION
## Objective
Allow a trusted bootstrap administrator to issue a restricted child context for an explicit Ravi agent and canonical session identity.

## Problem
The Hub needs to hand a browser client a short-lived context bound to the main agent and session, but the existing issuer could only inherit the bootstrap administrator identity.

## Solution
Add admin-only agent, session-key, and session-name delegation options to context issue. Validate the identity tuple, preserve parent lineage, retain capability narrowing, and synchronize every generated SDK and OpenAPI contract.

## Practical impact
Fresh Hub-managed Ravis can revoke bootstrap administration after minting a least-privilege browser context that acts only as the canonical main agent in its main session.

## What does NOT change
Normal callers cannot delegate identity. Existing context inheritance, capability narrowing, expiry, signature validation, and provider-neutral session execution remain unchanged.

## Validation
Build and typecheck passed. Every executed repository test passed. TypeScript, both OpenAPI snapshots, Swift, and Dart drift checks all pass with the generated artifacts committed.

## Risks
A defect in the admin gate or identity tuple validation could issue an over-privileged or incoherent child context. Tests cover non-admin denial, partial tuple rejection, lineage, and capability narrowing.

## Rollback
Revert this pull request and keep the Hub direct-client rollout disabled. No persisted schema migration is introduced in Ravi Core, so rollback requires no data transformation.