### PR TITLE
fix(sessions): retire session_chat_bindings so detach cannot resurrect

### DIFF
--- a/.ravi/specs/channels/chats/CHECKS.md
+++ b/.ravi/specs/channels/chats/CHECKS.md
@@ -2,7 +2,9 @@
 
 ## Checks
 
-- A canonical chat MUST be able to bind to more than one Ravi agent session.
+- A canonical chat MUST belong to at most one active session. Multiple
+  sessions MAY have historical/detached rows, but only one active
+  `session_chat_subscription` may own the chat.
 - Chat participants MUST be stored at chat scope; session participants MUST NOT
   overwrite the canonical chat membership list.
 - A group, room, or thread MUST NOT be represented as a person contact.

--- a/.ravi/specs/channels/chats/RUNBOOK.md
+++ b/.ravi/specs/channels/chats/RUNBOOK.md
@@ -18,5 +18,6 @@
 
 - If a group appears as a contact, route the fix through the chat/contact
   migration boundary.
-- If output goes to the wrong surface, debug session chat bindings before
-  changing transport delivery.
+- If output goes to the wrong surface, inspect `session_chat_subscriptions`
+  (active chats and the default output) before changing transport delivery.
+  Do not look for `session_chat_bindings`.

--- a/.ravi/specs/channels/chats/SPEC.md
+++ b/.ravi/specs/channels/chats/SPEC.md
@@ -115,21 +115,26 @@ Constraints:
 - `contact_id` and `agent_id` are denormalized convenience fields derived from platform identity ownership.
 - Participant rows MUST tolerate unresolved actors.
 
-### `session_chat_bindings`
+### `session_chat_subscriptions`
 
-This MAY be a dedicated table or fields on `sessions`.
+This is the sole session↔chat attach ledger (see `sessions/attach`).
 
 Fields:
 
 - `session_key`
 - `chat_id`
-- `agent_id`
-- `route_id`
-- `binding_reason`
-- `created_at`
-- `updated_at`
+- `role`
+- `output_attached_at`
+- `detached_at`
+- attach audit fields (`attached_by_*`, `attached_reason`, timestamps)
 
-The binding records which chat a runtime session belongs to. It does not define who participates in the chat.
+One canonical chat belongs to at most one active session. One session MAY have
+many active chats. At most one active output exists per session. This table
+does not define who participates in the chat.
+
+Retired: `session_chat_bindings`. Compatibility migration converts leftover
+useful rows into subscriptions once, then drops that table. Runtime MUST NOT
+recreate it.
 
 ## Prompt Chat Context
 
@@ -223,7 +228,7 @@ Migration SHOULD move or project this data into:
 
 - `chats`
 - `chat_participants`
-- `session_chat_bindings` or equivalent fields on `sessions`
+- `session_chat_subscriptions` (one-time convert from retired `session_chat_bindings`)
 - per-message/per-event chat and actor metadata
 
 `omni_group_metadata` MAY remain as a raw transport cache, but it MUST NOT be the only place Ravi stores group participants.
@@ -239,7 +244,7 @@ These legacy surfaces MUST be removed, split, or reduced to explicit compatibili
 | group identity stored as contact | `chats` | all route/policy/session flows resolve group by chat |
 | `omni_group_metadata.participants_json` as participant source of truth | `chat_participants` | group participants are queryable from Ravi chat model |
 | `account_pending.is_group` sharing pending-contact semantics | pending chat/route review backed by `chats` | pending humans and pending chats have separate flows; chat approval creates route review state without creating contacts |
-| `sessions.group_id` as implicit chat identity | `session_chat_bindings.chat_id` or explicit `sessions.chat_id` | sessions bind to canonical chat id |
+| `sessions.group_id` as implicit chat identity | `session_chat_subscriptions.chat_id` | sessions attach to canonical chat id |
 | `sessions.last_to`/`last_channel`/`last_account_id` as only outbound target memory | explicit chat binding + last target provenance | gateway/outbound can resolve via chat binding |
 | `message_metadata.chat_id` without canonical chat/actor ids | message metadata with `chat_id`, `actor_type`, `platform_identity_id`, `contact_id`, `agent_id` | reply/media reinjection can use canonical chat + actor metadata |
 | `session_events.source_chat_id` without canonical chat/actor ids | session events with canonical chat and actor metadata | traces can show semantic actor while preserving raw source ids |
@@ -256,7 +261,7 @@ Omni raw inbound
   -> resolve/upsert platform identity
   -> upsert chat_participant
   -> resolve route/session for target agent
-  -> bind session to chat
+  -> attach session_chat_subscription (never a legacy binding)
   -> persist message/event actor metadata
 ```
 

--- a/.ravi/specs/channels/chats/WHY.md
+++ b/.ravi/specs/channels/chats/WHY.md
@@ -7,3 +7,7 @@ thread can host multiple Ravi agent sessions, each with its own state.
 Keeping chat, participant, actor, and session data separate prevents group chats
 from being modeled as people, keeps prompt participant lists scoped to the chat
 they describe, and preserves raw Omni ids only as provenance.
+
+Session attach lives on `session_chat_subscriptions`, not on a second 1:1
+binding table. A chat may host many historical sessions, but only one active
+subscription may own it.

--- a/.ravi/specs/sessions/CHECKS.md
+++ b/.ravi/specs/sessions/CHECKS.md
@@ -6,6 +6,8 @@
 - Renaming `session_name` MUST NOT rewrite `session_key`.
 - Session reset MUST clear provider continuity state but MUST NOT drop attach
   subscriptions.
+- Attach/detach MUST persist only on `session_chat_subscriptions`. Detach MUST
+  remain detached after repeated database initialization.
 - Deleting a session MUST cascade to delete its subscriptions.
 - Session visibility MUST be enforced: principals MUST only list, inspect, read,
   recap, trace, or mutate sessions they own or hold `access`/`modify` grants for.

--- a/.ravi/specs/sessions/RUNBOOK.md
+++ b/.ravi/specs/sessions/RUNBOOK.md
@@ -17,6 +17,9 @@
   never `session_key`.
 - Reset: clears provider continuity state but preserves attach subscriptions.
 - Delete: cascades to delete the session's subscriptions.
+- Attach/detach: `session_chat_subscriptions` is the only ledger. After
+  `ravi sessions detach`, a leftover `session_chat_bindings` row MUST NOT
+  exist or come back on the next process start.
 
 ## Diagnosing Effective Model
 

--- a/.ravi/specs/sessions/SPEC.md
+++ b/.ravi/specs/sessions/SPEC.md
@@ -69,8 +69,8 @@ Sessions do NOT own:
 ## Definitions
 
 - `session`: runtime container for one agent. Identified by a stable `session_key`. Has a canonical `session_name` for human reference.
-- `session_chat_binding`: pre-existing one-to-one record stating "this session belongs to chat X" (see `channels/chats`). It records the *primary* / *origin* chat.
-- `session_chat_subscription`: record stating "chat X is wired to session S". Introduced by `sessions/attach`. One session MAY have many. One active subscription MAY be marked as the output attachment.
+- `session_chat_subscription`: record stating "chat X is wired to session S". One session MAY have many. One active subscription MAY be marked as the output attachment. This is the sole attach/output ledger.
+- `session_chat_binding`: retired 1:1 compatibility table. Existing databases MAY still contain it until the one-time migrate/drop. Runtime MUST NOT read, write, or recreate it.
 - `session_participant`: runtime participation projection (see `contacts/identity-graph`). It is not a permission and not an attach record.
 - `session_key`: durable composite identifier (see `src/router/session-key.ts`). MUST remain stable for the session's lifetime.
 
@@ -78,7 +78,7 @@ Sessions do NOT own:
 
 - A session MUST always belong to exactly one agent.
 - A session MUST have a stable `session_key`. Renaming the canonical `session_name` MUST NOT rewrite `session_key`.
-- A session MAY have one or more attached chats (see `sessions/attach`). The original `session_chat_bindings` row identifies the primary chat for legacy compatibility.
+- A session MAY have one or more attached chats (see `sessions/attach`). Active attachments and the default output live only on `session_chat_subscriptions`.
 - A physical provider turn MUST keep one immutable reply surface. Different chats and threads MUST be serialized into separate turns.
 - An inbound turn MUST reply to its attached source chat or thread. The default output attachment is used only when a turn has no inbound source.
 - An unattached inbound source or a source-less turn without a default output MUST NOT emit externally.
@@ -148,7 +148,7 @@ Agents MUST consult `ravi sessions actions --json` before using a conversational
 ## Known Failure Modes
 
 - Confusing `session_key` identity with `session_name` (display) — leads to broken routing when a session is renamed.
-- Treating `session_chat_bindings` as "the only chat" instead of "the primary chat" — blocks multi-input attach.
+- Reintroducing `session_chat_bindings` as a second attach ledger — detach can appear to succeed and then resurrect on the next CLI bootstrap.
 - Reintroducing `focus` as a separate primitive instead of using `attach` as the output attachment.
 - Mutating the active turn source when a later chat message arrives — causes cross-channel routing leaks.
 - Mentioning a conversational tool in the prompt without exposing it through `ravi sessions actions --json`.

--- a/.ravi/specs/sessions/WHY.md
+++ b/.ravi/specs/sessions/WHY.md
@@ -25,12 +25,13 @@ has the same leak once the leftover source is stripped. Persist already
 stores the assistant row; emit must fail closed instead of inventing a
 chat sink.
 
-## Why Attach Is Separate From Bindings
+## Why Attach Uses Subscriptions Only
 
-The original `session_chat_bindings` row records the primary/origin chat.
-Multi-input work needs additional wiring, so `session_chat_subscription`
-(attach) is a distinct concept. Treating bindings as "the only chat" would block
-multi-chat input and cause replies in the wrong chat.
+`session_chat_subscriptions` records every participating chat and the one
+default output. The retired `session_chat_bindings` 1:1 row was a second
+ledger: detach cleared the subscription but left the binding, and startup
+backfill could recreate the attachment or fail the unique output index.
+Migration converts leftover useful rows once and drops the table.
 
 ## Why Effective Model Is Resolved, Not Stored
 

--- a/.ravi/specs/sessions/attach/CHECKS.md
+++ b/.ravi/specs/sessions/attach/CHECKS.md
@@ -26,6 +26,14 @@
 - `sessions.send` input MUST NOT grow a `from` field. `[from:]` remains
   only `callerSessionKey` inside `[System] Inform:`.
 - Detaching the output chat MUST clear output for that session.
+- Detach MUST remain detached after repeated database initialization. A
+  leftover `session_chat_bindings` row MUST NOT resurrect the subscription
+  or fail the unique output-per-session index.
+- Repeated detach MUST be idempotent and MUST preserve unrelated chats and
+  session history.
+- Inbound routing MUST attach through `session_chat_subscriptions` only.
+- `ravi sessions attach|detach --json` MUST report attached, default output,
+  remaining active subscriptions, and `legacy.status: none`.
 - Attach/detach during a running turn MUST NOT redirect that turn's captured
   reply target.
 - Different source chats and threads MUST run as separate serialized turns.

--- a/.ravi/specs/sessions/attach/RUNBOOK.md
+++ b/.ravi/specs/sessions/attach/RUNBOOK.md
@@ -24,8 +24,13 @@
 10. For a real WhatsApp/Slack inbound turn, the runtime prompt MUST start
     with `[session surface] This turn came from a …`. The persisted user
     row MAY keep that prefix.
-11. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
-12. Do not add a `from` field to `sessions.send`. App identity stays on
+11. Confirm `session_chat_bindings` is absent after init. Detach MUST remain
+    detached across `closeRouterDb()` / `getDb()` and leftover bindings MUST
+    not come back as subscriptions.
+12. `ravi sessions attach|detach --json` MUST show attached/default-output
+    state, remaining active subscriptions, and `legacy.status: none`.
+13. Do not reintroduce `speech`, `mute`, `unmute`, or `focus`.
+14. Do not add a `from` field to `sessions.send`. App identity stays on
     `context issue`; `[from:]` is only `callerSessionKey` inside Inform.
 
 ## Validation

--- a/.ravi/specs/sessions/attach/SPEC.md
+++ b/.ravi/specs/sessions/attach/SPEC.md
@@ -152,6 +152,11 @@ is the escape hatch. Chat-attached `-w` still means delivered.
   output.
 - `detach` removes the subscription and clears it as default.
 - `subscriptions` lists active chats and the default marker.
+- `--json` attach/detach MUST report the final state: session identity/name,
+  requested chat id, whether that chat is attached, whether it is the default
+  output, remaining active subscriptions (chat id, role, default output,
+  detached flag), and explicit `legacy.status` of `none` for
+  `session_chat_bindings`. Human output MUST summarize the same state.
 
 There is no speech mode. `mute`, `unmute`, and `focus` are not part of this
 capability.
@@ -161,10 +166,22 @@ wiring.
 
 ## Persistence
 
+- `session_chat_subscriptions` is the sole source of truth for attach, detach,
+  inbound chat participation, and default output.
+- One chat belongs to at most one active session. One session MAY have many
+  active chats. At most one active output exists per session.
+- `detach` removes the active association and clears default output for that
+  chat. It MUST NOT delete the session or its history. Repeated detach is
+  idempotent.
 - Resetting provider continuity MUST preserve chat subscriptions.
 - Deleting a session MUST cascade to its subscriptions.
 - Existing databases may retain obsolete speech columns; runtime and CLI code
   MUST ignore them. New schemas do not create them.
+- Legacy `session_chat_bindings` MUST NOT be created, read, or written at
+  runtime. Compatibility migration converts leftover useful rows into
+  subscriptions once, then drops the table. Migration MUST be idempotent and
+  MUST NOT resurrect an intentionally detached pair or insert a second active
+  output for a session.
 
 ## Validation
 
@@ -172,11 +189,22 @@ wiring.
 bun test src/router/session-attach.test.ts src/runtime/session-output-target.test.ts
 bun test src/runtime/delivery-queue.test.ts src/runtime/session-dispatcher.test.ts
 bun test src/runtime/session-surface-hint.test.ts src/omni/consumer-context.test.ts
+bun test src/cli/commands/sessions.test.ts
 bun test src/channels/slack/socket-mode.test.ts src/channels/slack/thread-lifecycle.test.ts
 ```
 
 Regression coverage MUST include:
 
+- detach with another output selected in the same session;
+- detach with no competing output, with no resurrection after repeated DB
+  initialization;
+- repeated detach remaining idempotent;
+- one-time binding migration being idempotent and never violating the unique
+  output index;
+- preservation of unrelated chats and session history;
+- inbound consumer creating/using subscriptions only, never legacy bindings;
+- CLI attach/detach JSON and human output exposing final attached/default
+  state and reporting no legacy binding;
 - Slack active, WhatsApp queued, then one reply to each source in order;
 - two Slack threads remaining separate;
 - source-less output using the default attachment;

--- a/.ravi/specs/sessions/attach/WHY.md
+++ b/.ravi/specs/sessions/attach/WHY.md
@@ -14,6 +14,12 @@ session destination for emit: leftover `lastChannel` and the default output
 attachment must not become WhatsApp/Slack. Attach stays fail-closed for
 chat delivery. Persist + `sessions.read` remain the sink.
 
+`session_chat_subscriptions` is the only attach ledger. The retired
+`session_chat_bindings` table was a 1:1 leftover that detach did not clear, so
+startup backfill could resurrect a detached chat or fail the unique
+output-per-session index. Migration converts leftover useful rows once, then
+drops the table. Runtime MUST NOT recreate it.
+
 The `[session surface]` line tells the model where a normal reply returns.
 That instruction is model-visible on every new logical turn, including
 operator CLI-only and HTTP `sessions.send`.

--- a/src/channels/backend.test.ts
+++ b/src/channels/backend.test.ts
@@ -5,7 +5,7 @@ import {
   dbCreateAgent,
   dbGetChannelBackendIngressReceipt,
   dbGetChatMessage,
-  dbGetSessionChatBinding,
+  dbGetSessionOutputAttachment,
   dbUpsertChat,
   dbUpsertChatMessage,
 } from "../router/router-db.js";
@@ -87,10 +87,10 @@ describe("channel backend ingress", () => {
     expect(dbGetChatMessage(result.binding!.messageId)?.content).toEqual({
       blocks: [{ type: "text", text: "fixture input" }],
     });
-    expect(dbGetSessionChatBinding(receipt!.sessionKey)).toMatchObject({
+    expect(dbGetSessionOutputAttachment(receipt!.sessionKey)).toMatchObject({
       chatId: result.binding?.chatId,
-      agentId: "agent-a",
-      bindingReason: "channel_backend",
+      sessionKey: receipt!.sessionKey,
+      attachedReason: "channel_backend",
     });
     expect(published).toHaveLength(1);
     expect(published[0]).toMatchObject({

--- a/src/channels/backend.ts
+++ b/src/channels/backend.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { publishSessionPrompt, type PublishSessionPromptOptions } from "../omni/session-stream.js";
 import {
   dbAcceptChannelBackendIngress,
-  dbBindSessionToChat,
   dbClaimChannelBackendIngressPublication,
   dbGetAgent,
   dbGetChatMessage,
@@ -13,7 +12,7 @@ import {
   type ChannelBackendIngressReceiptRecord,
 } from "../router/router-db.js";
 import { getAgentCwd } from "../router/resolver.js";
-import { getOrCreateSession, getSession, updateSessionName } from "../router/sessions.js";
+import { attachChatToSession, getOrCreateSession, getSession, updateSessionName } from "../router/sessions.js";
 import type { ChannelBackendPromptMetadata, MessageContext, MessageTarget } from "../runtime/message-types.js";
 import { logger } from "../utils/logger.js";
 
@@ -632,12 +631,13 @@ function ensureChannelBackendSession(receipt: ChannelBackendIngressReceiptRecord
   } else if (session.name !== receipt.sessionName) {
     throw new Error(`Session ${receipt.sessionKey} already uses name ${session.name}; expected ${receipt.sessionName}`);
   }
-  dbBindSessionToChat({
+  attachChatToSession({
     sessionKey: receipt.sessionKey,
     chatId: receipt.chatId,
-    agentId: receipt.agentId,
-    bindingReason: "channel_backend",
-    seenAt: receipt.acceptedAt,
+    role: "primary",
+    attachedByType: "system",
+    attachedReason: "channel_backend",
+    setOutputTarget: true,
   });
 }
 

--- a/src/channels/outbound-consumer.test.ts
+++ b/src/channels/outbound-consumer.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
-import { getOrCreateSession } from "../router/sessions.js";
-import { dbBindSessionToChat, dbUpsertChat, dbUpsertChatMessage } from "../router/router-db.js";
+import { attachChatToSession, getOrCreateSession } from "../router/sessions.js";
+import { dbUpsertChat, dbUpsertChatMessage } from "../router/router-db.js";
 import { createSlackThreadLifecycle, getSlackThreadLifecycle } from "./slack/thread-lifecycle-store.js";
 import type { NativeChatActionDelivery, NativeTextDelivery } from "./native/types.js";
 import {
@@ -422,10 +422,11 @@ describe("channel outbound consumer", () => {
         platformChatId: "C123",
         chatType: "channel",
       });
-      dbBindSessionToChat({
+      attachChatToSession({
         sessionKey: "ravi-channels",
         chatId: rootChat.id,
-        agentId: "main",
+        attachedByType: "system",
+        setOutputTarget: true,
       });
       createSlackThreadLifecycle({
         requestId: "slack-thread:req-1",
@@ -1022,10 +1023,11 @@ describe("channel outbound consumer", () => {
         platformChatId: "C123",
         chatType: "channel",
       });
-      dbBindSessionToChat({
+      attachChatToSession({
         sessionKey: "ravi-channels",
         chatId: acceptedChat.id,
-        agentId: "main",
+        attachedByType: "system",
+        setOutputTarget: true,
       });
       const assistant = dbUpsertChatMessage({
         chatId: acceptedChat.id,
@@ -1046,10 +1048,11 @@ describe("channel outbound consumer", () => {
         platformChatId: "C456",
         chatType: "channel",
       });
-      dbBindSessionToChat({
+      attachChatToSession({
         sessionKey: "ravi-channels",
         chatId: movedChat.id,
-        agentId: "main",
+        attachedByType: "system",
+        setOutputTarget: true,
       });
       const job = makeJob();
       job.request.origin.responsePhase = "final_answer";

--- a/src/channels/outbound-consumer.ts
+++ b/src/channels/outbound-consumer.ts
@@ -5,7 +5,7 @@ import { getAgentPlatformIdentity } from "../contacts.js";
 import { getSessionByName } from "../router/index.js";
 import {
   dbGetChatMessage,
-  dbGetSessionChatBinding,
+  dbGetSessionDefaultChatId,
   dbMarkChatMessageDeleted,
   dbMarkChatMessageEdited,
   dbSaveMessageMeta,
@@ -629,8 +629,8 @@ const DEFAULT_PERSISTENCE_DEPENDENCIES: PersistDeliveredMessageDependencies = {
   resolveContext: ({ job, instanceId }) => {
     const session = getSessionByName(job.request.origin.sessionName);
     const agentId = session?.agentId;
-    const binding = session?.sessionKey ? dbGetSessionChatBinding(session.sessionKey) : null;
-    const canonicalChatId = job.request.target.canonicalChatId ?? binding?.chatId;
+    const attachedChatId = session?.sessionKey ? dbGetSessionDefaultChatId(session.sessionKey) : null;
+    const canonicalChatId = job.request.target.canonicalChatId ?? attachedChatId;
     const agentIdentity = agentId
       ? getAgentPlatformIdentity({
           agentId,

--- a/src/channels/slack/socket-mode.test.ts
+++ b/src/channels/slack/socket-mode.test.ts
@@ -24,6 +24,7 @@ import {
   dbGetChat,
   dbGetChannelBackendIngressReceiptByTurnId,
   dbGetContext,
+  dbLegacySessionChatBindingsTableExists,
   dbListChatParticipants,
   dbUpsertChat,
   dbUpsertInstance,
@@ -819,6 +820,7 @@ describe("Slack Socket Mode routing", () => {
         role: "primary",
       }),
     ]);
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
   });
 
   it("persists a message envelope before ack and resumes it after transient publication failure", async () => {

--- a/src/channels/slack/socket-mode.ts
+++ b/src/channels/slack/socket-mode.ts
@@ -19,7 +19,6 @@ import {
   isChatCompatibleWithSession,
 } from "../../router/index.js";
 import {
-  dbBindSessionToChat,
   dbListChatParticipants,
   dbUpsertChat,
   dbUpsertChatMessage,
@@ -1540,14 +1539,6 @@ export class SlackSocketModeService {
     });
     const sessionName = resolved.sessionName ?? resolved.sessionKey;
 
-    dbBindSessionToChat({
-      sessionKey: resolved.sessionKey,
-      chatId: canonicalChat.id,
-      agentId: resolved.agent.id,
-      routeId: null,
-      bindingReason: "slack_socket_mode",
-      seenAt: message.eventTimeMs,
-    });
     syncSlackSessionSubscription(resolved.sessionKey, canonicalChat.id);
     let createdEventOwnedByProgrammaticLifecycle = false;
     if (routeThreadId) {
@@ -1668,14 +1659,6 @@ export class SlackSocketModeService {
           ...slackTeamProvenance(message),
           channelId: message.channelId,
         },
-        seenAt: message.eventTimeMs,
-      });
-      dbBindSessionToChat({
-        sessionKey: resolved.sessionKey,
-        chatId: rootChat.id,
-        agentId: resolved.agent.id,
-        routeId: null,
-        bindingReason: "slack_socket_mode:chat_and_thread",
         seenAt: message.eventTimeMs,
       });
       syncSlackSessionSubscription(resolved.sessionKey, rootChat.id, { forceInput: true });

--- a/src/channels/slack/thread-lifecycle.ts
+++ b/src/channels/slack/thread-lifecycle.ts
@@ -15,10 +15,9 @@ import {
   updateSessionThreadId,
 } from "../../router/index.js";
 import {
-  dbBindSessionToChat,
   dbFindChat,
   dbGetChat,
-  dbGetSessionChatBinding,
+  dbGetSessionDefaultChatId,
   dbUpsertChat,
 } from "../../router/router-db.js";
 import type { SessionEntry } from "../../router/types.js";
@@ -231,8 +230,8 @@ export function ensureSlackThreadLifecycleForSession(session: SessionEntry): Sla
   const existing = findSlackThreadLifecycleByChildSession(session.sessionKey);
   if (existing) return existing;
 
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  const chat = binding ? dbGetChat(binding.chatId) : null;
+  const chatId = dbGetSessionDefaultChatId(session.sessionKey);
+  const chat = chatId ? dbGetChat(chatId) : null;
   if (!chat || chat.channel.toLowerCase() !== "slack" || chat.chatType !== "thread") {
     throw new Error(`Session is not attached to a Slack thread: ${session.name ?? session.sessionKey}`);
   }
@@ -445,13 +444,6 @@ function materializeSlackThreadChild(record: SlackThreadLifecycleRecord): {
       threadTs: record.providerThreadId,
       parentSessionKey: record.parentSessionKey,
     },
-  });
-  dbBindSessionToChat({
-    sessionKey: child.sessionKey,
-    chatId: threadChat.id,
-    agentId: child.agentId,
-    routeId: null,
-    bindingReason: "slack_thread_create_action",
   });
   attachChatToSession({
     sessionKey: child.sessionKey,

--- a/src/channels/slack/thread-lifecycle.ts
+++ b/src/channels/slack/thread-lifecycle.ts
@@ -14,12 +14,7 @@ import {
   updateSessionSource,
   updateSessionThreadId,
 } from "../../router/index.js";
-import {
-  dbFindChat,
-  dbGetChat,
-  dbGetSessionDefaultChatId,
-  dbUpsertChat,
-} from "../../router/router-db.js";
+import { dbFindChat, dbGetChat, dbGetSessionDefaultChatId, dbUpsertChat } from "../../router/router-db.js";
 import type { SessionEntry } from "../../router/types.js";
 import type {
   ChannelTurnAction,

--- a/src/cli/commands/channels-json.test.ts
+++ b/src/cli/commands/channels-json.test.ts
@@ -274,7 +274,6 @@ mock.module("../../router/router-db.js", () => ({
     chatParticipants.push(input);
     return input;
   },
-  dbBindSessionToChat: (input: Record<string, unknown>) => input,
   dbUpdateAgent: (id: string, updates: Partial<{ cwd: string; provider?: string; model?: string }>) => {
     const current = knownAgents.get(id) ?? { id, cwd: "/tmp" };
     const updated = { ...current, ...updates, id };

--- a/src/cli/commands/group.test.ts
+++ b/src/cli/commands/group.test.ts
@@ -148,7 +148,6 @@ mock.module("../../router/router-db.js", () => ({
     upsertChatParticipantCalls.push(input);
   },
   dbCreateRoute: (input: Record<string, unknown>) => ({ id: "route-1", ...input }),
-  dbBindSessionToChat: () => {},
 }));
 
 mock.module("../../channels/session-prompt.js", () => ({

--- a/src/cli/commands/group.ts
+++ b/src/cli/commands/group.ts
@@ -13,7 +13,6 @@ import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
 import { commandEnvelopeReturnSchema, declareCommandReturns } from "./operational-return-schemas.js";
 import { findContactsByTag, getContact, getContactById, normalizePhone, searchContacts } from "../../contacts.js";
 import {
-  dbBindSessionToChat,
   dbCreateRoute,
   dbFindChat,
   dbGetInstance,
@@ -1326,12 +1325,6 @@ export class GroupCommands {
           channel: "whatsapp",
           accountId: acctId,
           chatId: `group:${groupId}`,
-        });
-        dbBindSessionToChat({
-          sessionKey,
-          chatId: chat.id,
-          agentId: agent,
-          bindingReason: "whatsapp.group.create",
         });
         const attachment = attachChatToSession({
           sessionKey,

--- a/src/cli/commands/self.test.ts
+++ b/src/cli/commands/self.test.ts
@@ -25,9 +25,8 @@ let inlineContext: FakeContext | undefined;
 let resolvedContext: FakeContext | undefined;
 let resolvedContextOptions: unknown;
 let session: Record<string, unknown> | null = null;
-let chatBinding: Record<string, unknown> | null = null;
+let chatAttachment: Record<string, unknown> | null = null;
 let chat: Record<string, unknown> | null = null;
-let boundRoute: Record<string, unknown> | null = null;
 let sessionRoutes: Record<string, unknown>[] = [];
 let chatParticipants: Record<string, unknown>[] = [];
 let messageMeta: Record<string, unknown>[] = [];
@@ -61,9 +60,9 @@ mock.module("../../router/sessions.js", () => ({
 
 mock.module("../../router/router-db.js", () => ({
   ...actualRouterDbModule,
-  dbGetSessionChatBinding: () => chatBinding,
+  dbGetSessionOutputAttachment: () => chatAttachment,
+  dbListSessionChatSubscriptions: () => (chatAttachment ? [chatAttachment] : []),
   dbGetChat: () => chat,
-  dbGetRouteById: () => boundRoute,
   dbListRoutesBySessionName: () => sessionRoutes,
   dbListChatParticipants: () => chatParticipants,
   dbListMessageMetaByChatId: (_chatId: string, limit: number) => {
@@ -139,12 +138,13 @@ function seedLinkedContext(): void {
     updatedAt: 3000,
     createdAt: 900,
   };
-  chatBinding = {
+  chatAttachment = {
     sessionKey: "agent:main:main",
     chatId: "chat_123",
-    agentId: "main",
-    routeId: 7,
-    bindingReason: "route",
+    role: "primary",
+    attachedByType: "system",
+    attachedReason: "route",
+    outputAttachedAt: 3000,
     createdAt: 1000,
     updatedAt: 3000,
   };
@@ -161,15 +161,16 @@ function seedLinkedContext(): void {
     createdAt: 1000,
     updatedAt: 3000,
   };
-  boundRoute = {
-    id: 7,
-    pattern: "group:120363",
-    accountId: "main",
-    agent: "main",
-    priority: 10,
-    channel: "whatsapp",
-  };
-  sessionRoutes = [];
+  sessionRoutes = [
+    {
+      id: 7,
+      pattern: "group:120363",
+      accountId: "main",
+      agent: "main",
+      priority: 10,
+      channel: "whatsapp",
+    },
+  ];
   chatParticipants = [
     {
       id: "cp_1",
@@ -237,9 +238,8 @@ describe("SelfCommands", () => {
     inlineContext = undefined;
     resolvedContext = undefined;
     session = null;
-    chatBinding = null;
+    chatAttachment = null;
     chat = null;
-    boundRoute = null;
     sessionRoutes = [];
     chatParticipants = [];
     messageMeta = [];

--- a/src/cli/commands/self.ts
+++ b/src/cli/commands/self.ts
@@ -18,17 +18,17 @@ import { resolveSession } from "../../router/sessions.js";
 import type { RouteConfig, SessionEntry } from "../../router/types.js";
 import {
   dbGetChat,
-  dbGetRouteById,
-  dbGetSessionChatBinding,
+  dbGetSessionOutputAttachment,
   dbListChatParticipants,
   dbListMessageMetaByChatId,
   dbListRoutesBySessionName,
+  dbListSessionChatSubscriptions,
   type ChatParticipantRecord,
   type ChatRecord,
   type ContextCapability,
   type ContextRecord,
   type MessageMetadata,
-  type SessionChatBindingRecord,
+  type SessionChatSubscriptionRecord,
 } from "../../router/router-db.js";
 
 type SectionStatus = "ok" | "partial" | "missing" | "unavailable";
@@ -215,6 +215,10 @@ interface SelfContextPacket {
   description: "Read the current Ravi agent/session/chat context",
   scope: "open",
 })
+function resolveSessionChatAttachment(sessionKey: string): SessionChatSubscriptionRecord | null {
+  return dbGetSessionOutputAttachment(sessionKey) ?? dbListSessionChatSubscriptions(sessionKey)[0] ?? null;
+}
+
 export class SelfCommands {
   @Command({ name: "whoami", description: "Show the current agent/session identity" })
   @CommandAccess({ kind: "read", resource: "self", action: "whoami", risk: "low" })
@@ -325,11 +329,11 @@ export class SelfCommands {
   private buildPacket(options: { depth: SelfDepth; limit: number }): SelfContextPacket {
     const context = this.requireResolvedContext();
     const session = this.resolveCurrentSession(context);
-    const binding = session.data ? dbGetSessionChatBinding(session.data.sessionKey) : null;
-    const chatRecord = binding ? dbGetChat(binding.chatId) : null;
-    const route = this.buildRouteSection(session.data, binding);
-    const chat = this.buildChatSection(context, binding, chatRecord, options.depth);
-    const recent = this.buildRecentSection(context, binding, chatRecord, options.limit);
+    const attachment = session.data ? resolveSessionChatAttachment(session.data.sessionKey) : null;
+    const chatRecord = attachment ? dbGetChat(attachment.chatId) : null;
+    const route = this.buildRouteSection(session.data);
+    const chat = this.buildChatSection(context, attachment, chatRecord, options.depth);
+    const recent = this.buildRecentSection(context, attachment, chatRecord, options.limit);
     const actor = this.buildActorSection(context, recent);
     const permissions = this.buildPermissionsSection(context);
     const knowledge = this.buildKnowledgeSection();
@@ -394,36 +398,40 @@ export class SelfCommands {
 
   private buildChatSection(
     context: ContextRecord,
-    binding: SessionChatBindingRecord | null,
+    attachment: SessionChatSubscriptionRecord | null,
     chat: ChatRecord | null,
     depth: SelfDepth,
   ): SelfSection<SelfChatSummary> {
-    if (!binding && !context.source) {
-      return { status: "missing", reason: "no canonical chat binding or source context found" };
+    if (!attachment && !context.source) {
+      return { status: "missing", reason: "no canonical chat attachment or source context found" };
     }
 
     const data: SelfChatSummary = {
-      binding: binding
+      binding: attachment
         ? {
-            sessionKey: binding.sessionKey,
-            chatId: binding.chatId,
-            routeId: binding.routeId ?? null,
-            bindingReason: binding.bindingReason ?? null,
-            updatedAt: binding.updatedAt,
+            sessionKey: attachment.sessionKey,
+            chatId: attachment.chatId,
+            routeId: null,
+            bindingReason: attachment.attachedReason ?? null,
+            updatedAt: attachment.updatedAt,
           }
         : null,
       chat: chat ? serializeChat(chat) : null,
       sourceFallback: context.source ?? null,
     };
 
-    if (depth === "full" && binding) {
-      data.participants = dbListChatParticipants(binding.chatId).map(serializeChatParticipant);
+    if (depth === "full" && attachment) {
+      data.participants = dbListChatParticipants(attachment.chatId).map(serializeChatParticipant);
     }
 
-    if (binding && !chat) {
-      return { status: "partial", reason: `chat binding points to missing chat ${binding.chatId}`, data };
+    if (attachment && !chat) {
+      return { status: "partial", reason: `chat attachment points to missing chat ${attachment.chatId}`, data };
     }
-    return { status: binding ? "ok" : "partial", reason: binding ? undefined : "using source fallback only", data };
+    return {
+      status: attachment ? "ok" : "partial",
+      reason: attachment ? undefined : "using source fallback only",
+      data,
+    };
   }
 
   private buildActorSection(
@@ -448,16 +456,13 @@ export class SelfCommands {
     return { status: "missing", reason: "no actor metadata found in context, environment, or recent messages" };
   }
 
-  private buildRouteSection(
-    session: SessionEntry | undefined,
-    binding: SessionChatBindingRecord | null,
-  ): SelfSection<SelfRouteSummary> {
-    if (!session && !binding?.routeId) {
+  private buildRouteSection(session: SessionEntry | undefined): SelfSection<SelfRouteSummary> {
+    if (!session) {
       return { status: "missing", reason: "no session or route binding available" };
     }
 
-    const boundRoute = binding?.routeId ? dbGetRouteById(binding.routeId) : null;
-    const sessionRoutes = session?.name ? dbListRoutesBySessionName(session.name) : [];
+    const sessionRoutes = session.name ? dbListRoutesBySessionName(session.name) : [];
+    const boundRoute = sessionRoutes[0] ?? null;
     return {
       status: boundRoute || sessionRoutes.length > 0 ? "ok" : "missing",
       reason: boundRoute || sessionRoutes.length > 0 ? undefined : "no route is explicitly bound to this session",
@@ -470,11 +475,11 @@ export class SelfCommands {
 
   private buildRecentSection(
     context: ContextRecord,
-    binding: SessionChatBindingRecord | null,
+    attachment: SessionChatSubscriptionRecord | null,
     chat: ChatRecord | null,
     limit: number,
   ): SelfSection<SelfRecentSummary> {
-    const chatId = binding?.chatId ?? chat?.id ?? context.source?.chatId ?? null;
+    const chatId = attachment?.chatId ?? chat?.id ?? context.source?.chatId ?? null;
     if (!chatId) {
       return { status: "missing", reason: "no chat id available for recent message lookup" };
     }

--- a/src/cli/commands/self.ts
+++ b/src/cli/commands/self.ts
@@ -210,15 +210,15 @@ interface SelfContextPacket {
   nextReads: string[];
 }
 
+function resolveSessionChatAttachment(sessionKey: string): SessionChatSubscriptionRecord | null {
+  return dbGetSessionOutputAttachment(sessionKey) ?? dbListSessionChatSubscriptions(sessionKey)[0] ?? null;
+}
+
 @Group({
   name: "self",
   description: "Read the current Ravi agent/session/chat context",
   scope: "open",
 })
-function resolveSessionChatAttachment(sessionKey: string): SessionChatSubscriptionRecord | null {
-  return dbGetSessionOutputAttachment(sessionKey) ?? dbListSessionChatSubscriptions(sessionKey)[0] ?? null;
-}
-
 export class SelfCommands {
   @Command({ name: "whoami", description: "Show the current agent/session identity" })
   @CommandAccess({ kind: "read", resource: "self", action: "whoami", risk: "low" })

--- a/src/cli/commands/sessions.test.ts
+++ b/src/cli/commands/sessions.test.ts
@@ -43,7 +43,6 @@ let chatHistoryByChat: Array<Record<string, unknown>> = [];
 let messageMetadataRows: Array<Record<string, unknown>> = [];
 const chatRecords = new Map<string, Record<string, unknown>>();
 let sessionSubscriptions: Array<Record<string, unknown>> = [];
-const sessionChatBindings = new Map<string, Record<string, unknown>>();
 const sessionTurnUsageSummaries = new Map<string, Record<string, unknown>>();
 let agentChatMessagesPage: {
   total: number;
@@ -292,7 +291,6 @@ mock.module("../../router/index.js", () => ({
 mock.module("../../router/router-db.js", () => ({
   ...actualRouterDbModule,
   dbGetChat: (chatId: string) => chatRecords.get(chatId) ?? actualRouterDbModule.dbGetChat(chatId),
-  dbGetSessionChatBinding: (sessionKey: string) => sessionChatBindings.get(sessionKey) ?? null,
   dbFindAgentChatMessageByRef: (input: Record<string, unknown>) => {
     lastAgentMessageLookup = input;
     return agentMessageByRef;
@@ -479,7 +477,6 @@ beforeEach(() => {
   messageMetadataRows = [];
   chatRecords.clear();
   sessionSubscriptions = [];
-  sessionChatBindings.clear();
   agentChatMessagesPage = { total: 0, limit: 10, offset: 0, items: [] };
   lastAgentChatMessagesQuery = null;
   lastAgentMessageLookup = null;

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -52,6 +52,7 @@ import {
   extendSession,
   makeSessionPermanent,
   attachChatToSession,
+  describeSessionChatAssociation,
   detachChatFromSession,
   getSessionTurnUsageSummary,
   listSessionSubscriptions,
@@ -92,7 +93,6 @@ import {
   dbFindChatByRef,
   dbGetAgentChatActionCounts,
   dbGetChat,
-  dbGetSessionChatBinding,
   dbGetMessageMeta,
   dbListAgentChatMessagesPage,
   dbListContexts,
@@ -652,9 +652,28 @@ function sessionActionChatIds(session: SessionEntry): string[] {
   for (const subscription of listSessionSubscriptions(session.sessionKey)) {
     ids.add(subscription.chatId);
   }
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  if (binding?.chatId) ids.add(binding.chatId);
   return Array.from(ids);
+}
+
+function formatSessionChatAssociationHuman(state: {
+  attached: boolean;
+  defaultOutput: boolean;
+  subscriptions: Array<{ chatId: string; role: string; defaultOutput: boolean }>;
+  legacy: { status: string };
+}): void {
+  console.log(`Attached: ${state.attached ? "yes" : "no"}`);
+  const defaultOutput = state.subscriptions.find((subscription) => subscription.defaultOutput);
+  console.log(`Default output: ${defaultOutput?.chatId ?? "none"}`);
+  if (state.subscriptions.length === 0) {
+    console.log("Active subscriptions: none");
+  } else {
+    console.log("Active subscriptions:");
+    for (const subscription of state.subscriptions) {
+      const marker = subscription.defaultOutput ? " default-output" : "";
+      console.log(`  - ${subscription.chatId} [${subscription.role}]${marker}`);
+    }
+  }
+  console.log(`Legacy bindings: ${state.legacy.status}`);
 }
 
 async function queueSlackChatAction(
@@ -5847,12 +5866,13 @@ export class SessionCommands {
       });
       const sessionRef = session.name ?? session.sessionKey;
       const detachCommand = buildSessionDetachCommand(sessionRef, chat.id);
+      const state = describeSessionChatAssociation(session.sessionKey, chat.id, session.name);
       if (asJson) {
         printJson({
-          attached: result.created,
+          ...state,
+          created: result.created,
           outputAttached: result.outputAttached,
           subscription: result.subscription,
-          session: { name: session.name, sessionKey: session.sessionKey },
           chat: {
             id: chat.id,
             title: chat.title,
@@ -5867,7 +5887,7 @@ export class SessionCommands {
       }
       const verb = result.created ? "Attached" : "Already attached";
       console.log(`${verb} chat ${chat.id} (${chat.title ?? "no title"}) to session ${sessionRef}`);
-      console.log(`Output target: ${chat.id}`);
+      formatSessionChatAssociationHuman(state);
       console.log(`Detach hint: ${detachCommand}`);
     } catch (err) {
       if (err instanceof SessionAttachConflictError) {
@@ -5921,22 +5941,18 @@ export class SessionCommands {
       fail(`Chat not found: ${chatRef}`);
       return;
     }
-    const result = detachChatFromSession(session.sessionKey, chat.id);
+    const result = detachChatFromSession(session.sessionKey, chat.id, session.name);
     if (asJson) {
-      printJson({
-        detached: result.detached,
-        outputDetached: result.outputDetached,
-        sessionKey: session.sessionKey,
-        chatId: chat.id,
-      });
+      printJson(result);
       return;
     }
     if (result.detached) {
-      const suffix = result.outputDetached ? " and cleared it as output target" : "";
+      const suffix = result.outputDetached ? " and cleared it as default output" : "";
       console.log(`Detached chat ${chat.id} from session ${session.name ?? session.sessionKey}${suffix}`);
     } else {
       console.log(`Chat ${chat.id} is not currently attached to ${session.name ?? session.sessionKey}`);
     }
+    formatSessionChatAssociationHuman(result);
   }
 
   @Command({

--- a/src/cli/commands/stickers.ts
+++ b/src/cli/commands/stickers.ts
@@ -13,7 +13,7 @@ import { buildCliOffsetPagination, paginateCliItems } from "../pagination.js";
 import { cliOffsetPaginationSchema, looseObjectSchema } from "../return-schemas.js";
 import { nats } from "../../nats.js";
 import { configStore } from "../../config-store.js";
-import { dbGetChat, dbGetSessionChatBinding } from "../../router/router-db.js";
+import { dbGetChat, dbGetSessionDefaultChatId } from "../../router/router-db.js";
 import { resolveSession } from "../../router/sessions.js";
 import type { SessionEntry } from "../../router/types.js";
 import {
@@ -122,8 +122,8 @@ function serializeSticker(sticker: StickerCatalogEntry): Record<string, unknown>
 }
 
 function targetFromSession(session: SessionEntry): StickerSendTarget | null {
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  const chat = binding ? dbGetChat(binding.chatId) : null;
+  const chatId = dbGetSessionDefaultChatId(session.sessionKey);
+  const chat = chatId ? dbGetChat(chatId) : null;
   if (chat) {
     const accountId = configStore.resolveAccountName(chat.instanceId) ?? session.lastAccountId ?? chat.instanceId;
     const separator = chat.platformChatId.indexOf("#");

--- a/src/gateway-session-trace.test.ts
+++ b/src/gateway-session-trace.test.ts
@@ -3,7 +3,6 @@ import { configStore } from "./config-store.js";
 import { createContact, getContact, upsertAgentPlatformIdentity } from "./contacts.js";
 import { Gateway, SILENT_TOKEN } from "./gateway.js";
 import {
-  dbBindSessionToChat,
   dbFindChatMessage,
   dbGetChatMessage,
   dbGetMessageMeta,
@@ -12,7 +11,7 @@ import {
   dbUpsertChatMessage,
   dbUpsertInstance,
 } from "./router/router-db.js";
-import { getOrCreateSession, updateSessionName } from "./router/sessions.js";
+import { attachChatToSession, getOrCreateSession, updateSessionName } from "./router/sessions.js";
 import { recordDeliveryTrace } from "./session-trace/channel-trace.js";
 import { listSessionEvents } from "./session-trace/session-trace-db.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "./test/ravi-state.js";
@@ -256,11 +255,12 @@ describe("Gateway session trace instrumentation", () => {
       platformChatId: "5511999999999@s.whatsapp.net",
       chatType: "dm",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_canonical_trace",
+      attachedByType: "system",
+      attachedReason: "test_canonical_trace",
+      setOutputTarget: true,
     });
     dbSaveMessageMeta("inbound-1", "5511999999999@s.whatsapp.net", {
       canonicalChatId: chat.id,
@@ -317,11 +317,12 @@ describe("Gateway session trace instrumentation", () => {
       platformChatId: "120363000000000000@g.us",
       chatType: "group",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_delete_own_outbound",
+      attachedByType: "system",
+      attachedReason: "test_delete_own_outbound",
+      setOutputTarget: true,
     });
     const own = dbUpsertChatMessage({
       chatId: chat.id,
@@ -375,11 +376,12 @@ describe("Gateway session trace instrumentation", () => {
       platformChatId: "120363000000000000@g.us",
       chatType: "group",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_edit_own_outbound",
+      attachedByType: "system",
+      attachedReason: "test_edit_own_outbound",
+      setOutputTarget: true,
     });
     const own = dbUpsertChatMessage({
       chatId: chat.id,
@@ -442,11 +444,12 @@ describe("Gateway session trace instrumentation", () => {
       platformChatId: "5511999999999@s.whatsapp.net",
       chatType: "dm",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_dm_outbound_projection",
+      attachedByType: "system",
+      attachedReason: "test_dm_outbound_projection",
+      setOutputTarget: true,
     });
     const gateway = makeGateway(mock(async () => ({ messageId: "outbound-dm-1" })));
 
@@ -481,11 +484,12 @@ describe("Gateway session trace instrumentation", () => {
       platformChatId: "120363000000000000@g.us",
       chatType: "group",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_group_outbound_projection",
+      attachedByType: "system",
+      attachedReason: "test_group_outbound_projection",
+      setOutputTarget: true,
     });
     const gateway = makeGateway(mock(async () => ({ messageId: "outbound-group-1" })));
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -39,7 +39,7 @@ import type { StickerSendEvent } from "./stickers/send.js";
 import { getSessionByName } from "./router/index.js";
 import {
   dbGetChat,
-  dbGetSessionChatBinding,
+  dbGetSessionDefaultChatId,
   dbMarkChatMessageDeleted,
   dbMarkChatMessageEdited,
   dbSaveMessageMeta,
@@ -1348,8 +1348,8 @@ export class Gateway {
     try {
       const session = getSessionByName(sessionName);
       const agentId = session?.agentId;
-      const binding = session?.sessionKey ? dbGetSessionChatBinding(session.sessionKey) : null;
-      const canonicalChatId = target.canonicalChatId ?? binding?.chatId;
+      const attachedChatId = session?.sessionKey ? dbGetSessionDefaultChatId(session.sessionKey) : null;
+      const canonicalChatId = target.canonicalChatId ?? attachedChatId;
       const agentIdentity = agentId
         ? getAgentPlatformIdentity({
             agentId,
@@ -1413,8 +1413,8 @@ export class Gateway {
 
     try {
       const session = getSessionByName(sessionName);
-      const binding = session?.sessionKey ? dbGetSessionChatBinding(session.sessionKey) : null;
-      const chatId = target.canonicalChatId ?? binding?.chatId;
+      const attachedChatId = session?.sessionKey ? dbGetSessionDefaultChatId(session.sessionKey) : null;
+      const chatId = target.canonicalChatId ?? attachedChatId;
       if (!chatId) return;
 
       const chat = dbGetChat(chatId);

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1358,7 +1358,7 @@ export class Gateway {
           })
         : null;
       dbSaveMessageMeta(messageId, chatId, {
-        canonicalChatId,
+        canonicalChatId: canonicalChatId ?? undefined,
         actorType: "agent",
         agentId,
         platformIdentityId: agentIdentity?.id,

--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -19,7 +19,6 @@ const actualDbCanonicalizeDmChatForContact = actualRouterDbModule.dbCanonicalize
 const actualDbContactDmNormalizedChatId = actualRouterDbModule.dbContactDmNormalizedChatId;
 const actualDbUpsertChatMessage = actualRouterDbModule.dbUpsertChatMessage;
 const actualDbUpsertChatParticipant = actualRouterDbModule.dbUpsertChatParticipant;
-const actualDbBindSessionToChat = actualRouterDbModule.dbBindSessionToChat;
 const actualDbUpsertSessionParticipant = actualRouterDbModule.dbUpsertSessionParticipant;
 const actualGetOrCreateSession = actualRouterSessionsModule.getOrCreateSession;
 const actualGetSession = actualRouterSessionsModule.getSession;
@@ -234,9 +233,6 @@ mock.module("../router/router-db.js", () => ({
     chatParticipantCalls.push(input);
     return actualDbUpsertChatParticipant(input);
   }),
-  dbBindSessionToChat: mock((input: Parameters<typeof actualDbBindSessionToChat>[0]) =>
-    actualDbBindSessionToChat(input),
-  ),
   dbUpsertSessionParticipant: mock((input: Parameters<typeof actualDbUpsertSessionParticipant>[0]) => {
     sessionParticipantCalls.push(input);
     return actualDbUpsertSessionParticipant(input);
@@ -689,6 +685,7 @@ describe("OmniConsumer channel context", () => {
       role: "primary",
     });
     expect(subscriptions[0].outputAttachedAt).toBeDefined();
+    expect(actualRouterDbModule.dbLegacySessionChatBindingsTableExists()).toBe(false);
     expect(promptCalls).toHaveLength(2);
     expect(promptCalls[1][1].prompt).not.toContain("[session surface");
   });

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -46,7 +46,6 @@ import {
   upsertAgentPlatformIdentity,
 } from "../contacts.js";
 import {
-  dbBindSessionToChat,
   dbCanonicalizeDmChatForContact,
   dbContactDmNormalizedChatId,
   dbFindChat,
@@ -1338,20 +1337,9 @@ export class OmniConsumer {
       threadId,
       peerKind,
     });
-    const routeId = (resolved.route as { id?: number } | undefined)?.id ?? null;
-    dbBindSessionToChat({
-      sessionKey: resolved.sessionKey,
-      chatId: canonicalChat.id,
-      agentId: resolved.agent.id,
-      routeId,
-      bindingReason: "inbound_route",
-      seenAt: msgTs,
-    });
-
-    // sessions/attach: keep the subscriptions index in sync with the
-    // legacy 1:1 binding. First-time chats become `primary`; subsequent
-    // chats routed into an existing session become `input`. Idempotent
-    // on re-routing the same chat.
+    // sessions/attach: first-time chats become `primary`; subsequent chats
+    // routed into an existing session become `input`. Idempotent on
+    // re-routing the same chat. Inbound never writes legacy bindings.
     // See .ravi/specs/sessions/attach/SPEC.md
     try {
       const existingSubscriptions = listSessionSubscriptions(resolved.sessionKey);
@@ -1378,8 +1366,8 @@ export class OmniConsumer {
       // Conflict means the chat is currently attached to another session;
       // the override block above already detected and reused that owner
       // (so we shouldn't reach this path with a conflicting chat). Log
-      // defensively and let the inbound continue — the legacy
-      // `session_chat_bindings` row is still authoritative for now.
+      // defensively and let the inbound continue — active subscriptions
+      // are the sole attach source of truth.
       log.warn("Failed to record session_chat_subscription", {
         chatId: canonicalChat.id,
         sessionKey: resolved.sessionKey,

--- a/src/router/chat-schema.test.ts
+++ b/src/router/chat-schema.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Database } from "bun:sqlite";
 import { join } from "node:path";
 import {
-  dbBindSessionToChat,
   dbAddChatToReadingList,
   dbCanonicalizeDmChatForContact,
   dbCreateCanonicalActorMessage,
@@ -14,14 +13,13 @@ import {
   dbFindAgentChatMessageByRef,
   dbGetAgentChatActionCounts,
   dbContactDmNormalizedChatId,
-  dbGetSessionChatBinding,
   dbGetChatReadingDelta,
   dbListAgentChatMessagesPage,
   dbListChatIdsByContactIds,
   dbListChats,
   dbListChatParticipants,
   dbListChatReadingListMembers,
-  dbListSessionChatBindings,
+  dbListSessionChatSubscriptions,
   dbListSessionParticipants,
   dbMarkChatReadingCursor,
   dbUpsertChat,
@@ -38,7 +36,7 @@ import {
   getDb,
 } from "./router-db.js";
 import { recomputeChatReadingListMembers } from "../chats/reading-lists.js";
-import { getOrCreateSession } from "./sessions.js";
+import { attachChatToSession, getOrCreateSession, SessionAttachConflictError } from "./sessions.js";
 import { attachTagSlugsToAsset } from "../tags/helpers.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 
@@ -62,7 +60,7 @@ describe("identity chat schema", () => {
         SELECT name
         FROM sqlite_master
         WHERE type = 'table'
-          AND name IN ('chats', 'chat_messages', 'chat_participants', 'session_chat_bindings', 'session_participants')
+          AND name IN ('chats', 'chat_messages', 'chat_participants', 'session_chat_subscriptions', 'session_participants')
         ORDER BY name
       `,
       )
@@ -72,7 +70,7 @@ describe("identity chat schema", () => {
       "chat_messages",
       "chat_participants",
       "chats",
-      "session_chat_bindings",
+      "session_chat_subscriptions",
       "session_participants",
     ]);
   });
@@ -191,7 +189,7 @@ describe("identity chat schema", () => {
     expect(message.created).toBe(true);
   });
 
-  it("allows one chat to bind to multiple sessions while keeping chat and session participants separate", () => {
+  it("keeps chat and session participants separate while a chat has one active session", () => {
     const chat = dbUpsertChat({
       channel: "whatsapp-baileys",
       instanceId: "instance-1",
@@ -204,18 +202,22 @@ describe("identity chat schema", () => {
     const first = getOrCreateSession("agent:main:whatsapp:main:group:120363424772797713", "main", "/tmp/main");
     const second = getOrCreateSession("agent:support:whatsapp:main:group:120363424772797713", "main", "/tmp/main");
 
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey: first.sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test",
+      attachedByType: "system",
+      attachedReason: "test",
+      setOutputTarget: true,
     });
-    dbBindSessionToChat({
-      sessionKey: second.sessionKey,
-      chatId: chat.id,
-      agentId: "support",
-      bindingReason: "test",
-    });
+    expect(() =>
+      attachChatToSession({
+        sessionKey: second.sessionKey,
+        chatId: chat.id,
+        attachedByType: "system",
+        attachedReason: "test",
+        setOutputTarget: true,
+      }),
+    ).toThrow(SessionAttachConflictError);
 
     dbUpsertChatParticipant({
       chatId: chat.id,
@@ -231,8 +233,8 @@ describe("identity chat schema", () => {
       role: "human",
     });
 
-    expect(dbListSessionChatBindings(chat.id)).toHaveLength(2);
-    expect(dbGetSessionChatBinding(first.sessionKey)?.chatId).toBe(chat.id);
+    expect(dbListSessionChatSubscriptions(first.sessionKey)).toHaveLength(1);
+    expect(dbListSessionChatSubscriptions(second.sessionKey)).toHaveLength(0);
     expect(dbListChatParticipants(chat.id)).toHaveLength(1);
     expect(dbListSessionParticipants(first.sessionKey)).toHaveLength(1);
     expect(dbListSessionParticipants(second.sessionKey)).toHaveLength(0);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -97,7 +97,7 @@ export {
   getDefaultDmScope,
   getAnnounceCompaction,
   getAccountForAgent,
-  dbGetSessionChatBinding,
+  dbGetSessionDefaultChatId,
   // Schema (for validation)
   DmScopeSchema,
   // Database management

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -419,16 +419,6 @@ interface ChatReadingCursorRow {
   updated_at: number;
 }
 
-interface SessionChatBindingRow {
-  session_key: string;
-  chat_id: string;
-  agent_id: string | null;
-  route_id: number | null;
-  binding_reason: string | null;
-  created_at: number;
-  updated_at: number;
-}
-
 interface SessionParticipantRow {
   id: string;
   session_key: string;
@@ -991,16 +981,6 @@ export interface UpsertChatParticipantInput {
   source?: ChatParticipantSource | null;
   metadata?: Record<string, unknown> | null;
   seenAt?: number;
-}
-
-export interface SessionChatBindingRecord {
-  sessionKey: string;
-  chatId: string;
-  agentId?: string;
-  routeId?: number;
-  bindingReason?: string;
-  createdAt: number;
-  updatedAt: number;
 }
 
 export interface SessionParticipantRecord {
@@ -1639,21 +1619,6 @@ function getDb(): Database {
     );
     CREATE INDEX IF NOT EXISTS idx_chat_reading_cursor_events_scope
       ON chat_reading_cursor_events(list_id, chat_id, reader_type, reader_id, created_at DESC);
-
-    CREATE TABLE IF NOT EXISTS session_chat_bindings (
-      session_key TEXT NOT NULL REFERENCES sessions(session_key) ON DELETE CASCADE,
-      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
-      agent_id TEXT,
-      route_id INTEGER,
-      binding_reason TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      PRIMARY KEY (session_key, chat_id)
-    );
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_session_chat_bindings_session
-      ON session_chat_bindings(session_key);
-    CREATE INDEX IF NOT EXISTS idx_session_chat_bindings_chat
-      ON session_chat_bindings(chat_id);
 
     CREATE TABLE IF NOT EXISTS session_chat_subscriptions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -3848,47 +3813,50 @@ function ensureIdentityChatMigrations(database: Database): void {
   //      recent active row per chat) so the UNIQUE index can install;
   //   2. drop any legacy non-unique index by the same name (created by
   //      older code on this branch);
-  //   3. install the partial UNIQUE index;
-  //   4. backfill from session_chat_bindings, picking one binding per
-  //      chat (the most recent) so legacy 1:N data does not regenerate
-  //      duplicates after cleanup.
+  //   3. install the partial UNIQUE active-chat index;
+  //   4. one-time convert leftover session_chat_bindings into
+  //      subscriptions (never a second output; never resurrect a
+  //      detached pair), then DROP the legacy table;
+  //   5. assign a default output only when a session has none;
+  //   6. install the partial UNIQUE output-per-session index.
   // The whole sequence is wrapped in a transaction so a concurrent
   // writer (e.g. the daemon's consumer doing `attachChatToSession`)
   // cannot squeeze an INSERT between dedupe and CREATE UNIQUE INDEX,
   // which would make the CREATE fail and leave the migration half-done.
   database.transaction(() => {
-    dedupeSessionChatSubscriptions(database);
-    database.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_active_chat");
-    database.exec(
-      "CREATE UNIQUE INDEX IF NOT EXISTS idx_session_chat_subscriptions_active_chat ON session_chat_subscriptions(chat_id) WHERE detached_at IS NULL",
-    );
-    backfillSessionChatSubscriptionsFromBindings(database);
-    backfillSessionOutputAttachments(database);
-    database.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_output_target");
-    database.exec(
-      "CREATE UNIQUE INDEX IF NOT EXISTS idx_session_chat_subscriptions_output_target ON session_chat_subscriptions(session_key) WHERE detached_at IS NULL AND output_attached_at IS NOT NULL",
-    );
+    runSessionChatSubscriptionMigrations(database);
   })();
 }
 
 /**
- * Test-only: re-run the dedupe + backfill migration steps on the current
+ * Test-only: re-run the subscription migration (dedupe, one-time legacy
+ * binding convert/drop, output backfill, unique indexes) on the current
  * database. Production callers must rely on `ensureIdentityChatMigrations`
- * running once at startup.
+ * running at startup. Safe to call repeatedly.
  */
 export function dbRunSessionAttachMigrationForTests(): void {
-  const db = getDb();
-  dedupeSessionChatSubscriptions(db);
-  db.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_active_chat");
-  db.exec(
+  runSessionChatSubscriptionMigrations(getDb());
+}
+
+function runSessionChatSubscriptionMigrations(database: Database): void {
+  dedupeSessionChatSubscriptions(database);
+  database.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_active_chat");
+  database.exec(
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_session_chat_subscriptions_active_chat ON session_chat_subscriptions(chat_id) WHERE detached_at IS NULL",
   );
-  backfillSessionChatSubscriptionsFromBindings(db);
-  backfillSessionOutputAttachments(db);
-  db.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_output_target");
-  db.exec(
+  migrateAndDropSessionChatBindings(database);
+  backfillSessionOutputAttachments(database);
+  database.exec("DROP INDEX IF EXISTS idx_session_chat_subscriptions_output_target");
+  database.exec(
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_session_chat_subscriptions_output_target ON session_chat_subscriptions(session_key) WHERE detached_at IS NULL AND output_attached_at IS NOT NULL",
   );
+}
+
+function tableExists(database: Database, name: string): boolean {
+  const row = database.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) as
+    | { 1: number }
+    | undefined;
+  return Boolean(row);
 }
 
 function dedupeSessionChatSubscriptions(database: Database): void {
@@ -3921,14 +3889,20 @@ function dedupeSessionChatSubscriptions(database: Database): void {
   }
 }
 
-function backfillSessionChatSubscriptionsFromBindings(database: Database): void {
-  const now = Date.now();
-  // Backfill at most ONE subscription per chat. When legacy
-  // session_chat_bindings has multiple sessions sharing the same chat
-  // (allowed by the legacy schema), pick the most recently updated row
-  // (tiebreak by session_key for determinism). This matches the spec
-  // invariant "one chat → one session" at the cost of losing the older
-  // bindings; operators can manually attach to recover if needed.
+/**
+ * One-time retirement of `session_chat_bindings`.
+ *
+ * Existing active subscriptions win. A leftover binding is converted only
+ * when that chat has no active subscription and the (session, chat) pair
+ * has no prior subscription row (active or detached). Converted rows are
+ * inserted without output so a second output cannot violate the unique
+ * session output index; `backfillSessionOutputAttachments` assigns output
+ * only when a session has none. The table is then dropped and is never
+ * created again.
+ */
+function migrateAndDropSessionChatBindings(database: Database): void {
+  if (!tableExists(database, "session_chat_bindings")) return;
+
   const result = database
     .prepare(
       `
@@ -3939,11 +3913,13 @@ function backfillSessionChatSubscriptionsFromBindings(database: Database): void 
       )
       SELECT
         ranked.session_key, ranked.chat_id, 'primary', 'system', NULL,
-        'backfill-from-session-chat-bindings', NULL,
-        ?, ?, ?, NULL
+        'migrate-from-session-chat-bindings', NULL,
+        NULL, ranked.created_at, ranked.updated_at, NULL
       FROM (
         SELECT b.session_key,
                b.chat_id,
+               b.created_at,
+               b.updated_at,
                ROW_NUMBER() OVER (
                  PARTITION BY b.chat_id
                  ORDER BY b.updated_at DESC, b.session_key
@@ -3956,12 +3932,18 @@ function backfillSessionChatSubscriptionsFromBindings(database: Database): void 
           WHERE s.chat_id = ranked.chat_id
             AND s.detached_at IS NULL
         )
+        AND NOT EXISTS (
+          SELECT 1 FROM session_chat_subscriptions s
+          WHERE s.session_key = ranked.session_key
+            AND s.chat_id = ranked.chat_id
+        )
     `,
     )
-    .run(now, now, now);
+    .run();
   if (result.changes > 0) {
-    log.info("Backfilled session_chat_subscriptions from session_chat_bindings", { rows: result.changes });
+    log.info("Migrated session_chat_bindings into session_chat_subscriptions", { rows: result.changes });
   }
+  database.exec("DROP TABLE IF EXISTS session_chat_bindings");
 }
 
 function backfillSessionOutputAttachments(database: Database): void {
@@ -4332,18 +4314,6 @@ function rowToChatReadingCursor(row: ChatReadingCursorRow): ChatReadingCursorRec
   };
 }
 
-function rowToSessionChatBinding(row: SessionChatBindingRow): SessionChatBindingRecord {
-  return {
-    sessionKey: row.session_key,
-    chatId: row.chat_id,
-    agentId: row.agent_id ?? undefined,
-    routeId: row.route_id ?? undefined,
-    bindingReason: row.binding_reason ?? undefined,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
-}
-
 function rowToSessionParticipant(row: SessionParticipantRow): SessionParticipantRecord {
   return {
     id: row.id,
@@ -4663,26 +4633,6 @@ function mergeChatParticipantsIntoTarget(
   }
 }
 
-function mergeSessionChatBindingsIntoTarget(database: Database, sourceChatId: string, targetChatId: string): void {
-  const rows = database
-    .prepare("SELECT session_key FROM session_chat_bindings WHERE chat_id = ?")
-    .all(sourceChatId) as Array<{ session_key: string }>;
-  for (const row of rows) {
-    const existing = database
-      .prepare("SELECT 1 FROM session_chat_bindings WHERE session_key = ? AND chat_id = ?")
-      .get(row.session_key, targetChatId);
-    if (existing) {
-      database
-        .prepare("DELETE FROM session_chat_bindings WHERE session_key = ? AND chat_id = ?")
-        .run(row.session_key, sourceChatId);
-    } else {
-      database
-        .prepare("UPDATE session_chat_bindings SET chat_id = ? WHERE session_key = ? AND chat_id = ?")
-        .run(targetChatId, row.session_key, sourceChatId);
-    }
-  }
-}
-
 function mergeSessionChatSubscriptionsIntoTarget(
   database: Database,
   sourceChatId: string,
@@ -4857,7 +4807,6 @@ function canonicalizeDmChatForContact(database: Database, input: CanonicalizeDmC
 
   mergeChatMessagesIntoTarget(database, source.id, target.id, now);
   mergeChatParticipantsIntoTarget(database, source.id, target.id, now);
-  mergeSessionChatBindingsIntoTarget(database, source.id, target.id);
   mergeSessionChatSubscriptionsIntoTarget(database, source.id, target.id, now);
   mergeReadingListMembersIntoTarget(database, source.id, target.id, now);
   mergeReadingCursorsIntoTarget(database, source.id, target.id, now);
@@ -5458,50 +5407,6 @@ function acceptChannelBackendIngress(
   };
 }
 
-function bindSessionToChat(
-  database: Database,
-  input: {
-    sessionKey: string;
-    chatId: string;
-    agentId?: string | null;
-    routeId?: number | null;
-    bindingReason?: string | null;
-    seenAt?: number;
-  },
-): SessionChatBindingRecord {
-  const now = input.seenAt ?? Date.now();
-  database
-    .prepare(
-      `
-      INSERT INTO session_chat_bindings (
-        session_key, chat_id, agent_id, route_id, binding_reason, created_at, updated_at
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(session_key) DO UPDATE SET
-        chat_id = excluded.chat_id,
-        agent_id = COALESCE(excluded.agent_id, session_chat_bindings.agent_id),
-        route_id = COALESCE(excluded.route_id, session_chat_bindings.route_id),
-        binding_reason = COALESCE(excluded.binding_reason, session_chat_bindings.binding_reason),
-        updated_at = excluded.updated_at
-    `,
-    )
-    .run(
-      input.sessionKey,
-      input.chatId,
-      input.agentId ?? null,
-      input.routeId ?? null,
-      input.bindingReason ?? null,
-      now,
-      now,
-    );
-
-  const row = database.prepare("SELECT * FROM session_chat_bindings WHERE session_key = ?").get(input.sessionKey) as
-    | SessionChatBindingRow
-    | undefined;
-  if (!row) throw new Error(`Session chat binding not found after upsert: ${input.sessionKey}`);
-  return rowToSessionChatBinding(row);
-}
-
 interface ExistingSessionParticipantMatches {
   semantic?: string;
   owner?: string;
@@ -5624,6 +5529,37 @@ function upsertSessionParticipant(database: Database, input: UpsertSessionPartic
   return rowToSessionParticipant(row);
 }
 
+function ensureBackfillSessionChatSubscription(
+  database: Database,
+  input: { sessionKey: string; chatId: string; seenAt: number },
+): void {
+  const activeChat = database
+    .prepare("SELECT 1 FROM session_chat_subscriptions WHERE chat_id = ? AND detached_at IS NULL")
+    .get(input.chatId);
+  if (activeChat) return;
+  const existingPair = database
+    .prepare("SELECT 1 FROM session_chat_subscriptions WHERE session_key = ? AND chat_id = ?")
+    .get(input.sessionKey, input.chatId);
+  if (existingPair) return;
+  const hasOutput = database
+    .prepare(
+      "SELECT 1 FROM session_chat_subscriptions WHERE session_key = ? AND detached_at IS NULL AND output_attached_at IS NOT NULL",
+    )
+    .get(input.sessionKey);
+  database
+    .prepare(
+      `
+      INSERT INTO session_chat_subscriptions (
+        session_key, chat_id, role, attached_by_type, attached_by_id,
+        attached_reason, context_snapshot_at_attach_json,
+        output_attached_at, created_at, updated_at, detached_at
+      )
+      VALUES (?, ?, 'primary', 'system', NULL, 'legacy-session-backfill', NULL, ?, ?, ?, NULL)
+    `,
+    )
+    .run(input.sessionKey, input.chatId, hasOutput ? null : input.seenAt, input.seenAt, input.seenAt);
+}
+
 function backfillChatModel(database: Database): void {
   const now = Date.now();
   executeWrite(
@@ -5732,11 +5668,9 @@ function backfillChatModel(database: Database): void {
           },
           seenAt: row.updated_at || row.created_at || now,
         });
-        bindSessionToChat(database, {
+        ensureBackfillSessionChatSubscription(database, {
           sessionKey: row.session_key,
           chatId: chat.id,
-          agentId: row.agent_id,
-          bindingReason: "legacy_session_backfill",
           seenAt: row.updated_at || now,
         });
       }
@@ -8510,31 +8444,6 @@ export function dbListChatParticipants(chatId: string): ChatParticipantRecord[] 
   return rows.map(rowToChatParticipant);
 }
 
-export function dbBindSessionToChat(input: {
-  sessionKey: string;
-  chatId: string;
-  agentId?: string | null;
-  routeId?: number | null;
-  bindingReason?: string | null;
-  seenAt?: number;
-}): SessionChatBindingRecord {
-  return bindSessionToChat(getDb(), input);
-}
-
-export function dbGetSessionChatBinding(sessionKey: string): SessionChatBindingRecord | null {
-  const row = getDb().prepare("SELECT * FROM session_chat_bindings WHERE session_key = ?").get(sessionKey) as
-    | SessionChatBindingRow
-    | undefined;
-  return row ? rowToSessionChatBinding(row) : null;
-}
-
-export function dbListSessionChatBindings(chatId: string): SessionChatBindingRecord[] {
-  const rows = getDb()
-    .prepare("SELECT * FROM session_chat_bindings WHERE chat_id = ? ORDER BY updated_at DESC")
-    .all(chatId) as SessionChatBindingRow[];
-  return rows.map(rowToSessionChatBinding);
-}
-
 export function dbUpsertSessionParticipant(input: UpsertSessionParticipantInput): SessionParticipantRecord {
   return upsertSessionParticipant(getDb(), input);
 }
@@ -8868,6 +8777,94 @@ export function dbDetachSessionChatSubscription(sessionKey: string, chatId: stri
     )
     .run(now, now, sessionKey, chatId);
   return result.changes > 0;
+}
+
+/**
+ * Default chat for a session: the active output attachment, otherwise the
+ * first remaining active subscription. Replaces the retired 1:1
+ * `session_chat_bindings` lookup.
+ */
+export function dbGetSessionDefaultChatId(sessionKey: string): string | null {
+  const output = dbGetSessionOutputAttachment(sessionKey);
+  if (output) return output.chatId;
+  return dbListSessionChatSubscriptions(sessionKey)[0]?.chatId ?? null;
+}
+
+/**
+ * Latest subscription row for a (session, chat) pair, including detached.
+ */
+export function dbGetSessionChatSubscription(
+  sessionKey: string,
+  chatId: string,
+): SessionChatSubscriptionRecord | null {
+  const row = getDb()
+    .prepare(
+      `
+      SELECT *
+      FROM session_chat_subscriptions
+      WHERE session_key = ? AND chat_id = ?
+      ORDER BY CASE WHEN detached_at IS NULL THEN 0 ELSE 1 END, updated_at DESC, id DESC
+      LIMIT 1
+    `,
+    )
+    .get(sessionKey, chatId) as SessionChatSubscriptionRow | undefined;
+  return row ? rowToSessionChatSubscription(row) : null;
+}
+
+export function dbLegacySessionChatBindingsTableExists(): boolean {
+  return tableExists(getDb(), "session_chat_bindings");
+}
+
+/**
+ * Test-only: recreate the retired `session_chat_bindings` table long enough
+ * to plant leftover rows and exercise the one-time migrate/drop path.
+ * Production schema never creates this table.
+ */
+export function dbPlantLegacySessionChatBindingForTests(input: {
+  sessionKey: string;
+  chatId: string;
+  agentId?: string | null;
+  routeId?: number | null;
+  bindingReason?: string | null;
+  seenAt?: number;
+}): void {
+  const database = getDb();
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS session_chat_bindings (
+      session_key TEXT NOT NULL REFERENCES sessions(session_key) ON DELETE CASCADE,
+      chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      agent_id TEXT,
+      route_id INTEGER,
+      binding_reason TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (session_key, chat_id)
+    );
+  `);
+  const now = input.seenAt ?? Date.now();
+  database
+    .prepare(
+      `
+      INSERT INTO session_chat_bindings (
+        session_key, chat_id, agent_id, route_id, binding_reason, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(session_key, chat_id) DO UPDATE SET
+        agent_id = excluded.agent_id,
+        route_id = excluded.route_id,
+        binding_reason = excluded.binding_reason,
+        updated_at = excluded.updated_at
+    `,
+    )
+    .run(
+      input.sessionKey,
+      input.chatId,
+      input.agentId ?? null,
+      input.routeId ?? null,
+      input.bindingReason ?? null,
+      now,
+      now,
+    );
 }
 
 // ============================================================================

--- a/src/router/router-db.ts
+++ b/src/router/router-db.ts
@@ -8793,10 +8793,7 @@ export function dbGetSessionDefaultChatId(sessionKey: string): string | null {
 /**
  * Latest subscription row for a (session, chat) pair, including detached.
  */
-export function dbGetSessionChatSubscription(
-  sessionKey: string,
-  chatId: string,
-): SessionChatSubscriptionRecord | null {
+export function dbGetSessionChatSubscription(sessionKey: string, chatId: string): SessionChatSubscriptionRecord | null {
   const row = getDb()
     .prepare(
       `

--- a/src/router/session-attach.test.ts
+++ b/src/router/session-attach.test.ts
@@ -216,7 +216,7 @@ describe("sessions/attach — subscriptions + output attachment", () => {
     const chat = makeChat("solo-chat");
     attachChatToSession({ sessionKey: session.sessionKey, chatId: chat.id, role: "primary" });
     const result = detachChatFromSession(session.sessionKey, chat.id);
-    expect(result).toEqual({ detached: true, outputDetached: true });
+    expect(result).toMatchObject({ detached: true, outputDetached: true, attached: false, defaultOutput: false });
     expect(listSessionSubscriptions(session.sessionKey)).toHaveLength(0);
   });
 
@@ -379,7 +379,9 @@ describe("sessions/attach — migration (dedupe + one-time binding drop)", () =>
     expect(olderSubs).toHaveLength(0);
     expect(newerSubs).toHaveLength(1);
     expect(newerSubs[0].outputAttachedAt).toBeUndefined();
-    expect(listSessionSubscriptions(newer.sessionKey).find((s) => s.chatId === existingOutput.id)?.outputAttachedAt).toBeNumber();
+    expect(
+      listSessionSubscriptions(newer.sessionKey).find((s) => s.chatId === existingOutput.id)?.outputAttachedAt,
+    ).toBeNumber();
   });
 
   it("does not resurrect an intentionally detached pair from a leftover binding", () => {
@@ -521,9 +523,10 @@ describe("sessions/attach — CLI final state", () => {
     expect(attachHuman).toContain(`Default output: ${chat.id}`);
     expect(attachHuman).toContain("Legacy bindings: none");
 
-    const detachJson = JSON.parse(
-      captureStdout(() => commands.detach(session.sessionKey, chat.id, true)),
-    ) as Record<string, unknown>;
+    const detachJson = JSON.parse(captureStdout(() => commands.detach(session.sessionKey, chat.id, true))) as Record<
+      string,
+      unknown
+    >;
     expect(detachJson).toMatchObject({
       session: { sessionKey: session.sessionKey },
       chatId: chat.id,

--- a/src/router/session-attach.test.ts
+++ b/src/router/session-attach.test.ts
@@ -21,7 +21,9 @@ import {
   isChatCompatibleWithSession,
 } from "./sessions.js";
 import {
-  dbBindSessionToChat,
+  closeRouterDb,
+  dbLegacySessionChatBindingsTableExists,
+  dbPlantLegacySessionChatBindingForTests,
   dbRunSessionAttachMigrationForTests,
   dbUpsertChat,
   dbUpsertInstance,
@@ -131,13 +133,72 @@ describe("sessions/attach — subscriptions + output attachment", () => {
     const session = makeSession("s3");
     const chat = makeChat("c3");
     attachChatToSession({ sessionKey: session.sessionKey, chatId: chat.id });
-    const first = detachChatFromSession(session.sessionKey, chat.id);
+    const first = detachChatFromSession(session.sessionKey, chat.id, session.name);
     expect(first.detached).toBe(true);
     expect(first.outputDetached).toBe(true);
+    expect(first.attached).toBe(false);
+    expect(first.defaultOutput).toBe(false);
+    expect(first.legacy).toEqual({ table: "session_chat_bindings", status: "none" });
     expect(listSessionSubscriptions(session.sessionKey)).toHaveLength(0);
-    const second = detachChatFromSession(session.sessionKey, chat.id);
+    const second = detachChatFromSession(session.sessionKey, chat.id, session.name);
     expect(second.detached).toBe(false);
     expect(second.outputDetached).toBe(false);
+    expect(second.attached).toBe(false);
+    expect(second.legacy.status).toBe("none");
+  });
+
+  it("detach with another output selected keeps that output and is idempotent", () => {
+    const session = makeSession("detach-other-output");
+    const outputChat = makeChat("keep-output");
+    const extraChat = makeChat("detach-extra");
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: outputChat.id, setOutputTarget: true });
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: extraChat.id, setOutputTarget: false });
+
+    const first = detachChatFromSession(session.sessionKey, extraChat.id, session.name);
+    expect(first.detached).toBe(true);
+    expect(first.outputDetached).toBe(false);
+    expect(first.attached).toBe(false);
+    expect(first.subscriptions).toEqual([
+      expect.objectContaining({
+        chatId: outputChat.id,
+        defaultOutput: true,
+        detached: false,
+      }),
+    ]);
+
+    const second = detachChatFromSession(session.sessionKey, extraChat.id, session.name);
+    expect(second.detached).toBe(false);
+    expect(second.attached).toBe(false);
+    expect(listSessionSubscriptions(session.sessionKey).map((row) => row.chatId)).toEqual([outputChat.id]);
+    expect(listSessionSubscriptions(session.sessionKey)[0].outputAttachedAt).toBeNumber();
+  });
+
+  it("detach with no competing output does not resurrect after repeated db init", () => {
+    const session = makeSession("no-compete");
+    const chat = makeChat("only-output");
+    const other = makeChat("unrelated-history");
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: chat.id });
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: other.id, setOutputTarget: false });
+    dbPlantLegacySessionChatBindingForTests({
+      sessionKey: session.sessionKey,
+      chatId: chat.id,
+      bindingReason: "stale-after-detach",
+      seenAt: 9_000,
+    });
+
+    detachChatFromSession(session.sessionKey, chat.id);
+    expect(listSessionSubscriptions(session.sessionKey).map((row) => row.chatId)).toEqual([other.id]);
+
+    closeRouterDb();
+    getDb();
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
+    expect(listSessionSubscriptions(session.sessionKey).map((row) => row.chatId)).toEqual([other.id]);
+    expect(findSessionByAttachedChat(chat.id)).toBeNull();
+
+    closeRouterDb();
+    getDb();
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
+    expect(listSessionSubscriptions(session.sessionKey).map((row) => row.chatId)).toEqual([other.id]);
   });
 
   it("detach-then-reattach reuses the soft-deleted row", () => {
@@ -281,7 +342,7 @@ describe("sessions/attach — instance isolation", () => {
   });
 });
 
-describe("sessions/attach — migration (dedupe + backfill)", () => {
+describe("sessions/attach — migration (dedupe + one-time binding drop)", () => {
   beforeEach(async () => {
     stateDir = await createIsolatedRaviState("ravi-session-attach-migration-");
   });
@@ -290,57 +351,84 @@ describe("sessions/attach — migration (dedupe + backfill)", () => {
     stateDir = null;
   });
 
-  it("backfill picks at most one subscription per chat when legacy bindings overlap", () => {
-    // Two sessions share the same legacy chat binding — possible under
-    // the pre-attach 1:1 schema, which only had PK(session_key, chat_id)
-    // and no cross-session UNIQUE.
+  it("converts the newest leftover binding per chat and never creates a second output", () => {
     const older = makeSession("older");
     const newer = makeSession("newer");
     const shared = makeChat("shared-legacy");
+    const existingOutput = makeChat("existing-output");
+    attachChatToSession({ sessionKey: newer.sessionKey, chatId: existingOutput.id, setOutputTarget: true });
 
-    dbBindSessionToChat({
+    dbPlantLegacySessionChatBindingForTests({
       sessionKey: older.sessionKey,
       chatId: shared.id,
       bindingReason: "legacy",
       seenAt: 1_000,
     });
-    dbBindSessionToChat({
+    dbPlantLegacySessionChatBindingForTests({
       sessionKey: newer.sessionKey,
       chatId: shared.id,
       bindingReason: "legacy",
       seenAt: 2_000,
     });
 
-    // Manually wipe any subscription created by the initial migration so
-    // we can re-run the backfill against the legacy bindings.
-    getDb().prepare("DELETE FROM session_chat_subscriptions WHERE chat_id = ?").run(shared.id);
     dbRunSessionAttachMigrationForTests();
 
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
     const olderSubs = listSessionSubscriptions(older.sessionKey).filter((s) => s.chatId === shared.id);
     const newerSubs = listSessionSubscriptions(newer.sessionKey).filter((s) => s.chatId === shared.id);
-    expect(olderSubs.length + newerSubs.length).toBe(1);
-    // Most recent binding wins (newer.updated_at > older.updated_at).
-    expect(newerSubs).toHaveLength(1);
-    expect(newerSubs[0].outputAttachedAt).toBeNumber();
     expect(olderSubs).toHaveLength(0);
+    expect(newerSubs).toHaveLength(1);
+    expect(newerSubs[0].outputAttachedAt).toBeUndefined();
+    expect(listSessionSubscriptions(newer.sessionKey).find((s) => s.chatId === existingOutput.id)?.outputAttachedAt).toBeNumber();
   });
 
-  it("migration is idempotent — re-running keeps the same state and same schema", () => {
+  it("does not resurrect an intentionally detached pair from a leftover binding", () => {
+    const session = makeSession("stale-bind");
+    const keep = makeChat("keep-output");
+    const detached = makeChat("stale-detached");
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: keep.id, setOutputTarget: true });
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: detached.id, setOutputTarget: false });
+    detachChatFromSession(session.sessionKey, detached.id);
+    dbPlantLegacySessionChatBindingForTests({
+      sessionKey: session.sessionKey,
+      chatId: detached.id,
+      bindingReason: "stale",
+      seenAt: 9_000,
+    });
+
+    expect(() => dbRunSessionAttachMigrationForTests()).not.toThrow();
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
+    expect(findSessionByAttachedChat(detached.id)).toBeNull();
+    expect(listSessionSubscriptions(session.sessionKey).map((row) => row.chatId)).toEqual([keep.id]);
+    expect(listSessionSubscriptions(session.sessionKey)[0].outputAttachedAt).toBeNumber();
+  });
+
+  it("migration is idempotent — re-running keeps the same state and drops the legacy table", () => {
     const session = makeSession("idem-sess");
     const chat = makeChat("idem-chat");
-    dbBindSessionToChat({ sessionKey: session.sessionKey, chatId: chat.id, bindingReason: "legacy", seenAt: 1_000 });
-    getDb().prepare("DELETE FROM session_chat_subscriptions WHERE chat_id = ?").run(chat.id);
+    dbPlantLegacySessionChatBindingForTests({
+      sessionKey: session.sessionKey,
+      chatId: chat.id,
+      bindingReason: "legacy",
+      seenAt: 1_000,
+    });
 
     dbRunSessionAttachMigrationForTests();
     const after1 = listSessionSubscriptions(session.sessionKey);
     expect(after1).toHaveLength(1);
     expect(after1[0].outputAttachedAt).toBeNumber();
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
 
-    // Re-run; should not crash, should not duplicate, should not lose data.
     dbRunSessionAttachMigrationForTests();
     const after2 = listSessionSubscriptions(session.sessionKey);
     expect(after2).toHaveLength(1);
     expect(after2[0].id).toBe(after1[0].id);
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
+
+    closeRouterDb();
+    getDb();
+    expect(listSessionSubscriptions(session.sessionKey)).toHaveLength(1);
+    expect(dbLegacySessionChatBindingsTableExists()).toBe(false);
 
     const idx = getDb()
       .prepare("SELECT sql FROM sqlite_master WHERE name = 'idx_session_chat_subscriptions_active_chat'")
@@ -375,5 +463,83 @@ describe("sessions/attach — migration (dedupe + backfill)", () => {
     expect(bSubs).toHaveLength(1);
     expect(bSubs[0].outputAttachedAt).toBeNumber();
     expect(findSessionByAttachedChat(chat.id)?.sessionKey).toBe(sessionB.sessionKey);
+  });
+});
+
+describe("sessions/attach — CLI final state", () => {
+  beforeEach(async () => {
+    stateDir = await createIsolatedRaviState("ravi-session-attach-cli-");
+  });
+  afterEach(async () => {
+    await cleanupIsolatedRaviState(stateDir);
+    stateDir = null;
+  });
+
+  function captureStdout(run: () => void): string {
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((value) => String(value)).join(" "));
+    };
+    try {
+      run();
+      return lines.join("\n");
+    } finally {
+      console.log = original;
+    }
+  }
+
+  it("prints JSON and human attach/detach state with no legacy binding", async () => {
+    const { SessionCommands } = await import("../cli/commands/sessions.js");
+    const commands = new SessionCommands();
+    const session = makeSession("cli-state");
+    const chat = makeChat("cli-chat");
+    const other = makeChat("cli-other");
+    attachChatToSession({ sessionKey: session.sessionKey, chatId: other.id, setOutputTarget: true });
+
+    const attachJson = JSON.parse(
+      captureStdout(() => commands.attach(session.sessionKey, chat.id, "cli-test", true)),
+    ) as Record<string, unknown>;
+    expect(attachJson).toMatchObject({
+      session: { sessionKey: session.sessionKey },
+      chatId: chat.id,
+      attached: true,
+      defaultOutput: true,
+      created: true,
+      legacy: { table: "session_chat_bindings", status: "none" },
+    });
+    expect(attachJson.subscriptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ chatId: chat.id, defaultOutput: true, detached: false }),
+        expect.objectContaining({ chatId: other.id, defaultOutput: false, detached: false }),
+      ]),
+    );
+
+    const attachHuman = captureStdout(() => commands.attach(session.sessionKey, chat.id, undefined, false));
+    expect(attachHuman).toContain("Already attached");
+    expect(attachHuman).toContain("Attached: yes");
+    expect(attachHuman).toContain(`Default output: ${chat.id}`);
+    expect(attachHuman).toContain("Legacy bindings: none");
+
+    const detachJson = JSON.parse(
+      captureStdout(() => commands.detach(session.sessionKey, chat.id, true)),
+    ) as Record<string, unknown>;
+    expect(detachJson).toMatchObject({
+      session: { sessionKey: session.sessionKey },
+      chatId: chat.id,
+      attached: false,
+      defaultOutput: false,
+      detached: true,
+      outputDetached: true,
+      legacy: { table: "session_chat_bindings", status: "none" },
+    });
+    expect(detachJson.subscriptions).toEqual([
+      expect.objectContaining({ chatId: other.id, defaultOutput: false, detached: false }),
+    ]);
+
+    const detachHuman = captureStdout(() => commands.detach(session.sessionKey, chat.id, false));
+    expect(detachHuman).toContain("is not currently attached");
+    expect(detachHuman).toContain("Attached: no");
+    expect(detachHuman).toContain("Legacy bindings: none");
   });
 });

--- a/src/router/sessions.test.ts
+++ b/src/router/sessions.test.ts
@@ -141,9 +141,10 @@ describe("sessions store", () => {
     expect(attached.find((entry) => entry.chatId === slackChat.id)?.outputAttachedAt).toBeUndefined();
     expect(attached.find((entry) => entry.chatId === whatsappChat.id)?.outputAttachedAt).toBeNumber();
 
-    expect(detachChatFromSession(session.sessionKey, whatsappChat.id)).toEqual({
+    expect(detachChatFromSession(session.sessionKey, whatsappChat.id)).toMatchObject({
       detached: true,
       outputDetached: true,
+      attached: false,
     });
     expect(listSessionSubscriptions(session.sessionKey)).toEqual([
       expect.objectContaining({ chatId: slackChat.id, outputAttachedAt: undefined }),

--- a/src/router/sessions.ts
+++ b/src/router/sessions.ts
@@ -1141,6 +1141,55 @@ export interface AttachChatToSessionResult {
   outputAttached: boolean;
 }
 
+export interface SessionChatAssociationSubscriptionState {
+  chatId: string;
+  role: SessionChatSubscriptionRecord["role"];
+  defaultOutput: boolean;
+  detached: boolean;
+}
+
+export interface SessionChatAssociationState {
+  session: { name?: string; sessionKey: string };
+  chatId: string;
+  attached: boolean;
+  defaultOutput: boolean;
+  subscriptions: SessionChatAssociationSubscriptionState[];
+  legacy: { table: "session_chat_bindings"; status: "none" | "removed" };
+}
+
+export interface DetachChatFromSessionResult extends SessionChatAssociationState {
+  detached: boolean;
+  outputDetached: boolean;
+}
+
+export function describeSessionChatAssociation(
+  sessionKey: string,
+  chatId: string,
+  sessionName?: string | null,
+): SessionChatAssociationState {
+  const active = dbListSessionChatSubscriptions(sessionKey);
+  const requested = active.find((subscription) => subscription.chatId === chatId);
+  return {
+    session: {
+      ...(sessionName ? { name: sessionName } : {}),
+      sessionKey,
+    },
+    chatId,
+    attached: Boolean(requested),
+    defaultOutput: requested?.outputAttachedAt !== undefined,
+    subscriptions: active.map((subscription) => ({
+      chatId: subscription.chatId,
+      role: subscription.role,
+      defaultOutput: subscription.outputAttachedAt !== undefined,
+      detached: false,
+    })),
+    legacy: {
+      table: "session_chat_bindings",
+      status: "none",
+    },
+  };
+}
+
 /**
  * Attach a chat to a session. Enforces the cross-session uniqueness rule:
  * a canonical chat can only be attached to one session at a time. Re-attach
@@ -1213,14 +1262,23 @@ export function attachChatToSession(input: AttachChatToSessionInput): AttachChat
 export function detachChatFromSession(
   sessionKey: string,
   chatId: string,
-): { detached: boolean; outputDetached: boolean } {
+  sessionName?: string | null,
+): DetachChatFromSessionResult {
   const active = dbListSessionChatSubscriptions(sessionKey);
   const target = active.find((s) => s.chatId === chatId);
-  if (!target) return { detached: false, outputDetached: false };
+  if (!target) {
+    return {
+      detached: false,
+      outputDetached: false,
+      ...describeSessionChatAssociation(sessionKey, chatId, sessionName),
+    };
+  }
 
+  const detached = dbDetachSessionChatSubscription(sessionKey, chatId);
   return {
-    detached: dbDetachSessionChatSubscription(sessionKey, chatId),
+    detached,
     outputDetached: target.outputAttachedAt !== undefined,
+    ...describeSessionChatAssociation(sessionKey, chatId, sessionName),
   };
 }
 

--- a/src/runtime/runtime-request-builder.test.ts
+++ b/src/runtime/runtime-request-builder.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { dbBindSessionToChat, dbUpsertChat } from "../router/router-db.js";
-import { getOrCreateSession } from "../router/index.js";
+import { dbUpsertChat } from "../router/router-db.js";
+import { attachChatToSession, getOrCreateSession } from "../router/index.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import type { RuntimeLaunchPrompt } from "./message-types.js";
 import { resolveRuntimePromptSource, rotateRuntimeProviderEnvironment } from "./runtime-request-builder.js";
@@ -30,11 +30,12 @@ describe("resolveRuntimePromptSource", () => {
       chatType: "group",
       title: "Ravi - Audit",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey: session.sessionKey,
       chatId: chat.id,
-      agentId: "audit",
-      bindingReason: "test",
+      attachedByType: "system",
+      attachedReason: "test",
+      setOutputTarget: true,
     });
 
     const prompt: RuntimeLaunchPrompt = {

--- a/src/runtime/runtime-request-builder.ts
+++ b/src/runtime/runtime-request-builder.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { DEFAULT_DELIVERY_BARRIER } from "../delivery-barriers.js";
 import type { AgentConfig, SessionEntry } from "../router/index.js";
-import { dbGetChat, dbGetSessionChatBinding, dbGetSetting } from "../router/router-db.js";
+import { dbGetChat, dbGetSessionDefaultChatId, dbGetSetting } from "../router/router-db.js";
 import { configStore } from "../config-store.js";
 import {
   buildRuntimeTracePromptSectionMetadata,
@@ -293,9 +293,9 @@ function splitCanonicalPlatformChat(platformChatId: string): { chatId: string; t
 }
 
 function resolveSourceFromSessionChatBinding(session: SessionEntry): RuntimeMessageTarget | undefined {
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  if (!binding) return undefined;
-  const chat = dbGetChat(binding.chatId);
+  const chatId = dbGetSessionDefaultChatId(session.sessionKey);
+  if (!chatId) return undefined;
+  const chat = dbGetChat(chatId);
   if (!chat) return undefined;
   const accountId = configStore.resolveAccountName(chat.instanceId) ?? session.lastAccountId ?? chat.instanceId;
   if (!accountId) return undefined;
@@ -311,9 +311,9 @@ function resolveSourceFromSessionChatBinding(session: SessionEntry): RuntimeMess
 
 function enrichSourceFromSessionChatBinding(source: RuntimeMessageTarget, session: SessionEntry): RuntimeMessageTarget {
   if (source.canonicalChatId) return source;
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  if (!binding) return source;
-  const chat = dbGetChat(binding.chatId);
+  const chatId = dbGetSessionDefaultChatId(session.sessionKey);
+  if (!chatId) return source;
+  const chat = dbGetChat(chatId);
   if (!chat || !isSourceForChat(source, chat)) return source;
   return {
     ...source,

--- a/src/runtime/runtime-request-context.test.ts
+++ b/src/runtime/runtime-request-context.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createContact } from "../contacts.js";
 import { canWithCapabilities } from "../permissions/provider-runtime.js";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
-import { dbBindSessionToChat, dbCreateAgent, dbGetContext, dbUpdateAgent, dbUpsertChat } from "../router/router-db.js";
-import { getOrCreateSession, resetSession } from "../router/sessions.js";
+import { dbCreateAgent, dbGetContext, dbUpdateAgent, dbUpsertChat } from "../router/router-db.js";
+import { attachChatToSession, getOrCreateSession, resetSession } from "../router/sessions.js";
 import { dbCreateTagDefinition } from "../tags/index.js";
 import { dbCreateTask, dbDispatchTask } from "../tasks/task-db.js";
 import type { AgentConfig } from "../router/index.js";
@@ -118,11 +118,12 @@ describe("runtime request context authority", () => {
       chatType: "group",
       title: "Runtime test",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: agent.id,
-      bindingReason: "test",
+      attachedByType: "system",
+      attachedReason: "test",
+      setOutputTarget: true,
     });
     resetSession(sessionKey);
 

--- a/src/session-trace/channel-trace.test.ts
+++ b/src/session-trace/channel-trace.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
 import { getOrCreateSession, updateSessionName } from "../router/sessions.js";
-import { dbBindSessionToChat, dbUpsertChat } from "../router/router-db.js";
+import { dbUpsertChat } from "../router/router-db.js";
+import { attachChatToSession } from "../router/sessions.js";
 import { listSessionEvents } from "./session-trace-db.js";
 import {
   normalizeSessionTraceSource,
@@ -181,11 +182,12 @@ describe("channel session trace", () => {
       platformChatId: "5511999999999@s.whatsapp.net",
       chatType: "dm",
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test_legacy_response_fallback",
+      attachedByType: "system",
+      attachedReason: "test_legacy_response_fallback",
+      setOutputTarget: true,
     });
 
     recordResponseEmittedTrace({

--- a/src/session-trace/channel-trace.ts
+++ b/src/session-trace/channel-trace.ts
@@ -2,7 +2,7 @@ import type { MessageTarget, ResponseMessage } from "../runtime/message-types.js
 import { configStore } from "../config-store.js";
 import { getAgentPlatformIdentity } from "../contacts.js";
 import { getSessionByName } from "../router/index.js";
-import { dbFindChat, dbGetMessageMeta, dbGetSessionChatBinding, type ChatType } from "../router/router-db.js";
+import { dbFindChat, dbGetMessageMeta, dbGetSessionDefaultChatId, type ChatType } from "../router/router-db.js";
 import { recordSessionEvent } from "./session-trace-db.js";
 import type { SessionEventRecord } from "./types.js";
 
@@ -314,11 +314,11 @@ function resolveCanonicalTraceSource(
 ): NormalizedSessionTraceSource {
   const messageMeta = source.messageId ? dbGetMessageMeta(source.messageId) : null;
   const chatIdFromSource = findCanonicalChatIdFromSource(source);
-  const binding = dbGetSessionChatBinding(sessionKey);
-  // Legacy fallback removal condition: remove binding/raw lookup once all prompt/response/delivery sources
-  // carry canonicalChatId plus per-message actor metadata at emit time.
+  const attachedChatId = dbGetSessionDefaultChatId(sessionKey);
+  // Fallback to the session's current output/active chat when the source
+  // did not carry a canonical chat id.
   const canonicalChatId =
-    source.canonicalChatId ?? messageMeta?.canonicalChatId ?? chatIdFromSource ?? binding?.chatId ?? null;
+    source.canonicalChatId ?? messageMeta?.canonicalChatId ?? chatIdFromSource ?? attachedChatId ?? null;
   const sourceIsAgentActor = source.actorType === "agent";
 
   return {

--- a/src/session-trace/session-trace.test.ts
+++ b/src/session-trace/session-trace.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
-import { getOrCreateSession, updateSessionName } from "../router/sessions.js";
-import { recordDeliveryTrace } from "./channel-trace.js";
+import { attachChatToSession, getOrCreateSession, updateSessionName } from "../router/sessions.js";
+import { dbUpsertChat } from "../router/router-db.js";
+import { recordDeliveryTrace, recordResponseEmittedTrace } from "./channel-trace.js";
 import { querySessionTrace } from "./query.js";
 import { recordAdapterRequestTrace } from "./runtime-trace.js";
 import {
@@ -164,6 +165,49 @@ describe("session trace query", () => {
       providerTimestamp: 1_713_000_000_000,
       responsePhase: "commentary",
       idempotencyKey: "runtime:main:emit-1:slack:T1:C123:thread",
+    });
+  });
+
+  it("resolves response trace canonical chat from session subscription default chat", () => {
+    const sessionKey = "agent:main:subscription-target";
+    const sessionName = "main-subscription-target";
+    getOrCreateSession(sessionKey, "main", "/tmp/ravi-agent");
+    updateSessionName(sessionKey, sessionName);
+    const chat = dbUpsertChat({
+      channel: "whatsapp",
+      instanceId: "11111111-1111-1111-1111-111111111111",
+      platformChatId: "5511999999999@s.whatsapp.net",
+      chatType: "dm",
+    });
+    attachChatToSession({
+      sessionKey,
+      chatId: chat.id,
+      attachedByType: "system",
+      attachedReason: "test_subscription_trace_fallback",
+      setOutputTarget: true,
+    });
+
+    recordResponseEmittedTrace({
+      sessionName,
+      response: {
+        response: "hi",
+        target: {
+          channel: "whatsapp-baileys",
+          accountId: "main",
+          chatId: "5511999999999@s.whatsapp.net",
+        },
+        _emitId: "emit-subscription",
+      },
+      timestamp: 30,
+    });
+
+    const event = listSessionEvents(sessionKey)[0];
+    expect(event).toMatchObject({
+      eventType: "response.emitted",
+      sourceChatId: "5511999999999@s.whatsapp.net",
+      canonicalChatId: chat.id,
+      actorType: "agent",
+      actorAgentId: "main",
     });
   });
 });

--- a/src/threads/service.test.ts
+++ b/src/threads/service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../test/ravi-state.js";
-import { dbBindSessionToChat, dbUpsertChat } from "../router/router-db.js";
+import { dbUpsertChat } from "../router/router-db.js";
+import { attachChatToSession } from "../router/sessions.js";
 import { getOrCreateSession } from "../router/sessions.js";
 import {
   addThreadEntry,
@@ -86,12 +87,12 @@ describe("threads service", () => {
       title: "Ravi Threads",
       seenAt: 1000,
     });
-    dbBindSessionToChat({
+    attachChatToSession({
       sessionKey: targetSession.sessionKey,
       chatId: chat.id,
-      agentId: "main",
-      bindingReason: "test",
-      seenAt: 1000,
+      attachedByType: "system",
+      attachedReason: "test",
+      setOutputTarget: true,
     });
 
     const created = prepareThreadHandoff({

--- a/src/threads/service.ts
+++ b/src/threads/service.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { SQLQueryBindings } from "bun:sqlite";
 import type { MessageTarget } from "../runtime/message-types.js";
-import { dbFindChat, dbGetSessionChatBinding, getDb } from "../router/router-db.js";
+import { dbFindChat, dbGetSessionDefaultChatId, getDb } from "../router/router-db.js";
 import type { SessionEntry } from "../router/types.js";
 import type {
   ThreadActor,
@@ -828,8 +828,8 @@ function upsertDefaultHandoffLinks(
 }
 
 function deriveThreadScopeForSession(session: Pick<SessionEntry, "sessionKey">, source?: MessageTarget): ThreadPointer {
-  const binding = dbGetSessionChatBinding(session.sessionKey);
-  if (binding) return { type: "chat", id: binding.chatId };
+  const attachedChatId = dbGetSessionDefaultChatId(session.sessionKey);
+  if (attachedChatId) return { type: "chat", id: attachedChatId };
   if (source?.canonicalChatId) return { type: "chat", id: source.canonicalChatId };
   if (source?.channel && source.chatId) {
     for (const instanceId of uniqueStrings([source.instanceId, source.accountId, ""])) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Close [GitHub issue #462](https://github.com/filipexyz/ravi/issues/462): `ravi sessions detach` must stay detached across CLI restarts, and bootstrap must never fail on a leftover `session_chat_bindings` row.

## Problem

- `sessions detach` soft-deleted `session_chat_subscriptions` but left the matching `session_chat_bindings` row.
- The next CLI bootstrap ran `backfillSessionChatSubscriptionsFromBindings()`, which recreated the detached pair as an active subscription with output.
- If the session already had another active output, startup failed with `UNIQUE constraint failed: session_chat_subscriptions.session_key` and every command died during `cli bootstrap`.

## Solution

- `session_chat_subscriptions` is the sole attach/output ledger.
- New databases never create `session_chat_bindings`.
- Existing databases convert leftover *useful* bindings once, then drop the table:
  - rank leftover rows by `updated_at` (then `session_key`);
  - skip chats that already have an active subscription;
  - skip any `(session, chat)` pair that already has a subscription row, including detached (no resurrection);
  - insert converted rows **without** output so a second output cannot violate the unique index;
  - assign default output only when a session has none;
  - drop the legacy table. Migration is idempotent on repeated `getDb()`.
- Inbound, Slack, WhatsApp group create, and Channel backend attach through subscriptions only. `dbBindSessionToChat` / `dbGetSessionChatBinding` / `dbListSessionChatBindings` are gone.
- `sessions attach|detach --json` (and human output) now report session identity, requested chat, attached/default-output, remaining active subscriptions, and `legacy.status: none`.

## Practical impact

- Operators can detach a chat and restart CLI processes without the chat coming back or bootstrap dying.
- Existing DBs with leftover bindings migrate automatically on next open.
- Callers that used the old 1:1 binding now resolve the session default chat from the active output attachment (else the first active subscription).

## What does NOT change

- Attach/detach command names and the detach command itself.
- One chat → at most one active session; one session → many active chats; at most one active output.
- Routes still choose which session receives inbound; subscriptions still say which chats participate and which is default output.
- Session history, unrelated chats, and provider continuity are preserved.
- OpenAPI/SDK were not regenerated: attach/detach already use the generic command envelope.

## Validation

- `bun test src/router/session-attach.test.ts src/router/chat-schema.test.ts src/omni/consumer-context.test.ts src/channels/backend.test.ts src/cli/commands/self.test.ts src/router/sessions.test.ts` — pass
- `bun tsc --noEmit` — pass
- `bunx biome check` on all edited source files — pass
- Full `make quality` still reports pre-existing repo-wide biome issues unrelated to this PR

## Risks

- Existing databases that still have `session_chat_bindings` are migrated on first open. Repeated initialization must converge to the same subscription state.
- Channel/backend/self callers now read the subscription/output model instead of the 1:1 binding. Default-chat fallback is output attachment, then first active subscription.

## Rollback

- Revert this PR. Do not reintroduce a startup backfill that writes `output_attached_at` for every leftover binding.

## Follow-ups

- None required for #462. Broader storage-boundary work in #243 remains separate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-039b9408-5a11-45ff-87d2-0b6fd2714025?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-039b9408-5a11-45ff-87d2-0b6fd2714025&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

