### PR TITLE
fix(runtime): make Ravi the per-tool Grok authority after PR 459

### DIFF
--- a/.ravi/specs/runtime/providers/grok/CHECKS.md
+++ b/.ravi/specs/runtime/providers/grok/CHECKS.md
@@ -10,7 +10,9 @@
 - `startSession` starts a fake ACP client and returns a valid runtime handle.
 - `interrupt()` sends `session/cancel` and emits `turn.interrupted`.
 - Resume uses `session/load` with the stored ACP `sessionId` and matching cwd.
-- Spawn args include `agent stdio`, `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, and Ravi-derived `--allow` / `--deny`. They MUST NOT include `--always-approve`.
+- Spawn args include `agent stdio`, `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, `--no-subagents` unless Agent/Task is granted, `--tools` with internal IDs, and `--deny` for ungranted classes. They MUST NOT include `--always-approve` or class-wide `--allow Bash` / `--allow Read` for a mere tool grant.
+- Empty grants still emit `--no-subagents` and `--disallowed-tools` covering `todo_write` and `Agent`.
+- Unknown ACP tools fail closed. Incoming `session/request_permission` is answered over the fake transport. Authorize throws become reject/cancelled.
 - Command override reads `RAVI_GROK_COMMAND`.
 - `xhigh|max|ultra` map to native `--effort high`.
 - `prepareSession` wires `approveRuntimeRequest` from Ravi host services.

--- a/.ravi/specs/runtime/providers/grok/RUNBOOK.md
+++ b/.ravi/specs/runtime/providers/grok/RUNBOOK.md
@@ -10,7 +10,7 @@
 
 ## Start A Session
 
-1. Spawn `grok --no-auto-update --no-alt-screen --permission-mode default` plus Ravi-derived `--allow` / `--deny` / `--tools`, then `agent stdio`. Do not pass `--always-approve`.
+1. Spawn `grok --no-auto-update --no-alt-screen --permission-mode default` plus `--tools` internal IDs, `--deny` ungranted classes, `--disallowed-tools` for the rest, and `--no-subagents` unless Agent is granted, then `agent stdio`. Do not pass `--always-approve` or class-wide `--allow Bash` / `--allow Read`.
 2. Attach a strict JSONL reader to stdout.
 3. Capture stderr for logs only.
 4. Send `initialize`, then `authenticate` when auth methods are advertised.

--- a/.ravi/specs/runtime/providers/grok/SPEC.md
+++ b/.ravi/specs/runtime/providers/grok/SPEC.md
@@ -56,7 +56,7 @@ The MVP MUST use ACP. Headless streaming-json is a worse fit for Ravi's live ses
 - Execution mode: subprocess ACP JSON-RPC.
 - Process boundary: one `grok agent stdio` process per Ravi runtime session handle.
 - Command override: `RAVI_GROK_COMMAND`, same pattern as `RAVI_PI_COMMAND`.
-- Spawn flags: `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, Ravi-derived `--allow` / `--deny` / `--tools` / `--disallowed-tools`, optional `-m`, `--effort`, and `--append-system-prompt`. `--always-approve` and `--permission-mode bypassPermissions` MUST NOT be the permission model.
+- Spawn flags: `--no-auto-update`, `--no-alt-screen`, `--permission-mode default`, Ravi-derived `--deny` class rules, `--tools` / `--disallowed-tools` using Grok internal IDs, `--no-subagents` unless the host granted Agent/Task, optional scoped `--allow Class(pattern)` only for real scoped grants, optional `-m`, `--effort`, and `--append-system-prompt`. `--always-approve`, bare `--allow Bash` / `--allow Read`, and `--permission-mode bypassPermissions` MUST NOT be the permission model.
 - Prompt submission: ACP `session/prompt` with `[{ type: "text", text }]`.
 - Session state: ACP `sessionId` plus cwd and model stored in `RuntimeSessionState.params`.
 - Display id: ACP `sessionId`.
@@ -100,9 +100,9 @@ Initial advertised capabilities MUST be:
 - `session/load` resumes a stored `sessionId` when the agent advertises `loadSession`.
 - `session/prompt` starts a normal Ravi-delivered user prompt.
 - `session/cancel` maps to `interrupt()` and `turn.interrupt`.
-- Incoming `session/request_permission` MUST be authorized by Ravi host services (`canUseTool` / `authorizeToolUse` / `authorizeCommandExecution`). Allow only when Ravi grants the mapped tool (and the executable/command when the request is a shell call). Otherwise select a reject option or cancel.
+- Incoming `session/request_permission` MUST be authorized by Ravi host services. Map Grok internal IDs such as `run_terminal_cmd` onto Ravi names (`Bash`). Allow only `allow_once`; reject only `reject_once`. Never select `allow_always`. Unknown tools fail closed. A shell call MUST pass both `canUseTool("Bash")` and `authorizeCommandExecution`. If authorization throws, respond JSON-RPC reject/cancelled — never swallow.
 - Incoming ACP client methods other than `session/request_permission` MUST be rejected with JSON-RPC method-not-found.
-- Spawn-time `--allow` / `--deny` / `--tools` / `--disallowed-tools` MUST be materialized from the same Ravi grants. Missing hooks fail closed (deny every hosted Grok tool). This is the hard limit even if Grok auto-executes a tool without asking over ACP.
+- Spawn-time `--tools` / `--disallowed-tools` MUST use Grok internal IDs (`read_file`, `run_terminal_cmd`, `todo_write`, `task`, …), not class names. `--allow` / `--deny` keep Grok class/rule names. A tool grant enables the tool via `--tools` and MUST NOT emit a class-wide `--allow Bash` or `--allow Read`. Empty grants MUST still strip auto-exec tools (`todo_write`, Agent/subagents, skill invocation, command/subagent control) via a full `--disallowed-tools` catalog plus `--no-subagents`. Missing hooks fail closed.
 
 ## Event Mapping
 

--- a/.ravi/specs/runtime/providers/grok/WHY.md
+++ b/.ravi/specs/runtime/providers/grok/WHY.md
@@ -35,8 +35,8 @@ Grok has its own tools and ACP permission requests. Ravi remains the authority t
 
 `--always-approve` and ACP auto-allow are not a permission model. Grok may also execute some tools without sending `session/request_permission`, so Ravi enforces limits in two places:
 
-- Spawn-time `--allow` / `--deny` / `--tools` materialized from Ravi `canUseTool` grants. `deny` wins even if Grok later tries to auto-run.
-- Live ACP `session/request_permission` mapped onto Ravi host services (`authorizeToolUse`, `authorizeCommandExecution` for shell).
+- Spawn-time `--tools` internal IDs plus `--deny` class rules materialized from Ravi `canUseTool` grants. A grant enables the tool; it does not auto-approve the class. `deny` / `--disallowed-tools` / `--no-subagents` win even if Grok later tries to auto-run `todo_write`, Agent, or skills.
+- Live ACP `session/request_permission` mapped onto Ravi host services (`canUseTool` and, for shell, `authorizeCommandExecution`). Both are required for `tool_and_executable`.
 
 Client ACP `fs` / `terminal` methods stay disabled. Ravi is still a runtime adapter, not an IDE host.
 

--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   authorizeGrokAcpPermission,
   buildGrokAcpProcessArgs,
   buildGrokAcpSpawnEnv,
+  createGrokAcpSubprocessTransport,
   createGrokRuntimeProvider,
   extractGrokPermissionTool,
+  GROK_FAIL_CLOSED_TOOL_IDS,
   mapGrokToolNameToRavi,
   resolveGrokToolAccessRules,
   selectGrokAuthMethod,
@@ -126,42 +131,83 @@ describe("Grok Build runtime provider", () => {
   });
 
   it("spawns grok agent stdio under Ravi-hosted permission rules, not always-approve", () => {
-    expect(
-      buildGrokAcpProcessArgs({
-        model: "grok-4",
-        effort: "ultra",
-        systemPromptAppend: "Ravi instructions",
-        allowTools: ["Read"],
-        denyTools: ["Bash", "Edit"],
-      }),
-    ).toEqual([
-      "--no-auto-update",
-      "--no-alt-screen",
-      "--permission-mode",
-      "default",
-      "--allow",
-      "Read",
-      "--deny",
-      "Bash",
-      "--deny",
-      "Edit",
-      "--tools",
-      "Read",
-      "-m",
-      "grok-4",
-      "--effort",
-      "high",
-      "--append-system-prompt",
-      "Ravi instructions",
-      "agent",
-      "stdio",
-    ]);
-    expect(
-      buildGrokAcpProcessArgs({
-        denyTools: ["Bash", "Read"],
-      }),
-    ).toEqual(expect.arrayContaining(["--permission-mode", "default", "--disallowed-tools", "Bash,Read"]));
-    expect(buildGrokAcpProcessArgs({ allowTools: ["Read"] }).join(" ")).not.toContain("--always-approve");
+    const args = buildGrokAcpProcessArgs({
+      model: "grok-4",
+      effort: "ultra",
+      systemPromptAppend: "Ravi instructions",
+      allowTools: ["Read"],
+      denyTools: ["Bash", "Edit", "Grep", "WebFetch", "WebSearch", "MCPTool", "TodoWrite", "Agent", "Skill"],
+    });
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--no-auto-update",
+        "--no-alt-screen",
+        "--permission-mode",
+        "default",
+        "--deny",
+        "Bash",
+        "--deny",
+        "Edit",
+        "--tools",
+        "read_file,list_dir",
+        "--no-subagents",
+        "-m",
+        "grok-4",
+        "--effort",
+        "high",
+        "--append-system-prompt",
+        "Ravi instructions",
+        "agent",
+        "stdio",
+      ]),
+    );
+    expect(args.join("\0")).not.toContain("--allow\0Read");
+    expect(args.join("\0")).not.toContain("--allow\0Bash");
+    expect(args).not.toContain("--always-approve");
+    expect(args).not.toContain("bypassPermissions");
+    expect(args.includes("Read") && args[args.indexOf("Read") - 1] === "--tools").toBe(false);
+  });
+
+  it("uses Grok internal tool IDs on --tools and never class-wide --allow for a Bash grant", () => {
+    const args = buildGrokAcpProcessArgs({
+      allowTools: ["Bash"],
+      denyTools: ["Read", "Edit", "Grep", "WebFetch", "WebSearch", "MCPTool", "TodoWrite", "Agent", "Skill"],
+    });
+    expect(args).toEqual(expect.arrayContaining(["--tools", "run_terminal_cmd", "--deny", "Read", "--no-subagents"]));
+    expect(args.join("\0")).not.toContain("--allow\0Bash");
+    expect(args).not.toContain("--always-approve");
+    const toolsValue = args[args.indexOf("--tools") + 1];
+    expect(toolsValue).toBe("run_terminal_cmd");
+    expect(toolsValue).not.toContain("Bash");
+    expect(toolsValue).not.toContain("Read");
+    expect(toolsValue).not.toContain("Edit");
+  });
+
+  it("fail-closes empty grants by stripping Agent/todo_write and passing --no-subagents", () => {
+    const args = buildGrokAcpProcessArgs({
+      allowTools: [],
+      denyTools: [],
+    });
+    const disallowed = args[args.indexOf("--disallowed-tools") + 1];
+    expect(args).toEqual(expect.arrayContaining(["--permission-mode", "default", "--no-subagents"]));
+    expect(args).not.toContain("--tools");
+    expect(disallowed).toContain("todo_write");
+    expect(disallowed).toContain("Agent");
+    expect(disallowed).toContain("task");
+    expect(disallowed).toContain("run_terminal_cmd");
+    expect(GROK_FAIL_CLOSED_TOOL_IDS).toEqual(expect.arrayContaining(["todo_write", "Agent", "task"]));
+    expect(args).not.toContain("--always-approve");
+  });
+
+  it("emits scoped --allow rules only when they are real grants, never a bare class", () => {
+    const args = buildGrokAcpProcessArgs({
+      allowTools: ["Read"],
+      denyTools: ["Bash"],
+      allowRules: ["Read(src/**)", "Read", "Bash(git *)"],
+    });
+    expect(args).toEqual(expect.arrayContaining(["--allow", "Read(src/**)", "--allow", "Bash(git *)"]));
+    expect(args.join("\0")).not.toContain("--allow\0Read\0");
+    expect(args.join("\0")).not.toContain("--allow\0Bash\0");
   });
 
   it("maps strongest Ravi effort values onto Grok high", () => {
@@ -192,11 +238,49 @@ describe("Grok Build runtime provider", () => {
     expect(selectGrokPermissionOutcome(options)).toEqual({ outcome: "selected", optionId: "reject-once" });
   });
 
+  it("selects only allow_once / reject_once and never allow_always or disallow", () => {
+    expect(
+      selectGrokPermissionOutcome(
+        [
+          { optionId: "disallow", kind: "disallow" },
+          { optionId: "allow-always", kind: "allow_always" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        "allow",
+      ),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+    expect(
+      selectGrokPermissionOutcome(
+        [
+          { optionId: "allow-always", kind: "allow_always" },
+          { optionId: "disallow", kind: "disallow" },
+        ],
+        "allow",
+      ),
+    ).toEqual({ outcome: "cancelled" });
+    expect(
+      selectGrokPermissionOutcome(
+        [
+          { optionId: "allow-always", kind: "allow_always" },
+          { optionId: "reject-once", kind: "reject_once" },
+        ],
+        "reject",
+      ),
+    ).toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
+
   it("maps Grok ACP tool names onto Ravi/Claude tool identities", () => {
     expect(mapGrokToolNameToRavi("Read file")).toBe("Read");
     expect(mapGrokToolNameToRavi("read")).toBe("Read");
+    expect(mapGrokToolNameToRavi("read_file")).toBe("Read");
+    expect(mapGrokToolNameToRavi("list_dir")).toBe("Read");
     expect(mapGrokToolNameToRavi("bash")).toBe("Bash");
+    expect(mapGrokToolNameToRavi("run_terminal_cmd")).toBe("Bash");
+    expect(mapGrokToolNameToRavi("search_replace")).toBe("Edit");
     expect(mapGrokToolNameToRavi("Write")).toBe("Edit");
+    expect(mapGrokToolNameToRavi("todo_write")).toBe("TodoWrite");
+    expect(mapGrokToolNameToRavi("task")).toBe("Agent");
+    expect(mapGrokToolNameToRavi("get_command_or_subagent_output")).toBe("Agent");
     expect(
       extractGrokPermissionTool({
         toolCall: { title: "Read file", kind: "read", rawInput: { path: "README.md" } },
@@ -205,13 +289,34 @@ describe("Grok Build runtime provider", () => {
       toolName: "Read",
       input: { path: "README.md" },
     });
+    expect(
+      extractGrokPermissionTool({
+        toolCall: { toolName: "run_terminal_cmd", rawInput: { command: "git status" } },
+      }),
+    ).toEqual({
+      toolName: "Bash",
+      input: { command: "git status" },
+    });
   });
 
   it("fail-closes spawn rules when no Ravi tool hook is present", async () => {
-    await expect(resolveGrokToolAccessRules()).resolves.toEqual({
-      allow: [],
-      deny: ["Bash", "Edit", "Read", "Grep", "WebFetch", "WebSearch", "MCPTool"],
-    });
+    const rules = await resolveGrokToolAccessRules();
+    expect(rules.allow).toEqual([]);
+    expect(rules.deny).toEqual([
+      "Bash",
+      "Edit",
+      "Read",
+      "Grep",
+      "WebFetch",
+      "WebSearch",
+      "MCPTool",
+      "TodoWrite",
+      "Agent",
+      "Skill",
+    ]);
+    expect(rules.allowToolIds).toEqual([]);
+    expect(rules.allowSubagents).toBe(false);
+    expect(rules.denyToolIds).toEqual(expect.arrayContaining(["todo_write", "Agent", "task", "run_terminal_cmd"]));
   });
 
   it("materializes spawn allow/deny from Ravi canUseTool grants", async () => {
@@ -219,10 +324,28 @@ describe("Grok Build runtime provider", () => {
       behavior: toolName === "Read" || toolName === "Grep" ? ("allow" as const) : ("deny" as const),
       reason: `${toolName} permission denied.`,
     });
-    await expect(resolveGrokToolAccessRules(canUseTool)).resolves.toEqual({
-      allow: ["Read", "Grep"],
-      deny: ["Bash", "Edit", "WebFetch", "WebSearch", "MCPTool"],
-    });
+    const rules = await resolveGrokToolAccessRules(canUseTool);
+    expect(rules.allow).toEqual(["Read", "Grep"]);
+    expect(rules.deny).toEqual(["Bash", "Edit", "WebFetch", "WebSearch", "MCPTool", "TodoWrite", "Agent", "Skill"]);
+    expect(rules.allowToolIds).toEqual(["read_file", "list_dir", "grep"]);
+    expect(rules.allowSubagents).toBe(false);
+  });
+
+  it("fail-closes unknown Grok tools that are not in the hosted catalog", async () => {
+    await expect(
+      authorizeGrokAcpPermission(
+        {
+          options: [
+            { optionId: "reject-once", kind: "reject_once" },
+            { optionId: "allow-once", kind: "allow_once" },
+          ],
+          toolCall: { toolName: "mystery_auto_exec", rawInput: {} },
+        },
+        {
+          canUseTool: async () => ({ behavior: "allow" }),
+        },
+      ),
+    ).resolves.toEqual({ outcome: "selected", optionId: "reject-once" });
   });
 
   it("fail-closes ACP permission requests when Ravi hooks are missing", async () => {
@@ -275,7 +398,8 @@ describe("Grok Build runtime provider", () => {
     expect(outcome).toEqual({ outcome: "selected", optionId: "allow-once" });
   });
 
-  it("routes Grok shell permission requests through command execution approval", async () => {
+  it("routes Grok shell permission requests through canUseTool(Bash) and command execution", async () => {
+    const tools: string[] = [];
     const commands: string[] = [];
     const outcome = await authorizeGrokAcpPermission(
       {
@@ -283,10 +407,13 @@ describe("Grok Build runtime provider", () => {
           { optionId: "reject-once", kind: "reject_once" },
           { optionId: "allow-once", kind: "allow_once" },
         ],
-        toolCall: { kind: "bash", rawInput: { command: "git status" } },
+        toolCall: { toolName: "run_terminal_cmd", rawInput: { command: "git status" } },
       },
       {
-        canUseTool: async () => ({ behavior: "allow" }),
+        canUseTool: async (toolName) => {
+          tools.push(toolName);
+          return { behavior: toolName === "Bash" ? "allow" : "deny" };
+        },
         approveRuntimeRequest: async (request) => {
           if (request.kind === "command_execution" && typeof request.input?.command === "string") {
             commands.push(request.input.command);
@@ -296,8 +423,42 @@ describe("Grok Build runtime provider", () => {
         },
       },
     );
+    expect(tools).toContain("Bash");
     expect(commands).toEqual(["git status"]);
     expect(outcome).toEqual({ outcome: "selected", optionId: "allow-once" });
+  });
+
+  it("denies a shell call when canUseTool(Bash) is missing even if the command would be approved", async () => {
+    const outcome = await authorizeGrokAcpPermission(
+      {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { toolName: "run_terminal_cmd", rawInput: { command: "git status" } },
+      },
+      {
+        canUseTool: async () => ({ behavior: "deny", reason: "Bash denied." }),
+        approveRuntimeRequest: async () => ({ approved: true }),
+      },
+    );
+    expect(outcome).toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
+
+  it("denies a shell call when a command is present but no executable authorizer exists", async () => {
+    const outcome = await authorizeGrokAcpPermission(
+      {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+        ],
+        toolCall: { toolName: "run_terminal_cmd", rawInput: { command: "git status" } },
+      },
+      {
+        canUseTool: async () => ({ behavior: "allow" }),
+      },
+    );
+    expect(outcome).toEqual({ outcome: "selected", optionId: "reject-once" });
   });
 
   it("wires prepareSession approvals through Ravi host services", async () => {
@@ -353,12 +514,18 @@ describe("Grok Build runtime provider", () => {
 
     expect(transport.starts[0]).toMatchObject({
       allowTools: ["Read"],
-      denyTools: ["Bash", "Edit", "Grep", "WebFetch", "WebSearch", "MCPTool"],
+      denyTools: ["Bash", "Edit", "Grep", "WebFetch", "WebSearch", "MCPTool", "TodoWrite", "Agent", "Skill"],
+      allowSubagents: false,
     });
-    expect(buildGrokAcpProcessArgs(transport.starts[0])).toEqual(
-      expect.arrayContaining(["--allow", "Read", "--deny", "Bash", "--tools", "Read"]),
+    const spawned = buildGrokAcpProcessArgs(transport.starts[0]);
+    expect(spawned).toEqual(
+      expect.arrayContaining(["--deny", "Bash", "--tools", "read_file,list_dir", "--no-subagents"]),
     );
-    expect(buildGrokAcpProcessArgs(transport.starts[0])).not.toContain("--always-approve");
+    expect(spawned.join("\0")).not.toContain("--allow\0Read");
+    expect(spawned.join("\0")).not.toContain("--allow\0Bash");
+    expect(spawned).not.toContain("--always-approve");
+    expect(spawned[spawned.indexOf("--tools") + 1]).not.toContain("Read");
+    expect(spawned[spawned.indexOf("--disallowed-tools") + 1]).toEqual(expect.stringContaining("todo_write"));
   });
 
   it("closes the Grok ACP transport idempotently", async () => {
@@ -449,7 +616,14 @@ describe("Grok Build runtime provider", () => {
       cwd: "/tmp",
       model: "grok-4",
       effort: "high",
+      allowTools: [],
+      allowSubagents: false,
     });
+    const emptyGrantArgs = buildGrokAcpProcessArgs(transport.starts[0]);
+    expect(emptyGrantArgs).toEqual(expect.arrayContaining(["--no-subagents", "--disallowed-tools"]));
+    expect(emptyGrantArgs[emptyGrantArgs.indexOf("--disallowed-tools") + 1]).toEqual(
+      expect.stringContaining("todo_write"),
+    );
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
       "authenticate",
@@ -657,7 +831,111 @@ describe("Grok Build runtime provider", () => {
     expect(events.filter((event) => event.type === "text.delta")).toHaveLength(0);
     expect(events.at(-1)?.type).toBe("turn.complete");
   });
+
+  it("answers incoming ACP session/request_permission over a fake transport", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-grok-acp-"));
+    const responsePath = join(dir, "permission.json");
+    const command = writeFakeGrokAcpCommand(dir, responsePath);
+    const authorized: string[] = [];
+    const transport = createGrokAcpSubprocessTransport({
+      command: process.execPath,
+      commandArgs: [command],
+      authorizePermission: async (params) => {
+        authorized.push(extractGrokPermissionTool(params).toolName);
+        return authorizeGrokAcpPermission(params, {
+          canUseTool: async (toolName) => ({
+            behavior: toolName === "Read" ? "allow" : "deny",
+          }),
+        });
+      },
+    });
+
+    await transport.start({
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? "/usr/bin" },
+      allowTools: ["Read"],
+      denyTools: ["Bash"],
+    });
+    const init = await transport.request("initialize", { protocolVersion: 1, clientInfo: { name: "ravi" } });
+    expect(init).toMatchObject({ protocolVersion: 1 });
+    await waitFor(() => existsSync(responsePath));
+    const recorded = JSON.parse(readFileSync(responsePath, "utf8")) as {
+      result?: { outcome?: { outcome?: string; optionId?: string } };
+    };
+    expect(authorized).toEqual(["Read"]);
+    expect(recorded.result?.outcome).toEqual({ outcome: "selected", optionId: "allow-once" });
+    await transport.close();
+  });
+
+  it("responds cancelled when incoming ACP authorization throws instead of swallowing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ravi-grok-acp-throw-"));
+    const responsePath = join(dir, "permission.json");
+    const command = writeFakeGrokAcpCommand(dir, responsePath);
+    const transport = createGrokAcpSubprocessTransport({
+      command: process.execPath,
+      commandArgs: [command],
+      authorizePermission: async () => {
+        throw new Error("host authorization exploded");
+      },
+    });
+
+    await transport.start({
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? "/usr/bin" },
+    });
+    await transport.request("initialize", { protocolVersion: 1, clientInfo: { name: "ravi" } });
+    await waitFor(() => existsSync(responsePath));
+    const recorded = JSON.parse(readFileSync(responsePath, "utf8")) as {
+      result?: { outcome?: { outcome?: string; optionId?: string } };
+    };
+    expect(recorded.result?.outcome).toEqual({ outcome: "selected", optionId: "reject-once" });
+    await transport.close();
+  });
 });
+
+function writeFakeGrokAcpCommand(dir: string, responsePath: string): string {
+  const script = join(dir, "fake-grok.mjs");
+  writeFileSync(
+    script,
+    `import { createInterface } from "node:readline";
+import { writeFileSync } from "node:fs";
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let message;
+  try { message = JSON.parse(line); } catch { return; }
+  if (message.method === "initialize") {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { protocolVersion: 1, authMethods: [], agentCapabilities: {} },
+    }) + "\\n");
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 9001,
+      method: "session/request_permission",
+      params: {
+        options: [
+          { optionId: "reject-once", kind: "reject_once" },
+          { optionId: "allow-once", kind: "allow_once" },
+          { optionId: "allow-always", kind: "allow_always" },
+        ],
+        toolCall: { toolName: "read_file", rawInput: { path: "README.md" } },
+      },
+    }) + "\\n");
+    return;
+  }
+  if (message.id === 9001) {
+    writeFileSync(${JSON.stringify(responsePath)}, JSON.stringify(message));
+    return;
+  }
+  if (typeof message.id === "number") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }) + "\\n");
+  }
+});
+`,
+  );
+  return script;
+}
 
 function createStartRequest(text: string, overrides: Partial<RuntimeStartRequest> = {}): RuntimeStartRequest {
   return {

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -33,19 +33,128 @@ const GROK_ACP_PROTOCOL_VERSION = 1;
 
 export type GrokEffort = "none" | "minimal" | "low" | "medium" | "high";
 
-export const GROK_HOSTED_TOOLS = ["Bash", "Edit", "Read", "Grep", "WebFetch", "WebSearch", "MCPTool"] as const;
+/**
+ * Grok permission-rule class names for `--allow` / `--deny`.
+ * These are not `--tools` / `--disallowed-tools` IDs.
+ */
+export const GROK_HOSTED_TOOLS = [
+  "Bash",
+  "Edit",
+  "Read",
+  "Grep",
+  "WebFetch",
+  "WebSearch",
+  "MCPTool",
+  "TodoWrite",
+  "Agent",
+  "Skill",
+] as const;
 
 export type GrokHostedTool = (typeof GROK_HOSTED_TOOLS)[number];
 
-const GROK_TOOL_ALIASES: Record<GrokHostedTool, readonly string[]> = {
-  Bash: ["Shell", "Terminal"],
-  Edit: ["Write"],
-  Read: ["ReadFile", "ListDir"],
-  Grep: ["Glob"],
-  WebFetch: ["WebFetch"],
-  WebSearch: ["WebSearch"],
-  MCPTool: ["MCPTool"],
+/**
+ * Official Grok 1.0.5 `--tools` / `--disallowed-tools` internal IDs.
+ * Sources: xAI Grok CLI `--tools` table (`run_terminal_cmd`, `read_file`,
+ * `list_dir`, `search_replace`, `grep`, `todo_write`, `task`, …), built-in
+ * tools table (`search_tool`, `use_tool`, `kill_task`, `get_task_output`),
+ * and background-task docs (`get_command_or_subagent_output`,
+ * `wait_commands_or_subagents`, `kill_command_or_subagent`). `Agent` is the
+ * documented `--disallowed-tools` subagent entry. `Skill` is the Ravi/Claude
+ * skill-invocation name; unrecognized IDs are skipped by Grok.
+ */
+const GROK_TOOL_CATALOG: Record<
+  GrokHostedTool,
+  {
+    aliases: readonly string[];
+    internalIds: readonly string[];
+    permissionPrefix: boolean;
+    autoExec: boolean;
+    subagents?: boolean;
+  }
+> = {
+  Bash: {
+    aliases: ["Shell", "Terminal"],
+    internalIds: ["run_terminal_cmd"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  Edit: {
+    aliases: ["Write"],
+    internalIds: ["search_replace"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  Read: {
+    aliases: ["ReadFile", "ListDir"],
+    internalIds: ["read_file", "list_dir"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  Grep: {
+    aliases: ["Glob"],
+    internalIds: ["grep"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  WebFetch: {
+    aliases: ["WebFetch"],
+    internalIds: ["web_fetch"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  WebSearch: {
+    aliases: ["WebSearch"],
+    internalIds: ["web_search"],
+    permissionPrefix: false,
+    autoExec: false,
+  },
+  MCPTool: {
+    aliases: ["MCPTool"],
+    internalIds: ["search_tool", "use_tool"],
+    permissionPrefix: true,
+    autoExec: false,
+  },
+  TodoWrite: {
+    aliases: ["TodoWrite"],
+    internalIds: ["todo_write"],
+    permissionPrefix: false,
+    autoExec: true,
+  },
+  Agent: {
+    aliases: ["Task", "TaskOutput", "TaskStop", "Agent"],
+    internalIds: [
+      "task",
+      "get_command_or_subagent_output",
+      "get_task_output",
+      "wait_tasks",
+      "wait_commands_or_subagents",
+      "kill_task",
+      "kill_command_or_subagent",
+    ],
+    permissionPrefix: false,
+    autoExec: true,
+    subagents: true,
+  },
+  Skill: {
+    aliases: ["Skill"],
+    internalIds: ["Skill"],
+    permissionPrefix: false,
+    autoExec: true,
+  },
 };
+
+const GROK_TOOL_ALIASES: Record<GrokHostedTool, readonly string[]> = Object.fromEntries(
+  GROK_HOSTED_TOOLS.map((tool) => [tool, GROK_TOOL_CATALOG[tool].aliases]),
+) as Record<GrokHostedTool, readonly string[]>;
+
+/** Extra documented IDs to strip on empty/deny so Grok cannot auto-exec them. */
+export const GROK_FAIL_CLOSED_TOOL_IDS = [
+  ...new Set([
+    ...GROK_HOSTED_TOOLS.flatMap((tool) => [...GROK_TOOL_CATALOG[tool].internalIds]),
+    "Agent",
+    "grep_search",
+  ]),
+];
 
 export interface GrokAcpStartInput {
   cwd: string;
@@ -55,11 +164,18 @@ export interface GrokAcpStartInput {
   systemPromptAppend?: string;
   allowTools?: string[];
   denyTools?: string[];
+  /** Scoped permission rules only, e.g. `Read(src/**)` or `Bash(git *)`. Never a bare class. */
+  allowRules?: string[];
+  allowSubagents?: boolean;
 }
 
 export interface GrokToolAccessRules {
   allow: string[];
   deny: string[];
+  allowToolIds: string[];
+  denyToolIds: string[];
+  allowRules: string[];
+  allowSubagents: boolean;
 }
 
 export type GrokPermissionOutcome = { outcome: "selected"; optionId: string } | { outcome: "cancelled" };
@@ -302,14 +418,24 @@ export function createGrokAcpSubprocessTransport(
       return;
     }
     void (async () => {
-      const outcome = options.authorizePermission
-        ? await options.authorizePermission(params, { interrupted })
-        : await authorizeGrokAcpPermission(params, { interrupted });
-      await writeMessage({
-        jsonrpc: "2.0",
-        id,
-        result: { outcome },
-      });
+      try {
+        const outcome = options.authorizePermission
+          ? await options.authorizePermission(params, { interrupted })
+          : await authorizeGrokAcpPermission(params, { interrupted });
+        await writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: { outcome },
+        });
+      } catch {
+        const fallback = selectGrokPermissionOutcome(params.options, "reject");
+        const outcome: GrokPermissionOutcome = fallback.outcome === "selected" ? fallback : { outcome: "cancelled" };
+        await writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: { outcome },
+        });
+      }
     })().catch(() => {});
   };
 
@@ -482,19 +608,48 @@ export function createGrokAcpSubprocessTransport(
 }
 
 export function buildGrokAcpProcessArgs(
-  input: Pick<GrokAcpStartInput, "model" | "effort" | "systemPromptAppend" | "allowTools" | "denyTools">,
+  input: Pick<
+    GrokAcpStartInput,
+    "model" | "effort" | "systemPromptAppend" | "allowTools" | "denyTools" | "allowRules" | "allowSubagents"
+  >,
 ): string[] {
+  const granted = new Set((input.allowTools ?? []).filter(isGrokHostedTool));
+  const denied = uniqueStrings(
+    (input.denyTools?.length ? input.denyTools : GROK_HOSTED_TOOLS.filter((tool) => !granted.has(tool))).filter(
+      isGrokHostedTool,
+    ),
+  ).filter(isGrokHostedTool);
+  const allowToolIds = uniqueStrings(input.allowTools ? toolIdsForHostedClasses([...granted]) : []);
+  const denyToolIds = uniqueStrings([
+    ...denied.flatMap((tool) => [...GROK_TOOL_CATALOG[tool].internalIds]),
+    ...GROK_FAIL_CLOSED_TOOL_IDS.filter((id) => !allowToolIds.includes(id)),
+  ]);
+  const allowSubagents = input.allowSubagents === true || granted.has("Agent");
+
   const args = ["--no-auto-update", "--no-alt-screen", "--permission-mode", "default"];
-  for (const tool of input.allowTools ?? []) {
-    args.push("--allow", tool);
+  for (const rule of input.allowRules ?? []) {
+    if (isGrokScopedPermissionRule(rule)) {
+      args.push("--allow", rule);
+    }
   }
-  for (const tool of input.denyTools ?? []) {
-    args.push("--deny", tool);
+  for (const tool of denied) {
+    if (GROK_TOOL_CATALOG[tool].permissionPrefix) {
+      args.push("--deny", tool);
+    }
+    if (tool === "Edit") {
+      args.push("--deny", "Write");
+    }
   }
-  if ((input.allowTools?.length ?? 0) > 0) {
-    args.push("--tools", input.allowTools!.join(","));
-  } else if ((input.denyTools?.length ?? 0) > 0) {
-    args.push("--disallowed-tools", input.denyTools!.join(","));
+  if (allowToolIds.length > 0) {
+    args.push("--tools", allowToolIds.join(","));
+    args.push("--disallowed-tools", denyToolIds.join(","));
+  } else {
+    // Empty `--tools` is ignored by Grok 1.0.5. A full documented denylist plus
+    // `--no-subagents` is the fail-closed equivalent that strips auto-exec tools.
+    args.push("--disallowed-tools", GROK_FAIL_CLOSED_TOOL_IDS.join(","));
+  }
+  if (!allowSubagents) {
+    args.push("--no-subagents");
   }
   const model = input.model?.trim();
   if (model && model !== "default") {
@@ -510,6 +665,14 @@ export function buildGrokAcpProcessArgs(
   }
   args.push("agent", "stdio");
   return args;
+}
+
+export function isGrokScopedPermissionRule(rule: string): boolean {
+  return /^(Bash|Edit|Write|Read|Grep|WebFetch|MCPTool)\(.+\)$/.test(rule.trim());
+}
+
+function toolIdsForHostedClasses(classes: GrokHostedTool[]): string[] {
+  return classes.flatMap((tool) => [...GROK_TOOL_CATALOG[tool].internalIds]);
 }
 
 export function buildGrokAcpSpawnEnv(input: Pick<GrokAcpStartInput, "env">): NodeJS.ProcessEnv {
@@ -550,21 +713,24 @@ export function selectGrokPermissionOutcome(
   preference: "allow" | "reject" = "reject",
 ): GrokPermissionOutcome {
   const list = Array.isArray(options) ? options : [];
+  const wanted = preference === "allow" ? "allow_once" : "reject_once";
   const match = list.find((option) => {
     if (!isRecord(option)) {
       return false;
     }
-    const kind = firstString(option.kind)?.toLowerCase() ?? "";
-    const optionId = firstString(option.optionId, option.id)?.toLowerCase() ?? "";
-    return preference === "allow"
-      ? kind.includes("allow") || optionId.includes("allow")
-      : kind.includes("reject") || kind.includes("deny") || optionId.includes("reject") || optionId.includes("deny");
+    return grokPermissionOptionTokens(option).includes(wanted);
   });
   const optionId = isRecord(match) ? firstString(match.optionId, match.id) : undefined;
   if (!optionId) {
     return { outcome: "cancelled" };
   }
   return { outcome: "selected", optionId };
+}
+
+function grokPermissionOptionTokens(option: Record<string, unknown>): string[] {
+  return [firstString(option.kind), firstString(option.optionId, option.id)]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toLowerCase().replace(/[\s-]+/g, "_"));
 }
 
 export async function resolveGrokToolAccessRules(
@@ -579,7 +745,19 @@ export async function resolveGrokToolAccessRules(
       deny.push(tool);
     }
   }
-  return { allow, deny };
+  const allowToolIds = uniqueStrings(toolIdsForHostedClasses(allow.filter(isGrokHostedTool)));
+  const denyToolIds = uniqueStrings([
+    ...deny.filter(isGrokHostedTool).flatMap((tool) => [...GROK_TOOL_CATALOG[tool].internalIds]),
+    ...GROK_FAIL_CLOSED_TOOL_IDS.filter((id) => !allowToolIds.includes(id)),
+  ]);
+  return {
+    allow,
+    deny,
+    allowToolIds,
+    denyToolIds,
+    allowRules: [],
+    allowSubagents: allow.includes("Agent"),
+  };
 }
 
 export function mapGrokToolNameToRavi(name?: string): string {
@@ -595,9 +773,37 @@ export function mapGrokToolNameToRavi(name?: string): string {
     normalized.includes("bash") ||
     normalized.includes("shell") ||
     normalized === "execute" ||
-    normalized === "terminal"
+    normalized === "terminal" ||
+    normalized.includes("runterminalcmd") ||
+    normalized.includes("runterminalcommand")
   ) {
     return "Bash";
+  }
+  if (normalized === "todowrite" || normalized.includes("todowrite")) {
+    return "TodoWrite";
+  }
+  if (normalized === "skill" || normalized === "skillinvoke") {
+    return "Skill";
+  }
+  if (
+    normalized.includes("getcommandorsubagent") ||
+    normalized.includes("gettaskoutput") ||
+    normalized.includes("waittasks") ||
+    normalized.includes("waitcommandsorsubagents") ||
+    normalized.includes("killtask") ||
+    normalized.includes("killcommandorsubagent") ||
+    normalized === "wait" ||
+    normalized === "kill"
+  ) {
+    return "Agent";
+  }
+  if (
+    normalized === "task" ||
+    normalized === "agent" ||
+    normalized.includes("subagent") ||
+    normalized.includes("spawnsubagent")
+  ) {
+    return "Agent";
   }
   if (normalized.includes("webfetch") || normalized.includes("webget")) {
     return "WebFetch";
@@ -605,7 +811,7 @@ export function mapGrokToolNameToRavi(name?: string): string {
   if (normalized.includes("websearch") || normalized.includes("webquery")) {
     return "WebSearch";
   }
-  if (normalized.includes("mcp")) {
+  if (normalized.includes("mcp") || normalized === "searchtool" || normalized === "usetool") {
     return "MCPTool";
   }
   if (normalized.includes("grep") || normalized.includes("glob") || normalized.includes("searchcontent")) {
@@ -666,6 +872,8 @@ async function* runGrokTurns(
     systemPromptAppend: input.systemPromptAppend,
     allowTools: toolAccess.allow,
     denyTools: toolAccess.deny,
+    allowRules: toolAccess.allowRules,
+    allowSubagents: toolAccess.allowSubagents,
   };
   const eventIterator = transport.events[Symbol.asyncIterator]();
 
@@ -1028,7 +1236,7 @@ async function isGrokHostedToolAllowed(
   if (!canUseTool) {
     return false;
   }
-  const names = [tool, ...(GROK_TOOL_ALIASES[tool] ?? [])];
+  const names = tool === "Agent" ? ["Agent", "Task"] : [tool, ...(GROK_TOOL_ALIASES[tool] ?? [])];
   for (const name of names) {
     const result = await canUseTool(name, {});
     if (result.behavior === "allow") {
@@ -1044,8 +1252,20 @@ async function decideGrokToolAuthorization(
   rawRequest: Record<string, unknown>,
   handlers: GrokPermissionAuthorizationHandlers,
 ): Promise<boolean> {
+  const mapped = mapGrokToolNameToRavi(toolName);
+  if (!isKnownGrokAuthorizationTool(mapped) && !isKnownGrokAuthorizationTool(toolName)) {
+    return false;
+  }
+
+  const toolAllowed = await isGrokToolAllowedByHost(mapped === "tool" ? toolName : mapped, input, handlers);
   const command = firstString(input.command, input.cmd);
-  if (command && handlers.approveRuntimeRequest) {
+  if (command) {
+    if (!toolAllowed) {
+      return false;
+    }
+    if (!handlers.approveRuntimeRequest) {
+      return false;
+    }
     const result = await handlers.approveRuntimeRequest({
       kind: "command_execution",
       method: "session/request_permission",
@@ -1057,22 +1277,15 @@ async function decideGrokToolAuthorization(
   }
 
   if (handlers.canUseTool) {
-    const names = uniqueStrings([toolName, ...aliasesForGrokTool(toolName)]);
-    for (const name of names) {
-      const result = await handlers.canUseTool(name, input);
-      if (result.behavior === "allow") {
-        return true;
-      }
-    }
-    return false;
+    return toolAllowed;
   }
 
   if (handlers.approveRuntimeRequest) {
-    const kind = toolName === "Edit" || toolName === "Write" ? "file_change" : "permission";
+    const kind = mapped === "Edit" || mapped === "Write" ? "file_change" : "permission";
     const result = await handlers.approveRuntimeRequest({
       kind,
       method: "session/request_permission",
-      toolName,
+      toolName: mapped === "tool" ? toolName : mapped,
       input,
       rawRequest,
     });
@@ -1080,6 +1293,41 @@ async function decideGrokToolAuthorization(
   }
 
   return false;
+}
+
+async function isGrokToolAllowedByHost(
+  toolName: string,
+  input: Record<string, unknown>,
+  handlers: GrokPermissionAuthorizationHandlers,
+): Promise<boolean> {
+  if (!handlers.canUseTool) {
+    return false;
+  }
+  const names = uniqueStrings([toolName, ...aliasesForGrokTool(toolName)]);
+  for (const name of names) {
+    const result = await handlers.canUseTool(name, input);
+    if (result.behavior === "allow") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isKnownGrokAuthorizationTool(name: string): boolean {
+  if (isGrokHostedTool(name)) {
+    return true;
+  }
+  const mapped = mapGrokToolNameToRavi(name);
+  if (isGrokHostedTool(mapped)) {
+    return true;
+  }
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "");
+  return GROK_HOSTED_TOOLS.some((tool) =>
+    GROK_TOOL_ALIASES[tool].some((alias) => alias.toLowerCase().replace(/[\s_-]+/g, "") === normalized),
+  );
 }
 
 function aliasesForGrokTool(toolName: string): string[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Follow-up on merged PR 459. Restricted Grok can start, but Ravi was not yet the per-tool authority: spawn reused class names on `--tools`, emitted class-wide `--allow Bash` / `--allow Read`, and ACP authorization had fail-open holes. This PR makes Ravi decide each Grok tool.

Rebased/merged onto latest `dev` after PR 460 (`7ae089a`). ACP `initialize` still sends non-empty `clientInfo.version`.

## Problem

- `--tools` / `--disallowed-tools` reused class names (`Bash`, `Read`). Grok 1.0.5 expects internal IDs (`run_terminal_cmd`, `read_file`). Unrecognized IDs are skipped, so a class-name allowlist is not a backstop.
- `--allow Bash` / `--allow Read` auto-approve every invocation of that class and skip ACP. Luís forbade always-approve as the permission model. Path-scoped Read becoming unqualified `--allow Read` is the same bug.
- Empty grants used an incomplete `--disallowed-tools` catalog. Grok `default` auto-runs `todo_write`, Agent/subagents, skills, and command/subagent control without ACP.
- `decideGrokToolAuthorization` skipped `canUseTool("Bash")` when a command was present.
- `handleIncomingRequest` swallowed authorize throws, so Grok could fail-open.
- `selectGrokPermissionOutcome` used substring `includes("allow")`, which matches `disallow` and `allow_always`.

## Solution

- `--tools` / `--disallowed-tools` use official Grok internal IDs. `--allow` / `--deny` keep class/rule names.
- A tool grant enables the tool via `--tools` only. Never emit class-wide `--allow Bash` or `--allow Read`. Scoped `--allow Read(src/**)` / `--allow Bash(git *)` only when that is a real scoped grant.
- Always `--deny` ungranted permission-prefix classes. Always `--no-subagents` unless the host granted Agent/Task.
- Empty grants fail closed with the full documented `--disallowed-tools` catalog (`todo_write`, `task`, `Agent`, skill, get/wait/kill control IDs) plus `--no-subagents`. Empty `--tools` is ignored by Grok 1.0.5, so this is the documented equivalent.
- `decideGrokToolAuthorization` requires both `canUseTool(Bash)` and `authorizeCommandExecution` when a command is present (`tool_and_executable`). Map `run_terminal_cmd` to Bash.
- Unknown tools fail closed. Authorize throws respond JSON-RPC reject/cancelled. Select only `allow_once` / `reject_once`.
- Keep PR 460 `buildGrokAcpInitializeParams()` so `clientInfo.version` is always a non-empty string.

## Practical impact

- A bootstrap / empty-grant Grok session no longer keeps auto-exec tools Grok would run without asking.
- A Bash grant starts the tool but still hits Ravi ACP for each command.
- Incoming `session/request_permission` is answered by the host; a throw cannot fail-open.
- Grok 1.0.5 initialize still succeeds with `clientInfo.version`.

## What does NOT change

- `shouldUseTurnScopedAuthorityForPrompt`
- Restricted `toolAccessMode` check / no `full-access` requirement
- `permissionMode: "ravi-host"` and `supportsToolHooks: true`
- No `--always-approve` or `bypassPermissions` on Grok argv
- ACP `initialize` `clientInfo.version` from PR 460
- Codex / Claude / Pi / Hub / ravi_app

## Validation

- Merged `origin/dev` (`7ae089a`, PR 460) into this branch; no conflicts
- `bun run typecheck`
- `bun test src/runtime/grok-provider.test.ts` — 33 pass, including `includes a non-empty clientInfo.version on ACP initialize` plus spawn/ACP cases: unknown tool fail-closed; empty grants strip Agent/`todo_write` and pass `--no-subagents`; Bash grant does not argv `--allow Bash`; `--tools` uses `read_file` / `run_terminal_cmd`; fake transport incoming `session/request_permission`; no `--always-approve`
- Pre-push hook (full test suite + typecheck + SDK checks) passed

## Risks

- Grok CLI versions that use different internal IDs than 1.0.5 will skip unrecognized `--tools` entries. The catalog is sourced from the official `--tools` table, built-in tools table, and background-task docs; extra deny IDs are skipped harmlessly.
- `--tools` / `--disallowed-tools` remain headless-oriented flags. Live `grok agent stdio` 1.0.5 `--help` documents them; CI uses a fake ACP transport.

## Rollback

- Revert this PR. Grok returns to PR 459 spawn (class-name `--tools` + class-wide `--allow`) and the previous ACP holes. `clientInfo.version` from 460 stays on `dev`.

## Follow-ups

- None. PR 460 is already merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6bed68c-c5c5-4f88-b8c4-d974e630c8fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6bed68c-c5c5-4f88-b8c4-d974e630c8fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

