### PR TITLE
fix(pages): ship without --execute brake

### DIFF
--- a/.ravi/specs/artifacts/RUNBOOK.md
+++ b/.ravi/specs/artifacts/RUNBOOK.md
@@ -60,7 +60,7 @@ Hospedar HTML → skill `pages` (`ravi skills show pages`). The one-shot is
 `ravi pages ship`; do not choreograph `create` + `publish`.
 
 ```bash
-ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json --execute
+ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json
 ```
 
 If the HTML is already a local `art_*`, use advanced `ravi pages publish`

--- a/.ravi/specs/artifacts/SPEC.md
+++ b/.ravi/specs/artifacts/SPEC.md
@@ -200,19 +200,19 @@ remains the generic primitive under the hood.
 Canonical one-shot:
 
 ```bash
-ravi pages ship --title "Demo" --dir ./site --execute --json
+ravi pages ship --title "Demo" --dir ./site --json
 ```
 
 Advanced directory publish (existing host):
 
 ```bash
-ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html --execute
+ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html
 ```
 
 Advanced local artifact publish:
 
 ```bash
-ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --visibility public --execute
+ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --visibility public
 ```
 
 Synchronous generation remains available only when explicitly requested:

--- a/.ravi/specs/cli/console-scope/CHECKS.md
+++ b/.ravi/specs/cli/console-scope/CHECKS.md
@@ -80,9 +80,9 @@ owners:
 - `ravi pages list --json` can omit project when a default is set.
 - `ravi pages list --json` fails with a clear missing project message when no
   project default exists and more than one remote project is visible.
-- `ravi pages create <slug> --json --execute` uses the default project when project is
+- `ravi pages create <slug> --json` uses the default project when project is
   omitted and explicit project when provided.
-- `ravi pages publish <site> <target> --json --execute` uses the default
+- `ravi pages publish <site> <target> --json` uses the default
   project when `--project` is omitted.
 - `ravi bridges create --json` uses the default project when `--project` is
   omitted.

--- a/.ravi/specs/cli/console-scope/SPEC.md
+++ b/.ravi/specs/cli/console-scope/SPEC.md
@@ -403,7 +403,7 @@ Pages command semantics MUST stay explicit:
 Canonical Pages content publish:
 
 ```bash
-ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html --execute
+ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html
 ```
 
 Highest-priority commands:
@@ -475,11 +475,11 @@ errors.
 ## Acceptance Criteria
 
 - A runtime command launched inside a session with a session Console scope can
-  run `ravi pages create <slug> --json --execute` without passing a project.
+  run `ravi pages create <slug> --json` without passing a project.
 - The same command with explicit `--project other-project` uses the explicit
   project and reports `source="explicit"` in JSON/debug output.
 - A child CLI using only `RAVI_CONTEXT_KEY` can recover the same effective scope.
-- `ravi pages publish docs ./dist --json --execute` resolves the project from
+- `ravi pages publish docs ./dist --json` resolves the project from
   the shared scope when no `--project` is passed.
 - `ravi connectors connect google` resolves a project from the shared scope or
   fails with a clear next command when ambiguous.

--- a/.ravi/specs/cli/pages/CHECKS.md
+++ b/.ravi/specs/cli/pages/CHECKS.md
@@ -2,21 +2,20 @@
 
 ## Checks
 
-- `pages ship` without `--execute` MUST exit 3, MUST report `dryRun: true`
-  with `project`, `slug`, `titlePresent`, `contentKind`, `route`, `visibility`
-  and `entrypoint`, and MUST NOT expose body text or filesystem paths. It MUST
-  NOT call Console at all — not even the project scope resolution. With
-  `--execute` it MUST ensure the host (reuse an existing slug; do not fail)
-  then publish+activate. `--body` MUST be wrapped in a simple HTML5 document.
-  Success JSON MUST include `{url, site, slug, route, visibility, artifactId}`.
-- `pages publish` without `--execute` MUST exit 3, MUST report `dryRun: true`
-  with exactly `project`, `site`, `sourceKind`, path-basename-only
-  `sourceName`, `route`, `visibility` and `entrypointPresent`; it MUST NOT
-  expose the raw source path or title/description content, and MUST NOT call
-  Console at all — not even the project scope resolution. With `--execute`
-  the upload/release MUST happen.
-- `pages create` and `pages domains` without `--execute` MUST exit 3 before
-  credential reads, project resolution or any Console/provider request.
+- `pages ship` without `--execute` MUST ensure the host (reuse an existing
+  slug; do not fail) then publish+activate. It MUST NOT exit 3 with
+  `WRITE_REQUIRES_EXECUTE` and MUST talk to Console when args are valid.
+  `--execute` MUST be accepted as an unused no-op. `--body` MUST be wrapped
+  in a simple HTML5 document. Success JSON MUST include
+  `{url, site, slug, route, visibility, artifactId}`.
+- `pages create` without `--execute` MUST write the host record. It MUST NOT
+  exit 3 with `WRITE_REQUIRES_EXECUTE`. `--execute` MUST be accepted as an
+  unused no-op.
+- `pages publish` without `--execute` MUST upload/publish. It MUST NOT exit 3
+  with `WRITE_REQUIRES_EXECUTE` and MUST talk to Console when args are valid.
+  `--execute` MUST be accepted as an unused no-op.
+- `pages domains` without `--execute` MUST exit 3 before credential reads,
+  project resolution or any Console/provider request.
 - `pages password set` without `--execute` MUST exit 3 BEFORE the hidden
   password prompt and before any Console call; its plan MUST NOT contain a
   password key or raw route path and MUST use `routePresent` metadata.
@@ -31,20 +30,24 @@
   `SITE_NOT_FOUND` envelope (exit 1) with suggestedAction `ravi pages list
   --json`; a route not-found MUST surface as `ROUTE_NOT_FOUND` (exit 1) with
   suggestedAction `ravi pages published --json`.
-- A `ContractError` thrown by the brake or a not-found mapping MUST pass
-  through `runPagesCommand`'s CloudAuthError funnel untouched.
+- A `ContractError` thrown by the remaining brakes or a not-found mapping MUST
+  pass through `runPagesCommand`'s CloudAuthError funnel untouched.
 - A 400 Console response carrying `DOMAIN_SETUP_REQUIRED` MUST preserve that
   code through cloud-auth mapping and render the sanitized TXT/CNAME instruction
   with exit 1; other provider messages MUST remain redacted.
 - `pages list --fields a,b,c --json` and `pages published --fields a,b,c
   --json` MUST return items containing only the requested fields.
-- Unbraked ops (visibility reductions and `password status`) MUST keep
-  immediate behavior and be declared as unbraked in the spec.
-- The dry-run plans of `pages publish` and `pages ship` MUST work without
-  saved Console scope, showing `(Console scope default)` placeholders instead
-  of resolved refs.
+- Unbraked ops (`ship`, `create`, `publish`, visibility reductions and
+  `password status`) MUST keep immediate behavior and be declared as unbraked
+  in the spec.
+- The dry-run plan of `pages domains` MUST work without saved Console scope,
+  showing `(Console scope default)` placeholders instead of resolved refs.
 - `ravi skills show pages` and `ravi skills show ravi-system-pages` MUST
   resolve to the same skill. The default gate `pages` MUST load
   `ravi-system-pages` for `ravi pages` and `pages.password`.
+- The `pages` skill MUST teach `ravi pages ship … --json` as the only happy
+  path to get a URL, without required `--execute`, and MUST NOT teach
+  `create` + `publish` choreography. `create`/`publish` MAY appear only under
+  an advanced/compat section.
 - `bun test src/cli/commands/pages.test.ts` SHOULD pass after any change to
   the pages contract surface.

--- a/.ravi/specs/cli/pages/RUNBOOK.md
+++ b/.ravi/specs/cli/pages/RUNBOOK.md
@@ -5,9 +5,12 @@
 1. Read the rules: `ravi specs get cli/pages --mode rules --json`.
 2. Reproduce the failing call with `--json` and read `error.code` first; the
    code, not the message, is the branch point.
-3. Exit `3`: read `error.plan`, confirm the exposure change is intended, then
-   re-run the same command adding `--execute`. For `password set` the dry-run
-   never prompts — the prompt only appears with `--execute`.
+3. Exit `3`: this is only a remaining brake (`domains`, `password set/remove`,
+   or `update`/`visibility` switching to `public`). Read `error.plan`, confirm
+   the exposure change is intended, then re-run the same command adding
+   `--execute`. For `password set` the dry-run never prompts — the prompt only
+   appears with `--execute`. `ship`, `create` and `publish` do not use this
+   path; leftover `--execute` on those ops is ignored.
 4. Exit `1` + `SITE_NOT_FOUND`: list the real sites with `ravi pages list
    --json` and retry with an existing slug/id.
 5. Exit `1` + `ROUTE_NOT_FOUND`: list the live routes with `ravi pages
@@ -16,12 +19,15 @@
    missing or invalid — it is validated BEFORE the brake, on purpose.
 7. `AUTH_REQUIRED`/`AUTH_EXPIRED`: legacy CloudAuthError funnel, not the
    contract — run `ravi login`.
-8. If a create/domains/publish/ship/password write executed without `--execute`,
-   the brake regressed: check the op still calls `contractDryRun` before
-   `resolvePagesProject` (publish/ship/password) or before `updatePageSite`
-   (update/visibility with `public`).
-9. If a braked op in agent context reports a CloudAuthError instead of the
-   dry-run envelope, `runPagesCommand` lost the ContractError rethrow.
+8. If a domains/password write, or a visibility switch to `public`, executed
+   without `--execute`, the brake regressed: check the op still calls
+   `contractDryRun` before `resolvePagesProject` (domains/password) or before
+   `updatePageSite` (update/visibility with `public`).
+9. If `pages ship`, `pages create` or `pages publish` exits 3 with
+   `WRITE_REQUIRES_EXECUTE`, the unbrake regressed: those ops must write
+   immediately and treat `--execute` as a no-op.
+10. If a braked op in agent context reports a CloudAuthError instead of the
+    dry-run envelope, `runPagesCommand` lost the ContractError rethrow.
 
 ## Validation
 
@@ -32,9 +38,9 @@ bun test src/cli/commands/pages.test.ts
 Live checks against the local CLI (read-only or dry-run):
 
 ```bash
-ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json               # expect exit 3 + plan, no Console call
-ravi pages publish proj site ./dist --route / --visibility public --json  # expect exit 3 + plan, no Console call
-ravi pages create proj site --visibility private --json                   # expect exit 3 before credentials
+ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json               # happy path: ensure-host + publish immediately
+ravi pages create proj site --visibility private --json                   # advanced/compat: writes the host immediately
+ravi pages publish proj site ./dist --route / --visibility public --json  # advanced/compat: publishes immediately
 ravi pages domains proj site docs.example.com --json                      # expect exit 3 before credentials
 ravi pages domains proj site docs.example.com --execute                  # add shown DNS records, then rerun
 ravi pages password set proj site --route / --json                        # expect exit 3, no prompt

--- a/.ravi/specs/cli/pages/SPEC.md
+++ b/.ravi/specs/cli/pages/SPEC.md
@@ -51,19 +51,15 @@ contract errors rethrow first, recognizable Console not-found failures map to
    `ravi pages published --json`. Sites/routes live only in Console, so there
    is no cheap local candidate source — listing suggestedAction, never
    similarity suggestions.
-4. `pages create` and `pages domains` MUST default to dry-run and require
-   `--execute` before credential, project or provider resolution. Their plans
-   MUST contain only parsed identifiers, counts and presence metadata.
-   `pages publish` MUST also default to dry-run and require `--execute`; the
-   dry-run MUST report `dryRun: true` and an exact plan with `project`, `site`,
-   `sourceKind`, path-basename-only `sourceName`, `route`, `visibility` and
-   `entrypointPresent`. Raw source paths and title/description content MUST be
-   absent. The dry-run MUST NOT call Console at all — not even the project
-   scope resolution. `pages ship` MUST default to dry-run and require
-   `--execute` before credential, project or provider resolution. Its plan MUST
-   contain `project`, `slug`, `titlePresent`, `contentKind`, `route`,
-   `visibility` and `entrypoint`. Body text and filesystem paths MUST be
-   absent. Public visibility still requires `--execute`.
+4. `pages ship`, `pages create` and `pages publish` MUST execute immediately
+   when invoked with valid args. They MUST NOT dry-run, MUST NOT exit 3 with
+   `WRITE_REQUIRES_EXECUTE`, and MUST talk to Console (or fail on credentials /
+   usage) without `--execute`. `--execute` MAY remain as an unused
+   compatibility no-op so existing scripts keep working. Public visibility on
+   `ship`/`create`/`publish` is allowed in the same call. `pages domains` MUST
+   still default to dry-run and require `--execute` before credential, project
+   or provider resolution. Its plan MUST contain only parsed identifiers,
+   counts and presence metadata.
 5. `pages password set` and `pages password remove` MUST default to dry-run
    and require `--execute`. The `set` dry-run MUST fire BEFORE the hidden
    password prompt (a dry-run never reads secret material) and its plan MUST
@@ -97,13 +93,13 @@ contract errors rethrow first, recognizable Console not-found failures map to
 
 | op | class | brake |
 |---|---|---|
-| ship | ensures a host (create-or-reuse) then uploads bytes and activates a hosted route (external exposure, high) | dry-run + `--execute` |
-| publish | uploads bytes + (default) activates a public hosted route (external exposure, high) | dry-run + `--execute` |
+| ship | ensures a host (create-or-reuse) then uploads bytes and activates a hosted route | not braked / executes immediately (`--execute` unused no-op) |
+| publish | uploads bytes and (default) activates a hosted route | not braked / executes immediately (`--execute` unused no-op) |
 | password set | flips the route access policy on a live site (high) | dry-run + `--execute`, braked before the secret prompt |
 | password remove | widens who can reach the route, up to fully public (high) | dry-run + `--execute`, visibility validated first |
 | update / visibility → `public` | exposes already-hosted content to the open web | conditional dry-run + `--execute` |
 | update / visibility → `private`/`protected_link` | reduces exposure, reversible | not braked (declared) |
-| create | creates a host record in Ravi Console (external service mutation) | dry-run + `--execute` |
+| create | creates a host record in Ravi Console | not braked / executes immediately (`--execute` unused no-op) |
 | domains | changes provider-backed hostname bindings and routing | dry-run + `--execute` |
 
 There is no `pages remove`/route-removal command on this surface today; if one
@@ -122,14 +118,16 @@ is added it MUST arrive braked.
 
 ## Internal consumers
 
-The agent happy path is `ravi pages ship`, taught by the `pages` skill
+The agent-first happy path is `ravi pages ship`, taught by the `pages` skill
 (`ravi skills show pages` / `ravi skills show ravi-system-pages`) and by
-`AGENTS.md` ("Ravi Pages Publishing"). `create` stays host-only.
-`publish` stays the advanced upload primitive (including an existing `art_*`).
-The `contentPublishCommand` hint returned by `pages create`
-(`src/pages/client.ts`) still points at `pages publish --execute`.
-The `artifacts` skill MUST NOT teach Pages publishing; it points at skill
-`pages`.
+`AGENTS.md` ("Ravi Pages Publishing"). Agents MUST NOT choreograph
+`create` + `publish` to get a URL. `create` and `publish` remain implemented
+as advanced/compat commands (host-only create; publish onto an existing host
+or a local `art_*`) and MUST keep working. They MUST NOT be taught as the
+default path. The `contentPublishCommand` hint returned by `pages create`
+(`src/pages/client.ts`) still points at `pages publish` without a required
+`--execute`. The `artifacts` skill MUST NOT teach Pages publishing; it points
+at skill `pages`.
 
 The default skill gate `pages` (`/^pages(?:[._]|$)/` → `ravi-system-pages`)
 MUST load the skill for `ravi pages …` and `pages.password`.
@@ -147,11 +145,10 @@ MUST load the skill for `ravi pages …` and `pages.password`.
 - `bun test src/cli/commands/pages.test.ts` green (contract block included),
   no new failures vs the `dev` baseline.
 - Live checks on the local CLI: `pages ship --title T --body "<p>x</p>" --json`
-  → exit 3 before credentials; with `--execute` → ensure-site + publish and
-  JSON `{url,site,slug,route,visibility,artifactId}`; `pages create p s --json`
-  and `pages domains p s docs.example.com --json` → exit 3 before credentials;
-  `pages publish p s ./site --json` → exit 3, no Console call; with `--execute`
-  → publishes;
+  → ensure-site + publish and JSON `{url,site,slug,route,visibility,artifactId}`
+  (passing leftover `--execute` is a no-op); `pages create p s --json` →
+  writes the host immediately; `pages publish p s ./site --json` → publishes;
+  `pages domains p s docs.example.com --json` → exit 3 before credentials;
   `pages password set p s --json`
   → exit 3 without prompting; `pages visibility p s public --json` → exit 3;
   `pages visibility p s private --json` → immediate write; `pages list --json
@@ -167,7 +164,8 @@ MUST load the skill for `ravi pages …` and `pages.password`.
   in tests MUST run inside `runWithContext({}, ...)` so the contract helpers
   throw `ContractError` instead of killing the test process with
   `process.exit(3)`.
-- Braking `create` or `domains` after project resolution would let a dry-run
-  touch credential/provider state. Braking `password set` AFTER the prompt
-  would make dry-runs read secret material; the brake fires right after arg
-  parsing, before prompt and before any Console call.
+- Braking `domains` after project resolution would let a dry-run touch
+  credential/provider state. Braking `password set` AFTER the prompt would
+  make dry-runs read secret material; the brake fires right after arg
+  parsing, before prompt and before any Console call. `create`, `publish` and
+  `ship` are unbraked on purpose; leftover `--execute` is ignored.

--- a/.ravi/specs/cli/pages/WHY.md
+++ b/.ravi/specs/cli/pages/WHY.md
@@ -1,31 +1,39 @@
 # Pages agent-first CLI contract / WHY
 
-Pages is the surface where a local file becomes a URL anyone can open. A
-misunderstood `pages publish` is not a local mistake — bytes land on a hosted
-site and, by default, a release goes live. The same logic covers the password
-pair (`set` flips the route policy, `remove` can widen access up to fully
-public) and the visibility switch to `public`, which exposes content that is
-ALREADY hosted. `create` and `domains` do not upload bytes, but they still
-change provider-backed Console state and routing, so they are braked as
-external service mutations. Reducing visibility remains the emergency path
-that must never be slowed down.
+Pages is the surface where a local file becomes a URL anyone can open. The
+agent-first happy path is one command: `pages ship` (ensure host + publish).
+`create` (host record) and `publish` (upload onto an existing host or a
+local `art_*`) stay implemented as advanced/compat commands and also run
+immediately — asking for `--execute` after the caller already chose those
+writes does not add safety. They are not deleted and not the default
+teaching path. The remaining brakes cover mutations that change who can
+reach an already-hosted site: the password pair (`set` flips the route
+policy, `remove` can widen access up to fully public), domain binding
+(provider-backed hostname routing), and the visibility switch to `public`,
+which exposes content that is ALREADY hosted. Reducing visibility remains
+the emergency path that must never be slowed down.
 
 Decisions specific to this domain:
 
+- **Unify around `ship`.** The skill, CLI help and AGENTS.md teach only
+  `ravi pages ship` to get a URL. `create` + `publish` choreography is the
+  failure mode this surface exists to stop.
+- **Unbraked write verbs.** `ship`, `create` and `publish` execute
+  immediately. `--execute` stays accepted as a compatibility no-op so
+  existing agent scripts do not break.
 - **Conditional brake on `update`/`visibility`.** Braking every visibility
   change would put exit-3 friction inside "make it private NOW". The brake
   keys off the requested value: `public` → dry-run; `private`/`protected_link`
   → immediate. The rule is directional exposure, not the op name.
-- **Brake before scope resolution.** `pages create`, `pages domains`,
-  `pages publish` and `pages ship` resolve the Console project scope before
-  publishing; the brake fires even before that, so a
-  dry-run works offline and unauthenticated — the plan shows the parsed
-  intent (`(Console scope default)` placeholders) instead of resolved refs.
-- **One-shot `ship`, host-only `create`.** Agents were choreographing
-  `create` + `publish` (or worse, `artifacts publish`) to get a URL.
-  `create` stays a host record. `ship` ensures the host (reuse existing slug)
-  and publishes in one command. The `pages` skill teaches only `ship` as
-  “create a page”.
+- **Brake before scope resolution on remaining braked writes.** `pages
+  domains` and the password pair resolve the Console project scope before
+  mutating; the brake fires even before that, so a dry-run works offline
+  and unauthenticated — the plan shows the parsed intent
+  (`(Console scope default)` placeholders) instead of resolved refs.
+- **Host-only `create`, advanced `publish`.** `create` stays a host record.
+  `publish` stays the upload primitive for an existing host or a local
+  `art_*`. Both remain in the CLI. The `pages` skill mentions them only
+  under “Avançado / legado”.
 - **Brake before the password prompt.** A `password set` dry-run must never
   read a secret; the plan carries site/action and `routePresent` metadata only.
 - **Message-based not-found mapping.** Console reports unknown sites/routes as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,27 +54,21 @@ ravi skills show pages
 Happy path is one command — `ravi pages ship`. Do not choreograph `create` + `publish`.
 
 ```bash
-ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json --execute
+ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json
 ```
 
-`create` is host-only. `publish` is the advanced upload primitive (including an
-existing local `art_*`). They stay available for host work; the agent happy
-path is not `artifacts publish`.
+`create` is host-only compatibility. `publish` is the advanced upload primitive
+(including an existing local `art_*`). They stay available; the agent happy
+path is `ravi pages ship`, not `artifacts publish`.
 
 ```bash
-ravi pages create <project-ref> <site-slug> --visibility public --execute
-ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html --execute
+ravi pages create <project-ref> <site-slug> --visibility public
+ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --visibility public
 ```
 
-If a local Ravi artifact already exists, publish the artifact id:
-
-```bash
-ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --visibility public --execute
-```
-
-Host creation, domain binding, shipping, publishing and password changes are
-dry-run by default (exit 3): re-run with `--execute` to perform the external
-mutation. Public visibility still needs `--execute`.
+`ship`, `create` and `publish` execute immediately. Leftover `--execute` on
+those ops is ignored. Domain binding, password changes, and switching a site
+to public visibility are dry-run by default (exit 3): re-run with `--execute`.
 
 Protect an active route with a password without republishing its bytes:
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "7f762cac1007e469"
+    "version": "03cb96ac8ec5795a"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -59199,7 +59199,7 @@
                     "type": "boolean"
                   },
                   "execute": {
-                    "description": "Create the external Pages host record",
+                    "description": "Unused compatibility no-op; pages create always writes the host record",
                     "type": "boolean"
                   },
                   "project": {
@@ -59326,7 +59326,7 @@
           }
         },
         "security": [],
-        "summary": "Compatibility: ensure a Ravi Pages host record; does not upload HTML or assets",
+        "summary": "Advanced/compat: host-only Pages record; does not upload HTML. Prefer pages ship to get a URL",
         "tags": [
           "pages"
         ]
@@ -60129,7 +60129,7 @@
                     "type": "string"
                   },
                   "execute": {
-                    "description": "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+                    "description": "Unused compatibility no-op; pages publish always uploads and publishes",
                     "type": "boolean"
                   },
                   "idempotencyKey": {
@@ -60418,7 +60418,7 @@
           }
         },
         "security": [],
-        "summary": "Publish a directory, file, or local artifact to a project Pages host",
+        "summary": "Advanced/compat: upload to an existing host or local art_*; prefer pages ship unless the HTML is already art_*",
         "tags": [
           "pages"
         ]
@@ -60651,7 +60651,7 @@
                     "type": "string"
                   },
                   "execute": {
-                    "description": "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+                    "description": "Unused compatibility no-op; pages ship always ensures the host and publishes",
                     "type": "boolean"
                   },
                   "html": {

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "OpenAPI 3.1 spec auto-generated from the Ravi CLI registry. Each operation maps 1:1 to a `ravi <group> <command>` invocation.",
     "title": "Ravi API",
-    "version": "7f762cac1007e469"
+    "version": "03cb96ac8ec5795a"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -59199,7 +59199,7 @@
                     "type": "boolean"
                   },
                   "execute": {
-                    "description": "Create the external Pages host record",
+                    "description": "Unused compatibility no-op; pages create always writes the host record",
                     "type": "boolean"
                   },
                   "project": {
@@ -59326,7 +59326,7 @@
           }
         },
         "security": [],
-        "summary": "Compatibility: ensure a Ravi Pages host record; does not upload HTML or assets",
+        "summary": "Advanced/compat: host-only Pages record; does not upload HTML. Prefer pages ship to get a URL",
         "tags": [
           "pages"
         ]
@@ -60129,7 +60129,7 @@
                     "type": "string"
                   },
                   "execute": {
-                    "description": "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+                    "description": "Unused compatibility no-op; pages publish always uploads and publishes",
                     "type": "boolean"
                   },
                   "idempotencyKey": {
@@ -60418,7 +60418,7 @@
           }
         },
         "security": [],
-        "summary": "Publish a directory, file, or local artifact to a project Pages host",
+        "summary": "Advanced/compat: upload to an existing host or local art_*; prefer pages ship unless the HTML is already art_*",
         "tags": [
           "pages"
         ]
@@ -60651,7 +60651,7 @@
                     "type": "string"
                   },
                   "execute": {
-                    "description": "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+                    "description": "Unused compatibility no-op; pages ship always ensures the host and publishes",
                     "type": "boolean"
                   },
                   "html": {

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_schemas.generated.dart
@@ -49113,7 +49113,7 @@ class RaviSchemas {
       "type": "boolean"
     },
     "execute": {
-      "description": "Create the external Pages host record",
+      "description": "Unused compatibility no-op; pages create always writes the host record",
       "type": "boolean"
     },
     "project": {
@@ -49913,7 +49913,7 @@ class RaviSchemas {
       "type": "string"
     },
     "execute": {
-      "description": "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+      "description": "Unused compatibility no-op; pages publish always uploads and publishes",
       "type": "boolean"
     },
     "idempotencyKey": {
@@ -50383,7 +50383,7 @@ class RaviSchemas {
       "type": "string"
     },
     "execute": {
-      "description": "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+      "description": "Unused compatibility no-op; pages ship always ensures the host and publishes",
       "type": "boolean"
     },
     "html": {

--- a/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
+++ b/packages/ravi-os-dart-sdk/lib/src/ravi_version.generated.dart
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk dart check`.
 
 const raviSdkVersion = "0.1.0";
-const raviRegistryHash = "sha256:dd53ef81010a226c72ad8e6f080e96a4c08c4ddac1f6d407bf3fe840e3274644";
-const raviGitSha = "a7c043e47cb0";
+const raviRegistryHash = "sha256:2122e53226c7b3d1eb535226ef9bf986d02214157cf3e73ba3a1c244cb2fe816";
+const raviGitSha = "21f4e32093de";

--- a/packages/ravi-os-sdk/src/client.ts
+++ b/packages/ravi-os-sdk/src/client.ts
@@ -4186,7 +4186,7 @@ export class RaviClient {
   };
 
   readonly pages = {
-    /** Compatibility: ensure a Ravi Pages host record; does not upload HTML or assets */
+    /** Advanced/compat: host-only Pages record; does not upload HTML. Prefer pages ship to get a URL */
     create: async (args: string[], options?: {
       console?: string;
       defaultSite?: boolean;
@@ -4254,7 +4254,7 @@ export class RaviClient {
         });
       }
     },
-    /** Publish a directory, file, or local artifact to a project Pages host */
+    /** Advanced/compat: upload to an existing host or local art_*; prefer pages ship unless the HTML is already art_* */
     publish: async (args: string[], options?: {
       artifactSlug?: string;
       artifactVersion?: string;

--- a/packages/ravi-os-sdk/src/schemas.ts
+++ b/packages/ravi-os-sdk/src/schemas.ts
@@ -48442,7 +48442,7 @@ export const PagesCreateInputSchema = {
       "type": "boolean"
     },
     "execute": {
-      "description": "Create the external Pages host record",
+      "description": "Unused compatibility no-op; pages create always writes the host record",
       "type": "boolean"
     },
     "project": {
@@ -49232,7 +49232,7 @@ export const PagesPublishInputSchema = {
       "type": "string"
     },
     "execute": {
-      "description": "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+      "description": "Unused compatibility no-op; pages publish always uploads and publishes",
       "type": "boolean"
     },
     "idempotencyKey": {
@@ -49698,7 +49698,7 @@ export const PagesShipInputSchema = {
       "type": "string"
     },
     "execute": {
-      "description": "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+      "description": "Unused compatibility no-op; pages ship always ensures the host and publishes",
       "type": "boolean"
     },
     "html": {

--- a/packages/ravi-os-sdk/src/version.ts
+++ b/packages/ravi-os-sdk/src/version.ts
@@ -6,7 +6,7 @@
 export const SDK_VERSION = "0.2.1";
 
 /** SHA-256 fingerprint of the registry projection at codegen time. */
-export const REGISTRY_HASH = "sha256:dd53ef81010a226c72ad8e6f080e96a4c08c4ddac1f6d407bf3fe840e3274644";
+export const REGISTRY_HASH = "sha256:2122e53226c7b3d1eb535226ef9bf986d02214157cf3e73ba3a1c244cb2fe816";
 
 /** Git SHA of the source tree at codegen time. `"unknown"` outside git. */
-export const GIT_SHA = "a7c043e47cb0";
+export const GIT_SHA = "21f4e32093de";

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviSchemas.generated.swift
@@ -49113,7 +49113,7 @@ public enum RaviSchemas {
         "type": "boolean"
       },
       "execute": {
-        "description": "Create the external Pages host record",
+        "description": "Unused compatibility no-op; pages create always writes the host record",
         "type": "boolean"
       },
       "project": {
@@ -49913,7 +49913,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "execute": {
-        "description": "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+        "description": "Unused compatibility no-op; pages publish always uploads and publishes",
         "type": "boolean"
       },
       "idempotencyKey": {
@@ -50383,7 +50383,7 @@ public enum RaviSchemas {
         "type": "string"
       },
       "execute": {
-        "description": "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+        "description": "Unused compatibility no-op; pages ship always ensures the host and publishes",
         "type": "boolean"
       },
       "html": {

--- a/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
+++ b/packages/ravi-os-swift-sdk/Sources/RaviSDK/RaviVersion.generated.swift
@@ -3,5 +3,5 @@
 // Drift is detected by `ravi sdk swift check`.
 
 public let RAVI_SDK_VERSION = "0.1.0"
-public let RAVI_REGISTRY_HASH = "sha256:dd53ef81010a226c72ad8e6f080e96a4c08c4ddac1f6d407bf3fe840e3274644"
-public let RAVI_GIT_SHA = "a7c043e47cb0"
+public let RAVI_REGISTRY_HASH = "sha256:2122e53226c7b3d1eb535226ef9bf986d02214157cf3e73ba3a1c244cb2fe816"
+public let RAVI_GIT_SHA = "21f4e32093de"

--- a/src/cli/commands/pages.test.ts
+++ b/src/cli/commands/pages.test.ts
@@ -9,7 +9,7 @@ import { cleanupIsolatedRaviState, createIsolatedRaviState } from "../../test/ra
 import { CloudAuthError } from "../../cloud-auth/errors.js";
 import { ContractError } from "../agent-contract.js";
 import { runWithContext } from "../context.js";
-import { getCliOnlyMetadata, getOptionsMetadata } from "../decorators.js";
+import { getCliOnlyMetadata, getCommandsMetadata, getOptionsMetadata } from "../decorators.js";
 import { PagesCommands, PagesPasswordCommands } from "./pages.js";
 
 const tempDirs: string[] = [];
@@ -114,6 +114,18 @@ describe("pages CLI commands", () => {
       ),
     );
     expect(result).toMatchObject({ code: "PAYLOAD_INVALID" });
+  });
+
+  it("marks ship as the one-shot and create/publish as advanced/compat", () => {
+    const commands = getCommandsMetadata(PagesCommands);
+    const byName = Object.fromEntries(commands.map((command) => [command.name, command]));
+    expect(byName.ship?.description).toContain("One-shot");
+    expect(byName.ship?.helpAfter).toContain('ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json');
+    expect(byName.ship?.helpAfter).not.toContain("--json --execute");
+    expect(byName.create?.description).toMatch(/Advanced\/compat|host-only/i);
+    expect(byName.create?.helpAfter).toContain("Prefer");
+    expect(byName.publish?.description).toMatch(/Advanced\/compat|art_\*/);
+    expect(byName.publish?.helpAfter).toContain("Prefer");
   });
 
   it("does not expose a password argument or option in command metadata", () => {
@@ -252,6 +264,8 @@ describe("pages CLI commands", () => {
       site: { slug: "demo", defaultHostname: "demo.ravi.page" },
       url: "https://demo.ravi.page/",
     });
+    expect(payload.contentPublishCommand).toContain("ravi pages publish");
+    expect(payload.contentPublishCommand).not.toContain("--execute");
   });
 
   it("updates a project Pages site visibility through the Console CLI API", async () => {
@@ -643,35 +657,32 @@ describe("pages CLI commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("pages agent-first contract", () => {
-  it("create without --execute dry-runs before credentials or Console", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
-    let credentialReads = 0;
-    const client = makeClient(async (method, path) => {
-      calls.push({ method, path });
-      return {};
+  it("create without --execute writes the host immediately", async () => {
+    const calls: Array<{ method: string; path: string; body: unknown }> = [];
+    const client = makeClient(async (method, path, body) => {
+      calls.push({ method, path, body });
+      return {
+        id: "site_1",
+        slug: "demo",
+        defaultHostname: "demo.ravi.page",
+        defaultVisibility: "private",
+      };
     });
-    const command = new PagesCommands({
-      client,
-      readCredentials: () => {
-        credentialReads += 1;
-        return makeCredentials();
-      },
-    });
+    const command = new PagesCommands({ client, readCredentials: makeReadCredentials() });
 
-    const error = await expectContractError(
-      () => command.create(["proj", "demo"], undefined, "private", true, undefined, true),
-      "WRITE_REQUIRES_EXECUTE",
-      3,
+    const { output } = await captureConsole(() =>
+      command.create(["proj", "demo"], undefined, "private", true, undefined, true),
     );
+    const payload = JSON.parse(output);
 
-    expect(error.details.plan).toEqual({
-      project: "proj",
-      slug: "demo",
-      defaultVisibility: "private",
-      defaultSite: true,
-    });
-    expect(credentialReads).toBe(0);
-    expect(calls).toEqual([]);
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: "/api/cli/projects/proj/pages",
+        body: { slug: "demo", defaultVisibility: "private", isDefault: true },
+      },
+    ]);
+    expect(payload).toMatchObject({ success: true, site: { slug: "demo" } });
   });
 
   it("domains without --execute dry-runs before credentials or Console", async () => {
@@ -705,99 +716,62 @@ describe("pages agent-first contract", () => {
     expect(calls).toEqual([]);
   });
 
-  it("publish without --execute is a dry-run: exit 3 and no Console call at all", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
-    const client = makeClient(async (method, path) => {
-      calls.push({ method, path });
-      return [];
-    });
+  it("publish without --execute uploads immediately", async () => {
+    stateDir = await createIsolatedRaviState("ravi-pages-publish-unbraked-test-");
+    const dir = await tempDir();
+    await writeFile(join(dir, "index.html"), "<h1>Docs</h1>");
+    const calls: string[] = [];
+    const client = {
+      me: mock(async () => ({
+        user: { email: "alice@example.com" },
+        organization: { id: "org_1" },
+      })),
+      createPageUploadSession: mock(async () => {
+        calls.push("createPageUploadSession");
+        return {
+          uploadSession: { id: "upl_unbraked" },
+          uploadPolicy: { directUpload: false },
+        };
+      }),
+      finalizeArtifactPublish: mock(async () => {
+        calls.push("finalizeArtifactPublish");
+        return {
+          artifact: { id: "cloud_art_unbraked" },
+          site: { id: "site_1", slug: "demo", defaultHostname: "demo.ravi.page" },
+          url: "https://demo.ravi.page/guide",
+        };
+      }),
+    } as unknown as ConsoleApiClient;
     const command = new PagesCommands({ client, readCredentials: makeReadCredentials() });
 
-    const error = await expectContractError(
-      () =>
-        command.publish(
-          ["proj", "demo", "C:/sentinel/private"],
-          undefined,
-          "/guide",
-          "public",
-          "Docs",
-          undefined,
-          undefined,
-          "index.html",
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
-        ),
-      "WRITE_REQUIRES_EXECUTE",
-      3,
+    const { output } = await captureConsole(() =>
+      command.publish(
+        ["proj", "demo", dir],
+        undefined,
+        "/guide",
+        "public",
+        "Docs",
+        undefined,
+        undefined,
+        "index.html",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+      ),
     );
 
-    expect(error.details.dryRun).toBe(true);
-    expect(error.details.plan).toEqual({
-      project: "proj",
-      site: "demo",
-      sourceKind: "path",
-      sourceName: expect.stringContaining("[REDACTED:content"),
-      route: "/guide",
-      visibility: "public",
-      entrypointPresent: true,
+    expect(calls).toEqual(["createPageUploadSession", "finalizeArtifactPublish"]);
+    expect(JSON.parse(output)).toMatchObject({
+      success: true,
+      url: "https://demo.ravi.page/guide",
     });
-    expect(JSON.stringify(error.details.plan)).not.toContain("C:/sentinel/private");
-    expect(calls).toHaveLength(0);
-  });
-
-  it("publish identifies a local artifact without exposing unrelated publish content", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
-    const client = makeClient(async (method, path) => {
-      calls.push({ method, path });
-      return [];
-    });
-    const command = new PagesCommands({ client, readCredentials: makeReadCredentials() });
-
-    const error = await expectContractError(
-      () =>
-        command.publish(
-          ["proj", "demo", "art_demo_123"],
-          undefined,
-          undefined,
-          "private",
-          "SENTINEL_SECRET_7M4Q",
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
-        ),
-      "WRITE_REQUIRES_EXECUTE",
-      3,
-    );
-
-    expect(error.details.plan).toEqual({
-      project: "proj",
-      site: "demo",
-      sourceKind: "artifact",
-      sourceName: expect.stringContaining("[REDACTED:content"),
-      route: "/",
-      visibility: "private",
-      entrypointPresent: false,
-    });
-    expect(JSON.stringify(error.details.plan)).not.toContain("SENTINEL_SECRET_7M4Q");
-    expect(calls).toHaveLength(0);
   });
 
   it("password set without --execute never prompts for the password nor calls Console", async () => {
@@ -947,76 +921,76 @@ describe("pages agent-first contract", () => {
     expect(error.details.suggestedAction).toContain("ravi pages published");
   });
 
-  it("ship without --execute is a dry-run: exit 3 and no Console call at all", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
-    let credentialReads = 0;
-    const client = makeClient(async (method, path) => {
-      calls.push({ method, path });
-      return [];
-    });
-    const command = new PagesCommands({
-      client,
-      readCredentials: () => {
-        credentialReads += 1;
-        return makeCredentials();
-      },
-    });
+  it("ship without --execute publishes immediately and leftover --execute is a no-op", async () => {
+    stateDir = await createIsolatedRaviState("ravi-pages-ship-unbraked-test-");
+    const listAndCreate: Array<{ method: string; path: string; body: unknown }> = [];
+    const client = {
+      me: mock(async () => ({
+        user: { email: "alice@example.com" },
+        organization: { id: "org_1" },
+      })),
+      requestJson: mock(async (method: string, path: string, body: unknown) => {
+        listAndCreate.push({ method, path, body });
+        if (method === "GET" && path === "/api/cli/projects/proj/pages") {
+          return [
+            {
+              id: "site_1",
+              slug: "weekly-report",
+              defaultHostname: "weekly-report.ravi.page",
+              defaultVisibility: "private",
+            },
+          ];
+        }
+        throw new Error(`unexpected ${method} ${path}`);
+      }),
+      createPageUploadSession: mock(async () => ({
+        uploadSession: { id: "upl_unbraked_ship" },
+        uploadPolicy: { directUpload: false },
+      })),
+      finalizeArtifactPublish: mock(async () => ({
+        artifact: { id: "cloud_art_unbraked_ship" },
+        site: {
+          id: "site_1",
+          slug: "weekly-report",
+          defaultHostname: "weekly-report.ravi.page",
+        },
+        url: "https://weekly-report.ravi.page/",
+      })),
+    } as unknown as ConsoleApiClient;
+    const command = new PagesCommands({ client, readCredentials: makeReadCredentials() });
 
-    const error = await expectContractError(
-      () =>
-        command.ship(
-          [],
-          "proj",
-          "Weekly report",
-          "<h1>secret-body</h1>",
-          undefined,
-          undefined,
-          "private",
-          "/",
-          "index.html",
-          undefined,
-          true,
-        ),
-      "WRITE_REQUIRES_EXECUTE",
-      3,
-    );
+    const ship = (execute?: boolean) =>
+      command.ship(
+        [],
+        "proj",
+        "Weekly report",
+        "<h1>OK</h1>",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        execute,
+      );
 
-    expect(error.details.dryRun).toBe(true);
-    expect(error.details.plan).toEqual({
-      project: "proj",
+    const withoutExecute = await captureConsole(() => ship());
+    const withExecuteNoop = await captureConsole(() => ship(true));
+
+    expect(listAndCreate).toEqual([
+      { method: "GET", path: "/api/cli/projects/proj/pages", body: undefined },
+      { method: "GET", path: "/api/cli/projects/proj/pages", body: undefined },
+    ]);
+    expect(JSON.parse(withoutExecute.output)).toMatchObject({
+      artifactId: "cloud_art_unbraked_ship",
       slug: "weekly-report",
-      titlePresent: true,
-      contentKind: "body",
-      route: "/",
-      visibility: "private",
-      entrypoint: "index.html",
+      success: true,
+      url: "https://weekly-report.ravi.page/",
     });
-    expect(JSON.stringify(error.details.plan)).not.toContain("secret-body");
-    expect(credentialReads).toBe(0);
-    expect(calls).toHaveLength(0);
-
-    const noPositionals = await expectContractError(
-      () =>
-        command.ship(
-          [],
-          undefined,
-          "Weekly report",
-          "<h1>OK</h1>",
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
-        ),
-      "WRITE_REQUIRES_EXECUTE",
-      3,
-    );
-    expect(noPositionals.details.plan).toMatchObject({
-      project: "(Console scope default)",
+    expect(JSON.parse(withExecuteNoop.output)).toMatchObject({
+      success: true,
       slug: "weekly-report",
-      contentKind: "body",
     });
   });
 

--- a/src/cli/commands/pages.ts
+++ b/src/cli/commands/pages.ts
@@ -55,21 +55,50 @@ export interface PagesPasswordCommandDeps extends PagesCommandDeps {
 
 const PAGES_SHIP_HELP = `
 Examples:
-  ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json --execute
-  ravi pages ship demo --title "Landing" --html ./landing.html --visibility public --execute
-  ravi pages ship proj docs --title "Docs" --dir ./site --route / --execute --json
+  ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json
+  ravi pages ship demo --title "Landing" --html ./landing.html --visibility public
+  ravi pages ship proj docs --title "Docs" --dir ./site --route / --json
 
 Happy path:
   One command. Do not choreograph pages create + pages publish.
   --title is required. Pass exactly one of --body, --html, or --dir.
   Omit <slug> to generate it from --title. Existing slugs are reused.
+  Public visibility is allowed in the same call.
 
 Write brake:
-  Without --execute the command is a dry-run (exit 3) and never talks to Console.
-  Public visibility still requires --execute.
+  None. ship always ensures the host and publishes. --execute is accepted
+  and ignored for backwards compatibility.
 
 JSON:
   { url, site, slug, route, visibility, artifactId }
+`;
+
+const PAGES_CREATE_HELP = `
+Advanced / compatibility:
+  Host-only. Does not upload HTML or assets.
+  Prefer \`ravi pages ship --title <title> --body|--html|--dir … --json\` to get a URL.
+
+Examples:
+  ravi pages create demo --json
+  ravi pages create proj docs --visibility private --json
+
+Write brake:
+  None. create always writes the host record. --execute is accepted and ignored
+  for backwards compatibility.
+`;
+
+const PAGES_PUBLISH_HELP = `
+Advanced / compatibility:
+  Upload onto an existing host, or publish a local art_* already in the ledger.
+  Prefer \`ravi pages ship\` unless the HTML is already an art_* id.
+
+Examples:
+  ravi pages publish proj demo ./site --route / --json
+  ravi pages publish proj demo art_demo_123 --route / --json
+
+Write brake:
+  None. publish always uploads. --execute is accepted and ignored for
+  backwards compatibility.
 `;
 
 @Group({
@@ -162,7 +191,8 @@ export class PagesCommands {
 
   @Command({
     name: "create",
-    description: "Compatibility: ensure a Ravi Pages host record; does not upload HTML or assets",
+    description: "Advanced/compat: host-only Pages record; does not upload HTML. Prefer pages ship to get a URL",
+    helpAfter: PAGES_CREATE_HELP,
   })
   @CommandAccess({
     kind: "mutate",
@@ -182,25 +212,16 @@ export class PagesCommands {
     isDefault?: boolean,
     @Option({ flags: "--console <url>", description: "Console base URL" }) consoleUrl?: string,
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
-    @Option({ flags: "--execute", description: "Create the external Pages host record" }) execute?: boolean,
+    @Option({
+      flags: "--execute",
+      description: "Unused compatibility no-op; pages create always writes the host record",
+    })
+    execute?: boolean,
   ) {
-    // Creating a Pages host record mutates Ravi Console, so confirmation must
-    // happen before credential and project resolution.
+    void execute;
     return runPagesCommand("pages create", asJson, async () => {
       const parsed = parseCreateArgs(args, projectOption);
       const normalizedVisibility = normalizePageVisibility(visibility);
-      if (execute !== true) {
-        contractDryRun(
-          "pages create",
-          {
-            project: parsed.project ?? "(Console scope default)",
-            slug: parsed.slug,
-            defaultVisibility: normalizedVisibility ?? null,
-            defaultSite: Boolean(isDefault),
-          },
-          { asJson },
-        );
-      }
       const resolved = await resolvePagesProject(parsed.project, undefined, consoleUrl, this.deps);
       const result = await createPageSite(
         {
@@ -252,10 +273,11 @@ export class PagesCommands {
     @Option({ flags: "--json", description: "Print raw JSON result" }) asJson?: boolean,
     @Option({
       flags: "--execute",
-      description: "Actually ensure the host and publish; default is a dry-run that only shows the plan (exit 3)",
+      description: "Unused compatibility no-op; pages ship always ensures the host and publishes",
     })
     execute?: boolean,
   ) {
+    void execute;
     return runPagesCommand("pages ship", asJson, async () => {
       const parsed = parseShipArgs(args, projectOption);
       const title = requireShipTitle(titleOption);
@@ -263,26 +285,7 @@ export class PagesCommands {
       const resolvedEntrypoint = stringValue(entrypoint) ?? "index.html";
       const normalizedVisibility = normalizePageVisibility(visibility) ?? "private";
       const slug = parsed.slug ?? slugifyPageTitle(title);
-      const contentKind = await validateShipSourceInput({ body, dir, html });
-      if (execute !== true) {
-        // Write brake (Manual v2 7.8): ship creates/reuses a Console host and
-        // publishes bytes onto a hosted route. Dry-run before any Console call,
-        // including project scope resolution. The plan never carries body text
-        // or filesystem paths.
-        contractDryRun(
-          "pages ship",
-          {
-            project: parsed.project ?? "(Console scope default)",
-            slug,
-            titlePresent: true,
-            contentKind,
-            route: resolvedRoute,
-            visibility: normalizedVisibility,
-            entrypoint: resolvedEntrypoint,
-          },
-          { asJson },
-        );
-      }
+      await validateShipSourceInput({ body, dir, html });
       const resolved = await resolvePagesProject(parsed.project, undefined, consoleUrl, this.deps);
       const site = await ensurePageSite(
         {
@@ -335,7 +338,12 @@ export class PagesCommands {
     });
   }
 
-  @Command({ name: "publish", description: "Publish a directory, file, or local artifact to a project Pages host" })
+  @Command({
+    name: "publish",
+    description:
+      "Advanced/compat: upload to an existing host or local art_*; prefer pages ship unless the HTML is already art_*",
+    helpAfter: PAGES_PUBLISH_HELP,
+  })
   @CommandAccess({ kind: "mutate", resource: "pages", action: "publish", risk: "high", requiresConfirmation: true })
   async publish(
     @Arg("args", {
@@ -374,33 +382,15 @@ export class PagesCommands {
     siteOption?: string,
     @Option({
       flags: "--execute",
-      description: "Actually upload/publish to Pages; default is a dry-run that only shows the plan (exit 3)",
+      description: "Unused compatibility no-op; pages publish always uploads and publishes",
     })
     execute?: boolean,
   ) {
+    void execute;
     return runPagesCommand("pages publish", asJson, async () => {
       const parsed = parsePublishArgs(args, projectOption, siteOption);
       const normalizedVisibility = normalizePageVisibility(visibility);
       const parsedArtifactVersion = artifactVersion ? parseInteger(artifactVersion, "--artifact-version") : undefined;
-      if (execute !== true) {
-        // Write brake (Manual v2 7.8): publish uploads local bytes and (unless
-        // --no-activate) exposes them on a hosted Pages URL — external
-        // exposure. Dry-run by default and exit 3 before any Console call,
-        // including the project scope resolution.
-        contractDryRun(
-          "pages publish",
-          {
-            project: parsed.project ?? "(Console scope default)",
-            site: parsed.site ?? "(project default Pages host)",
-            sourceKind: /^art_[a-z0-9]+_[a-z0-9]+$/.test(parsed.source) ? "artifact" : "path",
-            sourceName: parsed.source.replace(/\\/g, "/").split("/").filter(Boolean).at(-1) ?? parsed.source,
-            route: route ?? "/",
-            visibility: normalizedVisibility ?? null,
-            entrypointPresent: Boolean(entrypoint),
-          },
-          { asJson },
-        );
-      }
       const resolved = await resolvePagesProject(parsed.project, undefined, consoleUrl, this.deps);
       const result = await publishArtifactToConsole(
         parsed.source,

--- a/src/cli/execute-consumers.test.ts
+++ b/src/cli/execute-consumers.test.ts
@@ -131,42 +131,6 @@ const executeInstructions = [
     path: "docs/cli/overview.mdx",
     instruction: "ravi heartbeat trigger <id> --execute",
   },
-  {
-    name: "Pages ship root instructions",
-    path: "AGENTS.md",
-    instruction: 'ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json --execute',
-  },
-  {
-    name: "Pages ship skill",
-    path: "src/plugins/internal/ravi-system/skills/pages/SKILL.md",
-    instruction: 'ravi pages ship --title "Relatório semanal" --body "<h1>OK</h1>" --json --execute',
-  },
-  {
-    name: "Pages create root instructions",
-    path: "AGENTS.md",
-    instruction: "ravi pages create <project-ref> <site-slug> --visibility public --execute",
-  },
-  {
-    name: "Pages ship artifact runbook",
-    path: ".ravi/specs/artifacts/RUNBOOK.md",
-    instruction: 'ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json --execute',
-  },
-  {
-    name: "Pages ship artifact spec",
-    path: ".ravi/specs/artifacts/SPEC.md",
-    instruction: 'ravi pages ship --title "Demo" --dir ./site --execute --json',
-  },
-  {
-    name: "Pages publish artifact spec",
-    path: ".ravi/specs/artifacts/SPEC.md",
-    instruction:
-      "ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html --execute",
-  },
-  {
-    name: "Pages create Console-scope acceptance",
-    path: ".ravi/specs/cli/console-scope/SPEC.md",
-    instruction: "ravi pages create <slug> --json --execute",
-  },
 ] as const;
 
 const obsoleteExecuteConsumers = [
@@ -241,6 +205,50 @@ const obsoleteExecuteConsumers = [
     path: ".ravi/specs/channels/slack/canvas/RUNBOOK.md",
     obsolete: "ravi slack canvas-access-delete F123 --users U123 --execute --json",
     current: "ravi slack canvas-access-delete F123 --users U123 --json",
+  },
+  {
+    name: "Pages ship root instructions",
+    path: "AGENTS.md",
+    obsolete: 'ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json --execute',
+    current: 'ravi pages ship --title "Weekly report" --body "<h1>OK</h1>" --json',
+  },
+  {
+    name: "Pages ship skill",
+    path: "src/plugins/internal/ravi-system/skills/pages/SKILL.md",
+    obsolete: 'ravi pages ship --title "Relatório semanal" --body "<h1>OK</h1>" --json --execute',
+    current: 'ravi pages ship --title "Relatório semanal" --body "<h1>OK</h1>" --json',
+  },
+  {
+    name: "Pages create root instructions",
+    path: "AGENTS.md",
+    obsolete: "ravi pages create <project-ref> <site-slug> --visibility public --execute",
+    current: "ravi pages create <project-ref> <site-slug> --visibility public",
+  },
+  {
+    name: "Pages ship artifact runbook",
+    path: ".ravi/specs/artifacts/RUNBOOK.md",
+    obsolete: 'ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json --execute',
+    current: 'ravi pages ship --title "Demo" --body "<h1>OK</h1>" --json',
+  },
+  {
+    name: "Pages ship artifact spec",
+    path: ".ravi/specs/artifacts/SPEC.md",
+    obsolete: 'ravi pages ship --title "Demo" --dir ./site --execute --json',
+    current: 'ravi pages ship --title "Demo" --dir ./site --json',
+  },
+  {
+    name: "Pages publish artifact spec",
+    path: ".ravi/specs/artifacts/SPEC.md",
+    obsolete:
+      "ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html --execute",
+    current:
+      "ravi pages publish <project-ref> <site-slug> ./site --route / --visibility public --entrypoint index.html",
+  },
+  {
+    name: "Pages create Console-scope acceptance",
+    path: ".ravi/specs/cli/console-scope/SPEC.md",
+    obsolete: "ravi pages create <slug> --json --execute",
+    current: "ravi pages create <slug> --json",
   },
 ] as const;
 

--- a/src/pages/client.ts
+++ b/src/pages/client.ts
@@ -516,9 +516,7 @@ function contentPublishCommandForSite(projectRef: string, site: PageSitePayload)
   const siteRef = stringValue(site.slug) ?? stringValue(site.id);
   if (!siteRef) return null;
   const visibility = stringValue(site.defaultVisibility) ?? stringValue(site.visibility) ?? "public";
-  // The publish op is braked (Manual v2 write brake): teach the flag that
-  // actually performs the upload, so agents don't stop at the dry-run.
-  return `ravi pages publish ${projectRef} ${siteRef} ./site --route / --visibility ${visibility} --entrypoint index.html --execute`;
+  return `ravi pages publish ${projectRef} ${siteRef} ./site --route / --visibility ${visibility} --entrypoint index.html`;
 }
 
 function requireText(value: string | undefined, label: string): string {

--- a/src/plugins/internal/ravi-system/skills/pages/SKILL.md
+++ b/src/plugins/internal/ravi-system/skills/pages/SKILL.md
@@ -24,9 +24,9 @@ Taxonomia de saída:
 - `2` erro de uso (falta `--title`, `--body`/`--html`/`--dir` conflitantes, slug inválido).
 - `3` freio de escrita — não é erro. Nada foi enviado/exposto; o envelope traz `dryRun:true` e `plan`. Revise e repita com `--execute`.
 
-`pages ship` é dry-run por default. `--execute` é obrigatório para criar/reusar o host e publicar — inclusive com `--visibility public`.
+Exit 3 **não** se aplica a `pages ship`, `pages create` nem `pages publish`. Esses ops escrevem na hora. `--execute` nesses três é no-op (aceito por compatibilidade). O freio continua em `password set/remove`, `domains` e `visibility`/`update` para `public`.
 
-`--json` de sucesso:
+`--json` de sucesso do ship:
 
 ```json
 { "url": "https://demo.ravi.page/", "site": {}, "slug": "demo", "route": "/", "visibility": "private", "artifactId": "art_xxx" }
@@ -34,15 +34,15 @@ Taxonomia de saída:
 
 Checklist:
 
-- Tratei exit 3 como freio (revisei o `plan`) e não como falha?
-- Usei só `ravi pages ship` para criar a página, sem `create` + `publish`?
+- Usei só `ravi pages ship` para obter a URL, sem `create` + `publish`?
+- Tratei exit 3 como freio só em password/domains/visibility→public, nunca em ship?
 
 ## One-shot
 
 ```bash
-ravi pages ship --title "Relatório semanal" --body "<h1>OK</h1>" --json --execute
-ravi pages ship --title "Landing" --html ./landing.html --visibility public --execute --json
-ravi pages ship --title "Docs" --dir ./site --entrypoint index.html --execute --json
+ravi pages ship --title "Relatório semanal" --body "<h1>OK</h1>" --json
+ravi pages ship --title "Landing" --html ./landing.html --visibility public --json
+ravi pages ship --title "Docs" --dir ./site --entrypoint index.html --json
 ```
 
 Regras:
@@ -52,8 +52,7 @@ Regras:
 - Defaults: `--visibility private`, `--route /`, `--entrypoint index.html`.
 - Slug existente: reusa o host. Não falha.
 - `[project]` é opcional (scope do Console). `--project` também vale.
-
-Sem `--execute` o comando só mostra o plano (exit 3) e não fala com o Console.
+- `--visibility public` vale no mesmo comando. Não precisa de `--execute`.
 
 ## Listar
 
@@ -62,14 +61,13 @@ ravi pages list --json
 ravi pages published --json
 ```
 
-## Avançado (não é o happy path)
+## Avançado / legado
 
-`create` só cria o host. `publish` sobe bytes num host já existente. Use só se o one-shot não cabe.
-
-Se o HTML **já** está no ledger local como `art_*`:
+Não é o happy path. `create` só cria o host. `publish` sobe bytes num host já existente, ou publica um `art_*` que **já** está no ledger local. Prefira `ship` salvo o HTML já ser um `art_*`.
 
 ```bash
-ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --execute --json
+ravi pages create <slug> --json
+ravi pages publish <project-ref> <site-slug> <artifact-id> --route / --json
 ```
 
 ## Password / visibility / domain


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Make `ravi pages ship` the one-shot happy path that actually publishes. Remove the dry-run / `--execute` brake from `ship`, `create`, and `publish`. Teach only `ship` as the way to get a URL.

## Problem

Luís’s product call: `ship` is the intentional write. Requiring `--execute` after the caller already chose `ship` (or `create` / `publish`) does not add safety — it just forces a second identical call. Agents were choreographing `create` + `publish` and always passing `--execute`.

Password, domains, and switching a site **to** `public` still need a brake. Those stay dry-run by default.

## Solution

- `pages ship`, `pages create`, and `pages publish` write immediately when args are valid. No `contractDryRun`, no exit 3 `WRITE_REQUIRES_EXECUTE`.
- `--execute` on those three ops is kept as an unused compatibility no-op so existing scripts do not break.
- Public visibility is allowed in the same `ship` / `create` / `publish` call.
- Skill, CLI help, and SPEC teach **only** `ravi pages ship … --json` as the happy path. `create` (host-only) and `publish` (existing host or local `art_*`) stay implemented and are marked advanced/compat. Commands are not deleted.
- Remaining brakes unchanged: `password set` / `remove`, `domains`, and `update` / `visibility` when switching to `public`.

## Practical impact

- Agents can ship a page in one command: `ravi pages ship --title "…" --body "<h1>OK</h1>" --json`.
- Scripts that still pass `--execute` on ship/create/publish keep working.
- Exit 3 still means “review the plan, then `--execute`” for password, domains, and visibility→public only.

## What does NOT change

- Content contract for ship (`--title` plus exactly one of `--body` / `--html` / `--dir`).
- `create` / `publish` command existence and behavior (except the brake).
- Password, domains, and conditional public-visibility brakes.
- No new confirmation UX. No CORS / media / LID / session-attach work.

## Validation

- `bun test src/cli/commands/pages.test.ts src/pages/ship.test.ts src/cli/execute-consumers.test.ts src/cli/confirmation-policy.test.ts` — 42 pass, 0 fail
- `bun tsc --noEmit`
- `bunx biome check` on edited source
- Regenerated TS / Dart / Swift SDK + OpenAPI so option/description drift is current
- `bun run sdk:check` and sibling SDK/OpenAPI checks passed

[Focused pages tests 42/42](https://cursor.com/agents/bc-e9ac8c66-09b8-4b71-a7fa-b35709ae6f29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpages_unbrake_tests.log)

## Risks

- A mistaken `ship` / `create` / `publish` now hits Console immediately. That is the product decision.
- Agents that still pass `--execute` are fine; agents that treat exit 3 as required for ship will stop seeing that path.

## Rollback

Revert this commit. The previous dry-run + `--execute` contract returns.

## Follow-ups

- None required for this surface. `create` / `publish` remain available as advanced/compat; deletion is out of scope.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ac8c66-09b8-4b71-a7fa-b35709ae6f29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ac8c66-09b8-4b71-a7fa-b35709ae6f29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

