### PR TITLE
fix(runtime): send clientInfo.version on Grok ACP initialize

### DIFF
--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import {
   authorizeGrokAcpPermission,
+  buildGrokAcpInitializeParams,
   buildGrokAcpProcessArgs,
   buildGrokAcpSpawnEnv,
   createGrokRuntimeProvider,
   extractGrokPermissionTool,
   mapGrokToolNameToRavi,
+  resolveGrokAcpClientVersion,
   resolveGrokToolAccessRules,
   selectGrokAuthMethod,
   selectGrokPermissionOutcome,
@@ -359,6 +361,39 @@ describe("Grok Build runtime provider", () => {
       expect.arrayContaining(["--allow", "Read", "--deny", "Bash", "--tools", "Read"]),
     );
     expect(buildGrokAcpProcessArgs(transport.starts[0])).not.toContain("--always-approve");
+  });
+
+  it("includes a non-empty clientInfo.version on ACP initialize", async () => {
+    const rejectedByGrok105 = {
+      protocolVersion: 1,
+      clientInfo: { name: "ravi", title: "Ravi Runtime" },
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+    };
+    const params = buildGrokAcpInitializeParams();
+    const version = resolveGrokAcpClientVersion();
+
+    expect(version.length).toBeGreaterThan(0);
+    expect(params).not.toEqual(rejectedByGrok105);
+    expect(params).not.toHaveProperty("version");
+    expect(params.protocolVersion).toBe(1);
+    expect(params.clientInfo).toEqual({
+      name: "ravi",
+      title: "Ravi Runtime",
+      version,
+    });
+    expect(params.clientInfo).not.toEqual({ name: "ravi", title: "Ravi Runtime" });
+    expect(typeof params.clientInfo.version).toBe("string");
+    expect(params.clientInfo.version.length).toBeGreaterThan(0);
+
+    const transport = new FakeGrokAcpTransport();
+    await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("init")).events,
+    );
+
+    expect(transport.requests.find((request) => request.method === "initialize")?.params).toEqual(params);
   });
 
   it("closes the Grok ACP transport idempotently", async () => {

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -1,5 +1,8 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath } from "node:url";
 import type { RuntimeEffort } from "./effort.js";
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
 import type {
@@ -30,6 +33,25 @@ const DEFAULT_GROK_RPC_TIMEOUT_MS = 30_000;
 const GROK_INTERRUPT_GRACE_MS = 1_000;
 const GROK_RUNTIME_CONTROL_OPERATIONS: RuntimeControlOperation[] = ["turn.interrupt"];
 const GROK_ACP_PROTOCOL_VERSION = 1;
+const GROK_ACP_CLIENT_NAME = "ravi";
+const GROK_ACP_CLIENT_TITLE = "Ravi Runtime";
+const GROK_ACP_CLIENT_VERSION_FALLBACK = "ravi";
+
+export interface GrokAcpInitializeParams {
+  protocolVersion: number;
+  clientInfo: {
+    name: string;
+    title: string;
+    version: string;
+  };
+  clientCapabilities: {
+    fs: {
+      readTextFile: boolean;
+      writeTextFile: boolean;
+    };
+    terminal: boolean;
+  };
+}
 
 export type GrokEffort = "none" | "minimal" | "low" | "medium" | "high";
 
@@ -481,6 +503,38 @@ export function createGrokAcpSubprocessTransport(
   };
 }
 
+export function resolveGrokAcpClientVersion(): string {
+  return (
+    firstString(process.env.npm_package_version, process.env.RAVI_VERSION, readNearbyRaviPackageVersion()) ??
+    GROK_ACP_CLIENT_VERSION_FALLBACK
+  );
+}
+
+export function buildGrokAcpInitializeParams(): GrokAcpInitializeParams {
+  return {
+    protocolVersion: GROK_ACP_PROTOCOL_VERSION,
+    clientInfo: {
+      name: GROK_ACP_CLIENT_NAME,
+      title: GROK_ACP_CLIENT_TITLE,
+      version: resolveGrokAcpClientVersion(),
+    },
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+  };
+}
+
+function readNearbyRaviPackageVersion(): string | undefined {
+  try {
+    const packagePath = join(dirname(fileURLToPath(import.meta.url)), "../../package.json");
+    const pkg = JSON.parse(readFileSync(packagePath, "utf8")) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildGrokAcpProcessArgs(
   input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend" | "allowTools" | "denyTools">,
 ): string[] {
@@ -837,17 +891,7 @@ async function initializeGrokSession(
   input: RuntimeStartRequest,
   state: GrokSessionRuntimeState,
 ): Promise<void> {
-  const init = await transport.request("initialize", {
-    protocolVersion: GROK_ACP_PROTOCOL_VERSION,
-    clientInfo: {
-      name: "ravi",
-      title: "Ravi Runtime",
-    },
-    clientCapabilities: {
-      fs: { readTextFile: false, writeTextFile: false },
-      terminal: false,
-    },
-  });
+  const init = await transport.request("initialize", buildGrokAcpInitializeParams());
   const initRecord = isRecord(init) ? init : {};
   const agentCapabilities = isRecord(initRecord.agentCapabilities) ? initRecord.agentCapabilities : {};
   state.loadSessionSupported = agentCapabilities.loadSession === true;

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -37,7 +37,7 @@ const GROK_ACP_CLIENT_NAME = "ravi";
 const GROK_ACP_CLIENT_TITLE = "Ravi Runtime";
 const GROK_ACP_CLIENT_VERSION_FALLBACK = "ravi";
 
-export interface GrokAcpInitializeParams {
+export interface GrokAcpInitializeParams extends Record<string, unknown> {
   protocolVersion: number;
   clientInfo: {
     name: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Fix live Grok hosting on ravi.bot@3.260831.1: Grok CLI 1.0.5 rejects ACP `initialize` before any prompt because `clientInfo.version` is missing.

## Problem

- `ravi sessions send` to a grok agent (restricted/bootstrap, not full-access) starts streaming, then dies immediately with `Invalid params` from `grok-provider.ts`.
- Direct JSON-RPC against `grok --permission-mode default agent stdio` rejects:

```
initialize({ protocolVersion: 1, clientInfo: { name: "ravi", title: "Ravi Runtime" }, ... })
```

with `missing field \`version\``. A top-level `params.version` still fails. `clientInfo.version` (any non-empty string) makes initialize succeed.

## Solution

- Send `clientInfo.version` as a non-empty string on ACP initialize, keeping `protocolVersion` and optional `title`.
- Resolve version from `npm_package_version` / `RAVI_VERSION` / nearby `package.json`, then a dedicated `"ravi"` fallback. Do not add a root-level `version` field.
- `GrokAcpInitializeParams` extends `Record<string, unknown>` so ACP `transport.request` and tests typecheck (Quality Gate typecheck on 68681331).
- Cover the handshake in `grok-provider.test.ts`: initialize params include `clientInfo.name` + `clientInfo.version`, and the old payload without version is exactly what we must not send.

## Practical impact

- Restricted Grok sessions can get past initialize on Grok CLI 1.0.5 and continue the PR 459 ravi-host permission path.

## What does NOT change

- `shouldUseTurnScopedAuthorityForPrompt`
- Restricted `toolAccessMode` / least-privilege `canUseTool` host decisions
- `permissionMode: "ravi-host"`
- No `--always-approve`
- `authenticate({ methodId, _meta: { headless: true } })` and `session/new` (`{ cwd, mcpServers: [] }`)
- Hub / ravi_app / unrelated refactors
- `effectiveModel` / `env_fallback` (still sonnet on the live probe; out of scope)

## Validation

- `bun tsc --noEmit` — clean
- `bun test src/runtime/grok-provider.test.ts` — 24 pass, 0 fail, including `includes a non-empty clientInfo.version on ACP initialize`
- Pre-push hook: typecheck + full `bun test` passed before push of 6334dbe0
- Live confirmation on this box: patched only the installed ravi.bot@3.260831.1 bundle initialize payload with `clientInfo.version = "3.260831.1"` (kept `protocolVersion` and `title`). After `pm2 restart ravi`, `grok-probe` answered `pong`. The previous `Invalid params` / `missing field \`version\`` is gone.

## Risks

- Grok 1.0.5 may still reject later handshake steps (`authenticate`, `session/new`). Those stay unchanged unless a later live rejection is proven.

## Rollback

- Revert this PR. The previous initialize payload is rejected by Grok 1.0.5, so hosting stays broken until a replacement lands.

## Follow-ups

- None for this PR. Authenticate / session/new only if Grok 1.0.5 is proven to reject those payloads too.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16b47b11-5156-4427-a0a3-0441d3b012d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16b47b11-5156-4427-a0a3-0441d3b012d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

