### PR TITLE
fix(sessions): persist each visible assistant message as its own row

### DIFF
--- a/src/channels/runtime-events.test.ts
+++ b/src/channels/runtime-events.test.ts
@@ -684,7 +684,7 @@ describe("channel runtime event projection", () => {
     expect(readback.terminalEvent).toBeUndefined();
   });
 
-  it("retains suppressed non-commentary outcomes locally without projecting them", async () => {
+  it("keeps suppressed non-commentary outcomes off the channel and off durable chat.db rows", async () => {
     const metadata = await acceptedMetadata();
     const events: KnownChannelRuntimeEvent[] = [];
     const outputs: ChannelOutputEnvelope[] = [];
@@ -749,7 +749,7 @@ describe("channel runtime event projection", () => {
       getHistory(metadata.binding.sessionId)
         .filter((message) => message.role === "assistant")
         .map((message) => message.content),
-    ).toEqual(["Routine finished HEARTBEAT_OK\n\nNo response requested."]);
+    ).toEqual([]);
   });
 
   it("does not project assistant content from an interrupted channel turn", async () => {

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -712,6 +712,49 @@ describe("SessionCommands wait mode", () => {
     expect(responseText).not.toContain("@@SILENT@@");
   });
 
+  it("joins this turn's assistant rows for CLI-only send -w", async () => {
+    runtimeEvents = [{ type: "turn.complete" }];
+    chatHistory = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+    ];
+    chatHistoryAfterSnapshot = [
+      { id: 1, role: "user", content: "old prompt" },
+      { id: 2, role: "assistant", content: "previous" },
+      { id: 3, role: "user", content: "say two things" },
+      { id: 4, role: "assistant", content: "Part one." },
+      { id: 5, role: "assistant", content: "Part two." },
+    ];
+
+    const commands = new SessionCommands();
+    let responseText = "";
+    const chars = await (commands as any).streamToSession(
+      "grok-cli-probe",
+      "say two things",
+      {
+        sessionKey: "agent:grok-cli-probe:main",
+        name: "grok-cli-probe",
+        agentId: "grok-cli-probe",
+        agentCwd: "/tmp/grok-cli-probe",
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        silent: true,
+        cliDestination: true,
+        onResponse: (chunk: string) => {
+          responseText += chunk;
+        },
+      },
+    );
+
+    expect(responseText).toBe("Part one.\n\nPart two.");
+    expect(chars).toBe("Part one.\n\nPart two.".length);
+    expect(responseText).not.toContain("previous");
+  });
+
   it("throws on timeout instead of treating the wait as success", async () => {
     const commands = new SessionCommands();
     const originalSetTimeout = globalThis.setTimeout;
@@ -2228,6 +2271,12 @@ describe("SessionCommands read", () => {
       "opção 1, 2 e 3",
       "qual o melhor?",
     ]);
+    expect(payload.messages[0].id).toBe(1);
+    expect(payload.messages[1].id).toBe(2);
+    expect(payload.messages[0].createdAt).toBe("2026-04-20T04:29:35.000Z");
+    expect(payload.messages[1].createdAt).toBe("2026-04-20T04:30:48.000Z");
+    expect(payload.messages[0].time).toBe("2026-04-20T04:29:35.000Z");
+    expect(payload.messages[1].time).toBe("2026-04-20T04:30:48.000Z");
     expect(payload.messages[0].source).toEqual({
       agentId: "main",
       channel: "whatsapp-baileys",
@@ -2235,6 +2284,55 @@ describe("SessionCommands read", () => {
       chatId: "63295117615153@lid",
       sourceMessageId: "wamid-1",
     });
+  });
+
+  it("keeps sequential assistant rows distinct on read --json instead of one joined blob", () => {
+    chatHistory = [
+      {
+        id: 1,
+        session_id: "main-dm-615153",
+        role: "user",
+        content: "hello",
+        created_at: "2026-04-20 04:29:35",
+      },
+      {
+        id: 2,
+        session_id: "main-dm-615153",
+        role: "assistant",
+        content: "welcome",
+        created_at: "2026-04-20 04:29:36",
+      },
+      {
+        id: 3,
+        session_id: "main-dm-615153",
+        role: "user",
+        content: "ping",
+        created_at: "2026-04-20 04:30:48",
+      },
+      {
+        id: 4,
+        session_id: "main-dm-615153",
+        role: "assistant",
+        content: "pong",
+        created_at: "2026-04-20 04:30:49",
+      },
+    ];
+
+    const payload = JSON.parse(
+      captureLogs(() => {
+        new SessionCommands().read("main-dm-615153", "10", true);
+      }),
+    );
+
+    expect(payload.messages).toHaveLength(4);
+    expect(payload.messages.map((message: { role: string; text: string; id: number }) => [message.id, message.role, message.text])).toEqual([
+      [1, "user", "hello"],
+      [2, "assistant", "welcome"],
+      [3, "user", "ping"],
+      [4, "assistant", "pong"],
+    ]);
+    expect(payload.messages[3].text).not.toContain(payload.messages[1].text);
+    expect(payload.messages.every((message: { createdAt: string }) => message.createdAt.endsWith("Z"))).toBe(true);
   });
 
   it("omits the advertised skill catalog from default read --json", () => {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1182,6 +1182,25 @@ function buildSessionMutationJson(
   };
 }
 
+function toIsoTimestamp(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "";
+  if (typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? trimmed : date.toISOString();
+  }
+  // SQLite datetime('now') is UTC without a timezone suffix.
+  const normalized = trimmed.includes(" ") ? trimmed.replace(" ", "T") : trimmed;
+  const withZone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(normalized) ? normalized : `${normalized}Z`;
+  const date = new Date(withZone);
+  return Number.isNaN(date.getTime()) ? trimmed : date.toISOString();
+}
+
 function normalizeChatDbMessage(message: Message): NormalizedTranscriptMessage {
   const source =
     message.agent_id || message.channel || message.account_id || message.chat_id || message.source_message_id
@@ -1193,10 +1212,13 @@ function normalizeChatDbMessage(message: Message): NormalizedTranscriptMessage {
           sourceMessageId: message.source_message_id ?? null,
         }
       : undefined;
+  const createdAt = toIsoTimestamp(message.created_at);
   return {
     role: message.role,
     text: message.content,
-    time: message.created_at ? new Date(message.created_at).toLocaleTimeString() : "",
+    time: createdAt,
+    id: message.id,
+    ...(createdAt ? { createdAt } : {}),
     ...(source ? { source } : {}),
   };
 }
@@ -1433,10 +1455,12 @@ function readMessageMetadataFallback(session: SessionEntry, limit: number): Norm
           ? `[${meta.mediaType} message${meta.mediaPath ? `: ${meta.mediaPath}` : ""}]`
           : "";
       if (!text) return null;
+      const createdAt = toIsoTimestamp(meta.createdAt);
       return {
         role: "user" as const,
         text,
-        time: meta.createdAt ? new Date(meta.createdAt).toLocaleTimeString() : "",
+        time: createdAt,
+        ...(createdAt ? { createdAt } : {}),
       };
     })
     .filter((message): message is NormalizedTranscriptMessage => message !== null);
@@ -6635,6 +6659,8 @@ export interface NormalizedTranscriptMessage {
   role: "user" | "assistant";
   text: string;
   time: string;
+  id?: number;
+  createdAt?: string;
   source?: {
     agentId: string | null;
     channel: string | null;
@@ -6680,7 +6706,8 @@ function extractClaudeTranscriptMessages(raw: string): NormalizedTranscriptMessa
         messages.push({
           role: "user",
           text: content.trim(),
-          time: entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "",
+          time: toIsoTimestamp(entry.timestamp),
+          ...(entry.timestamp ? { createdAt: toIsoTimestamp(entry.timestamp) } : {}),
         });
       } else if (entry.type === "assistant" && entry.message?.content) {
         const parts = entry.message.content as Array<{
@@ -6696,7 +6723,8 @@ function extractClaudeTranscriptMessages(raw: string): NormalizedTranscriptMessa
         messages.push({
           role: "assistant",
           text,
-          time: entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "",
+          time: toIsoTimestamp(entry.timestamp),
+          ...(entry.timestamp ? { createdAt: toIsoTimestamp(entry.timestamp) } : {}),
         });
       }
     } catch {
@@ -6733,13 +6761,15 @@ function extractCodexTranscriptMessages(raw: string): NormalizedTranscriptMessag
         messages.push({
           role: "user",
           text,
-          time: entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "",
+          time: toIsoTimestamp(entry.timestamp),
+          ...(entry.timestamp ? { createdAt: toIsoTimestamp(entry.timestamp) } : {}),
         });
       } else if (payloadType === "agent_message") {
         messages.push({
           role: "assistant",
           text,
-          time: entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "",
+          time: toIsoTimestamp(entry.timestamp),
+          ...(entry.timestamp ? { createdAt: toIsoTimestamp(entry.timestamp) } : {}),
         });
       }
     } catch {

--- a/src/cli/session-cli-surface.test.ts
+++ b/src/cli/session-cli-surface.test.ts
@@ -88,6 +88,18 @@ describe("session CLI surface", () => {
     expect(readThisTurnAssistantText(messages.slice(0, 2), 2)).toBeNull();
   });
 
+  it("joins this turn's assistant rows after the cursor for send -w", () => {
+    const messages = [
+      { id: 1, role: "user", content: "old" },
+      { id: 2, role: "assistant", content: "previous" },
+      { id: 3, role: "user", content: "say two things" },
+      { id: 4, role: "assistant", content: "Part one." },
+      { id: 5, role: "assistant", content: "Part two." },
+    ];
+    expect(readThisTurnAssistantText(messages, 2)).toEqual({ text: "Part one.\n\nPart two." });
+    expect(readThisTurnAssistantText(messages, 2)?.text).not.toContain("previous");
+  });
+
   it("waits when persist lags after turn.complete", async () => {
     const prior = [
       { id: 1, role: "user", content: "old" },

--- a/src/cli/session-cli-surface.ts
+++ b/src/cli/session-cli-surface.ts
@@ -61,10 +61,12 @@ export function snapshotTranscriptCursor(messages: Array<{ id: number }>): numbe
 }
 
 export function readThisTurnAssistantText(messages: TranscriptMessageLike[], afterId: number): { text: string } | null {
-  const newer = messages.filter((message) => message.id > afterId);
-  const lastAssistant = [...newer].reverse().find((message) => message.role === "assistant");
-  if (!lastAssistant) return null;
-  return { text: sanitizeCliAssistantText(lastAssistant.content) };
+  const assistantParts = messages
+    .filter((message) => message.id > afterId && message.role === "assistant")
+    .map((message) => sanitizeCliAssistantText(message.content))
+    .filter((text) => text.length > 0);
+  if (assistantParts.length === 0) return null;
+  return { text: assistantParts.join("\n\n") };
 }
 
 export async function waitForThisTurnAssistantText(input: WaitForThisTurnAssistantInput): Promise<string | null> {

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -1732,6 +1732,18 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     return runtimeSessionParams;
   };
 
+  const persistVisibleAssistantMessage = (text: string) => {
+    const trimmedVisible = text.trim();
+    if (!trimmedVisible) return;
+    saveMessage(sessionName, "assistant", trimmedVisible, session.providerSessionId ?? session.sdkSessionId ?? null, {
+      agentId: streaming.agentId,
+      channel: streaming.currentSource?.channel,
+      accountId: streaming.currentSource?.accountId,
+      chatId: streaming.currentSource?.chatId,
+      sourceMessageId: streaming.currentSource?.sourceMessageId,
+    });
+  };
+
   const emitResponse = async (text: string, metadata?: RuntimeEventMetadata) => {
     const mediaParts = isCommentaryResponse(metadata) ? [] : pendingGeneratedMedia.splice(0);
     const channelBackendOwnsText = streaming.currentChannelBackend !== undefined;
@@ -2388,7 +2400,10 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
                 },
                 preview: messageText,
               });
-              if (!commentaryResponse) {
+              // Only user-visible (observed) non-commentary text accumulates.
+              // Silent / heartbeat / no-response / prompt-too-long stay off the
+              // persist buffer so they cannot become durable assistant rows.
+              if (observe && !commentaryResponse) {
                 responseText = appendAssistantResponse(responseText, messageText);
               }
             };
@@ -2453,6 +2468,7 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
               });
               if (!commentaryResponse) {
                 channelResponseText = appendAssistantResponse(channelResponseText, messageText);
+                persistVisibleAssistantMessage(messageText);
               } else if (streaming.agentMode !== "sentinel") {
                 await projectRuntimeEventToChannel({
                   ...event,
@@ -2815,18 +2831,8 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
           await emitResponse("", event.metadata);
         }
 
-        if (!streaming.interrupted && responseText.trim()) {
-          const sdkId = event.providerSessionId;
-          saveMessage(sessionName, "assistant", responseText.trim(), sdkId, {
-            agentId: streaming.agentId,
-            channel: streaming.currentSource?.channel,
-            accountId: streaming.currentSource?.accountId,
-            chatId: streaming.currentSource?.chatId,
-            sourceMessageId: streaming.currentSource?.sourceMessageId,
-          });
-        }
-
-        // Reset for next turn
+        // Visible assistant rows are INSERTed per assistant.message. turn.complete
+        // only closes the in-memory buffer so the next turn cannot mash into it.
         responseText = "";
         channelResponseText = "";
         clearPendingGeneratedMedia();

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -2525,7 +2525,7 @@ describe("runtime session trace instrumentation", () => {
     expect(assistant.some(({ content }) => content.includes("Part one.\n\nPart two."))).toBe(false);
   });
 
-  it("does not persist silent heartbeat, no-response, or prompt-too-long assistant text", async () => {
+  it("does not persist silent heartbeat, no-response, or @@SILENT@@ assistant text", async () => {
     const streaming = makeStreamingSession();
     seedAdapterTrace(streaming, "turn-silent-no-row");
 

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -2546,6 +2546,15 @@ describe("runtime session trace instrumentation", () => {
     expect(getRecentHistory(SESSION_NAME).filter(({ role }) => role === "assistant")).toEqual([]);
   });
 
+  it("does not persist prompt-too-long assistant text as a durable row", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-prompt-too-long-no-row");
+
+    await runTraceLoop(streaming, makeRuntimeSession([{ type: "assistant.message", text: "prompt is too long" }]));
+
+    expect(getRecentHistory(SESSION_NAME).filter(({ role }) => role === "assistant")).toEqual([]);
+  });
+
   it("keeps sequential user/assistant turns as distinct chat.db rows", async () => {
     saveMessage(SESSION_NAME, "user", "hello", null, { agentId: AGENT_ID });
     const first = makeStreamingSession();

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -2501,6 +2501,95 @@ describe("runtime session trace instrumentation", () => {
     ).toEqual(["Final answer only."]);
   });
 
+  it("persists each visible assistant.message as its own chat.db row in one physical turn", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-two-visible-parts");
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        { type: "assistant.message", text: "Part one." },
+        { type: "assistant.message", text: "Part two." },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-after",
+          usage: { inputTokens: 1, outputTokens: 2 },
+        },
+      ]),
+    );
+
+    const assistant = getRecentHistory(SESSION_NAME).filter(({ role }) => role === "assistant");
+    expect(assistant.map(({ content }) => content)).toEqual(["Part one.", "Part two."]);
+    expect(assistant).toHaveLength(2);
+    expect(assistant[0]!.id).not.toBe(assistant[1]!.id);
+    expect(assistant.some(({ content }) => content.includes("Part one.\n\nPart two."))).toBe(false);
+  });
+
+  it("does not persist silent heartbeat, no-response, or prompt-too-long assistant text", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-silent-no-row");
+
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        { type: "assistant.message", text: "Routine finished HEARTBEAT_OK" },
+        { type: "assistant.message", text: "No response requested." },
+        { type: "assistant.message", text: "@@SILENT@@" },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-after",
+          usage: { inputTokens: 1, outputTokens: 0 },
+        },
+      ]),
+    );
+
+    expect(getRecentHistory(SESSION_NAME).filter(({ role }) => role === "assistant")).toEqual([]);
+  });
+
+  it("keeps sequential user/assistant turns as distinct chat.db rows", async () => {
+    saveMessage(SESSION_NAME, "user", "hello", null, { agentId: AGENT_ID });
+    const first = makeStreamingSession();
+    seedAdapterTrace(first, "turn-seq-1");
+    await runTraceLoop(
+      first,
+      makeRuntimeSession([
+        { type: "assistant.message", text: "welcome" },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-1",
+          usage: { inputTokens: 1, outputTokens: 1 },
+        },
+      ]),
+    );
+
+    saveMessage(SESSION_NAME, "user", "ping", null, { agentId: AGENT_ID });
+    const second = makeStreamingSession();
+    seedAdapterTrace(second, "turn-seq-2");
+    await runTraceLoop(
+      second,
+      makeRuntimeSession([
+        { type: "assistant.message", text: "pong" },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-2",
+          usage: { inputTokens: 1, outputTokens: 1 },
+        },
+      ]),
+    );
+
+    const rows = getRecentHistory(SESSION_NAME);
+    expect(rows.map(({ role, content }) => [role, content])).toEqual([
+      ["user", "hello"],
+      ["assistant", "welcome"],
+      ["user", "ping"],
+      ["assistant", "pong"],
+    ]);
+    const assistants = rows.filter(({ role }) => role === "assistant");
+    expect(assistants).toHaveLength(2);
+    expect(assistants[1]!.content).not.toContain(assistants[0]!.content);
+    expect(assistants[0]!.content).not.toContain(assistants[1]!.content);
+  });
+
   it("classifies a provider login stub as turn.failed and keeps it off the transcript", async () => {
     updateRuntimeProviderState(SESSION_KEY, "codex", {
       providerSessionId: "codex-thread",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop mashed assistant history in `sessions.read` by fixing the **write / turn-boundary** path. The existing message format stays: one `messages[]` row is still one Flutter/Hub bubble. This PR does not invent a new protocol.

## Problem

- Assistant replies (and sometimes welcome + pongs) showed up as one concatenated string in `sessions.read`.
- The app was not merging. `host-event-loop.ts` appended every non-commentary `assistant.message` into one in-memory buffer, then did a single `saveMessage(..., responseText)` on `turn.complete`.
- Silent / heartbeat / no-response / prompt-too-long still called `recordAssistantState`, which appended into that persist buffer.
- `sessions.read` used `toLocaleTimeString()` as the primary clock, so clients lacked a stable id/time.

## Solution

- Persist each **user-visible** `assistant.message` as its own `saveMessage` INSERT (same moment as `emitResponse`), instead of one mashed blob at `turn.complete`.
- Do **not** append silent / heartbeat / no-response-requested / prompt-too-long into the persist buffer. Login stubs still convert the turn to `turn.failed` and never write an assistant row.
- `turn.complete` only clears `responseText` / `channelResponseText` so the next turn cannot mash into the previous buffer.
- `sessions.read` (`normalizeChatDbMessage`) now exposes stable numeric **`id`** and ISO **`time` / `createdAt`**.
- `sessions send -w` / `waitForThisTurnAssistantText` still returns this turn’s full assistant text by joining **this turn’s** assistant rows after the transcript cursor.

## Practical impact

- Flutter/Hub get one bubble per durable row again: two visible assistant parts in one physical turn become two rows; User1/Asst1/User2/Asst2 stay four rows.
- CLI `sessions send -w` still works, including multi-part turns (`Part one.` + `Part two.` → joined transcript).
- Clients can key/sort history on `id` and ISO `createdAt` without locale clocks.

## What does NOT change

- `sessions.read` message objects remain `{ role, text, time, ... }`. `id` / `createdAt` are additive.
- No Flutter unmash heuristics, no Hub `parts[]` patches, no event-sourced history redesign.
- Channel delivery shape is unchanged (`channelResponseText` still accumulates for terminal projection).
- `saveMessage` stays INSERT-only.

## Validation

- `bun test src/runtime/session-trace.test.ts src/cli/session-cli-surface.test.ts src/cli/commands/sessions.test.ts src/channels/runtime-events.test.ts src/db.test.ts src/sessions/recap.test.ts`
- New cases: two visible `assistant.message` events → two rows; silent/heartbeat/prompt-too-long/login-stub → no assistant row; User1/Asst1/User2/Asst2 with Asst2 ∉ Asst1; ISO `id`/`time`/`createdAt` on `sessions.read`; `send -w` joins this turn’s rows.

[Regression test summary](https://cursor.com/agents/bc-3d37b0c6-bfeb-46c2-8a72-f19466709f97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_history_regression_tests.log)

## Risks

- Providers that emit several visible `assistant.message` events in one physical turn now create several chat.db rows (intentional; matches emit).
- Additive `id` / ISO `time` on read is non-breaking for SDKs that ignore unknown fields; clients that parsed `time` as a locale clock will now see ISO-8601.

## Rollback

- Revert this branch / PR. Chat.db rows written by the new persist path remain valid INSERT rows.

## Follow-ups

- Flutter unmash heuristics
- Hub UI parts-array patches
- Stream-ops-only history redesign


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d37b0c6-bfeb-46c2-8a72-f19466709f97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d37b0c6-bfeb-46c2-8a72-f19466709f97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

