### PR TITLE
fix(router): canonicalize WhatsApp LID identity for inbound routes

### DIFF
--- a/src/cli/commands/instances.ts
+++ b/src/cli/commands/instances.ts
@@ -87,6 +87,7 @@ import type { SessionEntry } from "../../router/types.js";
 import { filterItemsByCanonicalTag } from "../../tags/helpers.js";
 import { searchTagBindingsForSelector } from "../../tags/service.js";
 import type { TagBinding } from "../../tags/types.js";
+import { canonicalizeRouteIdentity } from "../../utils/phone.js";
 import { formatCliRuntimeTarget, getCliRuntimeMismatchMessage, inspectCliRuntimeTarget } from "../runtime-target.js";
 import { formatInspectionSection, printInspectionField } from "../inspection-output.js";
 
@@ -203,15 +204,26 @@ function assertInstanceMutationRuntime(name: string, allowRuntimeMismatch?: bool
   }
 }
 
+function canonicalizeRoutePatternArg(pattern: string): string {
+  return canonicalizeRouteIdentity(pattern);
+}
+
+function isExactSimulatedRoutePattern(pattern: string): boolean {
+  const canonical = canonicalizeRoutePatternArg(pattern);
+  if (canonical.includes("*")) return false;
+  return canonical.startsWith("group:") || canonical.startsWith("lid:") || /^\d+$/.test(canonical);
+}
+
 function inspectRouteLiveWinner(
   name: string,
   pattern: string,
   channel?: string,
 ): { winningPattern: string; winningAgent: string } | null {
   const config = loadRouterConfig();
+  const canonical = canonicalizeRoutePatternArg(pattern);
 
-  if (pattern.startsWith("group:")) {
-    const groupId = pattern.slice("group:".length);
+  if (canonical.startsWith("group:")) {
+    const groupId = canonical.slice("group:".length);
     const resolved = matchRoute(config, {
       phone: groupId,
       groupId,
@@ -230,9 +242,9 @@ function inspectRouteLiveWinner(
     };
   }
 
-  if (!pattern.includes("*") && /^\d+$/.test(pattern)) {
+  if (canonical.startsWith("lid:") || (!canonical.includes("*") && /^\d+$/.test(canonical))) {
     const resolved = matchRoute(config, {
-      phone: pattern,
+      phone: canonical,
       accountId: name,
       ...(channel ? { channel } : {}),
     });
@@ -253,9 +265,8 @@ function inspectRouteLiveWinner(
 function getRouteLiveEffect(name: string, pattern: string, expectedAgent?: string, channel?: string) {
   const winner = inspectRouteLiveWinner(name, pattern, channel);
   if (!winner) {
-    const exactPattern = pattern.startsWith("group:") || (!pattern.includes("*") && /^\d+$/.test(pattern));
     return {
-      status: exactPattern ? "unresolved" : "skipped_broad_pattern",
+      status: isExactSimulatedRoutePattern(pattern) ? "unresolved" : "skipped_broad_pattern",
       verified: false,
       winningPattern: null,
       winningAgent: null,
@@ -451,8 +462,9 @@ function buildRouteListPayload(
 
 function printRouteDetails(op: string, name: string, pattern: string): void {
   requireInstance(op, name);
-  const route = dbGetRoute(pattern, name);
-  if (!route) failRouteNotFound(op, name, pattern);
+  const routePattern = canonicalizeRoutePatternArg(pattern);
+  const route = dbGetRoute(routePattern, name);
+  if (!route) failRouteNotFound(op, name, routePattern);
 
   console.log(`\nRoute: ${route.pattern} (instance: ${name})\n`);
   console.log(`  Agent:     ${route.agent}`);
@@ -463,17 +475,18 @@ function printRouteDetails(op: string, name: string, pattern: string): void {
   console.log(`  Channel:   ${route.channel ?? "(all channels)"}`);
   const routeTags = listRouteTags(route.id);
   console.log(`  Tags:      ${routeTags.length > 0 ? routeTags.map((tag) => tag.tagSlug).join(", ") : "-"}`);
-  console.log(`\n  Explain live routing: ravi routes explain ${name} "${pattern}"`);
-  console.log(`  Mutate config:        ravi instances routes set ${name} "${pattern}" <key> <value>`);
+  console.log(`\n  Explain live routing: ravi routes explain ${name} "${routePattern}"`);
+  console.log(`  Mutate config:        ravi instances routes set ${name} "${routePattern}" <key> <value>`);
 }
 
 function buildRouteDetailsPayload(op: string, name: string, pattern: string, asJson?: boolean) {
   requireInstance(op, name, asJson);
-  const route = dbGetRoute(pattern, name);
-  if (!route) failRouteNotFound(op, name, pattern, asJson);
+  const routePattern = canonicalizeRoutePatternArg(pattern);
+  const route = dbGetRoute(routePattern, name);
+  if (!route) failRouteNotFound(op, name, routePattern, asJson);
   return {
     instance: name,
-    pattern,
+    pattern: routePattern,
     route: {
       ...route,
       tags: listRouteTags(route.id),
@@ -499,28 +512,29 @@ function buildRouteExplanationPayload(op: string, name: string, pattern?: string
     };
   }
 
-  const configuredRoute = dbGetRoute(pattern, name);
+  const routePattern = canonicalizeRoutePatternArg(pattern);
+  const configuredRoute = dbGetRoute(routePattern, name);
   if (configuredRoute) {
     return {
       target,
       instance: name,
-      pattern,
+      pattern: routePattern,
       channel: channel ?? configuredRoute.channel ?? null,
       configuredRoute,
       liveEffect: getRouteLiveEffect(
         name,
-        pattern,
+        routePattern,
         configuredRoute.agent,
         channel ?? configuredRoute.channel ?? undefined,
       ),
     };
   }
 
-  const winner = inspectRouteLiveWinner(name, pattern, channel);
+  const winner = inspectRouteLiveWinner(name, routePattern, channel);
   return {
     target,
     instance: name,
-    pattern,
+    pattern: routePattern,
     channel: channel ?? null,
     configuredRoute: null,
     liveEffect: winner
@@ -550,24 +564,25 @@ function printRouteExplanation(op: string, name: string, pattern?: string, chann
     return;
   }
 
-  const configuredRoute = dbGetRoute(pattern, name);
+  const routePattern = canonicalizeRoutePatternArg(pattern);
+  const configuredRoute = dbGetRoute(routePattern, name);
   if (configuredRoute) {
     console.log(`  Config route:  ${configuredRoute.pattern} → ${configuredRoute.agent}`);
-    printRouteLiveEffect(name, pattern, configuredRoute.agent, channel ?? configuredRoute.channel ?? undefined);
-    console.log(`\n  Route details: ravi routes show ${name} "${pattern}"`);
-    console.log(`  Mutate config: ravi instances routes set ${name} "${pattern}" <key> <value>`);
+    printRouteLiveEffect(name, routePattern, configuredRoute.agent, channel ?? configuredRoute.channel ?? undefined);
+    console.log(`\n  Route details: ravi routes show ${name} "${routePattern}"`);
+    console.log(`  Mutate config: ravi instances routes set ${name} "${routePattern}" <key> <value>`);
     return;
   }
 
-  const winner = inspectRouteLiveWinner(name, pattern, channel);
+  const winner = inspectRouteLiveWinner(name, routePattern, channel);
   if (!winner) {
-    if (pattern.startsWith("group:") || (!pattern.includes("*") && /^\d+$/.test(pattern))) {
-      console.log(`  Live effect:   unresolved for ${pattern} on instance ${name}`);
+    if (isExactSimulatedRoutePattern(routePattern)) {
+      console.log(`  Live effect:   unresolved for ${routePattern} on instance ${name}`);
     } else {
-      console.log(`  Live effect:   broad pattern — exact winner check skipped for ${pattern}`);
+      console.log(`  Live effect:   broad pattern — exact winner check skipped for ${routePattern}`);
     }
-    console.log(`\n  Route details: ravi routes show ${name} "${pattern}"`);
-    console.log(`  Mutate config: ravi instances routes add ${name} "${pattern}" <agent>`);
+    console.log(`\n  Route details: ravi routes show ${name} "${routePattern}"`);
+    console.log(`  Mutate config: ravi instances routes add ${name} "${routePattern}" <agent>`);
     return;
   }
 
@@ -575,8 +590,8 @@ function printRouteExplanation(op: string, name: string, pattern?: string, chann
   console.log("  Live effect:   different winner");
   console.log(`  Winning route: ${winner.winningPattern}`);
   console.log(`  Winning agent: ${winner.winningAgent}`);
-  console.log(`\n  Route details: ravi routes show ${name} "${pattern}"`);
-  console.log(`  Mutate config: ravi instances routes add ${name} "${pattern}" <agent>`);
+  console.log(`\n  Route details: ravi routes show ${name} "${routePattern}"`);
+  console.log(`  Mutate config: ravi instances routes add ${name} "${routePattern}" <agent>`);
 }
 
 function sessionKeyAccountId(sessionKey: string): string | null {
@@ -592,6 +607,11 @@ function sessionBelongsToRouteAccount(session: SessionEntry, accountId: string):
   );
 }
 
+function isSharedMainSessionKey(sessionKey: string): boolean {
+  const parts = sessionKey.split(":");
+  return parts.length === 3 && parts[0] === "agent" && parts[2] === "main";
+}
+
 function deleteConflictingSessions(
   pattern: string,
   targetAgent: string,
@@ -599,32 +619,38 @@ function deleteConflictingSessions(
 ): number {
   const sessions = listSessions();
   let deleted = 0;
-  const normalizedPattern = pattern.toLowerCase();
+  const canonical = canonicalizeRoutePatternArg(pattern);
+  const normalizedPattern = canonical.toLowerCase();
   for (const session of sessions) {
     if (!sessionBelongsToRouteAccount(session, opts.accountId)) continue;
+    if (session.agentId === targetAgent) continue;
+    if (isSharedMainSessionKey(session.sessionKey)) continue;
+
     const normalizedSessionKey = session.sessionKey.toLowerCase();
+    const sessionName = (session.name ?? "").toLowerCase();
+    let shouldDelete = false;
+
     if (normalizedPattern.startsWith("group:")) {
-      const groupId = normalizedPattern.replace("group:", "");
-      if (normalizedSessionKey.includes(`group:${groupId}`) && session.agentId !== targetAgent) {
-        deleteSession(session.sessionKey);
-        if (!opts.silent) console.log(`  Deleted conflicting session: ${session.sessionKey}`);
-        deleted++;
-      }
+      const groupId = normalizedPattern.slice("group:".length);
+      shouldDelete = normalizedSessionKey.includes(`group:${groupId}`);
     } else if (normalizedPattern.startsWith("lid:")) {
-      const lid = normalizedPattern.replace("lid:", "");
-      if (normalizedSessionKey.includes(`lid:${lid}`) && session.agentId !== targetAgent) {
-        deleteSession(session.sessionKey);
-        if (!opts.silent) console.log(`  Deleted conflicting session: ${session.sessionKey}`);
-        deleted++;
-      }
-    } else if (pattern.includes("*")) {
-      const regex = new RegExp(pattern.replace(/\*/g, ".*"), "i");
+      const digits = normalizedPattern.slice("lid:".length);
+      const last6 = digits.slice(-6);
+      const hasLidToken = normalizedSessionKey.includes(`lid:${digits}`);
+      const hasLegacyDmPeer =
+        normalizedSessionKey.includes(`:dm:${digits}`) || normalizedSessionKey.endsWith(`dm:${digits}`);
+      const hasLegacyName = last6.length > 0 && sessionName.includes(`-dm-${last6}`);
+      shouldDelete = hasLidToken || hasLegacyDmPeer || hasLegacyName;
+    } else if (canonical.includes("*")) {
+      const regex = new RegExp(canonical.replace(/\*/g, ".*"), "i");
       const match = session.sessionKey.match(/dm:(\d+)/);
-      if (match && regex.test(match[1]) && session.agentId !== targetAgent) {
-        deleteSession(session.sessionKey);
-        if (!opts.silent) console.log(`  Deleted conflicting session: ${session.sessionKey}`);
-        deleted++;
-      }
+      shouldDelete = Boolean(match && regex.test(match[1]));
+    }
+
+    if (shouldDelete) {
+      deleteSession(session.sessionKey);
+      if (!opts.silent) console.log(`  Deleted conflicting session: ${session.sessionKey}`);
+      deleted++;
     }
   }
   return deleted;
@@ -1725,10 +1751,11 @@ export class InstancesRoutesCommands {
     const pri = priority !== undefined ? parseInt(priority, 10) : 0;
     if (Number.isNaN(pri)) fail(`Invalid priority: ${priority}`);
     assertInstanceMutationRuntime(name, allowRuntimeMismatch);
+    const storedPattern = canonicalizeRoutePatternArg(pattern);
 
     try {
       const route = dbCreateRoute({
-        pattern,
+        pattern: storedPattern,
         accountId: name,
         agent,
         priority: pri,
@@ -1740,9 +1767,9 @@ export class InstancesRoutesCommands {
       emitConfigChanged();
 
       // Remove from pending if applicable
-      let removedPending = removeAccountPending(name, pattern);
+      let removedPending = removeAccountPending(name, storedPattern);
       if (!removedPending) {
-        const contact = getContact(pattern);
+        const contact = getContact(storedPattern) ?? getContact(pattern);
         if (contact) {
           for (const id of contact.identities) {
             if (removeAccountPending(name, id.value)) {
@@ -1754,14 +1781,14 @@ export class InstancesRoutesCommands {
       }
 
       // Clean conflicting sessions
-      const cleaned = deleteConflictingSessions(pattern, agent, { accountId: name, silent: Boolean(asJson) });
+      const cleaned = deleteConflictingSessions(storedPattern, agent, { accountId: name, silent: Boolean(asJson) });
 
       const payload = {
         status: "added" as const,
         instance: name,
         route,
         target: inspectCliRuntimeTarget(name),
-        liveEffect: getRouteLiveEffect(name, pattern, agent, channel),
+        liveEffect: getRouteLiveEffect(name, storedPattern, agent, channel),
         removedPending,
         cleanedSessions: cleaned,
         changedCount: 1,
@@ -1772,8 +1799,8 @@ export class InstancesRoutesCommands {
         printInstanceMutationTarget(name);
         const policyLabel = policy ? ` [policy:${policy}]` : "";
         const channelLabel = channel ? ` [channel:${channel}]` : "";
-        console.log(`✓ Route added: ${pattern} → ${agent} (instance: ${name})${policyLabel}${channelLabel}`);
-        printRouteLiveEffect(name, pattern, agent, channel);
+        console.log(`✓ Route added: ${storedPattern} → ${agent} (instance: ${name})${policyLabel}${channelLabel}`);
+        printRouteLiveEffect(name, storedPattern, agent, channel);
         if (removedPending) console.log(`✓ Removed from pending`);
         if (cleaned > 0) console.log(`✓ Cleaned ${cleaned} conflicting session(s)`);
       }
@@ -1796,15 +1823,16 @@ export class InstancesRoutesCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     if (!dbGetInstance(name)) failInstanceNotFound("instances routes remove", name, asJson);
-    const route = dbGetRoute(pattern, name);
-    if (!route) failRouteNotFound("instances routes remove", name, pattern, asJson);
+    const routePattern = canonicalizeRoutePatternArg(pattern);
+    const route = dbGetRoute(routePattern, name);
+    if (!route) failRouteNotFound("instances routes remove", name, routePattern, asJson);
     assertInstanceMutationRuntime(name, allowRuntimeMismatch);
-    const deleted = dbDeleteRoute(pattern, name);
+    const deleted = dbDeleteRoute(routePattern, name);
     if (deleted) {
       const payload = {
         status: "removed" as const,
         instance: name,
-        pattern,
+        pattern: routePattern,
         route,
         target: inspectCliRuntimeTarget(name),
         changedCount: 1,
@@ -1814,13 +1842,13 @@ export class InstancesRoutesCommands {
       } else {
         printInstanceMutationTarget(name);
         console.log(
-          `✓ Route removed: ${pattern} (instance: ${name}) — restore with: ravi instances routes restore ${name} "${pattern}"`,
+          `✓ Route removed: ${routePattern} (instance: ${name}) — restore with: ravi instances routes restore ${name} "${routePattern}"`,
         );
       }
       emitConfigChanged();
       return payload;
     } else {
-      failRouteNotFound("instances routes remove", name, pattern, asJson);
+      failRouteNotFound("instances routes remove", name, routePattern, asJson);
     }
   }
 
@@ -1915,7 +1943,8 @@ export class InstancesRoutesCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
   ) {
     if (!dbGetInstance(name)) failInstanceNotFound("instances routes set", name, asJson);
-    if (!dbGetRoute(pattern, name)) failRouteNotFound("instances routes set", name, pattern, asJson);
+    const routePattern = canonicalizeRoutePatternArg(pattern);
+    if (!dbGetRoute(routePattern, name)) failRouteNotFound("instances routes set", name, routePattern, asJson);
     if (!ROUTE_SETTABLE_KEYS.includes(key as (typeof ROUTE_SETTABLE_KEYS)[number])) {
       fail(`Invalid key: ${key}. Valid keys: ${ROUTE_SETTABLE_KEYS.join(", ")}`);
     }
@@ -1948,23 +1977,23 @@ export class InstancesRoutesCommands {
     assertInstanceMutationRuntime(name, allowRuntimeMismatch);
 
     try {
-      const route = dbUpdateRoute(pattern, updates, name);
+      const route = dbUpdateRoute(routePattern, updates, name);
       emitConfigChanged();
 
       let cleaned = 0;
       if (key === "agent") {
-        cleaned = deleteConflictingSessions(pattern, value, { accountId: name, silent: Boolean(asJson) });
+        cleaned = deleteConflictingSessions(routePattern, value, { accountId: name, silent: Boolean(asJson) });
       }
 
       const payload = {
         status: "updated" as const,
         instance: name,
-        pattern,
+        pattern: routePattern,
         key,
         value: jsonValue,
         route,
         target: inspectCliRuntimeTarget(name),
-        liveEffect: key === "agent" && !clear ? getRouteLiveEffect(name, pattern, value, undefined) : null,
+        liveEffect: key === "agent" && !clear ? getRouteLiveEffect(name, routePattern, value, undefined) : null,
         cleanedSessions: cleaned,
         changedCount: 1,
       };
@@ -1972,9 +2001,9 @@ export class InstancesRoutesCommands {
         printJson(payload);
       } else {
         printInstanceMutationTarget(name);
-        console.log(`✓ ${key} set on route ${pattern} (instance: ${name}): ${clear ? "(cleared)" : value}`);
+        console.log(`✓ ${key} set on route ${routePattern} (instance: ${name}): ${clear ? "(cleared)" : value}`);
         if (key === "agent" && !clear) {
-          printRouteLiveEffect(name, pattern, value, undefined);
+          printRouteLiveEffect(name, routePattern, value, undefined);
         }
         if (cleaned > 0) console.log(`✓ Cleaned ${cleaned} conflicting session(s)`);
       }

--- a/src/cli/commands/routes.test.ts
+++ b/src/cli/commands/routes.test.ts
@@ -27,6 +27,7 @@ let deleteInstanceCalls: string[] = [];
 let contactStatuses = new Map<string, { status: string }>();
 let allowContactCalls: string[] = [];
 let liveWinner: { route?: { pattern?: string | null } | null; agentId: string } | null = null;
+let matchRouteCalls: Array<{ phone?: string; isGroup?: boolean; groupId?: string }> = [];
 let sessions: Array<Partial<SessionEntry> & Pick<SessionEntry, "sessionKey" | "agentId">> = [];
 let deletedSessionKeys: string[] = [];
 let pendingEntries: Array<{
@@ -181,7 +182,10 @@ mock.module("../../router/router-db.js", () => ({
 mock.module("../../router/index.js", () => ({
   ...actualRouterIndexModule,
   loadRouterConfig: () => ({}),
-  matchRoute: () => liveWinner,
+  matchRoute: (_config: unknown, params: { phone?: string; isGroup?: boolean; groupId?: string }) => {
+    matchRouteCalls.push({ phone: params.phone, isGroup: params.isGroup, groupId: params.groupId });
+    return liveWinner;
+  },
 }));
 
 mock.module("../../router/omni-ignore.js", () => ({
@@ -268,6 +272,7 @@ describe("RoutesCommands", () => {
     contactStatuses = new Map();
     allowContactCalls = [];
     liveWinner = null;
+    matchRouteCalls = [];
     sessions = [];
     deletedSessionKeys = [];
     pendingEntries = [];
@@ -571,6 +576,105 @@ describe("RoutesCommands", () => {
     expect(allowContactCalls).toEqual([]);
     expect(routes).toContainEqual(expect.objectContaining({ pattern: "group:123", agent: "sales" }));
   });
+
+  it("stores X@lid as lid:X and verifies live effect instead of skipping it as broad", () => {
+    liveWinner = {
+      route: { pattern: "lid:224420715061374" },
+      agentId: "john",
+    };
+
+    const payload = captureJson(() => {
+      new InstancesRoutesCommands().add(
+        "main",
+        "224420715061374@lid",
+        "john",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "whatsapp",
+        undefined,
+        true,
+      );
+    });
+
+    expect(routes).toContainEqual(expect.objectContaining({ pattern: "lid:224420715061374", agent: "john" }));
+    expect((payload.route as Record<string, unknown>).pattern).toBe("lid:224420715061374");
+    expect((payload.liveEffect as Record<string, unknown>).status).toBe("verified");
+    expect((payload.liveEffect as Record<string, unknown>).verified).toBe(true);
+    expect(matchRouteCalls).toContainEqual(expect.objectContaining({ phone: "lid:224420715061374" }));
+  });
+
+  it("looks up stored lid:X routes when the operator passes X@lid", () => {
+    routes = [
+      {
+        id: 1,
+        accountId: "main",
+        pattern: "lid:224420715061374",
+        agent: "john",
+      },
+    ];
+    liveWinner = {
+      route: { pattern: "lid:224420715061374" },
+      agentId: "john",
+    };
+
+    const payload = captureJson(() => {
+      new RoutesCommands().show("main", "224420715061374@lid", true);
+    });
+
+    expect((payload.route as Record<string, unknown>).pattern).toBe("lid:224420715061374");
+    expect(payload.pattern).toBe("lid:224420715061374");
+  });
+
+  it("deletes leftover bare-digit LID sessions and *-dm-<last6> names without touching agent:main:main", () => {
+    liveWinner = {
+      route: { pattern: "lid:224420715061374" },
+      agentId: "john",
+    };
+    sessions = [
+      {
+        sessionKey: "agent:main:dm:224420715061374",
+        agentId: "main",
+        accountId: "main",
+        lastAccountId: "main",
+        name: "main-dm-061374",
+      },
+      {
+        sessionKey: "agent:alex:whatsapp:main:dm:999",
+        agentId: "alex",
+        accountId: "main",
+        lastAccountId: "main",
+        name: "alex-dm-061374",
+      },
+      {
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        accountId: "main",
+        lastAccountId: "main",
+        name: "main",
+      },
+    ];
+
+    const payload = captureJson(() => {
+      new InstancesRoutesCommands().add(
+        "main",
+        "lid:224420715061374",
+        "john",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "whatsapp",
+        undefined,
+        true,
+      );
+    });
+
+    expect(payload.cleanedSessions).toBe(2);
+    expect(deletedSessionKeys.sort()).toEqual(["agent:alex:whatsapp:main:dm:999", "agent:main:dm:224420715061374"]);
+    expect(sessions.map((session) => session.sessionKey)).toEqual(["agent:main:main"]);
+  });
 });
 
 describe("instances/routes agent-first contract", () => {
@@ -581,6 +685,7 @@ describe("instances/routes agent-first contract", () => {
     contactStatuses = new Map();
     allowContactCalls = [];
     liveWinner = null;
+    matchRouteCalls = [];
     sessions = [];
     deletedSessionKeys = [];
     pendingEntries = [];

--- a/src/omni/consumer-context.test.ts
+++ b/src/omni/consumer-context.test.ts
@@ -50,6 +50,10 @@ let routeResult: Record<string, unknown> | null = null;
 let configuredAgentMode: "active" | "sentinel" = "active";
 let configuredRoutes: RouteConfig[] = [];
 let useAccountAgentFallback = true;
+const commitMatchedRouteCalls: Array<{
+  matched: { agentId: string; route?: { pattern?: string } };
+  params: { phone: string };
+}> = [];
 
 function defaultRouteResult(): Record<string, unknown> {
   return {
@@ -106,7 +110,10 @@ mock.module("../slash/index.js", () => ({
 mock.module("../router/index.js", () => ({
   ...actualRouterIndexModule,
   expandHome: (cwd: string) => cwd,
-  commitMatchedRoute: () => routeResult,
+  commitMatchedRoute: (matched: { agentId: string; route?: { pattern?: string } }, params: { phone: string }) => {
+    commitMatchedRouteCalls.push({ matched, params });
+    return routeResult;
+  },
 }));
 
 mock.module("../config-store.js", () => ({
@@ -129,6 +136,12 @@ mock.module("../config-store.js", () => ({
           id: "main",
           cwd: agentCwd,
           dmScope: "main",
+          mode: configuredAgentMode,
+        },
+        john: {
+          id: "john",
+          cwd: agentCwd,
+          dmScope: "per-peer",
           mode: configuredAgentMode,
         },
       },
@@ -302,6 +315,7 @@ describe("OmniConsumer channel context", () => {
     contactIntakeMode = "off";
     configuredRoutes = [];
     useAccountAgentFallback = true;
+    commitMatchedRouteCalls.length = 0;
     actualGetOrCreateSession("agent:main:whatsapp:main:group:120363424772797713", "main", agentCwd);
     promptCalls.length = 0;
     chatMessageCalls.length = 0;
@@ -638,6 +652,138 @@ describe("OmniConsumer channel context", () => {
       senderPhone: "5511947879044",
       isGroup: false,
     });
+    expect(commitMatchedRouteCalls).toHaveLength(1);
+    expect(commitMatchedRouteCalls[0]?.params.phone).toBe("5511947879044");
+    expect(commitMatchedRouteCalls[0]?.matched.agentId).toBe("main");
+  });
+
+  it("routes unresolved WhatsApp LID DMs by lid: identity instead of falling through to main", async () => {
+    const lidRoute: RouteConfig = {
+      pattern: "lid:224420715061374",
+      accountId: "main",
+      agent: "john",
+      priority: 10,
+      channel: "whatsapp",
+    };
+    const fallbackRoute: RouteConfig = {
+      pattern: "*",
+      accountId: "main",
+      agent: "main",
+      priority: 0,
+    };
+    configuredRoutes = [lidRoute, fallbackRoute];
+    useAccountAgentFallback = true;
+    routeResult = {
+      sessionKey: "agent:john:dm:lid:224420715061374",
+      sessionName: "john-dm-061374",
+      dmScope: "per-peer",
+      route: lidRoute,
+      agent: {
+        id: "john",
+        cwd: agentCwd,
+        mode: "active",
+      },
+    };
+    actualGetOrCreateSession("agent:john:dm:lid:224420715061374", "john", agentCwd);
+
+    const sender = {
+      send: mock(async () => {}),
+      sendTyping: mock(async () => {}),
+      markRead: mock(async () => {}),
+    };
+    const consumer = new OmniConsumer(sender as never, "http://omni.local", "test-key", {
+      resolveGroupMetadata: async () => null,
+    });
+
+    await consumer["handleMessageEvent"]("message.received.whatsapp-baileys.instance-1", {
+      id: "evt-dm-lid-unresolved",
+      type: "message.received",
+      payload: {
+        externalId: "msg-dm-lid-unresolved",
+        chatId: "224420715061374@lid",
+        from: "224420715061374@lid",
+        content: {
+          type: "text",
+          text: "oi",
+        },
+        rawPayload: {
+          pushName: "Dudu",
+          isGroup: false,
+        },
+      },
+      metadata: {
+        instanceId: "instance-1",
+        channelType: "whatsapp-baileys",
+        ingestMode: "realtime",
+      },
+      timestamp: Date.now(),
+    });
+
+    expect(commitMatchedRouteCalls).toHaveLength(1);
+    expect(commitMatchedRouteCalls[0]?.params.phone).toBe("lid:224420715061374");
+    expect(commitMatchedRouteCalls[0]?.matched.agentId).toBe("john");
+    expect(commitMatchedRouteCalls[0]?.matched.route?.pattern).toBe("lid:224420715061374");
+    expect(promptCalls).toHaveLength(1);
+  });
+
+  it("does not canonicalize Slack U-ids when routing DMs", async () => {
+    const slackRoute: RouteConfig = {
+      pattern: "U012ABCDEF",
+      accountId: "main",
+      agent: "john",
+      priority: 10,
+      channel: "slack",
+    };
+    configuredRoutes = [slackRoute];
+    useAccountAgentFallback = false;
+    routeResult = {
+      sessionKey: "agent:john:slack:dm:U012ABCDEF",
+      sessionName: "john-dm-abcdef",
+      dmScope: "per-peer",
+      route: slackRoute,
+      agent: {
+        id: "john",
+        cwd: agentCwd,
+        mode: "active",
+      },
+    };
+    actualGetOrCreateSession("agent:john:slack:dm:U012ABCDEF", "john", agentCwd);
+
+    const sender = {
+      send: mock(async () => {}),
+      sendTyping: mock(async () => {}),
+      markRead: mock(async () => {}),
+    };
+    const consumer = new OmniConsumer(sender as never, "http://omni.local", "test-key", {
+      resolveGroupMetadata: async () => null,
+    });
+
+    await consumer["handleMessageEvent"]("message.received.slack.instance-1", {
+      id: "evt-slack-uid",
+      type: "message.received",
+      payload: {
+        externalId: "msg-slack-uid",
+        chatId: "D012ABCDEF",
+        from: "U012ABCDEF",
+        content: {
+          type: "text",
+          text: "hello",
+        },
+        rawPayload: {
+          isDm: true,
+        },
+      },
+      metadata: {
+        instanceId: "instance-1",
+        channelType: "slack",
+        ingestMode: "realtime",
+      },
+      timestamp: Date.now(),
+    });
+
+    expect(commitMatchedRouteCalls).toHaveLength(1);
+    expect(commitMatchedRouteCalls[0]?.params.phone).toBe("U012ABCDEF");
+    expect(commitMatchedRouteCalls[0]?.matched.agentId).toBe("john");
   });
 
   it("keeps an existing primary output subscription on repeated inbound from the same chat", async () => {

--- a/src/omni/consumer.ts
+++ b/src/omni/consumer.ts
@@ -67,7 +67,7 @@ import {
 } from "../session-trace/channel-trace.js";
 import { recordRuntimeTraceEvent } from "../session-trace/runtime-trace.js";
 import { logger } from "../utils/logger.js";
-import { isBroadcastJid } from "../utils/phone.js";
+import { canonicalizeRouteIdentity, isBroadcastJid } from "../utils/phone.js";
 import type {
   MessageActorMetadata,
   MessageContext,
@@ -669,9 +669,24 @@ export class OmniConsumer {
     const senderPhone = stripJid(payload.from);
     const resolvedSenderPhone = this.resolveSenderPhone(rawPayload, senderPhone);
     const chatJid = payload.chatId;
-    // For routing: use the canonical phone for DMs when Omni resolved a LID,
-    // while preserving the raw sender as a fallback. Groups still route by chat JID.
-    const routePhone = isGroup ? chatJid : resolvedSenderPhone || senderPhone;
+    const inboundChannel = channelType.replace(/-baileys$/, "");
+    let routePhone: string;
+    if (isGroup) {
+      routePhone = chatJid;
+    } else if (inboundChannel === "whatsapp" && isWhatsAppLidSender(payload.from)) {
+      const explicitResolvedPhone =
+        rawPayloadString(rawPayload, "resolvedSenderPhone") ??
+        cleanString((rawPayload?.key as Record<string, unknown> | undefined)?.participantAlt);
+      const resolvedIsPhone =
+        explicitResolvedPhone != null &&
+        !isWhatsAppLidSender(explicitResolvedPhone) &&
+        !explicitResolvedPhone.trim().toLowerCase().startsWith("lid:");
+      routePhone = canonicalizeRouteIdentity(resolvedIsPhone ? explicitResolvedPhone : payload.from);
+    } else if (inboundChannel === "whatsapp") {
+      routePhone = canonicalizeRouteIdentity(resolvedSenderPhone || payload.from);
+    } else {
+      routePhone = resolvedSenderPhone || senderPhone;
+    }
 
     // Channel detection: Slack/Discord non-DM channels use "channel" peerKind.
     // accountId is still included in the session key for full isolation.

--- a/src/router/resolver.test.ts
+++ b/src/router/resolver.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { matchPattern, findRoute, matchRoute, resolveCommittedSessionKey } from "./resolver.js";
+import { parseSessionKey } from "./session-key.js";
 import type { RouterConfig, RouteConfig, AgentConfig } from "./types.js";
 
 // ============================================================================
@@ -33,12 +34,19 @@ const agentSupport: AgentConfig = {
   dmScope: "per-peer",
 };
 
+const agentJohn: AgentConfig = {
+  id: "john",
+  cwd: "/tmp/john",
+  dmScope: "per-peer",
+};
+
 function makeConfig(routes: RouteConfig[], overrides: Partial<RouterConfig> = {}): RouterConfig {
   return {
     agents: {
       main: agentMain,
       vendas: agentVendas,
       support: agentSupport,
+      john: agentJohn,
     },
     routes,
     defaultAgent: "main",
@@ -99,6 +107,12 @@ describe("matchPattern", () => {
   it("group: exact pattern match", () => {
     expect(matchPattern("group:123456789", "group:123456789")).toBe(true);
     expect(matchPattern("group:123456789", "group:000000000")).toBe(false);
+  });
+
+  it("bare digits and lid: do not match each other", () => {
+    expect(matchPattern("224420715061374", "lid:224420715061374")).toBe(false);
+    expect(matchPattern("lid:224420715061374", "224420715061374")).toBe(false);
+    expect(matchPattern("lid:224420715061374", "lid:224420715061374")).toBe(true);
   });
 });
 
@@ -286,6 +300,69 @@ describe("matchRoute — route.policy passthrough", () => {
 // matchRoute — accountId scoping
 // ============================================================================
 
+describe("matchRoute — WhatsApp LID identity", () => {
+  it("matches lid: inbound to an exact lid: route instead of * / default", () => {
+    const config = makeConfig(
+      [
+        { pattern: "lid:224420715061374", accountId: "main", agent: "john", priority: 10 },
+        { pattern: "*", accountId: "main", agent: "main", priority: 0 },
+      ],
+      { accountAgents: { main: "main" } },
+    );
+
+    const result = matchRoute(config, {
+      phone: "lid:224420715061374",
+      accountId: "main",
+      channel: "whatsapp",
+    });
+
+    expect(result?.agentId).toBe("john");
+    expect(result?.route?.pattern).toBe("lid:224420715061374");
+  });
+
+  it("does not match bare digits against a lid: route", () => {
+    const config = makeConfig(
+      [
+        { pattern: "lid:224420715061374", accountId: "main", agent: "john", priority: 10 },
+        { pattern: "*", accountId: "main", agent: "main", priority: 0 },
+      ],
+      { accountAgents: { main: "main" } },
+    );
+
+    const result = matchRoute(config, {
+      phone: "224420715061374",
+      accountId: "main",
+      channel: "whatsapp",
+    });
+
+    expect(result?.agentId).toBe("main");
+    expect(result?.route?.pattern).toBe("*");
+  });
+
+  it("still matches group: and glob routes", () => {
+    const config = makeConfig([
+      { pattern: "group:120363424772797713", accountId: "main", agent: "vendas", priority: 10 },
+      { pattern: "5511*", accountId: "main", agent: "support", priority: 5 },
+    ]);
+
+    expect(
+      matchRoute(config, {
+        phone: "120363424772797713@g.us",
+        accountId: "main",
+        isGroup: true,
+        groupId: "120363424772797713",
+      })?.agentId,
+    ).toBe("vendas");
+
+    expect(
+      matchRoute(config, {
+        phone: "5511999999999",
+        accountId: "main",
+      })?.agentId,
+    ).toBe("support");
+  });
+});
+
 describe("matchRoute — accountId scoping", () => {
   it("uses accountAgent mapping when no route matches", () => {
     const config = makeConfig([], {
@@ -384,5 +461,17 @@ describe("resolveCommittedSessionKey", () => {
         forcedRouteSessionName: "ravi-hil",
       }),
     ).toBe("agent:main:dm:5511999999999");
+  });
+});
+
+describe("parseSessionKey — LID peer ids", () => {
+  it("keeps lid:X intact on per-peer DM keys", () => {
+    const parsed = parseSessionKey("agent:john:dm:lid:224420715061374");
+    expect(parsed).toMatchObject({
+      agentId: "john",
+      peerKind: "dm",
+      peerId: "lid:224420715061374",
+      dmScope: "per-peer",
+    });
   });
 });

--- a/src/router/session-key.ts
+++ b/src/router/session-key.ts
@@ -87,12 +87,12 @@ export function parseSessionKey(key: string): Partial<SessionKeyParams> | null {
     return { agentId, dmScope: "main" };
   }
 
-  // agent:X:dm:PHONE (per-peer)
+  // agent:X:dm:PHONE (per-peer). Join remaining parts so lid:X stays intact.
   if (parts[2] === "dm") {
     return {
       agentId,
       peerKind: "dm",
-      peerId: parts[3],
+      peerId: parts.slice(3).join(":") || undefined,
       dmScope: "per-peer",
     };
   }

--- a/src/utils/phone.test.ts
+++ b/src/utils/phone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isBroadcastJid } from "./phone.js";
+import { canonicalizeRouteIdentity, isBroadcastJid } from "./phone.js";
 
 describe("isBroadcastJid", () => {
   it("recognizes WhatsApp status and broadcast-list feeds", () => {
@@ -12,5 +12,41 @@ describe("isBroadcastJid", () => {
     expect(isBroadcastJid("5511999999999@s.whatsapp.net")).toBe(false);
     expect(isBroadcastJid("123456@lid")).toBe(false);
     expect(isBroadcastJid("120363424772797713@g.us")).toBe(false);
+  });
+});
+
+describe("canonicalizeRouteIdentity", () => {
+  it("leaves glob patterns untouched", () => {
+    expect(canonicalizeRouteIdentity("5511*")).toBe("5511*");
+    expect(canonicalizeRouteIdentity("*")).toBe("*");
+    expect(canonicalizeRouteIdentity("  lid:*  ")).toBe("lid:*");
+  });
+
+  it("maps WhatsApp LID JID and lid: prefix to lid:<digits>", () => {
+    expect(canonicalizeRouteIdentity("224420715061374@lid")).toBe("lid:224420715061374");
+    expect(canonicalizeRouteIdentity("lid:224420715061374")).toBe("lid:224420715061374");
+    expect(canonicalizeRouteIdentity("lid:224420715061374@lid")).toBe("lid:224420715061374");
+  });
+
+  it("maps WhatsApp user JID and E.164 to digits", () => {
+    expect(canonicalizeRouteIdentity("5511999999999@s.whatsapp.net")).toBe("5511999999999");
+    expect(canonicalizeRouteIdentity("+55 11 99999-9999")).toBe("5511999999999");
+    expect(canonicalizeRouteIdentity("5511999999999")).toBe("5511999999999");
+  });
+
+  it("keeps group: and thread: prefixes and group JIDs", () => {
+    expect(canonicalizeRouteIdentity("120363424772797713@g.us")).toBe("group:120363424772797713");
+    expect(canonicalizeRouteIdentity("group:120363424772797713")).toBe("group:120363424772797713");
+    expect(canonicalizeRouteIdentity("thread:abc123")).toBe("thread:abc123");
+  });
+
+  it("does not strip Slack / Discord / Telegram ids", () => {
+    expect(canonicalizeRouteIdentity("U012ABCDEF")).toBe("U012ABCDEF");
+    expect(canonicalizeRouteIdentity("C0BG33ZUWJC")).toBe("C0BG33ZUWJC");
+    expect(canonicalizeRouteIdentity("D012ABCDEF")).toBe("D012ABCDEF");
+  });
+
+  it("never promotes bare digits to lid:", () => {
+    expect(canonicalizeRouteIdentity("224420715061374")).toBe("224420715061374");
   });
 });

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -85,6 +85,41 @@ export function normalizePhone(input: string): string {
 }
 
 /**
+ * Canonical identity for route matching and persistence.
+ *
+ * Unlike `normalizePhone`, the non-phone fallback does not strip letters.
+ * Slack `U…` / `C…` / `D…` ids (and other non-JID peers) stay unchanged.
+ * Bare digits are never promoted to `lid:` — LID only if marked `@lid` or `lid:`.
+ */
+export function canonicalizeRouteIdentity(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.includes("*")) return trimmed;
+
+  const lower = trimmed.toLowerCase();
+
+  if (lower.startsWith("lid:")) {
+    const rest = trimmed.slice(4);
+    const withoutServer = rest.toLowerCase().endsWith("@lid") ? rest.slice(0, -4) : rest;
+    return `lid:${withoutServer.replace(/\D/g, "")}`;
+  }
+
+  const parsed = parseJid(trimmed);
+  if (parsed) {
+    if (parsed.isLid) return `lid:${parsed.user}`;
+    if (parsed.isGroup) return `group:${parsed.user}`;
+    return parsed.user;
+  }
+
+  if (lower.startsWith("group:")) return `group:${trimmed.slice(6)}`;
+  if (lower.startsWith("thread:")) return `thread:${trimmed.slice(7)}`;
+
+  if (PHONE_RE.test(trimmed)) return trimmed.replace(/\D/g, "");
+
+  return trimmed;
+}
+
+/**
  * Convert a phone number to a WhatsApp JID.
  */
 export function phoneToJid(phone: string): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

WhatsApp LID DMs must route on a single canonical identity (`lid:<digits>`) so an unresolved inbound `from = xxx@lid` matches a `lid:xxx` route instead of falling through to the account default. This is a different production bug from #462 / #469 (session_chat_bindings).

## Problem

- Inbound WhatsApp `from = xxx@lid` was stripped to bare digits `xxx`.
- Operators stored `lid:xxx`, but `matchPattern` is exact, so the route never won.
- Fallback `*` / `accountAgents` sent the DM to `main` (Alex) and `generateSessionName` created `main-dm-061374`.
- `inspectRouteLiveWinner` treated `lid:` as a broad pattern (`skipped_broad_pattern`), so `routes add` printed success while inbound still missed.
- `deleteConflictingSessions` only looked for `lid:X` inside the session key, leaving `agent:main:dm:<digits>` alive.
- `parseSessionKey` split `agent:john:dm:lid:X` so `peerId` became `"lid"`.

## Solution

One helper, `canonicalizeRouteIdentity`, in `src/utils/phone.ts`. It is **not** `normalizePhone` (that fallback strips Slack `U…` letters).

Rules: globs stay raw; `lid:` / `@lid` → `lid:<digits>`; WhatsApp JID / E.164 → digits; `group:` / `thread:` kept; everything else (Slack/Discord/Telegram) unchanged. Bare digits are never promoted to `lid:`.

Call sites only:

- Inbound DM `routePhone` in `OmniConsumer.handleMessageEvent`: unresolved WhatsApp `@lid` → `lid:…`; #402 resolved E.164 still wins; Slack keeps the U-id.
- `instances routes add` persists the canonical pattern; show/remove/set/explain look up `X@lid` as `lid:X`.
- `inspectRouteLiveWinner` / `getRouteLiveEffect` simulate `matchRoute({ phone: "lid:X" })`.
- `deleteConflictingSessions` also deletes leftover `:dm:<digits>` keys and `*-dm-<last6>` names, but never `agent:main:main`.
- `parseSessionKey` joins remaining parts after `dm` so `peerId` stays `lid:X`.

## Practical impact

- WhatsApp LID DMs with no resolved phone now match `lid:X` routes (John) instead of defaulting to `main` (Alex).
- `ravi instances routes add main 2244…@lid john` stores `lid:2244…` and reports a verified live winner.
- Re-adding that route cleans the leftover Alex session `agent:main:dm:<digits>` / `main-dm-<last6>`.
- Slack / Discord / Telegram routing ids are unchanged.

## What does NOT change

- `matchRoute` / `matchPattern` matching rules (no alias matrix, no canonicalize-inside-match).
- Attach vs route precedence.
- #462 / #469 session_chat_bindings / lastChannel path.
- `stripJid` global behavior, `normalizePhone` fallback, `generateSessionName` formula.
- CORS / media / Pages / ravi-app / socket-mode.

## Validation

- `bun test src/utils/phone.test.ts src/router/resolver.test.ts src/cli/commands/routes.test.ts src/omni/consumer-context.test.ts` — 91 pass
- `bun tsc --noEmit`
- `bunx biome check` on edited files
- Pre-push hook passed

Coverage Gate: `src/omni/consumer-context.test.ts` and `src/router/resolver.test.ts` are in the PR diff.

## Risks

- Leftover DB rows still stored as `X@lid` will not match inbound `lid:X` until the operator re-adds the route (edges only; match stays exact).
- `deleteConflictingSessions` now also matches `*-dm-<last6>` names; shared `agent:<id>:main` sessions are excluded.

## Rollback

Revert this PR. Existing `lid:X` routes remain valid exact patterns.

## Follow-ups

None. Identity is one function at the edges; no further alias work is needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10b84ccd-d476-4974-8dbc-3fbae3d2ab71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10b84ccd-d476-4974-8dbc-3fbae3d2ab71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

