### PR TITLE
fix(runtime): run Grok sessions under restricted Ravi tool limits

### DIFF
--- a/.ravi/specs/runtime/providers/grok/CHECKS.md
+++ b/.ravi/specs/runtime/providers/grok/CHECKS.md
@@ -4,14 +4,16 @@
 
 - Provider id is `grok`.
 - Capability matrix includes every required structured field.
-- Restricted agents are rejected in the ACP MVP.
+- Restricted agents are accepted because `tools.permissionMode` is `ravi-host`.
+- A session without a given tool grant cannot use that tool (spawn deny + ACP reject).
+- A session with a narrow grant can use only those tools (spawn allow + ACP allow).
 - `startSession` starts a fake ACP client and returns a valid runtime handle.
 - `interrupt()` sends `session/cancel` and emits `turn.interrupted`.
 - Resume uses `session/load` with the stored ACP `sessionId` and matching cwd.
-- Spawn args include `agent stdio`, `--no-auto-update`, `--no-alt-screen`, and `--always-approve`.
+- Spawn args include `agent stdio`, `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, and Ravi-derived `--allow` / `--deny`. They MUST NOT include `--always-approve`.
 - Command override reads `RAVI_GROK_COMMAND`.
 - `xhigh|max|ultra` map to native `--effort high`.
-- `prepareSession` is omitted unless env/tools/approvals become required.
+- `prepareSession` wires `approveRuntimeRequest` from Ravi host services.
 
 ## Event Mapping Tests
 

--- a/.ravi/specs/runtime/providers/grok/RUNBOOK.md
+++ b/.ravi/specs/runtime/providers/grok/RUNBOOK.md
@@ -5,12 +5,12 @@
 1. Verify the `grok` executable is available, or set `RAVI_GROK_COMMAND`.
 2. Verify the target cwd exists and is the intended Ravi agent cwd.
 3. Verify Grok authentication: `grok login` or `XAI_API_KEY`.
-4. Verify the Ravi agent does not require restricted tool access in the ACP MVP.
+4. Verify the Ravi agent has the intended least-privilege grants. Restricted tool access is supported; full-access is not required.
 5. Verify `RuntimeCapabilities` compatibility passes before starting the provider.
 
 ## Start A Session
 
-1. Spawn `grok --no-auto-update --no-alt-screen --always-approve agent stdio`.
+1. Spawn `grok --no-auto-update --no-alt-screen --permission-mode default` plus Ravi-derived `--allow` / `--deny` / `--tools`, then `agent stdio`. Do not pass `--always-approve`.
 2. Attach a strict JSONL reader to stdout.
 3. Capture stderr for logs only.
 4. Send `initialize`, then `authenticate` when auth methods are advertised.
@@ -28,7 +28,7 @@
 ## Interrupt
 
 1. Send ACP `session/cancel` for the current `sessionId`.
-2. Auto-cancel any in-flight `session/request_permission` requests.
+2. Cancel any in-flight `session/request_permission` requests. Live requests that are not cancelled MUST be authorized by Ravi host services before selecting allow or reject.
 3. Expect `stopReason=cancelled` or a transport error, then emit `turn.interrupted` once.
 
 ## Resume

--- a/.ravi/specs/runtime/providers/grok/SPEC.md
+++ b/.ravi/specs/runtime/providers/grok/SPEC.md
@@ -56,13 +56,13 @@ The MVP MUST use ACP. Headless streaming-json is a worse fit for Ravi's live ses
 - Execution mode: subprocess ACP JSON-RPC.
 - Process boundary: one `grok agent stdio` process per Ravi runtime session handle.
 - Command override: `RAVI_GROK_COMMAND`, same pattern as `RAVI_PI_COMMAND`.
-- Spawn flags: `--no-auto-update`, `--no-alt-screen`, `--always-approve`, optional `-m`, `--effort`, and `--append-system-prompt`.
+- Spawn flags: `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, Ravi-derived `--allow` / `--deny` / `--tools` / `--disallowed-tools`, optional `-m`, `--effort`, and `--append-system-prompt`. `--always-approve` and `--permission-mode bypassPermissions` MUST NOT be the permission model.
 - Prompt submission: ACP `session/prompt` with `[{ type: "text", text }]`.
 - Session state: ACP `sessionId` plus cwd and model stored in `RuntimeSessionState.params`.
 - Display id: ACP `sessionId`.
 - System prompt mode: append Ravi instructions through `--append-system-prompt`; do not replace Grok's base prompt.
 - Tool mode: Grok uses its own built-in tools. Client ACP `fs` / `terminal` capabilities stay disabled.
-- Permission mode: provider-native. Restricted Ravi tool policy is unsupported and MUST be rejected by capability checks.
+- Permission mode: ravi-host. Restricted Ravi tool policy is required. Grok MUST start under least-privilege and MUST NOT use a tool Ravi did not grant.
 - MCP/plugins/remote spawn: not advertised in the MVP even though `session/new` accepts `mcpServers`.
 
 ## Capability Target
@@ -74,7 +74,7 @@ Initial advertised capabilities MUST be:
 - `execution`: `subprocess-rpc`.
 - `sessionState`: `provider-session-id` with cwd validation.
 - `usage`: `terminal-event`.
-- `tools.permissionMode`: `provider-native`.
+- `tools.permissionMode`: `ravi-host`.
 - `tools.accessRequirement`: `tool_and_executable`.
 - `tools.supportsParallelCalls`: false.
 - `systemPrompt`: `append`.
@@ -85,7 +85,7 @@ Initial advertised capabilities MUST be:
 - `supportsSessionResume`: true when `session/load` is advertised and a stored `sessionId` exists.
 - `supportsSessionFork`: false. Grok CLI `--fork-session` MUST NOT flip this bit until canonical fork materialization exists.
 - `supportsPartialText`: true.
-- `supportsToolHooks`: false.
+- `supportsToolHooks`: true.
 - `supportsHostSessionHooks`: false.
 - `supportsPlugins`: false.
 - `supportsMcpServers`: false.
@@ -100,8 +100,9 @@ Initial advertised capabilities MUST be:
 - `session/load` resumes a stored `sessionId` when the agent advertises `loadSession`.
 - `session/prompt` starts a normal Ravi-delivered user prompt.
 - `session/cancel` maps to `interrupt()` and `turn.interrupt`.
-- Incoming `session/request_permission` auto-selects an allow option because the MVP is provider-native and the process is spawned with `--always-approve`.
+- Incoming `session/request_permission` MUST be authorized by Ravi host services (`canUseTool` / `authorizeToolUse` / `authorizeCommandExecution`). Allow only when Ravi grants the mapped tool (and the executable/command when the request is a shell call). Otherwise select a reject option or cancel.
 - Incoming ACP client methods other than `session/request_permission` MUST be rejected with JSON-RPC method-not-found.
+- Spawn-time `--allow` / `--deny` / `--tools` / `--disallowed-tools` MUST be materialized from the same Ravi grants. Missing hooks fail closed (deny every hosted Grok tool). This is the hard limit even if Grok auto-executes a tool without asking over ACP.
 
 ## Event Mapping
 
@@ -138,7 +139,8 @@ That strongest-compatible mapping MUST stay covered by an explicit provider test
 - The provider MUST turn subprocess exit before terminal result into recoverable `turn.failed`.
 - The provider MUST NOT invent Grok Bot host gateways, A2A, or chat-completions-only HTTP transports.
 - The provider MUST NOT mutate Ravi tasks, emit channel messages, or add host branches in `bot.ts`, `session-launcher.ts`, or `runtime-request-builder.ts`.
-- The provider MUST not expose restricted Ravi agents until Grok permission requests are bridged to Ravi host services.
+- The provider MUST expose restricted Ravi agents and MUST route every Grok tool decision through Ravi host services or spawn-time allow/deny derived from those services.
+- The provider MUST NOT treat `--always-approve`, `--permission-mode bypassPermissions`, or ACP auto-allow as authorization.
 - The provider MUST not save ACP session ids as user-visible Ravi session names.
 - The provider MUST validate cwd before resuming a Grok session.
 - Native Grok `--fork-session` MUST NOT flip canonical `supportsSessionFork`.

--- a/.ravi/specs/runtime/providers/grok/WHY.md
+++ b/.ravi/specs/runtime/providers/grok/WHY.md
@@ -29,17 +29,16 @@ ACP (`grok agent stdio`) is the IDE/tool integration surface. It gives Ravi a na
 
 Grok Bot is a cloud teammate product. The xAI chat-completions/responses API is a model endpoint, not a coding-agent runtime. Both would violate the provider contract: they are not local execution engines that Ravi can adapt through `RuntimeStartRequest` -> native transport -> `RuntimeEvent`.
 
-## Why Tools Stay Provider-Native
+## Why Tools Are Ravi-Hosted
 
-Grok has its own tools and ACP permission requests. Ravi has its own permission model and currently tracks one active tool in the host event loop.
+Grok has its own tools and ACP permission requests. Ravi remains the authority that allows or denies those tools. Restricted / least-privilege sessions must start, and Grok must not use a tool Ravi did not grant.
 
-Bridging tools before the adapter is proven would create a confusing hybrid:
+`--always-approve` and ACP auto-allow are not a permission model. Grok may also execute some tools without sending `session/request_permission`, so Ravi enforces limits in two places:
 
-- Some tools would obey Ravi policy.
-- Some tools would obey Grok internals.
-- Client ACP `fs` / `terminal` methods would make Ravi an IDE host instead of a runtime adapter.
+- Spawn-time `--allow` / `--deny` / `--tools` materialized from Ravi `canUseTool` grants. `deny` wins even if Grok later tries to auto-run.
+- Live ACP `session/request_permission` mapped onto Ravi host services (`authorizeToolUse`, `authorizeCommandExecution` for shell).
 
-The MVP declares full Grok tool ownership, auto-approves through `--always-approve`, and blocks restricted Ravi agents.
+Client ACP `fs` / `terminal` methods stay disabled. Ravi is still a runtime adapter, not an IDE host.
 
 ## Why Resume Is Session-Id, Not File-Backed
 

--- a/src/runtime/delivery-queue.test.ts
+++ b/src/runtime/delivery-queue.test.ts
@@ -52,6 +52,7 @@ function makeStreamingSession(overrides: Partial<RuntimeHostStreamingSession> = 
 describe("runtime delivery queue", () => {
   it("distinguishes host write-ahead from Codex and Pi asynchronous tool observation", () => {
     expect(resolveRuntimeToolEffectFence("claude", "ravi-host")).toBe("host_write_ahead");
+    expect(resolveRuntimeToolEffectFence("grok", "ravi-host")).toBe("host_write_ahead");
     expect(resolveRuntimeToolEffectFence("codex", "ravi-host")).toBe("provider_event_only");
     expect(resolveRuntimeToolEffectFence("pi", "provider-native")).toBe("provider_event_only");
   });

--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+  authorizeGrokAcpPermission,
   buildGrokAcpProcessArgs,
   buildGrokAcpSpawnEnv,
   createGrokRuntimeProvider,
+  extractGrokPermissionTool,
+  mapGrokToolNameToRavi,
+  resolveGrokToolAccessRules,
   selectGrokAuthMethod,
   selectGrokPermissionOutcome,
   toGrokEffort,
@@ -10,7 +14,7 @@ import {
   type GrokAcpStartInput,
   type GrokAcpTransport,
 } from "./grok-provider.js";
-import type { RuntimeEvent, RuntimePromptMessage, RuntimeStartRequest } from "./types.js";
+import type { RuntimeEvent, RuntimeHostServices, RuntimePromptMessage, RuntimeStartRequest } from "./types.js";
 
 interface TestQueue<T> extends AsyncIterable<T> {
   push(value: T): void;
@@ -79,7 +83,7 @@ describe("Grok Build runtime provider", () => {
         semantics: "terminal-event",
       },
       tools: {
-        permissionMode: "provider-native",
+        permissionMode: "ravi-host",
         accessRequirement: "tool_and_executable",
         supportsParallelCalls: false,
       },
@@ -100,7 +104,7 @@ describe("Grok Build runtime provider", () => {
       supportsSessionResume: true,
       supportsSessionFork: false,
       supportsPartialText: true,
-      supportsToolHooks: false,
+      supportsToolHooks: true,
       supportsHostSessionHooks: false,
       supportsPlugins: false,
       supportsMcpServers: false,
@@ -121,17 +125,28 @@ describe("Grok Build runtime provider", () => {
     }
   });
 
-  it("spawns grok agent stdio with conservative headless flags", () => {
+  it("spawns grok agent stdio under Ravi-hosted permission rules, not always-approve", () => {
     expect(
       buildGrokAcpProcessArgs({
         model: "grok-4",
         effort: "ultra",
         systemPromptAppend: "Ravi instructions",
+        allowTools: ["Read"],
+        denyTools: ["Bash", "Edit"],
       }),
     ).toEqual([
       "--no-auto-update",
       "--no-alt-screen",
-      "--always-approve",
+      "--permission-mode",
+      "default",
+      "--allow",
+      "Read",
+      "--deny",
+      "Bash",
+      "--deny",
+      "Edit",
+      "--tools",
+      "Read",
       "-m",
       "grok-4",
       "--effort",
@@ -141,6 +156,12 @@ describe("Grok Build runtime provider", () => {
       "agent",
       "stdio",
     ]);
+    expect(
+      buildGrokAcpProcessArgs({
+        denyTools: ["Bash", "Read"],
+      }),
+    ).toEqual(expect.arrayContaining(["--permission-mode", "default", "--disallowed-tools", "Bash,Read"]));
+    expect(buildGrokAcpProcessArgs({ allowTools: ["Read"] }).join(" ")).not.toContain("--always-approve");
   });
 
   it("maps strongest Ravi effort values onto Grok high", () => {
@@ -161,13 +182,183 @@ describe("Grok Build runtime provider", () => {
     expect(selectGrokAuthMethod([{ id: "cached_token" }, { id: "xai.api_key" }], {})).toBe("cached_token");
   });
 
-  it("auto-selects an allow permission option", () => {
+  it("selects allow or reject permission options from Ravi's decision, never by default", () => {
+    const options = [
+      { optionId: "reject-once", kind: "reject_once" },
+      { optionId: "allow-once", kind: "allow_once" },
+    ];
+    expect(selectGrokPermissionOutcome(options, "allow")).toEqual({ outcome: "selected", optionId: "allow-once" });
+    expect(selectGrokPermissionOutcome(options, "reject")).toEqual({ outcome: "selected", optionId: "reject-once" });
+    expect(selectGrokPermissionOutcome(options)).toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
+
+  it("maps Grok ACP tool names onto Ravi/Claude tool identities", () => {
+    expect(mapGrokToolNameToRavi("Read file")).toBe("Read");
+    expect(mapGrokToolNameToRavi("read")).toBe("Read");
+    expect(mapGrokToolNameToRavi("bash")).toBe("Bash");
+    expect(mapGrokToolNameToRavi("Write")).toBe("Edit");
     expect(
-      selectGrokPermissionOutcome([
-        { optionId: "reject-once", kind: "reject_once" },
-        { optionId: "allow-once", kind: "allow_once" },
-      ]),
-    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+      extractGrokPermissionTool({
+        toolCall: { title: "Read file", kind: "read", rawInput: { path: "README.md" } },
+      }),
+    ).toEqual({
+      toolName: "Read",
+      input: { path: "README.md" },
+    });
+  });
+
+  it("fail-closes spawn rules when no Ravi tool hook is present", async () => {
+    await expect(resolveGrokToolAccessRules()).resolves.toEqual({
+      allow: [],
+      deny: ["Bash", "Edit", "Read", "Grep", "WebFetch", "WebSearch", "MCPTool"],
+    });
+  });
+
+  it("materializes spawn allow/deny from Ravi canUseTool grants", async () => {
+    const canUseTool = async (toolName: string) => ({
+      behavior: toolName === "Read" || toolName === "Grep" ? ("allow" as const) : ("deny" as const),
+      reason: `${toolName} permission denied.`,
+    });
+    await expect(resolveGrokToolAccessRules(canUseTool)).resolves.toEqual({
+      allow: ["Read", "Grep"],
+      deny: ["Bash", "Edit", "WebFetch", "WebSearch", "MCPTool"],
+    });
+  });
+
+  it("fail-closes ACP permission requests when Ravi hooks are missing", async () => {
+    await expect(
+      authorizeGrokAcpPermission({
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { kind: "read", rawInput: { path: "README.md" } },
+      }),
+    ).resolves.toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
+
+  it("denies an ACP permission request when Ravi did not grant the tool", async () => {
+    const outcome = await authorizeGrokAcpPermission(
+      {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { kind: "bash", rawInput: { command: "rm -rf /" } },
+      },
+      {
+        canUseTool: async (toolName) => ({
+          behavior: toolName === "Read" ? "allow" : "deny",
+          reason: `${toolName} permission denied.`,
+        }),
+      },
+    );
+    expect(outcome).toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
+
+  it("allows an ACP permission request only for tools Ravi granted", async () => {
+    const outcome = await authorizeGrokAcpPermission(
+      {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { kind: "read", rawInput: { path: "README.md" } },
+      },
+      {
+        canUseTool: async (toolName) => ({
+          behavior: toolName === "Read" ? "allow" : "deny",
+          reason: `${toolName} permission denied.`,
+        }),
+      },
+    );
+    expect(outcome).toEqual({ outcome: "selected", optionId: "allow-once" });
+  });
+
+  it("routes Grok shell permission requests through command execution approval", async () => {
+    const commands: string[] = [];
+    const outcome = await authorizeGrokAcpPermission(
+      {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { kind: "bash", rawInput: { command: "git status" } },
+      },
+      {
+        canUseTool: async () => ({ behavior: "allow" }),
+        approveRuntimeRequest: async (request) => {
+          if (request.kind === "command_execution" && typeof request.input?.command === "string") {
+            commands.push(request.input.command);
+            return { approved: request.input.command.startsWith("git ") };
+          }
+          return { approved: false, reason: "unexpected" };
+        },
+      },
+    );
+    expect(commands).toEqual(["git status"]);
+    expect(outcome).toEqual({ outcome: "selected", optionId: "allow-once" });
+  });
+
+  it("wires prepareSession approvals through Ravi host services", async () => {
+    const authorized: string[] = [];
+    const hostServices: RuntimeHostServices = {
+      authorizeCapability: async () => ({ allowed: true, inherited: false }),
+      authorizeCommandExecution: async (request) => {
+        authorized.push(`command:${request.command}`);
+        return { approved: request.command === "git status" };
+      },
+      authorizeToolUse: async (request) => {
+        authorized.push(`tool:${request.toolName}`);
+        return { approved: request.toolName === "Read" };
+      },
+      requestUserInput: async () => ({ approved: true, answers: {} }),
+      listDynamicTools: () => [],
+      executeDynamicTool: async () => ({ success: true, contentItems: [] }),
+    };
+    const prepared = await createGrokRuntimeProvider().prepareSession?.({
+      agentId: "grok-probe",
+      cwd: "/tmp",
+      hostServices,
+    });
+    const approve = prepared?.startRequest?.approveRuntimeRequest;
+    expect(approve).toBeTypeOf("function");
+    await expect(
+      approve!({
+        kind: "permission",
+        toolName: "Read",
+        input: { path: "README.md" },
+      }),
+    ).resolves.toEqual({ approved: true });
+    await expect(
+      approve!({
+        kind: "command_execution",
+        toolName: "Bash",
+        input: { command: "rm -rf /" },
+      }),
+    ).resolves.toEqual({ approved: false });
+    expect(authorized).toEqual(["tool:Read", "command:rm -rf /"]);
+  });
+
+  it("starts a restricted Grok session with only granted tools enabled", async () => {
+    const transport = new FakeGrokAcpTransport();
+    const canUseTool = async (toolName: string) => ({
+      behavior: toolName === "Read" ? ("allow" as const) : ("deny" as const),
+      reason: `${toolName} permission denied.`,
+    });
+
+    await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("leia", { canUseTool })).events,
+    );
+
+    expect(transport.starts[0]).toMatchObject({
+      allowTools: ["Read"],
+      denyTools: ["Bash", "Edit", "Grep", "WebFetch", "WebSearch", "MCPTool"],
+    });
+    expect(buildGrokAcpProcessArgs(transport.starts[0])).toEqual(
+      expect.arrayContaining(["--allow", "Read", "--deny", "Bash", "--tools", "Read"]),
+    );
+    expect(buildGrokAcpProcessArgs(transport.starts[0])).not.toContain("--always-approve");
   });
 
   it("closes the Grok ACP transport idempotently", async () => {
@@ -309,7 +500,7 @@ describe("Grok Build runtime provider", () => {
       type: "tool.started",
       toolUse: {
         id: "call_1",
-        name: "Read file",
+        name: "Read",
         input: { path: "README.md" },
       },
     });

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -3,16 +3,23 @@ import { StringDecoder } from "node:string_decoder";
 import type { RuntimeEffort } from "./effort.js";
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
 import type {
+  RuntimeApprovalHandler,
+  RuntimeApprovalQuestion,
+  RuntimeApprovalRequest,
   RuntimeControlOperation,
   RuntimeControlRequest,
   RuntimeControlResult,
   RuntimeControlState,
   RuntimeEvent,
   RuntimeEventMetadata,
+  RuntimeHostServices,
+  RuntimePrepareSessionRequest,
+  RuntimePrepareSessionResult,
   RuntimePromptMessage,
   RuntimeSessionHandle,
   RuntimeSessionState,
   RuntimeStartRequest,
+  RuntimeToolPermissionHandler,
   RuntimeToolUse,
   RuntimeUsage,
   SessionRuntimeProvider,
@@ -26,12 +33,41 @@ const GROK_ACP_PROTOCOL_VERSION = 1;
 
 export type GrokEffort = "none" | "minimal" | "low" | "medium" | "high";
 
+export const GROK_HOSTED_TOOLS = ["Bash", "Edit", "Read", "Grep", "WebFetch", "WebSearch", "MCPTool"] as const;
+
+export type GrokHostedTool = (typeof GROK_HOSTED_TOOLS)[number];
+
+const GROK_TOOL_ALIASES: Record<GrokHostedTool, readonly string[]> = {
+  Bash: ["Shell", "Terminal"],
+  Edit: ["Write"],
+  Read: ["ReadFile", "ListDir"],
+  Grep: ["Glob"],
+  WebFetch: ["WebFetch"],
+  WebSearch: ["WebSearch"],
+  MCPTool: ["MCPTool"],
+};
+
 export interface GrokAcpStartInput {
   cwd: string;
   env: NodeJS.ProcessEnv;
   model?: string;
   effort?: RuntimeEffort;
   systemPromptAppend?: string;
+  allowTools?: string[];
+  denyTools?: string[];
+}
+
+export interface GrokToolAccessRules {
+  allow: string[];
+  deny: string[];
+}
+
+export type GrokPermissionOutcome = { outcome: "selected"; optionId: string } | { outcome: "cancelled" };
+
+export interface GrokPermissionAuthorizationHandlers {
+  canUseTool?: RuntimeToolPermissionHandler;
+  approveRuntimeRequest?: RuntimeApprovalHandler;
+  interrupted?: boolean;
 }
 
 export interface GrokJsonRpcRequest {
@@ -85,6 +121,10 @@ interface CreateGrokAcpSubprocessTransportOptions {
   commandArgs?: string[];
   responseTimeoutMs?: number;
   promptTimeoutMs?: number;
+  authorizePermission?: (
+    params: Record<string, unknown>,
+    context: { interrupted: boolean },
+  ) => Promise<GrokPermissionOutcome>;
 }
 
 export interface CreateGrokRuntimeProviderOptions extends CreateGrokAcpSubprocessTransportOptions {
@@ -128,7 +168,7 @@ export function createGrokRuntimeProvider(options: CreateGrokRuntimeProviderOpti
           semantics: "terminal-event",
         },
         tools: {
-          permissionMode: "provider-native",
+          permissionMode: "ravi-host",
           accessRequirement: "tool_and_executable",
           supportsParallelCalls: false,
         },
@@ -149,7 +189,7 @@ export function createGrokRuntimeProvider(options: CreateGrokRuntimeProviderOpti
         supportsSessionResume: true,
         supportsSessionFork: false,
         supportsPartialText: true,
-        supportsToolHooks: false,
+        supportsToolHooks: true,
         supportsHostSessionHooks: false,
         supportsPlugins: false,
         supportsMcpServers: false,
@@ -157,7 +197,15 @@ export function createGrokRuntimeProvider(options: CreateGrokRuntimeProviderOpti
         toolAccessRequirement: "tool_and_executable",
       };
     },
+    prepareSession(input: RuntimePrepareSessionRequest): RuntimePrepareSessionResult {
+      return input.hostServices ? { startRequest: createGrokRuntimeStartRequest(input.hostServices) } : {};
+    },
     startSession(input) {
+      const state: GrokSessionRuntimeState = {
+        activeTurn: false,
+        interrupted: false,
+        loadSessionSupported: false,
+      };
       const transport =
         options.transport ??
         createGrokAcpSubprocessTransport({
@@ -165,13 +213,14 @@ export function createGrokRuntimeProvider(options: CreateGrokRuntimeProviderOpti
           commandArgs: options.commandArgs,
           responseTimeoutMs: options.responseTimeoutMs,
           promptTimeoutMs: options.promptTimeoutMs,
+          authorizePermission: (params, context) =>
+            authorizeGrokAcpPermission(params, {
+              canUseTool: input.canUseTool,
+              approveRuntimeRequest: input.approveRuntimeRequest,
+              interrupted: context.interrupted || state.interrupted,
+            }),
         });
-      const state: GrokSessionRuntimeState = {
-        activeTurn: false,
-        interrupted: false,
-        loadSessionSupported: false,
-        transport,
-      };
+      state.transport = transport;
 
       return {
         provider: "grok",
@@ -244,12 +293,7 @@ export function createGrokAcpSubprocessTransport(
     }
     const method = firstString(message.method);
     const params = isRecord(message.params) ? message.params : {};
-    let result: Record<string, unknown>;
-    if (method === "session/request_permission") {
-      result = interrupted
-        ? { outcome: { outcome: "cancelled" } }
-        : { outcome: selectGrokPermissionOutcome(params.options) };
-    } else {
+    if (method !== "session/request_permission") {
       void writeMessage({
         jsonrpc: "2.0",
         id,
@@ -257,11 +301,16 @@ export function createGrokAcpSubprocessTransport(
       }).catch(() => {});
       return;
     }
-    void writeMessage({
-      jsonrpc: "2.0",
-      id,
-      result,
-    }).catch(() => {});
+    void (async () => {
+      const outcome = options.authorizePermission
+        ? await options.authorizePermission(params, { interrupted })
+        : await authorizeGrokAcpPermission(params, { interrupted });
+      await writeMessage({
+        jsonrpc: "2.0",
+        id,
+        result: { outcome },
+      });
+    })().catch(() => {});
   };
 
   const handleLine = (line: string) => {
@@ -433,9 +482,20 @@ export function createGrokAcpSubprocessTransport(
 }
 
 export function buildGrokAcpProcessArgs(
-  input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend">,
+  input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend" | "allowTools" | "denyTools">,
 ): string[] {
-  const args = ["--no-auto-update", "--no-alt-screen", "--always-approve"];
+  const args = ["--no-auto-update", "--no-alt-screen", "--permission-mode", "default"];
+  for (const tool of input.allowTools ?? []) {
+    args.push("--allow", tool);
+  }
+  for (const tool of input.denyTools ?? []) {
+    args.push("--deny", tool);
+  }
+  if ((input.allowTools?.length ?? 0) > 0) {
+    args.push("--tools", input.allowTools!.join(","));
+  } else if ((input.denyTools?.length ?? 0) > 0) {
+    args.push("--disallowed-tools", input.denyTools!.join(","));
+  }
   const model = input.model?.trim();
   if (model && model !== "default") {
     args.push("-m", model);
@@ -487,26 +547,108 @@ export function selectGrokAuthMethod(authMethods: unknown[], env: NodeJS.Process
 
 export function selectGrokPermissionOutcome(
   options: unknown,
-): { outcome: "selected"; optionId: string } | { outcome: "cancelled" } {
+  preference: "allow" | "reject" = "reject",
+): GrokPermissionOutcome {
   const list = Array.isArray(options) ? options : [];
-  const allow = list.find((option) => {
+  const match = list.find((option) => {
     if (!isRecord(option)) {
       return false;
     }
     const kind = firstString(option.kind)?.toLowerCase() ?? "";
     const optionId = firstString(option.optionId, option.id)?.toLowerCase() ?? "";
-    return kind.includes("allow") || optionId.includes("allow");
+    return preference === "allow"
+      ? kind.includes("allow") || optionId.includes("allow")
+      : kind.includes("reject") || kind.includes("deny") || optionId.includes("reject") || optionId.includes("deny");
   });
-  const fallback = list.find((option) => isRecord(option) && firstString(option.optionId, option.id));
-  const optionId = isRecord(allow)
-    ? firstString(allow.optionId, allow.id)
-    : isRecord(fallback)
-      ? firstString(fallback.optionId, fallback.id)
-      : undefined;
+  const optionId = isRecord(match) ? firstString(match.optionId, match.id) : undefined;
   if (!optionId) {
     return { outcome: "cancelled" };
   }
   return { outcome: "selected", optionId };
+}
+
+export async function resolveGrokToolAccessRules(
+  canUseTool?: RuntimeToolPermissionHandler,
+): Promise<GrokToolAccessRules> {
+  const allow: string[] = [];
+  const deny: string[] = [];
+  for (const tool of GROK_HOSTED_TOOLS) {
+    if (await isGrokHostedToolAllowed(tool, canUseTool)) {
+      allow.push(tool);
+    } else {
+      deny.push(tool);
+    }
+  }
+  return { allow, deny };
+}
+
+export function mapGrokToolNameToRavi(name?: string): string {
+  const normalized =
+    name
+      ?.trim()
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "") ?? "";
+  if (!normalized) {
+    return "tool";
+  }
+  if (
+    normalized.includes("bash") ||
+    normalized.includes("shell") ||
+    normalized === "execute" ||
+    normalized === "terminal"
+  ) {
+    return "Bash";
+  }
+  if (normalized.includes("webfetch") || normalized.includes("webget")) {
+    return "WebFetch";
+  }
+  if (normalized.includes("websearch") || normalized.includes("webquery")) {
+    return "WebSearch";
+  }
+  if (normalized.includes("mcp")) {
+    return "MCPTool";
+  }
+  if (normalized.includes("grep") || normalized.includes("glob") || normalized.includes("searchcontent")) {
+    return "Grep";
+  }
+  if (
+    normalized.includes("edit") ||
+    normalized.includes("write") ||
+    normalized.includes("searchreplace") ||
+    normalized.includes("strreplace")
+  ) {
+    return "Edit";
+  }
+  if (normalized.includes("read") || normalized.includes("listdir") || normalized.includes("list_dir")) {
+    return "Read";
+  }
+  return name?.trim() || "tool";
+}
+
+export function extractGrokPermissionTool(params: Record<string, unknown>): {
+  toolName: string;
+  input: Record<string, unknown>;
+} {
+  const toolCall = isRecord(params.toolCall) ? params.toolCall : isRecord(params.tool_call) ? params.tool_call : params;
+  const rawName = firstString(toolCall.toolName, toolCall.tool_name, toolCall.name, toolCall.kind, toolCall.title);
+  const rawInput = toolCall.rawInput ?? toolCall.raw_input ?? toolCall.input ?? toolCall.arguments ?? params.rawInput;
+  return {
+    toolName: mapGrokToolNameToRavi(rawName),
+    input: isRecord(rawInput) ? rawInput : {},
+  };
+}
+
+export async function authorizeGrokAcpPermission(
+  params: Record<string, unknown>,
+  handlers: GrokPermissionAuthorizationHandlers = {},
+): Promise<GrokPermissionOutcome> {
+  if (handlers.interrupted) {
+    return { outcome: "cancelled" };
+  }
+
+  const { toolName, input } = extractGrokPermissionTool(params);
+  const approved = await decideGrokToolAuthorization(toolName, input, params, handlers);
+  return selectGrokPermissionOutcome(params.options, approved ? "allow" : "reject");
 }
 
 async function* runGrokTurns(
@@ -515,12 +657,15 @@ async function* runGrokTurns(
   state: GrokSessionRuntimeState,
 ): AsyncGenerator<RuntimeEvent> {
   const abortSignal = input.abortController.signal;
+  const toolAccess = await resolveGrokToolAccessRules(input.canUseTool);
   const startInput: GrokAcpStartInput = {
     cwd: input.cwd,
     env: input.env ?? process.env,
     model: input.model,
     effort: input.effort,
     systemPromptAppend: input.systemPromptAppend,
+    allowTools: toolAccess.allow,
+    denyTools: toolAccess.deny,
   };
   const eventIterator = transport.events[Symbol.asyncIterator]();
 
@@ -812,7 +957,7 @@ function normalizeGrokNotification(notification: GrokAcpNotification, context: G
 
 function buildGrokToolUse(update: Record<string, unknown>): RuntimeToolUse | null {
   const id = firstString(update.toolCallId, update.toolCallID);
-  const name = firstString(update.title, update.kind, update.toolName) ?? "tool";
+  const name = mapGrokToolNameToRavi(firstString(update.toolName, update.kind, update.title));
   if (!id) {
     return null;
   }
@@ -821,6 +966,136 @@ function buildGrokToolUse(update: Record<string, unknown>): RuntimeToolUse | nul
     name,
     input: update.rawInput ?? update.input ?? update.arguments,
   };
+}
+
+function createGrokRuntimeStartRequest(
+  hostServices: RuntimeHostServices,
+): NonNullable<RuntimePrepareSessionResult["startRequest"]> {
+  return {
+    approveRuntimeRequest: async (request) => authorizeGrokHostApproval(hostServices, request),
+  };
+}
+
+async function authorizeGrokHostApproval(
+  hostServices: RuntimeHostServices,
+  request: RuntimeApprovalRequest,
+): Promise<Awaited<ReturnType<RuntimeApprovalHandler>>> {
+  switch (request.kind) {
+    case "command_execution": {
+      const command = typeof request.input?.command === "string" ? request.input.command : "";
+      if (!command.trim()) {
+        return { approved: false, reason: "Grok command approval request did not include a command." };
+      }
+      return hostServices.authorizeCommandExecution({
+        command,
+        input: request.input,
+        eventData: buildGrokApprovalEventData(request),
+      });
+    }
+    case "file_change":
+    case "permission":
+      return hostServices.authorizeToolUse({
+        toolName: request.toolName ?? (request.kind === "file_change" ? "Edit" : "tool"),
+        input: request.input,
+        eventData: buildGrokApprovalEventData(request),
+      });
+    case "user_input":
+      return hostServices.requestUserInput({
+        questions: Array.isArray(request.input?.questions)
+          ? (request.input.questions as RuntimeApprovalQuestion[])
+          : [],
+        eventData: buildGrokApprovalEventData(request),
+      });
+  }
+}
+
+function buildGrokApprovalEventData(request: RuntimeApprovalRequest): Record<string, unknown> {
+  return {
+    runtimeApproval: {
+      provider: "grok",
+      kind: request.kind,
+      method: request.method,
+      toolName: request.toolName,
+      input: request.input,
+    },
+  };
+}
+
+async function isGrokHostedToolAllowed(
+  tool: GrokHostedTool,
+  canUseTool?: RuntimeToolPermissionHandler,
+): Promise<boolean> {
+  if (!canUseTool) {
+    return false;
+  }
+  const names = [tool, ...(GROK_TOOL_ALIASES[tool] ?? [])];
+  for (const name of names) {
+    const result = await canUseTool(name, {});
+    if (result.behavior === "allow") {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function decideGrokToolAuthorization(
+  toolName: string,
+  input: Record<string, unknown>,
+  rawRequest: Record<string, unknown>,
+  handlers: GrokPermissionAuthorizationHandlers,
+): Promise<boolean> {
+  const command = firstString(input.command, input.cmd);
+  if (command && handlers.approveRuntimeRequest) {
+    const result = await handlers.approveRuntimeRequest({
+      kind: "command_execution",
+      method: "session/request_permission",
+      toolName: "Bash",
+      input: { ...input, command },
+      rawRequest,
+    });
+    return result.approved;
+  }
+
+  if (handlers.canUseTool) {
+    const names = uniqueStrings([toolName, ...aliasesForGrokTool(toolName)]);
+    for (const name of names) {
+      const result = await handlers.canUseTool(name, input);
+      if (result.behavior === "allow") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (handlers.approveRuntimeRequest) {
+    const kind = toolName === "Edit" || toolName === "Write" ? "file_change" : "permission";
+    const result = await handlers.approveRuntimeRequest({
+      kind,
+      method: "session/request_permission",
+      toolName,
+      input,
+      rawRequest,
+    });
+    return result.approved;
+  }
+
+  return false;
+}
+
+function aliasesForGrokTool(toolName: string): string[] {
+  const canonical = mapGrokToolNameToRavi(toolName);
+  if (isGrokHostedTool(canonical)) {
+    return [...GROK_TOOL_ALIASES[canonical]];
+  }
+  return [];
+}
+
+function isGrokHostedTool(value: string): value is GrokHostedTool {
+  return (GROK_HOSTED_TOOLS as readonly string[]).includes(value);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
 }
 
 function mapGrokUsage(update: Record<string, unknown>, fallback: RuntimeUsage): RuntimeUsage {

--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -92,12 +92,19 @@ describe("runtime compatibility preflight", () => {
     expect(issues.map((issue) => issue.code)).toEqual(["restricted_tool_access_unsupported"]);
   });
 
-  it("blocks restricted tool access for Grok until Ravi-hosted tool hooks exist", () => {
-    const issues = getRuntimeCompatibilityIssues(createRuntimeProvider("grok"), {
-      toolAccessMode: "restricted",
-    });
+  it("allows Grok providers to satisfy restricted tool access through Ravi-hosted hooks", () => {
+    const provider = createRuntimeProvider("grok");
 
-    expect(issues.map((issue) => issue.code)).toEqual(["restricted_tool_access_unsupported"]);
+    expect(() =>
+      assertRuntimeCompatibility(provider, {
+        toolAccessMode: "restricted",
+      }),
+    ).not.toThrow();
+    expect(
+      getRuntimeCompatibilityIssues(provider, {
+        toolAccessMode: "restricted",
+      }),
+    ).toEqual([]);
   });
 
   it("supports registering additional runtime providers without changing the factory switch", () => {

--- a/src/runtime/provider-contract.test.ts
+++ b/src/runtime/provider-contract.test.ts
@@ -230,7 +230,7 @@ describe("runtime provider contract", () => {
         semantics: "terminal-event",
       },
       tools: {
-        permissionMode: "provider-native",
+        permissionMode: "ravi-host",
         accessRequirement: "tool_and_executable",
         supportsParallelCalls: false,
       },
@@ -247,7 +247,7 @@ describe("runtime provider contract", () => {
       supportsSessionResume: true,
       supportsSessionFork: false,
       supportsPartialText: true,
-      supportsToolHooks: false,
+      supportsToolHooks: true,
       supportsHostSessionHooks: false,
       supportsPlugins: false,
       supportsMcpServers: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Let a Ravi session host Grok Build without `full-access`, and make Ravi the authority that allows or denies Grok tools.

## Problem

- On 3.260829.2, a dedicated `grok-probe` session failed at `runtime.start` with `Runtime provider 'grok' requires full tool and executable access because Ravi permission hooks are unsupported`.
- `shouldUseTurnScopedAuthorityForPrompt` always returns `true`, so the launcher always passes `toolAccessMode: "restricted"`.
- Grok advertised `tools.permissionMode: "provider-native"` and auto-approved ACP `session/request_permission` while spawning with `--always-approve`. Granting `full-access` did not help because the compatibility gate never saw unrestricted.
- Grok CLI itself worked (`grok -p 'reply with the single word pong'` → `pong`). The failure was Ravi hosting, not Grok auth.

## Solution

- Advertise Grok as `ravi-host` with `supportsToolHooks: true` so restricted sessions can start.
- Materialize spawn-time `--allow` / `--deny` / `--tools` / `--disallowed-tools` from Ravi `canUseTool` grants. Missing hooks fail closed (deny every hosted Grok tool). `--deny` is the hard limit even if Grok auto-executes without asking over ACP.
- Spawn with `--permission-mode default`. Do **not** use `--always-approve` or `bypassPermissions` as the permission model.
- Map ACP `session/request_permission` to Ravi host services (`canUseTool` / `authorizeToolUse` / `authorizeCommandExecution` for shell). Select allow only when Ravi grants the tool.
- Wire `prepareSession` so Grok approvals go through the same host services as Codex.

## Practical impact

- A bootstrap or narrowly granted Grok agent can start.
- A session without a given tool grant cannot use that tool; a session with a narrow grant can use only those tools.
- Turn-scoped authority stays enabled (`shouldUseTurnScopedAuthorityForPrompt` is unchanged).

## What does NOT change

- Codex and Claude restricted-mode behavior.
- Pi still rejects restricted tool access until it has Ravi-hosted hooks.
- The turn-scoped authority stub is not flipped off to make Grok boot.

## Validation

- `bunx tsc --noEmit --pretty false`
- `bun test src/runtime/grok-provider.test.ts src/runtime/index.test.ts src/runtime/provider-contract.test.ts src/runtime/delivery-queue.test.ts src/runtime/claude-provider.test.ts src/runtime/codex-provider.test.ts src/runtime/pi-provider.test.ts src/cli/commands/sessions.test.ts src/cli/commands/doctor.test.ts`

## Risks

- Grok CLI versions that ignore ACP permission requests still cannot run a denied tool because spawn-time `--deny` wins. A newly added Grok tool that is not in `GROK_HOSTED_TOOLS` could fall through until the catalog is updated.
- `--tools` / `--disallowed-tools` syntax is the documented Grok CLI surface; live CLI flag parsing is not exercised in CI (fake ACP transport).

## Rollback

- Revert this PR. Grok returns to `provider-native` and restricted sessions fail closed at compatibility again.

## Follow-ups

- Expand `GROK_HOSTED_TOOLS` if Grok adds more built-in tool classes.
- Optional live smoke: restricted `grok-probe` text-only prompt, then a tool-using prompt with a narrow Read grant and a Bash deny.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b520db4e-db71-41cb-a0a6-8d5364be040c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b520db4e-db71-41cb-a0a6-8d5364be040c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

