### PR TITLE
fix(sessions): queue overlapping send and always emit a turn terminal

### DIFF
--- a/.ravi/specs/sessions/CHECKS.md
+++ b/.ravi/specs/sessions/CHECKS.md
@@ -31,6 +31,11 @@
 - Operator / HTTP / app `sessions.send` without `--channel`/`--to` MUST NOT
   emit to leftover `lastChannel` or the default output attachment. Persist
   MUST still store the assistant row for `sessions.read`.
+- A second `sessions.send` during an in-flight turn MUST queue and both
+  accepted sends MUST get a terminal `turn.complete` / `turn.failed` /
+  `turn.interrupted` plus a terminal `lastTurn`. The second send MUST NOT
+  hang open without a terminal. `sessions send -w` MUST wait for that send's
+  own terminal, not the overlapped turn's `turn.complete`.
 - Persist MUST refuse empty-join mash (`primeiro?Olá`) and keep one clean row
   per visible assistant utterance. Multi-message turns (`Part one.` +
   `Part two.`, or `A1_LIVESTR_X` + `A2_LIVESTR_X` + `A3_LIVESTR_X`) MUST

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -87,6 +87,7 @@ Sessions do NOT own:
 - `ravi sessions send` and related inter-session commands inject prompt/context into a Ravi session. They MUST NOT be documented as direct external channel delivery primitives. Visible outbound channel delivery belongs to the session response path or to explicit channel/media/outbound commands.
 - Operator CLI-only `sessions send` (no `--channel`/`--to`) sends the raw user text. `[System] Inform:` is reserved for agent-to-agent / in-context sends. `--raw` is the escape hatch.
 - CLI-only `sessions send -w` waits for this turn's assistant transcript after `turn.complete`. Chat-attached `-w` still means delivered. Attach remains fail-closed for chat emit.
+- Every accepted `sessions.send` (operator / HTTP / app) MUST end with a terminal runtime signal: `turn.complete`, `turn.failed`, or `turn.interrupted`. Overlapping sends while a turn is in flight MUST queue behind the live handle (`after_response`, the sessions.send default) and MUST NOT start a second physical provider turn or Hub route preflight. Clients that poll recover from `sessions info --json` `turnUsage.lastTurn` (`status` + `completedAt`).
 - Default `sessions read --json` is session + messages. The advertised skill catalog stays on `sessions visibility` or `sessions read --visibility`.
 - Bare `ravi tui` MUST require a session name (usage error). It MUST NOT default to `main`.
 - CLI-only session bootstrap MUST NOT inherit hardcoded `DEFAULT_RUNTIME_EFFORT = xhigh`. `sessions send --effort` sets an explicit override. The Ravi system prompt remains large.

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -113,6 +113,11 @@ import {
   snapshotTranscriptCursor,
   waitForThisTurnAssistantText,
 } from "../session-cli-surface.js";
+import {
+  createSessionSendWaitState,
+  isSessionSendWaitTerminal,
+  noteSessionSendWaitRuntimeEvent,
+} from "../session-send-wait.js";
 import type { RuntimeProviderId } from "../../runtime/types.js";
 import { publicRuntimeFailureDetail } from "../../runtime/public-failure.js";
 import { locateRuntimeTranscript } from "../../transcripts.js";
@@ -5593,9 +5598,14 @@ export class SessionCommands {
 
       (async () => {
         try {
+          let waitState = createSessionSendWaitState();
           for await (const event of runtimeStream) {
             const data = event.data as Record<string, unknown>;
             const type = data.type;
+            waitState = noteSessionSendWaitRuntimeEvent(waitState, type);
+            if (!isSessionSendWaitTerminal(waitState, type)) {
+              continue;
+            }
             if (type === "turn.complete") {
               settle({ kind: "complete" });
               break;

--- a/src/cli/session-send-wait.test.ts
+++ b/src/cli/session-send-wait.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createSessionSendWaitState,
+  isSessionSendWaitTerminal,
+  noteSessionSendWaitRuntimeEvent,
+} from "./session-send-wait.js";
+
+describe("session send wait terminal matching", () => {
+  it("settles a single send on the first terminal", () => {
+    let state = createSessionSendWaitState();
+    state = noteSessionSendWaitRuntimeEvent(state, "turn.started");
+    expect(isSessionSendWaitTerminal(state, "turn.complete")).toBe(true);
+  });
+
+  it("ignores the in-flight turn.complete after an overlapping send is queued", () => {
+    let state = createSessionSendWaitState();
+    state = noteSessionSendWaitRuntimeEvent(state, "dispatch.queued");
+    expect(isSessionSendWaitTerminal(state, "turn.complete")).toBe(false);
+    expect(isSessionSendWaitTerminal(state, "turn.failed")).toBe(false);
+    expect(isSessionSendWaitTerminal(state, "turn.interrupted")).toBe(false);
+
+    state = noteSessionSendWaitRuntimeEvent(state, "turn.started");
+    expect(isSessionSendWaitTerminal(state, "turn.complete")).toBe(true);
+  });
+
+  it("clears wait on failed or interrupted terminals for this send", () => {
+    let failed = createSessionSendWaitState();
+    failed = noteSessionSendWaitRuntimeEvent(failed, "turn.started");
+    expect(isSessionSendWaitTerminal(failed, "turn.failed")).toBe(true);
+
+    let interrupted = createSessionSendWaitState();
+    interrupted = noteSessionSendWaitRuntimeEvent(interrupted, "dispatch.queued");
+    interrupted = noteSessionSendWaitRuntimeEvent(interrupted, "turn.started");
+    expect(isSessionSendWaitTerminal(interrupted, "turn.interrupted")).toBe(true);
+  });
+});

--- a/src/cli/session-send-wait.ts
+++ b/src/cli/session-send-wait.ts
@@ -1,0 +1,36 @@
+export type SessionSendWaitState = {
+  queuedBehindActiveTurn: boolean;
+  seenOwnTurnStarted: boolean;
+};
+
+export const SESSION_SEND_TERMINAL_TYPES = new Set(["turn.complete", "turn.failed", "turn.interrupted"]);
+
+export function createSessionSendWaitState(): SessionSendWaitState {
+  return {
+    queuedBehindActiveTurn: false,
+    seenOwnTurnStarted: false,
+  };
+}
+
+export function noteSessionSendWaitRuntimeEvent(state: SessionSendWaitState, type: unknown): SessionSendWaitState {
+  if (type === "dispatch.queued") {
+    return { ...state, queuedBehindActiveTurn: true };
+  }
+  if (type === "turn.started") {
+    return { ...state, seenOwnTurnStarted: true };
+  }
+  return state;
+}
+
+export function isSessionSendWaitTerminal(state: SessionSendWaitState, type: unknown): boolean {
+  if (typeof type !== "string" || !SESSION_SEND_TERMINAL_TYPES.has(type)) {
+    return false;
+  }
+  if (state.seenOwnTurnStarted) {
+    return true;
+  }
+  // Single-send fallback: we subscribed before publish, so a terminal without
+  // dispatch.queued belongs to this send (turn.started may have been missed).
+  // After an overlap queue, ignore the in-flight turn's terminal.
+  return !state.queuedBehindActiveTurn;
+}

--- a/src/runtime/delivery-queue.ts
+++ b/src/runtime/delivery-queue.ts
@@ -511,6 +511,7 @@ export async function* createRuntimeMessageGenerator({
     }
     session.lastActivity = Date.now();
     session.currentTraceTurnTerminalRecorded = false;
+    session.runtimeTerminalSseEmitted = false;
 
     try {
       beforeTurnStart?.({

--- a/src/runtime/host-event-loop.ts
+++ b/src/runtime/host-event-loop.ts
@@ -1329,12 +1329,21 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
   };
 
   const emitRuntimeEvent = async (event: Record<string, unknown>) => {
+    if (event.type === "turn.complete" || event.type === "turn.failed" || event.type === "turn.interrupted") {
+      streaming.runtimeTerminalSseEmitted = true;
+    }
     const augmented = {
       ...event,
       ...(streaming.currentSource ? { _source: streaming.currentSource } : {}),
       ...(streaming.currentTurnProvenance ? { _turnProvenance: streaming.currentTurnProvenance } : {}),
     };
     await safeEmit(`ravi.session.${sessionName}.runtime`, augmented);
+  };
+  const emitHostRuntimeTerminal = async (event: Record<string, unknown>) => {
+    if (streaming.runtimeTerminalSseEmitted) {
+      return;
+    }
+    await emitRuntimeEvent(event);
   };
 
   interface PendingProviderRawEvent {
@@ -1482,6 +1491,14 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
       idleMs,
       autoRecovered,
     });
+    void emitHostRuntimeTerminal({
+      type: "turn.failed",
+      error: `Provider produced no runtime events for ${PROVIDER_TURN_INACTIVITY_TIMEOUT_MS}ms.`,
+      recoverable: true,
+      reason: PROVIDER_TURN_INACTIVITY_REASON,
+      timeoutMs: PROVIDER_TURN_INACTIVITY_TIMEOUT_MS,
+      idleMs,
+    });
   };
 
   const recordUnterminatedTurnExit = () => {
@@ -1546,6 +1563,19 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
         autoRecovered: Boolean(restartStashedReason),
         providerTerminalRecorded: Boolean(streaming.currentCrashRecoveryTerminal),
       },
+    });
+    void emitHostRuntimeTerminal({
+      type: eventType,
+      ...(eventType === "turn.failed"
+        ? {
+            error: timedOut
+              ? `Runtime ended without a terminal provider event after ${reason}.`
+              : `Runtime ended without a terminal provider event (${reason}).`,
+            recoverable: true,
+          }
+        : {}),
+      reason,
+      phase: "runtime.event_loop.finally",
     });
   };
 
@@ -2118,6 +2148,15 @@ export async function runRuntimeEventLoop(options: RunRuntimeEventLoopOptions): 
             providerStatus: receivedTerminalStatus,
             winningStatus: terminal.status,
             completedAt: terminal.completedAt,
+          });
+          const winningType = runtimeTurnAttemptTerminalEventType(terminal.status);
+          await emitHostRuntimeTerminal({
+            type: winningType,
+            ...(winningType === "turn.failed"
+              ? { error: "Turn already terminalized by another path", recoverable: true }
+              : {}),
+            reason: "first_terminal_won",
+            winningStatus: terminal.status,
           });
           break;
         }

--- a/src/runtime/host-session.ts
+++ b/src/runtime/host-session.ts
@@ -171,6 +171,8 @@ export interface RuntimeHostStreamingSession {
   currentTraceSystemPromptSha256?: string;
   currentTraceRequestBlobSha256?: string;
   currentTraceTurnTerminalRecorded?: boolean;
+  /** Whether this physical turn already published a runtime SSE terminal. */
+  runtimeTerminalSseEmitted?: boolean;
   /** Durable crash-recovery attempt currently owning the provider turn. */
   currentCrashRecoveryAttemptId?: string;
   /** First durable terminal fence for the current provider delivery. */

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -8,6 +8,7 @@ import {
   fenceRuntimeNativeSteerInput,
   runtimeModelBrokerConfigurationRequiresRestart,
   runtimeModelBrokerRouteRequiresRestart,
+  shouldQueuePromptOnLiveSession,
   stashPromptForStartingSession,
 } from "./session-dispatcher.js";
 import { createQueuedRuntimeUserMessage } from "./delivery-queue.js";
@@ -1685,6 +1686,96 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
     } finally {
       await cleanupIsolatedRaviState(stateDir);
     }
+  });
+
+  it("queues an overlapping sessions.send on the live turn instead of restarting", async () => {
+    const stateDir = await createIsolatedRaviState("ravi-runtime-dispatcher-overlap-send-");
+    try {
+      getOrCreateSession("agent:main:test:overlap-send", "main", stateDir, { name: "overlap-send" });
+      const interrupt = mock(async () => {});
+      const activeMessage = createQueuedRuntimeUserMessage({
+        prompt: "first send",
+        deliveryBarrier: "after_response",
+        _turnOrigin: buildSessionRelayTurnOrigin("send"),
+      });
+      const dispatcher = createDispatcher(2);
+      const activeSession = createActiveSession({
+        agentId: "main",
+        turnActive: true,
+        currentModel: "trace-model",
+        currentEffort: "low",
+        pendingMessages: [activeMessage],
+        currentTurnPendingIds: [activeMessage.pendingId!],
+        queryHandle: {
+          provider: "codex",
+          events: (async function* () {})(),
+          interrupt,
+        },
+      });
+      dispatcher.streamingSessions.set("overlap-send", activeSession);
+
+      expect(
+        shouldQueuePromptOnLiveSession(
+          "overlap-send",
+          activeSession,
+          {
+            prompt: "second send",
+            _turnOrigin: buildSessionRelayTurnOrigin("send"),
+            deliveryBarrier: "after_response",
+          },
+          "main",
+        ),
+      ).toBe(true);
+
+      await dispatcher.handlePromptImmediate("overlap-send", {
+        prompt: "second send",
+        _agentId: "main",
+        deliveryBarrier: "after_response",
+        deliveryBarrierSource: "default",
+        _turnOrigin: buildSessionRelayTurnOrigin("send"),
+      });
+
+      expect(activeSession.pendingMessages).toHaveLength(2);
+      expect(activeSession.pendingMessages[1]?.deliveryBarrier).toBe("after_response");
+      expect(activeSession.pendingMessages[1]?.launchPrompt?.prompt).toBe("second send");
+      expect(activeSession.queryHandle.provider).toBe("codex");
+      expect(activeSession.currentTurnSuperseded).not.toBe(true);
+      expect(activeSession.interrupted).not.toBe(true);
+      expect(interrupt).not.toHaveBeenCalled();
+    } finally {
+      await cleanupIsolatedRaviState(stateDir);
+    }
+  });
+
+  it("does not queue onto a live session that belongs to another agent", () => {
+    const activeSession = createActiveSession({
+      agentId: "main",
+      turnActive: true,
+    });
+    expect(
+      shouldQueuePromptOnLiveSession(
+        "other-agent",
+        activeSession,
+        { prompt: "second send", deliveryBarrier: "after_response" },
+        "other",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not queue an after_tool send that should interrupt the live turn", () => {
+    const activeSession = createActiveSession({
+      agentId: "main",
+      turnActive: true,
+      toolRunning: false,
+    });
+    expect(
+      shouldQueuePromptOnLiveSession(
+        "interrupt-send",
+        activeSession,
+        { prompt: "steer now", deliveryBarrier: "after_tool" },
+        "main",
+      ),
+    ).toBe(false);
   });
 
   it("queues another surface without replacing or interrupting the active turn", async () => {

--- a/src/runtime/session-dispatcher.test.ts
+++ b/src/runtime/session-dispatcher.test.ts
@@ -1762,6 +1762,22 @@ describe("RuntimeSessionDispatcher abort resolution", () => {
     ).toBe(false);
   });
 
+  it("does not queue a send that leaves the live task context", () => {
+    const activeSession = createActiveSession({
+      agentId: "main",
+      turnActive: true,
+      currentTaskBarrierTaskId: "task-live",
+    });
+    expect(
+      shouldQueuePromptOnLiveSession(
+        "task-exit",
+        activeSession,
+        { prompt: "normal turn", deliveryBarrier: "after_response" },
+        "main",
+      ),
+    ).toBe(false);
+  });
+
   it("does not queue an after_tool send that should interrupt the live turn", () => {
     const activeSession = createActiveSession({
       agentId: "main",

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -795,8 +795,19 @@ export class RuntimeSessionDispatcher {
       log.error("No agent found for prompt", { sessionName, agentId });
       return;
     }
+    const sessionRuntimeProviderOverride =
+      prompt._observation && prompt._runtimeProviderId ? undefined : sessionEntry?.runtimeProviderOverride;
+    if (existing && shouldQueuePromptOnLiveSession(sessionName, existing, prompt, agent.id)) {
+      await this.enqueuePromptOnLiveSession(sessionName, existing, prompt, {
+        sessionEntry,
+        agentId: sessionEntry?.agentId ?? agent.id,
+        daemonRestartMessages,
+      });
+      return;
+    }
+    let modelBrokerPlan: RuntimeModelBrokerPlan | undefined;
     const modelBrokerTurnId = prompt._modelBrokerTurnId ?? createSessionTraceTurnId();
-    const modelBrokerPlan = await planRuntimeModelBrokerRoute({
+    modelBrokerPlan = await planRuntimeModelBrokerRoute({
       agent,
       sessionKey: sessionEntry?.sessionKey ?? sessionName,
       turnId: modelBrokerTurnId,
@@ -805,8 +816,6 @@ export class RuntimeSessionDispatcher {
     if (modelBrokerPlan && prompt._modelBrokerTurnId !== modelBrokerTurnId) {
       prompt = { ...prompt, _modelBrokerTurnId: modelBrokerTurnId };
     }
-    const sessionRuntimeProviderOverride =
-      prompt._observation && prompt._runtimeProviderId ? undefined : sessionEntry?.runtimeProviderOverride;
     const requestedProvider: RuntimeProviderId = modelBrokerPlan
       ? modelBrokerPlan.lease.runtimeProvider
       : resolveRequestedRuntimeProvider({
@@ -1936,6 +1945,183 @@ export class RuntimeSessionDispatcher {
     await terminalizeCoalescedChannelMessages(sessionName, successor.coalescedMessages);
   }
 
+  private async enqueuePromptOnLiveSession(
+    sessionName: string,
+    existing: RuntimeHostStreamingSession,
+    prompt: RuntimeLaunchPrompt,
+    options: {
+      sessionEntry?: SessionEntry;
+      agentId: string;
+      daemonRestartMessages?: RuntimeUserMessage[];
+    },
+  ): Promise<void> {
+    const { sessionEntry, agentId, daemonRestartMessages } = options;
+    log.info("Streaming: pushing message to existing session", { sessionName, reason: "live_session_queue" });
+    if (sessionEntry) {
+      updateRuntimeSessionMetadata(sessionEntry.sessionKey, prompt);
+    }
+    const messageSource = prompt.source ?? existing.currentSource;
+    if (!prompt._resumeStashedMessages) {
+      saveMessage(
+        sessionName,
+        "user",
+        resolvePersistedUserText(prompt),
+        sessionEntry?.providerSessionId ?? sessionEntry?.sdkSessionId,
+        {
+          agentId,
+          channel: messageSource?.channel ?? prompt.context?.channelId,
+          accountId: messageSource?.accountId ?? prompt.context?.accountId,
+          chatId: messageSource?.chatId ?? prompt.context?.chatId,
+          sourceMessageId: messageSource?.sourceMessageId ?? prompt.context?.messageId,
+          commands: prompt.commands,
+        },
+      );
+    }
+
+    const barrier = getRuntimePromptDeliveryBarrier(prompt);
+    const queuedMessages = daemonRestartMessages ?? [createQueuedRuntimeUserMessage(prompt)];
+    appendUniqueRuntimeMessages(existing.pendingMessages, queuedMessages);
+    updateRuntimeLiveState(sessionName, {
+      activity: "thinking",
+      summary: existing.turnActive ? `queued ${existing.pendingMessages.length}` : "prompt queued",
+      agentId: existing.agentId,
+      runId: existing.traceRunId,
+      provider: existing.queryHandle.provider,
+      model: existing.currentModel,
+      source: prompt.source ?? existing.currentSource,
+    });
+
+    recordRuntimeTraceEvent({
+      sessionKey: sessionEntry?.sessionKey ?? sessionName,
+      sessionName,
+      agentId: existing.agentId,
+      runId: existing.traceRunId,
+      turnId: existing.currentTraceTurnId,
+      provider: existing.queryHandle.provider,
+      model: existing.currentModel,
+      eventType: "dispatch.push_existing",
+      eventGroup: "dispatch",
+      status: "queued",
+      source: prompt.source ?? existing.currentSource,
+      messageId: prompt.context?.messageId,
+      payloadJson: {
+        queueSize: existing.pendingMessages.length,
+        barrier: describeDeliveryBarrier(barrier),
+        barrierSource: prompt.deliveryBarrierSource ?? null,
+        taskBarrierTaskId: prompt.taskBarrierTaskId ?? null,
+        reason: "live_session_queue",
+      },
+    });
+
+    if (existing.pushMessage) {
+      const deliverableNow = hasDeliverableRuntimeMessages(sessionName, existing);
+      if (deliverableNow) {
+        log.info("Streaming: waking generator", {
+          sessionName,
+          queueSize: existing.pendingMessages.length,
+          barrier: describeDeliveryBarrier(barrier),
+        });
+        const resolver = existing.pushMessage;
+        existing.pushMessage = null;
+        resolver(null);
+      } else {
+        log.info("Streaming: queued without wake", {
+          sessionName,
+          queueSize: existing.pendingMessages.length,
+          barrier: describeDeliveryBarrier(barrier),
+          reason: "waiting_for_barrier",
+        });
+        recordRuntimeTraceEvent({
+          sessionKey: sessionEntry?.sessionKey ?? sessionName,
+          sessionName,
+          agentId: existing.agentId,
+          runId: existing.traceRunId,
+          turnId: existing.currentTraceTurnId,
+          provider: existing.queryHandle.provider,
+          model: existing.currentModel,
+          eventType: "dispatch.queued_busy",
+          eventGroup: "dispatch",
+          status: "queued",
+          source: prompt.source ?? existing.currentSource,
+          messageId: prompt.context?.messageId,
+          payloadJson: {
+            queueSize: existing.pendingMessages.length,
+            barrier: describeDeliveryBarrier(barrier),
+            barrierSource: prompt.deliveryBarrierSource ?? null,
+            reason: "waiting_for_barrier",
+          },
+        });
+        this.options
+          .safeEmit(`ravi.session.${sessionName}.runtime`, {
+            type: "dispatch.queued",
+            provider: existing.queryHandle.provider,
+            reason: "waiting_for_barrier",
+            barrier: describeDeliveryBarrier(barrier),
+            barrierSource: prompt.deliveryBarrierSource ?? null,
+            queueSize: existing.pendingMessages.length,
+            sessionState: describeSessionState(existing),
+            timestamp: new Date().toISOString(),
+          })
+          .catch((error) => {
+            log.warn("Failed to emit dispatch.queued event", { sessionName, error });
+          });
+      }
+      return;
+    }
+
+    const decision = shouldInterruptRuntimeForIncoming(sessionName, existing, barrier, prompt.taskBarrierTaskId);
+    if (decision.interrupt) {
+      return;
+    }
+    log.info("Streaming: queueing (busy)", {
+      sessionName,
+      queueSize: existing.pendingMessages.length,
+      barrier: describeDeliveryBarrier(barrier),
+      reason: decision.reason,
+      tool: existing.currentToolName,
+    });
+    recordRuntimeTraceEvent({
+      sessionKey: sessionEntry?.sessionKey ?? sessionName,
+      sessionName,
+      agentId: existing.agentId,
+      runId: existing.traceRunId,
+      turnId: existing.currentTraceTurnId,
+      provider: existing.queryHandle.provider,
+      model: existing.currentModel,
+      eventType: "dispatch.queued_busy",
+      eventGroup: "dispatch",
+      status: "queued",
+      source: prompt.source ?? existing.currentSource,
+      messageId: prompt.context?.messageId,
+      payloadJson: {
+        queueSize: existing.pendingMessages.length,
+        barrier: describeDeliveryBarrier(barrier),
+        barrierSource: prompt.deliveryBarrierSource ?? null,
+        reason: decision.reason,
+        tool: existing.currentToolName ?? null,
+      },
+    });
+    this.options
+      .safeEmit(`ravi.session.${sessionName}.runtime`, {
+        type: "dispatch.queued",
+        provider: existing.queryHandle.provider,
+        reason: decision.reason,
+        barrier: describeDeliveryBarrier(barrier),
+        barrierSource: prompt.deliveryBarrierSource ?? null,
+        queueSize: existing.pendingMessages.length,
+        tool: existing.currentToolName ?? null,
+        sessionState: describeSessionState(existing),
+        timestamp: new Date().toISOString(),
+      })
+      .catch((error) => {
+        log.warn("Failed to emit dispatch.queued event", { sessionName, error });
+      });
+    if (decision.reason === "idle_gap") {
+      wakeRuntimeSessionIfDeliverable(sessionName, this.streamingSessions);
+      this.scheduleIdleGapRecovery(sessionName, existing, sessionEntry?.sessionKey ?? sessionName);
+    }
+  }
+
   private async tryNativeRuntimeSteer(
     sessionName: string,
     existing: RuntimeHostStreamingSession,
@@ -2025,6 +2211,32 @@ export class RuntimeSessionDispatcher {
 
     return "accepted";
   }
+}
+
+export function shouldQueuePromptOnLiveSession(
+  sessionName: string,
+  existing: RuntimeHostStreamingSession,
+  prompt: RuntimeLaunchPrompt,
+  agentId: string,
+): boolean {
+  if (existing.done || existing.agentId !== agentId) {
+    return false;
+  }
+  if (prompt._resumeStashedMessages || prompt._daemonRestartResume || prompt._observation) {
+    return false;
+  }
+  if (
+    prompt._runtimeProviderId &&
+    !prompt._observation &&
+    existing.queryHandle.provider !== prompt._runtimeProviderId
+  ) {
+    return false;
+  }
+  const barrier = getRuntimePromptDeliveryBarrier(prompt);
+  if (canUseNativeRuntimeSteer(existing, barrier, prompt)) {
+    return false;
+  }
+  return !shouldInterruptRuntimeForIncoming(sessionName, existing, barrier, prompt.taskBarrierTaskId).interrupt;
 }
 
 export function runtimeModelBrokerConfigurationRequiresRestart(

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -799,7 +799,7 @@ export class RuntimeSessionDispatcher {
       prompt._observation && prompt._runtimeProviderId ? undefined : sessionEntry?.runtimeProviderOverride;
     if (existing && shouldQueuePromptOnLiveSession(sessionName, existing, prompt, agent.id)) {
       await this.enqueuePromptOnLiveSession(sessionName, existing, prompt, {
-        sessionEntry,
+        sessionEntry: sessionEntry ?? undefined,
         agentId: sessionEntry?.agentId ?? agent.id,
         daemonRestartMessages,
       });

--- a/src/runtime/session-dispatcher.ts
+++ b/src/runtime/session-dispatcher.ts
@@ -759,7 +759,7 @@ export class RuntimeSessionDispatcher {
       this.runtimeRecoveryRestartAttempts.delete(sessionName);
     }
     const routerConfig = configStore.getConfig();
-    const sessionEntry = getSessionByName(sessionName);
+    const sessionEntry = getSessionByName(sessionName) ?? getSession(sessionName);
     const existing = this.streamingSessions.get(sessionName);
     let daemonRestartMessages: RuntimeUserMessage[] | undefined;
     if (prompt._daemonRestartResume) {
@@ -2230,6 +2230,9 @@ export function shouldQueuePromptOnLiveSession(
     !prompt._observation &&
     existing.queryHandle.provider !== prompt._runtimeProviderId
   ) {
+    return false;
+  }
+  if (existing.currentTaskBarrierTaskId !== normalizePromptTaskBarrierTaskId(prompt.taskBarrierTaskId)) {
     return false;
   }
   const barrier = getRuntimePromptDeliveryBarrier(prompt);

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -14,6 +14,7 @@ import {
   type AgentConfig,
   type SessionEntry,
 } from "../router/index.js";
+import { getSessionTurnUsageSummary } from "../router/sessions.js";
 import { dbUpsertChat, getDb } from "../router/router-db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import { getSessionTraceBlob, getSessionTurn, listSessionEvents } from "../session-trace/session-trace-db.js";
@@ -1018,6 +1019,159 @@ describe("runtime session trace instrumentation", () => {
     expect(streaming.pendingMessages[2]?.launchPrompt?.prompt).toBe("hello from gateway");
     expect(streaming.pendingMessages[2]?.launchPrompt?._runtimePrompt).toContain("stays on this session");
     expect(streaming.pendingMessages[2]?.launchPrompt?._sessionSurfaceHintText).toContain("stays on this session");
+  });
+
+  it("queues a second sessions.send during an in-flight turn and emits a terminal for both", async () => {
+    const firstSend = createQueuedRuntimeUserMessage({
+      prompt: "first overlapping send",
+      deliveryBarrier: "after_response",
+      _turnOrigin: buildSessionRelayTurnOrigin("send"),
+    });
+    const streaming = makeStreamingSession({
+      agentMode: "active",
+      currentSource: undefined,
+      currentEffort: "low",
+      pendingMessages: [firstSend],
+      currentTurnPendingIds: firstSend.pendingId ? [firstSend.pendingId] : [],
+      turnActive: false,
+    });
+    const provider: SessionRuntimeProvider = {
+      id: PROVIDER,
+      getCapabilities: () => capabilities,
+      startSession: () => makeRuntimeSession([]),
+    };
+    const { runtimeRequest } = await buildRuntimeStartRequest({
+      runId: "run-overlap-send",
+      sessionName: SESSION_NAME,
+      prompt: {
+        prompt: "first overlapping send",
+        _turnOrigin: buildSessionRelayTurnOrigin("send"),
+        deliveryBarrier: "after_response",
+      },
+      session: makeSession(),
+      agent: makeAgent(),
+      runtimeProviderId: PROVIDER,
+      runtimeProvider: provider,
+      runtimeCapabilities: capabilities,
+      sessionCwd: stateDir ?? "/tmp",
+      dbSessionKey: SESSION_KEY,
+      model: MODEL,
+      runtimeResolution: {
+        options: { model: MODEL },
+        sources: { model: "agent_default", effort: null, thinking: null },
+        hasTaskRuntimeContext: false,
+      },
+      storedRuntimeSessionParams: undefined,
+      canResumeStoredSession: false,
+      resolvedSource: undefined,
+      streamingSession: streaming,
+      stashedMessages: new Map(),
+      defaultRuntimeProviderId: PROVIDER,
+      crashRecovery,
+    });
+
+    const providerTurns: string[] = [];
+    const readProviderTurn = async () => {
+      const next = await runtimeRequest.prompt.next();
+      if (next.done) throw new Error("runtime prompt stream ended before the queued overlapping send");
+      providerTurns.push(next.value.message.content);
+    };
+
+    let interruptCalls = 0;
+    let queuedDuringInFlight = false;
+    const dispatcher = new RuntimeSessionDispatcher({
+      instanceId: "trace-test",
+      maxConcurrentSessions: 10,
+      interactiveReservedSessions: 0,
+      safeEmit: async () => {},
+      notifyRuntimeRecoveryExhausted: async () => {},
+      getConfigModel: () => MODEL,
+      crashRecovery,
+    });
+    dispatcher.streamingSessions.set(SESSION_NAME, streaming);
+    const runtimeSession: RuntimeSessionHandle = {
+      provider: PROVIDER,
+      interrupt: async () => {
+        interruptCalls++;
+      },
+      events: (async function* () {
+        await readProviderTurn();
+        await dispatcher.handlePromptImmediate(SESSION_NAME, {
+          prompt: "second overlapping send",
+          _turnOrigin: buildSessionRelayTurnOrigin("send"),
+          _agentId: AGENT_ID,
+          deliveryBarrier: "after_response",
+          deliveryBarrierSource: "default",
+        });
+        queuedDuringInFlight = streaming.pendingMessages.some((message) =>
+          message.message.content.includes("second overlapping send"),
+        );
+        expect(queuedDuringInFlight).toBe(true);
+        expect(interruptCalls).toBe(0);
+        expect(
+          listSessionEvents(SESSION_KEY).filter((event) => event.eventType === "dispatch.queued_busy"),
+        ).toHaveLength(1);
+
+        yield { type: "assistant.message", text: "first reply" } satisfies RuntimeEvent;
+        yield {
+          type: "turn.complete",
+          providerSessionId: "provider-after-first-send",
+          usage: { inputTokens: 1, outputTokens: 1 },
+        } satisfies RuntimeEvent;
+
+        await readProviderTurn();
+        yield { type: "assistant.message", text: "second reply" } satisfies RuntimeEvent;
+        yield {
+          type: "turn.complete",
+          providerSessionId: "provider-after-second-send",
+          usage: { inputTokens: 1, outputTokens: 1 },
+        } satisfies RuntimeEvent;
+      })(),
+    };
+    streaming.queryHandle = runtimeSession;
+
+    const emitted: Array<{ topic: string; data: Record<string, unknown> }> = [];
+    try {
+      await runTraceLoop(streaming, runtimeSession, {
+        agent: makeAgent(),
+        streamingSessions: dispatcher.streamingSessions,
+        safeEmit: async (topic, data) => {
+          emitted.push({ topic, data });
+        },
+      });
+    } finally {
+      streaming.done = true;
+      streaming.onTurnComplete?.();
+      await runtimeRequest.prompt.return?.(undefined);
+    }
+
+    expect(queuedDuringInFlight).toBe(true);
+    expect(interruptCalls).toBe(0);
+    expect(providerTurns.some((prompt) => prompt.includes("first overlapping send"))).toBe(true);
+    expect(providerTurns.some((prompt) => prompt.includes("second overlapping send"))).toBe(true);
+
+    const runtimeTerminals = emitted.filter(
+      (entry) =>
+        entry.topic === `ravi.session.${SESSION_NAME}.runtime` &&
+        (entry.data.type === "turn.complete" ||
+          entry.data.type === "turn.failed" ||
+          entry.data.type === "turn.interrupted"),
+    );
+    expect(runtimeTerminals.map((entry) => entry.data.type)).toEqual(["turn.complete", "turn.complete"]);
+
+    const history = getRecentHistory(SESSION_NAME, 10);
+    expect(history.filter((message) => message.role === "user").map((message) => message.content)).toEqual(
+      expect.arrayContaining(["second overlapping send"]),
+    );
+    expect(history.filter((message) => message.role === "assistant").map((message) => message.content)).toEqual([
+      "first reply",
+      "second reply",
+    ]);
+
+    const lastTurn = getSessionTurnUsageSummary(SESSION_KEY).lastTurn;
+    expect(lastTurn?.status).toBe("complete");
+    expect(lastTurn?.completedAt).toBeGreaterThan(0);
+    expect(listSessionEvents(SESSION_KEY).filter((event) => event.eventType === "turn.complete")).toHaveLength(2);
   });
 
   it("does not emit session-relay HTTP send to leftover lastChannel or default output", async () => {
@@ -3622,6 +3776,7 @@ describe("runtime session trace instrumentation", () => {
       terminalReplayAllowed: false,
     });
     expect(emitted.some((event) => event.data.type === "provider.inactive")).toBe(true);
+    expect(emitted.some((event) => event.data.type === "turn.failed")).toBe(true);
 
     const events = listSessionEvents(SESSION_KEY);
     expect(events.some((event) => event.eventType === "session.timeout" && event.status === "timeout")).toBe(true);

--- a/src/runtime/session-trace.test.ts
+++ b/src/runtime/session-trace.test.ts
@@ -1022,6 +1022,7 @@ describe("runtime session trace instrumentation", () => {
   });
 
   it("queues a second sessions.send during an in-flight turn and emits a terminal for both", async () => {
+    updateSessionName(SESSION_KEY, SESSION_NAME);
     const firstSend = createQueuedRuntimeUserMessage({
       prompt: "first overlapping send",
       deliveryBarrier: "after_response",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop Flutter/Hub Wire clients from staying **working forever** when a second `sessions.send` overlaps an in-flight turn, or when SSE drops before a terminal event. Every accepted send now queues on the live handle (existing `after_response` barrier) and ends with a runtime terminal plus `lastTurn`.

## Problem

On canary `ravi.bot` 3.260902.3, overlapping `sessions/send` while a turn was already running left user rows in DB with **no** assistant row and **no** `turn.complete` / `lastTurn` for minutes. A fresh short send still worked (`turn.started` → `assistant.message` → `turn.complete` ~7s), so the gateway was not globally dead.

Root cause in code: `handlePromptImmediate` ran Hub `planRuntimeModelBrokerRoute()` **before** the live-session queue path. Implicit provider/effort mismatch (`trace-provider` / Hub vs agent default, or live `low` vs default `xhigh`) restarted the in-flight handle. Restart / inactivity / unterminated exits often wrote SQLite `lastTurn` but did **not** emit the runtime SSE terminal Flutter watches. `sessions send -w` also settled on **any** `turn.complete`, so an overlapped wait returned on the previous turn.

## Solution

- Queue an overlapping same-agent `after_response` send on the live session **before** Hub preflight or provider/effort restart (`shouldQueuePromptOnLiveSession` + `enqueuePromptOnLiveSession`).
- Keep the existing restart model for agent change, explicit provider override, native steer, interrupt barriers, and **leaving a task context**.
- Emit a host runtime SSE terminal (`turn.complete` / `turn.failed` / `turn.interrupted`) on inactivity and unterminated loop exit. Do not fabricate a terminal after crash-recovery ownership loss.
- `sessions send -w` waits for **this** send’s terminal: after `dispatch.queued`, ignore the in-flight `turn.complete` until the next `turn.started`.

## Practical impact

- Flutter / Hub Wire / HTTP `sessions.send`: overlapping sends are accepted and serialized; working can clear on a later terminal or by polling `lastTurn`.
- Operator `sessions send -w` no longer completes on the overlapped turn.
- Clients that only poll recover from `sessions info --json` → `turnUsage.lastTurn.status` + `completedAt`.

### Flutter / Hub Wire note

Subscribe to `ravi.session.<sessionName>.runtime` (or `GET /api/v1/_stream/sessions/{name}`).

| Event | Client action |
| --- | --- |
| `turn.complete` / `turn.failed` / `turn.interrupted` | Clear working. This is the terminal for the current physical turn. |
| `dispatch.queued` | Send was **accepted** and queued behind the live turn. Keep working; wait for a later terminal (or the next `turn.started` then that terminal). |
| SSE `network error` before a terminal | Do not stay working forever. Poll `sessions info --json` and treat `turnUsage.lastTurn.status` in `complete` \| `failed` \| `interrupted` \| `timeout` \| `aborted` with `completedAt > 0` as done. |
| `wait: true` | Wait for **this** send’s terminal, not the overlapped turn’s `turn.complete`. |

## What does NOT change

- Default `sessions.send` barrier remains `after_response` (queue, do not interrupt).
- Explicit `after_tool` / `immediate_interrupt` still use the existing interrupt / native-steer path.
- Leaving a live task context still restarts the physical session.
- Crash-recovery ownership loss still does not invent a latch/trace/SSE terminal.
- Package version is **not** bumped here. Next `ravi.bot` after Version And Publish: **3.260902.4**.

## Validation

- `bun test src/cli/session-send-wait.test.ts src/runtime/session-dispatcher.test.ts src/runtime/session-trace.test.ts src/cli/session-cli-surface.test.ts src/bot.runtime-guards.test.ts` → **153 pass, 0 fail**
- Pre-push hook (typecheck + repo test suite + SDK/OpenAPI drift) passed on push
- Key cases: overlapping send queues (no restart); both turns get `turn.complete` + assistant rows + terminal `lastTurn`; wait ignores overlapped terminal; task-context exit still restarts; ownership-loss does not fabricate SSE

## Risks

- A send that *should* restart (new agent, explicit provider, task-context change) is unchanged; if a new implicit identity drift appears, it will now queue instead of killing the live turn (intentional for overlap).
- Clients that treated `dispatch.queued` as “done” would be wrong; they should keep working until a terminal.

## Rollback

Revert this branch. Behavior returns to Hub-preflight-then-possible-restart. Flutter working-stuck can return under overlap.

## Follow-ups

- Version And Publish → canary `ravi.bot` **3.260902.4** (no bump in this PR)
- Flutter: clear working on the three terminals; after SSE drop poll `lastTurn`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f3b9e3c-091d-4ec9-8f7e-d11628207f3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f3b9e3c-091d-4ec9-8f7e-d11628207f3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

