### PR TITLE
fix(sessions): stop empty-join mash of assistant history

### DIFF
--- a/.ravi/specs/sessions/CHECKS.md
+++ b/.ravi/specs/sessions/CHECKS.md
@@ -31,4 +31,7 @@
 - Operator / HTTP / app `sessions.send` without `--channel`/`--to` MUST NOT
   emit to leftover `lastChannel` or the default output attachment. Persist
   MUST still store the assistant row for `sessions.read`.
+- Persist MUST refuse empty-join mash (`primeiro?Olá`) and keep one clean row
+  per visible assistant utterance. Multi-message turns (`Part one.` +
+  `Part two.`) MUST still persist as separate rows.
 - Bare `ravi tui` MUST fail with a usage error instead of opening `main`.

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -82,6 +82,7 @@ Sessions do NOT own:
 - A physical provider turn MUST keep one immutable reply surface. Different chats and threads MUST be serialized into separate turns.
 - An inbound turn MUST reply to its attached source chat or thread. The default output attachment is used only when a turn has no inbound source.
 - An unattached inbound source or a source-less turn without a default output MUST NOT emit externally.
+- A visible assistant utterance MUST persist as exactly one immutable chat.db row. Persist MUST NOT empty-join prior assistant history into a new row (`primeiro?Olá`). Multi-message turns MAY write several rows. Replay of already-stored assistant text MUST NOT INSERT again.
 - Operator / HTTP / app `sessions.send` (session-relay, no `--channel`/`--to`, no real inbound chat) is a session destination for emit. Leftover `lastChannel`/`lastTo` MUST NOT become `prompt.source` / `currentSource`. The default output attachment MUST NOT be the emit target. Chat emit stays fail-closed. Persist + `sessions.read` remain the sink.
 - `ravi sessions send` and related inter-session commands inject prompt/context into a Ravi session. They MUST NOT be documented as direct external channel delivery primitives. Visible outbound channel delivery belongs to the session response path or to explicit channel/media/outbound commands.
 - Operator CLI-only `sessions send` (no `--channel`/`--to`) sends the raw user text. `[System] Inform:` is reserved for agent-to-agent / in-context sends. `--raw` is the escape hatch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravi.bot",
-  "version": "3.260902.1",
+  "version": "3.260902.2",
   "description": "Personal multi-agent runtime for Ravi",
   "type": "module",
   "main": "dist/bundle/index.js",

--- a/src/runtime/assistant-transcript.test.ts
+++ b/src/runtime/assistant-transcript.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import {
+  coalesceAssistantTextBlocks,
+  looksLikeEmptyJoinMash,
+  peelPersistedAssistantPrefix,
+  resolveVisibleAssistantUtterances,
+  splitEmptyJoinedAssistantUtterances,
+} from "./assistant-transcript.js";
+
+describe("assistant transcript empty-join mash", () => {
+  it("detects the live primeiro?Olá empty-join pattern", () => {
+    expect(looksLikeEmptyJoinMash("primeiro?Olá")).toBe(true);
+    expect(looksLikeEmptyJoinMash("ok.Pong")).toBe(true);
+    expect(looksLikeEmptyJoinMash("Olá. A conexão")).toBe(false);
+    expect(looksLikeEmptyJoinMash("Hello. World")).toBe(false);
+    expect(looksLikeEmptyJoinMash("Part one.\n\nPart two.")).toBe(false);
+  });
+
+  it("splits empty-joined utterances and keeps spaced sentences intact", () => {
+    expect(splitEmptyJoinedAssistantUtterances("primeiro?Olá")).toEqual(["primeiro?", "Olá"]);
+    expect(splitEmptyJoinedAssistantUtterances("Olá. A conexão")).toEqual(["Olá. A conexão"]);
+    expect(splitEmptyJoinedAssistantUtterances("Part one.\n\nPart two.")).toEqual(["Part one.\n\nPart two."]);
+    expect(
+      splitEmptyJoinedAssistantUtterances(
+        "A conexão foi restabelecida.Olá. A conexão foi restabelecida.Oi. No que você quer trabalhar?",
+      ),
+    ).toEqual(["A conexão foi restabelecida.", "Olá. A conexão foi restabelecida.", "Oi. No que você quer trabalhar?"]);
+  });
+
+  it("coalesces token-like blocks but keeps empty-joined utterances apart", () => {
+    expect(coalesceAssistantTextBlocks(["ola", " mundo"])).toEqual(["ola mundo"]);
+    expect(coalesceAssistantTextBlocks(["Hello ", "world"])).toEqual(["Hello world"]);
+    expect(coalesceAssistantTextBlocks(["primeiro?", "Olá"])).toEqual(["primeiro?", "Olá"]);
+    expect(coalesceAssistantTextBlocks(["primeiro?Olá"])).toEqual(["primeiro?Olá"]);
+  });
+
+  it("peels already-persisted assistant history from a mashed blob", () => {
+    expect(peelPersistedAssistantPrefix("primeiro?OláOi. No que você quer trabalhar?", ["primeiro?", "Olá"])).toBe(
+      "Oi. No que você quer trabalhar?",
+    );
+    expect(peelPersistedAssistantPrefix("primeiro?Olá", ["primeiro?", "Olá"])).toBe("");
+    expect(peelPersistedAssistantPrefix("primeiro?\n\nOlá\n\nOi.", ["primeiro?", "Olá"])).toBe("Oi.");
+  });
+
+  it("resolves only the new clean utterance from a live mashed insert", () => {
+    const greeting = "Olá. A conexão foi restabelecida.";
+    const existing = [greeting, "primeiro?", "Olá", "ok.", "pong"];
+    expect(
+      resolveVisibleAssistantUtterances(
+        `${greeting}${greeting}primeiro?Oláok.pongOi. No que você quer trabalhar?`,
+        existing,
+      ),
+    ).toEqual(["Oi. No que você quer trabalhar?"]);
+    expect(resolveVisibleAssistantUtterances("primeiro?Olá", ["primeiro?"])).toEqual(["Olá"]);
+    expect(resolveVisibleAssistantUtterances("primeiro?Olá", existing)).toEqual([]);
+    expect(resolveVisibleAssistantUtterances("primeiro?", existing)).toEqual([]);
+    expect(resolveVisibleAssistantUtterances("Part one.", [])).toEqual(["Part one."]);
+    expect(resolveVisibleAssistantUtterances("Part one.\n\nPart two.", [])).toEqual(["Part one.\n\nPart two."]);
+  });
+
+  it("does not invent a Flutter-style unmash of a single clean greeting", () => {
+    expect(resolveVisibleAssistantUtterances("Oi. No que você quer trabalhar?", [])).toEqual([
+      "Oi. No que você quer trabalhar?",
+    ]);
+  });
+});

--- a/src/runtime/assistant-transcript.ts
+++ b/src/runtime/assistant-transcript.ts
@@ -1,0 +1,128 @@
+/**
+ * Turn-immutable assistant transcript helpers.
+ *
+ * Visible assistant utterances must stay one chat.db row each. Providers can
+ * still emit one `assistant.message` whose `text` is prior utterances
+ * empty-joined (`primeiro?Olá`) plus the new reply. Persist must refuse that
+ * blob, peel already-stored history, and keep only the new utterance(s).
+ */
+
+const UPPER_START = /^[\p{Lu}]/u;
+
+export function looksLikeEmptyJoinMash(text: string): boolean {
+  return findEmptyJoinBoundaries(text).length > 0;
+}
+
+export function splitEmptyJoinedAssistantUtterances(text: string): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const bounds = findEmptyJoinBoundaries(trimmed);
+  if (bounds.length === 0) return [trimmed];
+
+  const parts: string[] = [];
+  let last = 0;
+  for (const index of bounds) {
+    const part = trimmed.slice(last, index).trim();
+    if (part) parts.push(part);
+    last = index;
+  }
+  const tail = trimmed.slice(last).trim();
+  if (tail) parts.push(tail);
+  return parts.length > 0 ? parts : [trimmed];
+}
+
+export function coalesceAssistantTextBlocks(blocks: readonly string[]): string[] {
+  const result: string[] = [];
+  for (const raw of blocks) {
+    if (!raw) continue;
+    if (result.length === 0) {
+      result.push(raw);
+      continue;
+    }
+    const previous = result[result.length - 1]!;
+    if (shouldCoalesceAssistantBlocks(previous, raw)) {
+      result[result.length - 1] = previous + raw;
+      continue;
+    }
+    result.push(raw);
+  }
+  return result.map((block) => block.trim()).filter((block) => block.length > 0);
+}
+
+export function peelPersistedAssistantPrefix(text: string, existing: readonly string[]): string {
+  let remaining = text.trim();
+  let progressed = true;
+  const rows = [...new Set(existing.map((row) => row.trim()).filter((row) => row.length > 0))].sort(
+    (left, right) => right.length - left.length,
+  );
+
+  while (progressed && remaining) {
+    progressed = false;
+    for (const row of rows) {
+      if (remaining === row) return "";
+      if (!remaining.startsWith(row)) continue;
+      remaining = remaining
+        .slice(row.length)
+        .replace(/^(?:\n\n|\n)+/, "")
+        .trim();
+      progressed = true;
+      break;
+    }
+  }
+  return remaining;
+}
+
+export function resolveVisibleAssistantUtterances(
+  text: string,
+  existingAssistantRows: readonly string[] = [],
+): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const peeled = peelPersistedAssistantPrefix(trimmed, existingAssistantRows);
+  if (!peeled) return [];
+
+  const seen = new Set(existingAssistantRows.map((row) => row.trim()).filter(Boolean));
+  const utterances: string[] = [];
+  for (const part of splitEmptyJoinedAssistantUtterances(peeled)) {
+    if (seen.has(part)) continue;
+    utterances.push(part);
+    seen.add(part);
+  }
+  return utterances;
+}
+
+function findEmptyJoinBoundaries(text: string): number[] {
+  const bounds: number[] = [];
+  const pattern = /[.!?…](?=[\p{Lu}])/gu;
+  for (const match of text.matchAll(pattern)) {
+    const splitAt = (match.index ?? 0) + match[0].length;
+    const left = text.slice(0, splitAt).trim();
+    const right = text.slice(splitAt);
+    if (isConversationalEmptyJoin(left, right)) {
+      bounds.push(splitAt);
+    }
+  }
+  return bounds;
+}
+
+function isConversationalEmptyJoin(left: string, right: string): boolean {
+  if (!right || !UPPER_START.test(right)) return false;
+  const punct = left.slice(-1);
+  const leftBody = left.slice(0, -1).trim();
+  if (!leftBody) return false;
+  // Skip abbreviations such as "U." / "S." inside "U.S.Army".
+  if (leftBody.length <= 2 && /^[\p{Lu}]+$/u.test(leftBody) && punct === ".") return false;
+  if (punct === "?" || punct === "!") return right.length >= 2;
+  if (/^[\p{Ll}]+$/u.test(leftBody) && leftBody.length >= 2) return right.length >= 2;
+  return leftBody.length >= 4 && right.length >= 2;
+}
+
+function shouldCoalesceAssistantBlocks(previous: string, next: string): boolean {
+  if (next.startsWith(" ") || next.startsWith("\n")) return true;
+  if (/^[,;:]/.test(next.trimStart())) return true;
+  const joined = previous + next;
+  if (looksLikeEmptyJoinMash(joined)) return false;
+  if (/^[a-zà-ÿ]/u.test(next.trimStart())) return true;
+  return !/[.!?…]\s*$/.test(previous.trimEnd());
+}

--- a/src/runtime/claude-provider.test.ts
+++ b/src/runtime/claude-provider.test.ts
@@ -343,6 +343,48 @@ describe("createClaudeRuntimeProvider", () => {
     });
   });
 
+  it("does not empty-join distinct assistant text blocks into one message", async () => {
+    nextMessages = [
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "primeiro?" },
+            { type: "text", text: "Olá" },
+          ],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "claude-session-mash",
+        usage: {
+          input_tokens: 4,
+          output_tokens: 2,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    ];
+
+    const provider = createClaudeRuntimeProvider();
+    const session = provider.startSession(
+      makeStartRequest(
+        (async function* () {
+          yield {
+            type: "user" as const,
+            message: { role: "user" as const, content: "oi" },
+            session_id: "",
+            parent_tool_use_id: null,
+          };
+        })(),
+      ),
+    );
+
+    const events = await collectEvents(session.events);
+    expect(findEventsByType(events, "assistant.message").map((event) => event.text)).toEqual(["primeiro?", "Olá"]);
+  });
+
   it("passes an explicit native executable path when configured", async () => {
     nextMessages = [{ type: "result", subtype: "success", session_id: "claude-session-3" }];
 

--- a/src/runtime/claude-provider.ts
+++ b/src/runtime/claude-provider.ts
@@ -27,6 +27,7 @@ import { buildPluginSkillVisibilitySnapshot, emptySkillVisibilitySnapshot } from
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
 import { materializeRuntimeModelBroker } from "./model-broker-materializer.js";
 import { SANITIZED_ENV_VARS } from "../hooks/sanitize-bash.js";
+import { coalesceAssistantTextBlocks } from "./assistant-transcript.js";
 
 const nodeRequire = createRequire(import.meta.url);
 const CLAUDE_CODE_EXECUTABLE_ENV_KEYS = ["RAVI_CLAUDE_CODE_EXECUTABLE", "CLAUDE_CODE_EXECUTABLE"] as const;
@@ -601,11 +602,11 @@ async function* normalizeClaudeEvents(queryResult: Query): AsyncGenerator<Runtim
 
     if (message.type === "assistant") {
       const blocks = Array.isArray(message.message?.content) ? message.message.content : [];
-      let text = "";
+      const textBlocks: string[] = [];
 
       for (const block of blocks) {
         if (block?.type === "text" && typeof block.text === "string") {
-          text += block.text;
+          textBlocks.push(block.text);
         }
         if (block?.type === "tool_use" && typeof block.id === "string" && typeof block.name === "string") {
           yield {
@@ -616,7 +617,7 @@ async function* normalizeClaudeEvents(queryResult: Query): AsyncGenerator<Runtim
         }
       }
 
-      if (text) {
+      for (const text of coalesceAssistantTextBlocks(textBlocks)) {
         yield {
           type: "assistant.message",
           text,

--- a/src/runtime/context-window-recovery.test.ts
+++ b/src/runtime/context-window-recovery.test.ts
@@ -43,6 +43,18 @@ describe("runtime context window recovery", () => {
     expect(prompt.truncated).toBe(false);
   });
 
+  it("does not feed empty-join mashed assistant history as one blob", () => {
+    const prompt = buildRuntimeContextRecoveryPrompt({
+      sessionName: "main",
+      history: [message(1, "user", "continua"), message(2, "assistant", "primeiro?Olá")],
+    });
+
+    expect(prompt.prompt).toContain("primeiro?");
+    expect(prompt.prompt).toContain("Olá");
+    expect(prompt.prompt).not.toContain("primeiro?Olá");
+    expect(prompt.prompt.match(/Assistant /g)?.length).toBeGreaterThan(1);
+  });
+
   it("bounds recovered history by prompt size", () => {
     const history = Array.from({ length: 20 }, (_, index) =>
       message(index + 1, index % 2 === 0 ? "user" : "assistant", `msg-${index} ${"x".repeat(500)}`),

--- a/src/runtime/context-window-recovery.ts
+++ b/src/runtime/context-window-recovery.ts
@@ -1,4 +1,5 @@
 import type { Message } from "../db.js";
+import { splitEmptyJoinedAssistantUtterances } from "./assistant-transcript.js";
 import type { RuntimeProviderId } from "./types.js";
 
 export const RUNTIME_CONTEXT_WINDOW_RECOVERY_REASON = "runtime_context_window_exhausted";
@@ -172,7 +173,8 @@ function renderHistoryMessage(message: Message): string | undefined {
   if (!content) return undefined;
   const label = message.role === "assistant" ? "Assistant" : "User";
   const timestamp = message.created_at ? ` (${message.created_at})` : "";
-  return `${label}${timestamp}:\n${truncateContent(content, MESSAGE_CHAR_LIMIT)}`;
+  const parts = message.role === "assistant" ? splitEmptyJoinedAssistantUtterances(content) : [content];
+  return parts.map((part) => `${label}${timestamp}:\n${truncateContent(part, MESSAGE_CHAR_LIMIT)}`).join("\n\n");
 }
 
 function findLatestUserRequest(messages: Message[]): string | undefined {

--- a/src/runtime/grok-provider.test.ts
+++ b/src/runtime/grok-provider.test.ts
@@ -724,6 +724,43 @@ describe("Grok Build runtime provider", () => {
     ]);
   });
 
+  it("does not empty-join distinct ACP agent messages into one assistant.message", async () => {
+    const transport = new FakeGrokAcpTransport();
+    transport.responseFor = (method) => {
+      if (method === "session/prompt") {
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "primeiro?" },
+          }),
+        );
+        transport.pushEvent(
+          sessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "Olá" },
+          }),
+        );
+        return { stopReason: "end_turn" };
+      }
+      return defaultGrokResponse(method);
+    };
+
+    const events = await collectRuntimeEvents(
+      createGrokRuntimeProvider({ transport }).startSession(createStartRequest("oi")).events,
+    );
+
+    expect(
+      events
+        .filter(
+          (event): event is Extract<RuntimeEvent, { type: "assistant.message" }> => event.type === "assistant.message",
+        )
+        .map((event) => event.text),
+    ).toEqual(["primeiro?", "Olá"]);
+    expect(
+      events.some(
+        (event) => event.type === "assistant.message" && "text" in event && event.text.includes("primeiro?Olá"),
+      ),
+    ).toBe(false);
+  });
+
   it("resumes an ACP session with session/load when stored state exists", async () => {
     const transport = new FakeGrokAcpTransport();
     transport.responseFor = (method) => {

--- a/src/runtime/grok-provider.ts
+++ b/src/runtime/grok-provider.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 import type { RuntimeEffort } from "./effort.js";
+import { splitEmptyJoinedAssistantUtterances } from "./assistant-transcript.js";
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
 import type {
   RuntimeApprovalHandler,
@@ -1030,14 +1031,16 @@ async function* runGrokTurns(
         }
 
         if (context.assistantText) {
-          const message: RuntimeEvent = {
-            type: "assistant.message",
-            text: context.assistantText,
-            rawEvent: isRecord(result) ? result : { stopReason },
-            metadata,
-          };
-          if (terminalTracker.accept(message)) {
-            yield message;
+          for (const text of splitEmptyJoinedAssistantUtterances(context.assistantText)) {
+            const message: RuntimeEvent = {
+              type: "assistant.message",
+              text,
+              rawEvent: isRecord(result) ? result : { stopReason },
+              metadata,
+            };
+            if (terminalTracker.accept(message)) {
+              yield message;
+            }
           }
         }
 

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -24,6 +24,7 @@ import {
 import { recordRuntimeTraceEvent, recordTerminalTurnTrace } from "../session-trace/runtime-trace.js";
 import { applyTaskSessionTtlForAgent, shouldRefreshTaskSessionTtlOnTurnComplete } from "../tasks/session-retention.js";
 import { logger } from "../utils/logger.js";
+import { resolveVisibleAssistantUtterances } from "./assistant-transcript.js";
 import { revokeAgentRuntimeContextsForSession } from "./context-registry.js";
 import {
   buildRuntimeContextRecoveryPrompt,
@@ -1732,6 +1733,11 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
     return runtimeSessionParams;
   };
 
+  const recentAssistantContents = (): string[] =>
+    getRecentHistory(sessionName, 48)
+      .filter((message) => message.role === "assistant")
+      .map((message) => message.content);
+
   const persistVisibleAssistantMessage = (text: string) => {
     const trimmedVisible = text.trim();
     if (!trimmedVisible) return;
@@ -2376,13 +2382,13 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
               trimmed === "no response needed." ||
               trimmed === "no response needed";
             const commentaryResponse = isCommentaryResponse(event.metadata);
-            const recordAssistantState = (observe: boolean) => {
+            const recordAssistantState = (observe: boolean, text = messageText) => {
               if (observe) {
                 ensureCurrentTurnUserObservation();
                 pushObservationEvent("message.assistant", {
-                  preview: truncateObservationPreview(messageText),
+                  preview: truncateObservationPreview(text),
                   payload: {
-                    chars: messageText.length,
+                    chars: text.length,
                     metadata: event.metadata ?? null,
                   },
                 });
@@ -2395,16 +2401,16 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
                 eventGroup: "response",
                 status: "received",
                 payloadJson: {
-                  chars: messageText.length,
+                  chars: text.length,
                   metadata: event.metadata,
                 },
-                preview: messageText,
+                preview: text,
               });
               // Only user-visible (observed) non-commentary text accumulates.
               // Silent / heartbeat / no-response / prompt-too-long stay off the
               // persist buffer so they cannot become durable assistant rows.
               if (observe && !commentaryResponse) {
-                responseText = appendAssistantResponse(responseText, messageText);
+                responseText = appendAssistantResponse(responseText, text);
               }
             };
             if (promptTooLong) {
@@ -2457,34 +2463,59 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
               // This content will be persisted/projected/emitted. Fence replay
               // before any of those effects; silent and discarded responses do
               // not advance the materialized-output marker.
+              const visibleUtterances = commentaryResponse
+                ? [messageText]
+                : resolveVisibleAssistantUtterances(messageText, recentAssistantContents());
+              if (!commentaryResponse && visibleUtterances.length === 0) {
+                suppressProviderRawForCurrentTurn = true;
+                recordAssistantState(false);
+                log.info("Skipping replayed or empty-join mashed assistant history", {
+                  sessionName,
+                  textLen: messageText.length,
+                });
+                continue;
+              }
               markCurrentTurnAttemptSafety({ materializedOutput: true });
               fencePendingProviderRawEvent(correlatedProviderRawEvent);
-              recordAssistantState(true);
-              await emitRuntimeEvent({
-                type: "assistant.message",
-                provider: runtimeSession.provider,
-                text: messageText,
-                ...(event.metadata ? { metadata: event.metadata } : {}),
-              });
-              if (!commentaryResponse) {
-                channelResponseText = appendAssistantResponse(channelResponseText, messageText);
-                persistVisibleAssistantMessage(messageText);
-              } else if (streaming.agentMode !== "sentinel") {
-                await projectRuntimeEventToChannel({
-                  ...event,
-                  text: messageText,
+              for (const utterance of visibleUtterances) {
+                recordAssistantState(true, utterance);
+                await emitRuntimeEvent({
+                  type: "assistant.message",
+                  provider: runtimeSession.provider,
+                  text: utterance,
+                  ...(event.metadata ? { metadata: event.metadata } : {}),
+                });
+                if (!commentaryResponse) {
+                  channelResponseText = appendAssistantResponse(channelResponseText, utterance);
+                  persistVisibleAssistantMessage(utterance);
+                } else if (streaming.agentMode !== "sentinel") {
+                  await projectRuntimeEventToChannel({
+                    ...event,
+                    text: utterance,
+                  });
+                }
+                updateRuntimeLiveState(sessionName, {
+                  activity: "streaming",
+                  summary: truncateLiveSummary(utterance) || "response",
+                  agentId: agent.id,
+                  runId,
+                  provider: runtimeSession.provider,
+                  model,
+                  source: streaming.currentSource,
+                });
+                await emitResponse(utterance, event.metadata);
+              }
+              if (
+                !commentaryResponse &&
+                (visibleUtterances.length > 1 || visibleUtterances[0] !== messageText.trim())
+              ) {
+                log.info("Split empty-join assistant mash into turn-immutable rows", {
+                  sessionName,
+                  incomingLen: messageText.length,
+                  utteranceCount: visibleUtterances.length,
+                  utteranceLens: visibleUtterances.map((utterance) => utterance.length),
                 });
               }
-              updateRuntimeLiveState(sessionName, {
-                activity: "streaming",
-                summary: truncateLiveSummary(messageText) || "response",
-                agentId: agent.id,
-                runId,
-                provider: runtimeSession.provider,
-                model,
-                source: streaming.currentSource,
-              });
-              await emitResponse(messageText, event.metadata);
             }
           }
         }

--- a/src/runtime/pi-provider.ts
+++ b/src/runtime/pi-provider.ts
@@ -20,6 +20,7 @@ import type {
   RuntimeUsage,
   SessionRuntimeProvider,
 } from "./types.js";
+import { coalesceAssistantTextBlocks } from "./assistant-transcript.js";
 import { createRuntimeTerminalEventTracker } from "./terminality.js";
 import { buildPluginSkillVisibilitySnapshot } from "./skill-visibility.js";
 import {
@@ -747,8 +748,7 @@ function normalizePiEvent(event: PiRpcEvent, context: PiEventContext): RuntimeEv
       events.push({ type: "item.completed", item, rawEvent, metadata });
       if (message?.role === "assistant") {
         context.lastAssistantMessage = message;
-        const text = extractPiAssistantText(message);
-        if (text) {
+        for (const text of extractPiAssistantTexts(message)) {
           events.push({ type: "assistant.message", text, rawEvent, metadata });
         }
       }
@@ -1420,21 +1420,21 @@ function mapPiUsage(usage: PiUsage | undefined): RuntimeUsage {
   };
 }
 
-function extractPiAssistantText(message: PiAgentMessage): string {
+function extractPiAssistantTexts(message: PiAgentMessage): string[] {
   const content = message.content;
   if (typeof content === "string") {
-    return content;
+    return content.trim() ? [content.trim()] : [];
   }
   if (!Array.isArray(content)) {
-    return "";
+    return [];
   }
-  let text = "";
+  const blocks: string[] = [];
   for (const block of content) {
     if (isRecord(block) && block.type === "text" && typeof block.text === "string") {
-      text += block.text;
+      blocks.push(block.text);
     }
   }
-  return text;
+  return coalesceAssistantTextBlocks(blocks);
 }
 
 function findLastAssistantMessage(messages: unknown[]): PiAgentMessage | undefined {

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -2599,6 +2599,68 @@ describe("runtime session trace instrumentation", () => {
     expect(assistants[0]!.content).not.toContain(assistants[1]!.content);
   });
 
+  it("refuses empty-join mash of assistant history and keeps the new utterance clean", async () => {
+    saveMessage(SESSION_NAME, "user", "oi", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "assistant", "Olá. A conexão foi restabelecida.", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "assistant", "primeiro?", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "assistant", "Olá", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "assistant", "ok.", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "assistant", "pong", null, { agentId: AGENT_ID });
+    saveMessage(SESSION_NAME, "user", "oi", null, { agentId: AGENT_ID });
+
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-empty-join-mash");
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        {
+          type: "assistant.message",
+          text: "Olá. A conexão foi restabelecida.Olá. A conexão foi restabelecida.primeiro?Oláok.pongOi. No que você quer trabalhar?",
+        },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-mash",
+          usage: { inputTokens: 1, outputTokens: 8 },
+        },
+      ]),
+    );
+
+    const rows = getRecentHistory(SESSION_NAME, 20);
+    const assistants = rows.filter(({ role }) => role === "assistant");
+    expect(assistants.map(({ content }) => content)).toEqual([
+      "Olá. A conexão foi restabelecida.",
+      "primeiro?",
+      "Olá",
+      "ok.",
+      "pong",
+      "Oi. No que você quer trabalhar?",
+    ]);
+    expect(assistants.some(({ content }) => content.includes("primeiro?Olá"))).toBe(false);
+    expect(assistants.some(({ content }) => content.includes("ok.pong"))).toBe(false);
+    expect(assistants.at(-1)?.content).toBe("Oi. No que você quer trabalhar?");
+  });
+
+  it("splits a first-turn empty-join mash into separate rows", async () => {
+    const streaming = makeStreamingSession();
+    seedAdapterTrace(streaming, "turn-empty-join-first");
+    await runTraceLoop(
+      streaming,
+      makeRuntimeSession([
+        { type: "assistant.message", text: "primeiro?Olá" },
+        {
+          type: "turn.complete",
+          providerSessionId: "provider-first-mash",
+          usage: { inputTokens: 1, outputTokens: 2 },
+        },
+      ]),
+    );
+
+    const assistants = getRecentHistory(SESSION_NAME).filter(({ role }) => role === "assistant");
+    expect(assistants.map(({ content }) => content)).toEqual(["primeiro?", "Olá"]);
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0]!.id).not.toBe(assistants[1]!.id);
+  });
+
   it("classifies a provider login stub as turn.failed and keeps it off the transcript", async () => {
     updateRuntimeProviderState(SESSION_KEY, "codex", {
       providerSessionId: "codex-thread",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop new Hub/Flutter chat turns from INSERTing one empty-joined mashed assistant blob after #463. Each visible assistant utterance stays one clean, turn-immutable `chat.db` row.

## Problem

- Canary `207a6206-0dd5-45a5-a7db-db99b3ad2eaf` is on `ravi.bot` **3.260902.1** (PR #463).
- After Luís sent `"oi"`, session `main` wrote **one** new assistant row (id 46, 1470 chars) mashed with empty-join: `primeiro?Olá` / `ok.pong`, `Olá. A conexão` ×4, overnight ACK/PONG, ending `Oi. No que você quer trabalhar?`.
- Flutter is 1:1 with `messagesFromRead`. Hub DirectClient shows the mash inside one `<p>`.
- #463 only removed the old `\n\n` persist buffer at `turn.complete`. Live mash uses **empty string join**, so `event.text` is already mashed upstream of `persistVisibleAssistantMessage`, or persist still saved that blob as-is.

## Solution

- **Root cause (hardened, both hypotheses):** adapters still empty-join text blocks/chunks (`text += block.text`, Grok `assistantText += chunk`). After #463, persist writes that `event.text` as one INSERT. Once mashed rows exist, provider resume/history feeds them back and the next turn grows another mashed blob.
- Persist now peels already-stored assistant prefixes and splits conversational empty-join (`primeiro?Olá`) before write/emit. Exact history replay is dropped.
- Claude/Pi emit one `assistant.message` per coalesced text block. Grok splits a mashed ACP `assistantText` before the host loop.
- Context-window recovery renders mashed assistant rows as separate labeled utterances so history is not fed as one blob.
- Package version **3.260902.2** for Hub Testar.

## Practical impact

- A mashed incoming event becomes the new clean utterance only (or several clean rows on first-turn empty-join).
- Multi-message turns (`Part one.` + `Part two.`) still persist as two rows.
- `sessions send -w` still joins this turn's rows with `\n\n`.
- Canary Testar should pick up `3.260902.2`.

## What does NOT change

- No Flutter-only unmash heuristic and no Hub `parts[]` protocol change.
- `saveMessage` stays INSERT-only. `sessions.read` stays 1:1 with rows.
- Channel delivery still accumulates the current turn with `\n\n` for terminal projection.

## Validation

- `bun test src/runtime/assistant-transcript.test.ts src/runtime/context-window-recovery.test.ts src/runtime/session-trace.test.ts src/runtime/claude-provider.test.ts src/runtime/grok-provider.test.ts src/runtime/pi-provider.test.ts src/cli/session-cli-surface.test.ts src/cli/commands/sessions.test.ts src/channels/runtime-events.test.ts src/db.test.ts src/sessions/recap.test.ts`
- Result: **256 pass, 0 fail**.
- New cases fail on `primeiro?Olá` mash and pass for multi-message turns plus history peel of the live canary blob.

[Regression test summary](https://cursor.com/agents/bc-a640cbb8-5887-4c3a-8d2d-b1e0fe97d6f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_join_mash_regression_tests.log)

## Risks

- Aggressive empty-join split could separate rare abbreviation-like strings. Heuristic skips `U.`/`S.` and keeps spaced sentences (`Olá. A conexão`).
- Providers that emit several visible blocks in one physical turn now create several rows (intentional; matches emit).

## Rollback

- Revert this branch / PR. Rows already written by the new persist path remain valid INSERT rows.

## Follow-ups

- Canary Testar on `207a6206-0dd5-45a5-a7db-db99b3ad2eaf` with `3.260902.2`: send `"oi"` on `main` and confirm the new assistant id is a short clean row, not another mashed INSERT.
- Existing mashed ids (28, 30, 32, 38, 41, 46) stay in `chat.db`; they are not rewritten. New turns must not grow more mashed ids.

## How to verify on canary

1. Testar `ravi.bot` **3.260902.2** on canary `207a6206-0dd5-45a5-a7db-db99b3ad2eaf`.
2. Hub should show `raviVersion` `3.260902.2`.
3. On session `main`, send `"oi"`.
4. `sessions.read` should add one short assistant row (e.g. `Oi. No que você quer trabalhar?`), not a 1k+ empty-joined blob.
5. Confirm the new row does not contain `primeiro?Olá` or `ok.pong`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a640cbb8-5887-4c3a-8d2d-b1e0fe97d6f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a640cbb8-5887-4c3a-8d2d-b1e0fe97d6f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

